### PR TITLE
test: add integration turn cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ We are gradually, step by step, implementing a digital game. You can refer to th
 - Use **Evaluators** to orchestrate conditional or iterative logic. Effects may include an `evaluator` and nested `effects`; the evaluator resolves to a value controlling how many times the sub-effects run. For example, `{ evaluator: { type: "development", params: { id: "farm" } }, effects: [{ type: "resource", method: "add", params: { key: "gold", amount: 2 } }] }` applies the resource gain per matching development.
 - Define leaf effects with `type` and `method` keys to separate domains (Resource, Stat, Land, etc.) from operations (add, remove, till...). This keeps params well-typed and enables a uniform effect registry.
 
+## Testing guidelines
+- Always run `npm test` before submitting changes to ensure all unit and integration tests pass.
+
 Therefore, the main mission for agents is to understand the intended game, and it's mechanics/terminology, very well. This is necessary in order to build a proper abstract, extensible system that allows us to make changes to the game's configuration by just changing some simple configs (rather than needing to update tens of if-statements everywhere). Therefore, in this project, we focus on very correct architecture, structure, separation, and a correct implementation of principles such as OOP, SOLID, DRY, YAGNI, KISS, and so on. When in doubt, over-engineering is the answer, because later I will invent a new Building and I will want to configure it myself with some unique combination of costs/requirements/effects and it should 'just work' as it is being carried by systems that understand such concepts.
 
 Full game information can be read below.

