### PR TITLE
docs: document evaluator registry

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,6 +42,9 @@ The evaluator returns a multiplier that determines how often the nested effects
 run. Because triggers are decoupled from effect domains, any trigger can result
 in any effect, keeping behaviour entirely data‑driven.
 
+See the [evaluator registry README](../packages/engine/src/evaluators/README.md)
+for details on built-in handlers and registering custom ones.
+
 ## Registry Pattern
 
 Most subsystems rely on lightweight registries. A `Registry` maps string

--- a/packages/engine/src/evaluators/README.md
+++ b/packages/engine/src/evaluators/README.md
@@ -1,0 +1,31 @@
+# Evaluator Registry
+
+Evaluators compute numbers used by effects to determine how many times nested
+effects execute. They receive the evaluator definition and the current
+`EngineContext`, and return a numeric multiplier.
+
+Core evaluators are registered during engine bootstrap via
+`registerCoreEvaluators()`. This populates the `EVALUATORS` registry with the
+built-in `development` evaluator.
+
+```ts
+import { registerCoreEvaluators } from './evaluators'; // adjust path as needed
+
+registerCoreEvaluators();
+```
+
+## Custom evaluators
+
+To add a new evaluator from outside the engine, register a handler before
+running effects:
+
+```ts
+import { EVALUATORS, EvaluatorHandler } from './evaluators'; // adjust path as needed
+
+const doubleGold: EvaluatorHandler<number> = (def, ctx) =>
+  ctx.activePlayer.resources['gold'] * 2;
+
+EVALUATORS.add('doubleGold', doubleGold);
+```
+
+Once registered, effects can reference `{ evaluator: { type: 'doubleGold' }, effects: [...] }`.


### PR DESCRIPTION
## Summary
- describe evaluator registry and core registration
- show how to create a custom evaluator
- link evaluator docs from architecture overview

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68af45b3aeb88325bfa983338dcb6fb4