### PR TITLE
chore: run lint and tests in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,12 @@
 #!/usr/bin/env sh
+
+# Exit on errors
+set -e
+
+# Run lint-staged on changed files
 npx lint-staged
+
+# Run project-wide checks
+npm run lint
+npm run type-check
+npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ workflow for contributors so that changes remain consistent and easy to review.
 - Update documentation and tests in the same commit as the code change when
   possible.
 - Ensure `npm test` and `npm run type-check` pass before pushing.
+- The pre-commit hook runs `lint-staged`, `npm run lint`, `npm run type-check`, and `npm test`. Fix any issues before committing.
 - Limit commit message subject lines to ~70 characters.
 
 For architectural details see [ARCHITECTURE.md](docs/ARCHITECTURE.md). If in


### PR DESCRIPTION
## Summary
- expand pre-commit hook to run lint-staged, lint, type-check, and tests
- document pre-commit checks in contributing guide

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68af45aafe848325a2ea25b983871b2e