### PR TITLE
Add development edge case tests and decouple from config values

### DIFF
--- a/packages/engine/tests/actions/build_town_charter.test.ts
+++ b/packages/engine/tests/actions/build_town_charter.test.ts
@@ -40,8 +40,8 @@ describe('Build Town Charter action', () => {
     );
     expect(ctx.activePlayer.ap).toBe(apBefore - (buildCost[Resource.ap] || 0));
     const expandCostAfter = getActionCosts('expand', ctx);
-    expect(expandCostAfter[Resource.gold]).toBe(
-      (expandCostBefore[Resource.gold] || 0) + 2,
+    expect(expandCostAfter[Resource.gold]).toBeGreaterThan(
+      expandCostBefore[Resource.gold] || 0,
     );
   });
 });

--- a/packages/engine/tests/effects/add_building.test.ts
+++ b/packages/engine/tests/effects/add_building.test.ts
@@ -34,6 +34,6 @@ describe('building:add effect', () => {
     performAction('free_charter', ctx);
     expect(ctx.activePlayer.buildings.has('town_charter')).toBe(true);
     const after = getExpandGoldCost(ctx);
-    expect(after).toBe(before + 2);
+    expect(after).toBeGreaterThan(before);
   });
 });

--- a/packages/engine/tests/effects/add_development.test.ts
+++ b/packages/engine/tests/effects/add_development.test.ts
@@ -3,10 +3,12 @@ import {
   createEngine,
   performAction,
   createActionRegistry,
+  Stat,
 } from '../../src/index.ts';
 
-// Custom action to build a house on an empty land slot
+// Custom actions used to exercise the development:add handler
 const actions = createActionRegistry();
+// success case: build on empty land
 actions.add('build_house', {
   id: 'build_house',
   name: 'Build House',
@@ -19,15 +21,68 @@ actions.add('build_house', {
     },
   ],
 });
+// error case: land does not exist
+actions.add('build_house_bad_land', {
+  id: 'build_house_bad_land',
+  name: 'Build House Bad Land',
+  baseCosts: { ap: 0 },
+  effects: [
+    {
+      type: 'development',
+      method: 'add',
+      params: { id: 'house', landId: 'A-L9' },
+    },
+  ],
+});
+// error case: target land already full
+actions.add('build_house_full', {
+  id: 'build_house_full',
+  name: 'Build House Full',
+  baseCosts: { ap: 0 },
+  effects: [
+    {
+      type: 'development',
+      method: 'add',
+      params: { id: 'house', landId: 'A-L1' },
+    },
+  ],
+});
+
+function getHouseMaxPopGain(ctx: ReturnType<typeof createEngine>) {
+  const def = ctx.developments.get('house');
+  const eff = def?.onBuild?.find(
+    (e) =>
+      e.type === 'stat' &&
+      e.method === 'add' &&
+      e.params?.key === Stat.maxPopulation,
+  );
+  return eff?.params?.amount ?? 0;
+}
 
 describe('development:add effect', () => {
   it('adds house and applies onBuild effects', () => {
     const ctx = createEngine({ actions });
     const land = ctx.activePlayer.lands[1]; // A-L2
     const maxBefore = ctx.activePlayer.maxPopulation;
+    const slotsBefore = land.slotsUsed;
     performAction('build_house', ctx);
+    const gain = getHouseMaxPopGain(ctx);
     expect(land.developments).toContain('house');
-    expect(land.slotsUsed).toBe(1);
-    expect(ctx.activePlayer.maxPopulation).toBe(maxBefore + 1);
+    expect(land.slotsUsed).toBe(slotsBefore + 1);
+    expect(ctx.activePlayer.maxPopulation).toBe(maxBefore + gain);
+  });
+
+  it('throws if land does not exist', () => {
+    const ctx = createEngine({ actions });
+    expect(() => performAction('build_house_bad_land', ctx)).toThrow(
+      /Land A-L9 not found/,
+    );
+  });
+
+  it('throws if land has no free slots', () => {
+    const ctx = createEngine({ actions });
+    expect(() => performAction('build_house_full', ctx)).toThrow(
+      /No free slots on land A-L1/,
+    );
   });
 });

--- a/packages/engine/tests/effects/add_stat.test.ts
+++ b/packages/engine/tests/effects/add_stat.test.ts
@@ -26,7 +26,14 @@ describe('stat:add effect', () => {
     const ctx = createEngine({ actions });
     runDevelopment(ctx);
     const before = ctx.activePlayer.armyStrength;
+    const def = actions.get('train_army');
+    const amt = def.effects.find(
+      (e) =>
+        e.type === 'stat' &&
+        e.method === 'add' &&
+        e.params?.key === Stat.armyStrength,
+    )?.params?.amount as number;
     performAction('train_army', ctx);
-    expect(ctx.activePlayer.armyStrength).toBe(before + 3);
+    expect(ctx.activePlayer.armyStrength).toBe(before + amt);
   });
 });


### PR DESCRIPTION
## Summary
- cover `development:add` effect error paths and derive expectations from registry
- avoid config-coupled expectations in Town Charter building tests
- compute stat gains dynamically from action definitions

## Testing
- `npm test`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68af433908d0832591c68f55264c71cb