### PR TITLE
feat: add type checking step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
+      - run: npm run type-check
       - run: npm run test:coverage
       - uses: actions/upload-artifact@v4
         with:
@@ -29,5 +30,6 @@ jobs:
           with:
             node-version: '20'
         - run: npm ci
+        - run: npm run type-check
         - run: npm test
         - run: npm run build

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build packages/web",
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx",
+    "type-check": "tsc --noEmit",
     "test": "npm run lint && vitest run",
     "test:coverage": "npm run lint && vitest run --coverage"
   },


### PR DESCRIPTION
## Summary
- add `type-check` script to run the TypeScript compiler without emitting files
- run the new type-check script in CI before executing tests

## Testing
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae2752be388325b2f1eebc6b167f93