### PR TITLE
Add integration tests for building and action edge cases

### DIFF
--- a/tests/integration/building-placement.test.ts
+++ b/tests/integration/building-placement.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { performAction } from '../../packages/engine/src/index.ts';
+import { createTestContext, getActionCosts, getActionOutcome } from './fixtures';
+
+describe('Building placement integration', () => {
+  it('applies building effects to subsequent actions', () => {
+    const ctx = createTestContext();
+    ctx.activePlayer.ap = ctx.services.rules.defaultActionAPCost * 2;
+    const expandBefore = getActionOutcome('expand', ctx);
+    const buildCosts = getActionCosts('build_town_charter', ctx);
+    const resBefore = { ...ctx.activePlayer.resources };
+
+    performAction('build_town_charter', ctx);
+
+    expect(ctx.activePlayer.buildings.has('town_charter')).toBe(true);
+    for (const [key, cost] of Object.entries(buildCosts)) {
+      expect(ctx.activePlayer.resources[key]).toBe(resBefore[key] - cost);
+    }
+
+    const expandAfter = getActionOutcome('expand', ctx);
+    expect(expandAfter).not.toEqual(expandBefore);
+
+    const resPre = { ...ctx.activePlayer.resources };
+    const statsPre = { ...ctx.activePlayer.stats };
+    const landPre = ctx.activePlayer.lands.length;
+
+    performAction('expand', ctx);
+
+    for (const [key, cost] of Object.entries(expandAfter.costs)) {
+      const gain = expandAfter.results.resources[key] || 0;
+      expect(ctx.activePlayer.resources[key]).toBe(resPre[key] - cost + gain);
+    }
+    for (const [key, gain] of Object.entries(expandAfter.results.resources)) {
+      if (expandAfter.costs[key] === undefined) {
+        expect(ctx.activePlayer.resources[key]).toBe(resPre[key] + gain);
+      }
+    }
+    expect(ctx.activePlayer.lands.length).toBe(landPre + expandAfter.results.land);
+    for (const [key, gain] of Object.entries(expandAfter.results.stats)) {
+      expect(ctx.activePlayer.stats[key]).toBe(statsPre[key] + gain);
+    }
+  });
+});

