### PR TITLE
feat: add till land effect

### DIFF
--- a/src/engine/effects/index.ts
+++ b/src/engine/effects/index.ts
@@ -8,6 +8,7 @@ import { addStat } from "./add_stat";
 import { addDevelopment } from "./add_development";
 import { payResource } from "./pay_resource";
 import { addStatPct } from "./add_stat_pct";
+import { tillLand } from "./till_land";
 
 export interface EffectHandler {
   (effect: EffectDef, ctx: EngineContext): void;
@@ -26,6 +27,7 @@ export function registerCoreEffects(registry: EffectRegistry = EFFECTS) {
   registry.add("add_stat_pct", addStatPct);
   registry.add("add_development", addDevelopment);
   registry.add("pay_resource", payResource);
+  registry.add("till_land", tillLand);
 }
 
-export { addLand, addResource, addBuilding, addStat, addDevelopment, payResource, addStatPct };
+export { addLand, addResource, addBuilding, addStat, addDevelopment, payResource, addStatPct, tillLand };

--- a/src/engine/effects/till_land.ts
+++ b/src/engine/effects/till_land.ts
@@ -1,0 +1,10 @@
+import type { EffectHandler } from ".";
+
+export const tillLand: EffectHandler = (effect, ctx) => {
+  const landId = effect.params?.landId as string;
+  if (!landId) throw new Error("till_land requires landId");
+  const land = ctx.activePlayer.lands.find(l => l.id === landId);
+  if (!land) throw new Error(`Land ${landId} not found`);
+  const max = ctx.services.rules.maxSlotsPerLand;
+  land.slotsMax = Math.min(land.slotsMax + 1, max);
+};

--- a/tests/effects/till_land.test.ts
+++ b/tests/effects/till_land.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { createEngine, performAction, createActionRegistry } from '../../src/engine';
+
+describe('till_land effect', () => {
+  it('increases land slots up to the maximum', () => {
+    const actions = createActionRegistry();
+    actions.add('till', {
+      id: 'till',
+      name: 'Till',
+      baseCosts: { ap: 0 },
+      effects: [ { type: 'till_land', params: { landId: 'A-L2' } } ],
+    });
+    const ctx = createEngine({ actions });
+    const land = ctx.activePlayer.lands[1]; // A-L2
+    const before = land.slotsMax;
+    const expected = Math.min(before + 1, ctx.services.rules.maxSlotsPerLand);
+    performAction('till', ctx);
+    expect(land.slotsMax).toBe(expected);
+  });
+
+  it('does not exceed maxSlotsPerLand', () => {
+    const actions = createActionRegistry();
+    actions.add('till', {
+      id: 'till',
+      name: 'Till',
+      baseCosts: { ap: 0 },
+      effects: [ { type: 'till_land', params: { landId: 'A-L2' } } ],
+    });
+    const ctx = createEngine({ actions });
+    const land = ctx.activePlayer.lands[1];
+    const max = ctx.services.rules.maxSlotsPerLand;
+    const attempts = max - land.slotsMax + 1;
+    for (let i = 0; i < attempts; i++) {
+      performAction('till', ctx);
+    }
+    expect(land.slotsMax).toBe(max);
+  });
+});


### PR DESCRIPTION
## Summary
- add `till_land` effect to expand land slots while respecting configured maximum
- register `till_land` in core effect registry
- test slot growth and cap enforcement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae12eec1c48325b805e1ff733bb6ac