--- a/tests/integration/turn-cycle.test.ts
+++ b/tests/integration/turn-cycle.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEngine,
+  runDevelopment,
+  runUpkeep,
+  performAction,
+  Resource,
+  Phase,
+  POPULATIONS,
+  DEVELOPMENTS,
+  PopulationRole,
+  EngineContext,
+} from '../../packages/engine/src/index.ts';
+
+function getCouncilApGain() {
+  const effect = POPULATIONS.get(PopulationRole.Council).onDevelopmentPhase?.find(
+    e => e.type === 'resource' && e.method === 'add' && e.params?.key === Resource.ap,
+  );
+  return effect?.params.amount ?? 0;
+}
+
+function getFarmGoldGain() {
+  const effect = DEVELOPMENTS.get('farm').onDevelopmentPhase?.find(
+    e => e.type === 'resource' && e.method === 'add' && e.params?.key === Resource.gold,
+  );
+  return effect?.params.amount ?? 0;
+}
+
+function getCouncilUpkeepCost() {
+  const effect = POPULATIONS.get(PopulationRole.Council).onUpkeepPhase?.find(
+    e => e.type === 'resource' && e.method === 'remove' && e.params?.key === Resource.gold,
+  );
+  return effect?.params.amount ?? 0;
+}
+
+function getActionCosts(id: string, ctx: EngineContext) {
+  const def = ctx.actions.get(id);
+  const baseCosts = { ...(def.baseCosts || {}) };
+  if (baseCosts[Resource.ap] === undefined) baseCosts[Resource.ap] = ctx.services.rules.defaultActionAPCost;
+  return ctx.passives.applyCostMods(def.id, baseCosts, ctx);
+}
+
+function getExpandExpectations(ctx: EngineContext) {
+  const def = ctx.actions.get('expand');
+  const costs = getActionCosts('expand', ctx);
+  const landGain = def.effects
+    .filter(e => e.type === 'land' && e.method === 'add')
+    .reduce((sum, e) => sum + (e.params?.count ?? 0), 0);
+  const baseHappiness = def.effects
+    .filter(e => e.type === 'resource' && e.method === 'add' && e.params?.key === Resource.happiness)
+    .reduce((sum, e) => sum + (e.params?.amount ?? 0), 0);
+  const dummyCtx = { activePlayer: { happiness: 0 } } as EngineContext;
+  ctx.passives.runResultMods(def.id, dummyCtx);
+  const extraHappiness = dummyCtx.activePlayer.happiness;
+  return { costs, landGain, happinessGain: baseHappiness + extraHappiness };
+}
+
+describe('Turn cycle integration', () => {
+  it('processes development, upkeep, and main phases for both players', () => {
+    const ctx = createEngine();
+    expect(ctx.game.turn).toBe(1);
+    expect(ctx.game.currentPhase).toBe(Phase.Development);
+    expect(ctx.game.currentPlayerIndex).toBe(0);
+    const apGain = getCouncilApGain();
+    const farmGold = getFarmGoldGain();
+    const upkeepCost = getCouncilUpkeepCost();
+
+    // Player A development
+    ctx.game.currentPlayerIndex = 0;
+    const startGoldA = ctx.activePlayer.gold;
+    const startApA = ctx.activePlayer.ap;
+    runDevelopment(ctx);
+    expect(ctx.game.currentPhase).toBe(Phase.Development);
+    expect(ctx.activePlayer.ap).toBe(startApA + apGain);
+    expect(ctx.activePlayer.gold).toBe(startGoldA + farmGold);
+    const afterDevGoldA = ctx.activePlayer.gold;
+
+    // Player B development
+    ctx.game.currentPlayerIndex = 1;
+    const startGoldB = ctx.activePlayer.gold;
+    const startApB = ctx.activePlayer.ap;
+    runDevelopment(ctx);
+    expect(ctx.activePlayer.ap).toBe(startApB + apGain);
+    expect(ctx.activePlayer.gold).toBe(startGoldB + farmGold);
+    const afterDevGoldB = ctx.activePlayer.gold;
+
+    // Player A upkeep
+    ctx.game.currentPlayerIndex = 0;
+    runUpkeep(ctx);
+    expect(ctx.game.currentPhase).toBe(Phase.Upkeep);
+    expect(ctx.activePlayer.gold).toBe(afterDevGoldA - upkeepCost);
+
+    // Player B upkeep
+    ctx.game.currentPlayerIndex = 1;
+    runUpkeep(ctx);
+    expect(ctx.activePlayer.gold).toBe(afterDevGoldB - upkeepCost);
+
+    // Main phase actions
+    ctx.game.currentPhase = Phase.Main;
+
+    ctx.game.currentPlayerIndex = 0;
+    const expandA = getExpandExpectations(ctx);
+    const goldBeforeA = ctx.activePlayer.gold;
+    const apBeforeA = ctx.activePlayer.ap;
+    const landsBeforeA = ctx.activePlayer.lands.length;
+    const hapBeforeA = ctx.activePlayer.happiness;
+    performAction('expand', ctx);
+    expect(ctx.activePlayer.gold).toBe(goldBeforeA - (expandA.costs[Resource.gold] || 0));
+    expect(ctx.activePlayer.ap).toBe(apBeforeA - (expandA.costs[Resource.ap] || 0));
+    expect(ctx.activePlayer.lands.length).toBe(landsBeforeA + expandA.landGain);
+    expect(ctx.activePlayer.happiness).toBe(hapBeforeA + expandA.happinessGain);
+
+    ctx.game.currentPlayerIndex = 1;
+    const expandB = getExpandExpectations(ctx);
+    const goldBeforeB = ctx.activePlayer.gold;
+    const apBeforeB = ctx.activePlayer.ap;
+    const landsBeforeB = ctx.activePlayer.lands.length;
+    const hapBeforeB = ctx.activePlayer.happiness;
+    performAction('expand', ctx);
+    expect(ctx.activePlayer.gold).toBe(goldBeforeB - (expandB.costs[Resource.gold] || 0));
+    expect(ctx.activePlayer.ap).toBe(apBeforeB - (expandB.costs[Resource.ap] || 0));
+    expect(ctx.activePlayer.lands.length).toBe(landsBeforeB + expandB.landGain);
+    expect(ctx.activePlayer.happiness).toBe(hapBeforeB + expandB.happinessGain);
+
+    // End turn reset
+    ctx.game.turn += 1;
+    ctx.game.currentPhase = Phase.Development;
+    ctx.game.currentPlayerIndex = 0;
+    expect(ctx.game.turn).toBe(2);
+    expect(ctx.game.currentPhase).toBe(Phase.Development);
+    expect(ctx.game.currentPlayerIndex).toBe(0);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add integration test covering complete turn cycle across both players
- document testing guidelines for contributors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae24a500848325a4dfcf7b7818e959