--- a/tests/integration/edge-cases.test.ts
+++ b/tests/integration/edge-cases.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { performAction, Resource } from '../../packages/engine/src/index.ts';
+import { createTestContext, getActionCosts } from './fixtures';
+
+describe('Action edge cases', () => {
+  it('throws for unknown action', () => {
+    const ctx = createTestContext();
+    expect(() => performAction('not_real', ctx)).toThrow(/Unknown id/);
+  });
+
+  it('rejects actions when a required resource is exhausted', () => {
+    const ctx = createTestContext();
+    const costs = getActionCosts('expand', ctx);
+    const entries = Object.entries(costs).filter(([k]) => k !== Resource.ap);
+    if (entries.length === 0) return; // no non-AP cost to exhaust
+    const [key, amount] = entries[0];
+    ctx.activePlayer.resources[key] = (amount || 0) - 1;
+    expect(() => performAction('expand', ctx)).toThrow(new RegExp(`Insufficient ${key}`));
+    expect(ctx.activePlayer.resources[key]).toBe((amount || 0) - 1);
+  });
+
+  it('rejects actions when action points are exhausted', () => {
+    const ctx = createTestContext();
+    const cost = getActionCosts('expand', ctx);
+    ctx.activePlayer.ap = (cost[Resource.ap] || 0) - 1;
+    expect(() => performAction('expand', ctx)).toThrow(/Insufficient ap/);
+    expect(ctx.activePlayer.ap).toBe((cost[Resource.ap] || 0) - 1);
+  });
+});

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -1,0 +1,67 @@
+import {
+  createEngine,
+  EngineContext,
+  Resource,
+  EffectDef,
+} from '../../packages/engine/src/index.ts';
+import { PlayerState, Land } from '../../packages/engine/src/state/index.ts';
+import { runEffects } from '../../packages/engine/src/effects/index.ts';
+
+function clonePlayer(p: PlayerState) {
+  const c = new PlayerState(p.id, p.name);
+  c.resources = { ...p.resources } as any;
+  c.stats = { ...p.stats } as any;
+  c.population = { ...p.population } as any;
+  c.lands = p.lands.map(l => {
+    const nl = new Land(l.id, l.slotsMax);
+    nl.slotsUsed = l.slotsUsed;
+    nl.developments = [...l.developments];
+    return nl;
+  });
+  c.buildings = new Set([...p.buildings]);
+  return c;
+}
+
+export function createTestContext(overrides?: { gold?: number; ap?: number }) {
+  const ctx = createEngine();
+  if (overrides?.gold !== undefined) ctx.activePlayer.gold = overrides.gold;
+  if (overrides?.ap !== undefined) ctx.activePlayer.ap = overrides.ap;
+  return ctx;
+}
+
+export function getActionCosts(id: string, ctx: EngineContext) {
+  const def = ctx.actions.get(id);
+  const baseCosts = { ...(def.baseCosts || {}) };
+  if (baseCosts[Resource.ap] === undefined) baseCosts[Resource.ap] = ctx.services.rules.defaultActionAPCost;
+  return ctx.passives.applyCostMods(def.id, baseCosts, ctx);
+}
+
+export function simulateEffects(effects: EffectDef[], ctx: EngineContext, actionId?: string) {
+  const before = clonePlayer(ctx.activePlayer);
+  const dummy = clonePlayer(ctx.activePlayer);
+  const dummyCtx = { ...ctx, activePlayer: dummy } as EngineContext;
+  runEffects(effects, dummyCtx);
+  if (actionId) ctx.passives.runResultMods(actionId, dummyCtx);
+
+  const resources: Record<string, number> = {};
+  for (const key of Object.keys(before.resources)) {
+    const delta = dummy.resources[key as keyof typeof dummy.resources] - before.resources[key as keyof typeof before.resources];
+    if (delta !== 0) resources[key] = delta;
+  }
+
+  const stats: Record<string, number> = {};
+  for (const key of Object.keys(before.stats)) {
+    const delta = dummy.stats[key as keyof typeof dummy.stats] - before.stats[key as keyof typeof before.stats];
+    if (delta !== 0) stats[key] = delta;
+  }
+
+  const land = dummy.lands.length - before.lands.length;
+  return { resources, stats, land };
+}
+
+export function getActionOutcome(id: string, ctx: EngineContext) {
+  const def = ctx.actions.get(id);
+  const costs = getActionCosts(id, ctx);
+  const results = simulateEffects(def.effects, ctx, def.id);
+  return { costs, results };
+}

--- a/tests/integration/turn-cycle.test.ts
+++ b/tests/integration/turn-cycle.test.ts
@@ -9,51 +9,8 @@ import {
   POPULATIONS,
   DEVELOPMENTS,
   PopulationRole,
-  EngineContext,
 } from '../../packages/engine/src/index.ts';
