### PR TITLE
Add basic App render test for web package

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx",
-    "test": "npm run lint && vitest run --passWithNoTests"
+    "test": "npm run lint && vitest run"
   },
   "dependencies": {
     "@kingdom-builder/engine": "*",

--- a/packages/web/tests/App.test.tsx
+++ b/packages/web/tests/App.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import React from 'react';
+import App from '../src/App';
+
+vi.mock('@kingdom-builder/engine', () => ({
+  createEngine: () => ({}),
+}));
+
+describe('<App />', () => {
+  it('renders hello world', () => {
+    const html = renderToString(<App />);
+    expect(html).toContain('Hello World');
+  });
+});


### PR DESCRIPTION
## Summary
- add simple App component render test
- remove `--passWithNoTests` from web package test script

## Testing
- `npm test`
- `npm run e2e` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68af45abc698832591bc95b32a043040