### PR TITLE
refactor: add effect registry and modular handlers

### DIFF
--- a/src/engine/effects/README.md
+++ b/src/engine/effects/README.md
@@ -1,0 +1,21 @@
+# Effect Registry
+
+The engine resolves action effects through handler functions stored in the `EFFECTS` registry.
+Each handler implements the `EffectHandler` interface and is invoked with the raw effect
+definition and current `EngineContext`.
+
+Core handlers (`add_land`, `add_resource`, `add_building`) are registered during engine
+bootstrap via `registerCoreEffects()`.
+
+To add a new effect from outside the engine, register a handler before performing actions:
+
+```ts
+import { EFFECTS } from "./effects"; // adjust path as needed
+
+EFFECTS.add("heal_castle", (effect, ctx) => {
+  const amt = effect.params?.amount ?? 0;
+  ctx.me.resources["castleHP"] += amt;
+});
+```
+
+Once registered, any action can reference `type: "heal_castle"` in its effects list.

--- a/src/engine/effects/add_building.ts
+++ b/src/engine/effects/add_building.ts
@@ -1,0 +1,8 @@
+import type { EffectHandler } from ".";
+
+export const addBuilding: EffectHandler = (effect, ctx) => {
+  const id = effect.params!.id as string;
+  ctx.me.buildings.add(id);
+  const b = ctx.buildings.get(id);
+  b.passives?.(ctx.passives, ctx);
+};

--- a/src/engine/effects/add_land.ts
+++ b/src/engine/effects/add_land.ts
@@ -1,0 +1,10 @@
+import { Land } from "../state";
+import type { EffectHandler } from ".";
+
+export const addLand: EffectHandler = (effect, ctx) => {
+  const count = effect.params?.count ?? 1;
+  for (let i = 0; i < count; i++) {
+    const land = new Land(`${ctx.me.id}-L${ctx.me.lands.length + 1}`, ctx.services.rules.slotsPerNewLand);
+    ctx.me.lands.push(land);
+  }
+};

--- a/src/engine/effects/add_resource.ts
+++ b/src/engine/effects/add_resource.ts
@@ -1,0 +1,8 @@
+import type { EffectHandler } from ".";
+import type { ResourceKey } from "../state";
+
+export const addResource: EffectHandler = (effect, ctx) => {
+  const key = effect.params!.key as ResourceKey;
+  const amount = effect.params!.amount as number;
+  ctx.me.resources[key] = (ctx.me.resources[key] || 0) + amount;
+};

--- a/src/engine/effects/index.ts
+++ b/src/engine/effects/index.ts
@@ -1,0 +1,23 @@
+import { Registry } from "../registry";
+import type { EffectDef } from "../actions";
+import type { EngineContext } from "../context";
+import { addLand } from "./add_land";
+import { addResource } from "./add_resource";
+import { addBuilding } from "./add_building";
+
+export interface EffectHandler {
+  (effect: EffectDef, ctx: EngineContext): void;
+}
+
+export class EffectRegistry extends Registry<EffectHandler> {}
+
+export const EFFECTS = new EffectRegistry();
+
+// Registers the core engine effects. Should be called during engine bootstrap.
+export function registerCoreEffects(registry: EffectRegistry = EFFECTS) {
+  registry.add("add_land", addLand);
+  registry.add("add_resource", addResource);
+  registry.add("add_building", addBuilding);
+}
+
+export { addLand, addResource, addBuilding };


### PR DESCRIPTION
## Summary
- add effect registry and effect handler interface
- move land/resource/building effects into modular handlers
- refactor engine to dispatch effects through registry
- document registering custom effects

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ade625f9848325b29f683054ecc4bb