-
-function getCouncilApGain() {
-  const effect = POPULATIONS.get(PopulationRole.Council).onDevelopmentPhase?.find(
-    e => e.type === 'resource' && e.method === 'add' && e.params?.key === Resource.ap,
-  );
-  return effect?.params.amount ?? 0;
-}
-
-function getFarmGoldGain() {
-  const effect = DEVELOPMENTS.get('farm').onDevelopmentPhase?.find(
-    e => e.type === 'resource' && e.method === 'add' && e.params?.key === Resource.gold,
-  );
-  return effect?.params.amount ?? 0;
-}
-
-function getCouncilUpkeepCost() {
-  const effect = POPULATIONS.get(PopulationRole.Council).onUpkeepPhase?.find(
-    e => e.type === 'resource' && e.method === 'remove' && e.params?.key === Resource.gold,
-  );
-  return effect?.params.amount ?? 0;
-}
-
-function getActionCosts(id: string, ctx: EngineContext) {
-  const def = ctx.actions.get(id);
-  const baseCosts = { ...(def.baseCosts || {}) };
-  if (baseCosts[Resource.ap] === undefined) baseCosts[Resource.ap] = ctx.services.rules.defaultActionAPCost;
-  return ctx.passives.applyCostMods(def.id, baseCosts, ctx);
-}
-
-function getExpandExpectations(ctx: EngineContext) {
-  const def = ctx.actions.get('expand');
-  const costs = getActionCosts('expand', ctx);
-  const landGain = def.effects
-    .filter(e => e.type === 'land' && e.method === 'add')
-    .reduce((sum, e) => sum + (e.params?.count ?? 0), 0);
-  const baseHappiness = def.effects
-    .filter(e => e.type === 'resource' && e.method === 'add' && e.params?.key === Resource.happiness)
-    .reduce((sum, e) => sum + (e.params?.amount ?? 0), 0);
-  const dummyCtx = { activePlayer: { happiness: 0 } } as EngineContext;
-  ctx.passives.runResultMods(def.id, dummyCtx);
-  const extraHappiness = dummyCtx.activePlayer.happiness;
-  return { costs, landGain, happinessGain: baseHappiness + extraHappiness };
-}
+import { getActionOutcome, simulateEffects } from './fixtures';
 
 describe('Turn cycle integration', () => {
   it('processes development, upkeep, and main phases for both players', () => {
@@ -61,9 +18,21 @@ describe('Turn cycle integration', () => {
     expect(ctx.game.turn).toBe(1);
     expect(ctx.game.currentPhase).toBe(Phase.Development);
     expect(ctx.game.currentPlayerIndex).toBe(0);
-    const apGain = getCouncilApGain();
-    const farmGold = getFarmGoldGain();
-    const upkeepCost = getCouncilUpkeepCost();
+    const councilDev = simulateEffects(
+      POPULATIONS.get(PopulationRole.Council).onDevelopmentPhase || [],
+      ctx,
+    );
+    const apGain = councilDev.resources[Resource.ap] || 0;
+    const farmDev = simulateEffects(
+      DEVELOPMENTS.get('farm').onDevelopmentPhase || [],
+      ctx,
+    );
+    const farmGold = farmDev.resources[Resource.gold] || 0;
+    const councilUpkeep = simulateEffects(
+      POPULATIONS.get(PopulationRole.Council).onUpkeepPhase || [],
+      ctx,
+    );
+    const upkeepGold = councilUpkeep.resources[Resource.gold] || 0;
 
     // Player A development
     ctx.game.currentPlayerIndex = 0;
@@ -88,39 +57,55 @@ describe('Turn cycle integration', () => {
     ctx.game.currentPlayerIndex = 0;
     runUpkeep(ctx);
     expect(ctx.game.currentPhase).toBe(Phase.Upkeep);
-    expect(ctx.activePlayer.gold).toBe(afterDevGoldA - upkeepCost);
+    expect(ctx.activePlayer.gold).toBe(afterDevGoldA + upkeepGold);
 
     // Player B upkeep
     ctx.game.currentPlayerIndex = 1;
     runUpkeep(ctx);
-    expect(ctx.activePlayer.gold).toBe(afterDevGoldB - upkeepCost);
+    expect(ctx.activePlayer.gold).toBe(afterDevGoldB + upkeepGold);
 
     // Main phase actions
     ctx.game.currentPhase = Phase.Main;
 
     ctx.game.currentPlayerIndex = 0;
-    const expandA = getExpandExpectations(ctx);
-    const goldBeforeA = ctx.activePlayer.gold;
-    const apBeforeA = ctx.activePlayer.ap;
-    const landsBeforeA = ctx.activePlayer.lands.length;
-    const hapBeforeA = ctx.activePlayer.happiness;
+    const expandA = getActionOutcome('expand', ctx);
+    const resBeforeA = { ...ctx.activePlayer.resources };
+    const statsBeforeA = { ...ctx.activePlayer.stats };
+    const landBeforeA = ctx.activePlayer.lands.length;
     performAction('expand', ctx);
-    expect(ctx.activePlayer.gold).toBe(goldBeforeA - (expandA.costs[Resource.gold] || 0));
-    expect(ctx.activePlayer.ap).toBe(apBeforeA - (expandA.costs[Resource.ap] || 0));
-    expect(ctx.activePlayer.lands.length).toBe(landsBeforeA + expandA.landGain);
-    expect(ctx.activePlayer.happiness).toBe(hapBeforeA + expandA.happinessGain);
+    for (const [key, cost] of Object.entries(expandA.costs)) {
+      const gain = expandA.results.resources[key] || 0;
+      expect(ctx.activePlayer.resources[key]).toBe(resBeforeA[key] - cost + gain);
+    }
+    for (const [key, gain] of Object.entries(expandA.results.resources)) {
+      if (expandA.costs[key] === undefined) {
+        expect(ctx.activePlayer.resources[key]).toBe(resBeforeA[key] + gain);
+      }
+    }
+    expect(ctx.activePlayer.lands.length).toBe(landBeforeA + expandA.results.land);
+    for (const [key, gain] of Object.entries(expandA.results.stats)) {
+      expect(ctx.activePlayer.stats[key]).toBe(statsBeforeA[key] + gain);
+    }
 
     ctx.game.currentPlayerIndex = 1;
-    const expandB = getExpandExpectations(ctx);
-    const goldBeforeB = ctx.activePlayer.gold;
-    const apBeforeB = ctx.activePlayer.ap;
-    const landsBeforeB = ctx.activePlayer.lands.length;
-    const hapBeforeB = ctx.activePlayer.happiness;
+    const expandB = getActionOutcome('expand', ctx);
+    const resBeforeB = { ...ctx.activePlayer.resources };
+    const statsBeforeB = { ...ctx.activePlayer.stats };
+    const landBeforeB = ctx.activePlayer.lands.length;
     performAction('expand', ctx);
-    expect(ctx.activePlayer.gold).toBe(goldBeforeB - (expandB.costs[Resource.gold] || 0));
-    expect(ctx.activePlayer.ap).toBe(apBeforeB - (expandB.costs[Resource.ap] || 0));
-    expect(ctx.activePlayer.lands.length).toBe(landsBeforeB + expandB.landGain);
-    expect(ctx.activePlayer.happiness).toBe(hapBeforeB + expandB.happinessGain);
+    for (const [key, cost] of Object.entries(expandB.costs)) {
+      const gain = expandB.results.resources[key] || 0;
+      expect(ctx.activePlayer.resources[key]).toBe(resBeforeB[key] - cost + gain);
+    }
+    for (const [key, gain] of Object.entries(expandB.results.resources)) {
+      if (expandB.costs[key] === undefined) {
+        expect(ctx.activePlayer.resources[key]).toBe(resBeforeB[key] + gain);
+      }
+    }
+    expect(ctx.activePlayer.lands.length).toBe(landBeforeB + expandB.results.land);
+    for (const [key, gain] of Object.entries(expandB.results.stats)) {
+      expect(ctx.activePlayer.stats[key]).toBe(statsBeforeB[key] + gain);
+    }
 
     // End turn reset
     ctx.game.turn += 1;


### PR DESCRIPTION
## Summary
- introduce integration fixtures for reusable engine setup and cost helpers
- test building placement affects later actions via passives
- add edge-case integration tests for invalid actions and depleted resources
- refactor turn cycle test to use shared fixtures and simulated effects
- derive integration test expectations from action config rather than hardcoded values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af2c096f508325acae2848ab82b668