### PR TITLE
docs: add architecture and contributing guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,10 @@
 # Prime directive for Agents
 We are gradually, step by step, implementing a digital game. You can refer to the README.md for a summary of the game's general format and objective. The goal of Agents working on this project is to help structure the repository in such a way that we make progress towards our end-goal: A fully functional, robust, elegant and _extensible_ game. This is _not_ a type of game where we hardcode most things, stick to one config, and the game is done and forgotten. This game must be heavily configurable, possibly later by players themselves through a game config editor, but initially by ourselves for heavy AB & game design testing. We must be able to change nearly anything at a whim - Change configs, add buildings, add actions, invent new effects, invent new ratio's and thresholds for things, and so on.
 
+## Reference documents
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [ARCHITECTURE.md](docs/ARCHITECTURE.md)
+
 ## Abstraction guidelines
 - Model behaviour through formal **Triggers** and **Effects**. Avoid hard coded fields such as `apOnUpkeep`; instead, wire rules through the central effect system so that any trigger can resolve any effect.
 - When writing tests, derive expectations from the active configuration or from a mocked registry. Do not hard code numeric values like `toBe(10)` when the value comes from config; fetch it from the registry so tests continue to pass if configs change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thanks for your interest in improving Kingdom Builder! This guide describes the
+workflow for contributors so that changes remain consistent and easy to review.
+
+## Development Setup
+
+1. Install [Node.js](https://nodejs.org/) **18 or newer**.
+2. Install dependencies with `npm install`.
+3. Use `npm run dev` to start the web client during development.
+4. Run `npm run type-check` to ensure the codebase compiles under TypeScript.
+5. Run `npm run lint` to check formatting and unused imports.
+
+## Testing Conventions
+
+- Always run `npm test` before committing. The script runs ESLint and Vitest.
+- New features and bug fixes **must** include tests. Derive expectations from
+  the active configuration or mocked registries instead of hard-coded numbers.
+- Use the registry pattern to swap implementations in tests when needed. Avoid
+  importing concrete handlers directly.
+- Prefer high level integration tests for complex behaviours and unit tests for
+  individual effect handlers.
+
+## Commit Guidelines
+
+- Follow [Conventional Commits](https://www.conventionalcommits.org/). Use a
+  type and optional scope, e.g. `feat(engine): add farm effect`.
+- Keep commits focused; avoid mixing unrelated changes or drive-by edits.
+- Update documentation and tests in the same commit as the code change when
+  possible.
+- Ensure `npm test` and `npm run type-check` pass before pushing.
+- Limit commit message subject lines to ~70 characters.
+
+For architectural details see [ARCHITECTURE.md](docs/ARCHITECTURE.md). If in
+doubt about how to structure new behaviour, consult that document and existing
+tests for examples.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ Each turn flows through three phases:
 - Player order: A then B; B gains +1 ⚡️ Action Point on their first Development phase
 
 
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing conventions,
+and commit guidelines. For an overview of the engine architecture, read
+[ARCHITECTURE.md](docs/ARCHITECTURE.md).
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,78 @@
+# Architecture Overview
+
+The kingdom builder engine is designed for flexibility and extensibility.
+This document outlines the core systems that make it easy to bolt on new
+content without touching existing logic.
+
+## Trigger/Effect System
+
+Rules and content are encoded as declarative **effects** that respond to
+specific **triggers**. A trigger represents a moment in the game such as the
+start of the Development phase or the resolution of an action. When a trigger
+fires the engine looks up all matching effects and resolves them through the
+central registry.
+
+Each effect definition contains:
+
+- `type` – the domain being affected (`resource`, `land`, `stat`, etc.)
+- `method` – the operation to perform within that domain (`add`, `remove`,
+  `till`, ...)
+- `params` – optional parameters required by the handler
+- `effects` – optional nested effects to execute
+- `evaluator` – optional definition determining how many times `effects` run
+
+The engine processes effects with `runEffects`:
+
+```ts
+// Farm development: on every Development phase gain 2 Gold
+{
+  onDevelopmentPhase: [
+    { type: "resource", method: "add", params: { key: "gold", amount: 2 } }
+  ]
+}
+
+// Nested effect with evaluator: one resource per matching development
+{
+  evaluator: { type: "development", params: { id: "farm" } },
+  effects: [{ type: "resource", method: "add", params: { key: "gold", amount: 2 } }]
+}
+```
+
+The evaluator returns a multiplier that determines how often the nested effects
+run. Because triggers are decoupled from effect domains, any trigger can result
+in any effect, keeping behaviour entirely data‑driven.
+
+## Registry Pattern
+
+Most subsystems rely on lightweight registries. A `Registry` maps string
+identifiers to handler functions and throws if an unknown id is requested. Core
+registries include `EFFECTS`, `EVALUATORS`, `ACTIONS`, `BUILDINGS`,
+`DEVELOPMENTS` and `POPULATIONS`.
+
+Registries are intentionally mutable: tests or mods may replace entries or add
+new ones at runtime. This allows contributors to prototype new mechanics simply
+by registering additional handlers rather than modifying engine code. When
+testing, prefer overriding registries instead of stubbing modules.
+
+## Package Layout
+
+The repository uses a monorepo under `packages/`:
+
+- `packages/engine` – game rules, registries, effect handlers and tests.
+- `packages/web` – Vite + React client consuming the engine.
+
+Shared configuration files live at the repository root. Adding a new package or
+library should follow the same structure so shared tooling continues to work.
+
+## Extending the Engine
+
+To introduce new behaviour:
+
+1. Register any new effect or evaluator handlers before creating the engine.
+2. Define actions, developments, buildings or populations that use those
+   handlers via effect definitions.
+3. Write tests demonstrating the new content by overriding registries where
+   necessary.
+
+By leaning on triggers, effects and registries, almost any rule can be added
+purely through data.


### PR DESCRIPTION
## Summary
- document trigger/effect system, registries, and package layout with more detail
- expand contributing guide with stricter setup, testing, and commit rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af2bf532688325838874fd9376f30b