### PR TITLE
feat(engine): export action cost helper

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -55,6 +55,11 @@ function applyCostsWithPassives(
   return ctx.passives.applyCostMods(actionId, withDefaultAP, ctx);
 }
 
+export function getActionCosts(actionId: string, ctx: EngineContext): CostBag {
+  const def = ctx.actions.get(actionId);
+  return applyCostsWithPassives(def.id, def.baseCosts || {}, ctx);
+}
+
 function canPay(costs: CostBag, player: PlayerState): true | string {
   for (const key of Object.keys(costs) as ResourceKey[]) {
     const need = costs[key] ?? 0;

--- a/packages/engine/tests/actions/action-config.test.ts
+++ b/packages/engine/tests/actions/action-config.test.ts
@@ -6,15 +6,8 @@ import {
   Resource,
   EngineContext,
   createActionRegistry,
+  getActionCosts,
 } from '../../src/index.ts';
-
-function getActionCosts(id: string, ctx: EngineContext) {
-  const def = ctx.actions.get(id);
-  const baseCosts = { ...(def.baseCosts || {}) };
-  if (baseCosts[Resource.ap] === undefined)
-    baseCosts[Resource.ap] = ctx.services.rules.defaultActionAPCost;
-  return ctx.passives.applyCostMods(def.id, baseCosts, ctx);
-}
 
 function getExpandExpectations(ctx: EngineContext) {
   const expandDef = ctx.actions.get('expand');

--- a/packages/engine/tests/actions/build_town_charter.test.ts
+++ b/packages/engine/tests/actions/build_town_charter.test.ts
@@ -4,16 +4,8 @@ import {
   runDevelopment,
   performAction,
   Resource,
-  EngineContext,
+  getActionCosts,
 } from '../../src/index.ts';
-
-function getActionCosts(id: string, ctx: EngineContext) {
-  const def = ctx.actions.get(id);
-  const baseCosts = { ...(def.baseCosts || {}) };
-  if (baseCosts[Resource.ap] === undefined)
-    baseCosts[Resource.ap] = ctx.services.rules.defaultActionAPCost;
-  return ctx.passives.applyCostMods(def.id, baseCosts, ctx);
-}
 
 describe('Build Town Charter action', () => {
   it('rejects when gold is insufficient', () => {

--- a/packages/engine/tests/actions/expand.test.ts
+++ b/packages/engine/tests/actions/expand.test.ts
@@ -5,15 +5,8 @@ import {
   performAction,
   Resource,
   EngineContext,
+  getActionCosts,
 } from '../../src/index.ts';
-
-function getActionCosts(id: string, ctx: EngineContext) {
-  const def = ctx.actions.get(id);
-  const baseCosts = { ...(def.baseCosts || {}) };
-  if (baseCosts[Resource.ap] === undefined)
-    baseCosts[Resource.ap] = ctx.services.rules.defaultActionAPCost;
-  return ctx.passives.applyCostMods(def.id, baseCosts, ctx);
-}
 
 function getExpandExpectations(ctx: EngineContext) {
   const expandDef = ctx.actions.get('expand');

--- a/packages/engine/tests/effects/add_building.test.ts
+++ b/packages/engine/tests/effects/add_building.test.ts
@@ -4,6 +4,7 @@ import {
   performAction,
   createActionRegistry,
   Resource,
+  getActionCosts,
 } from '../../src/index.ts';
 
 // Custom action that grants Town Charter for free to test the effect handler
@@ -18,12 +19,7 @@ actions.add('free_charter', {
 });
 
 function getExpandGoldCost(ctx: ReturnType<typeof createEngine>) {
-  const def = ctx.actions.get('expand');
-  const baseCosts = { ...(def.baseCosts || {}) };
-  if (baseCosts[Resource.ap] === undefined) {
-    baseCosts[Resource.ap] = ctx.services.rules.defaultActionAPCost;
-  }
-  const costs = ctx.passives.applyCostMods(def.id, baseCosts, ctx);
+  const costs = getActionCosts('expand', ctx);
   return costs[Resource.gold] || 0;
 }
 

--- a/tests/integration/building-placement.test.ts
+++ b/tests/integration/building-placement.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { performAction } from '../../packages/engine/src/index.ts';
 import {
-  createTestContext,
+  performAction,
   getActionCosts,
-  getActionOutcome,
-} from './fixtures';
+} from '../../packages/engine/src/index.ts';
+import { createTestContext, getActionOutcome } from './fixtures';
 
 describe('Building placement integration', () => {
   it('applies building effects to subsequent actions', () => {

--- a/tests/integration/edge-cases.test.ts
+++ b/tests/integration/edge-cases.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { performAction, Resource } from '../../packages/engine/src/index.ts';
-import { createTestContext, getActionCosts } from './fixtures';
+import {
+  performAction,
+  Resource,
+  getActionCosts,
+} from '../../packages/engine/src/index.ts';
+import { createTestContext } from './fixtures';
 
 describe('Action edge cases', () => {
   it('throws for unknown action', () => {

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -1,8 +1,8 @@
 import {
   createEngine,
   EngineContext,
-  Resource,
   EffectDef,
+  getActionCosts,
 } from '../../packages/engine/src/index.ts';
 import { PlayerState, Land } from '../../packages/engine/src/state/index.ts';
 import { runEffects } from '../../packages/engine/src/effects/index.ts';
@@ -27,14 +27,6 @@ export function createTestContext(overrides?: { gold?: number; ap?: number }) {
   if (overrides?.gold !== undefined) ctx.activePlayer.gold = overrides.gold;
   if (overrides?.ap !== undefined) ctx.activePlayer.ap = overrides.ap;
   return ctx;
-}
-
-export function getActionCosts(id: string, ctx: EngineContext) {
-  const def = ctx.actions.get(id);
-  const baseCosts = { ...(def.baseCosts || {}) };
-  if (baseCosts[Resource.ap] === undefined)
-    baseCosts[Resource.ap] = ctx.services.rules.defaultActionAPCost;
-  return ctx.passives.applyCostMods(def.id, baseCosts, ctx);
 }
 
 export function simulateEffects(


### PR DESCRIPTION
## Summary
- add `getActionCosts` helper that applies passive cost modifiers
- update tests to use shared helper

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68af45b6de588325b4bfbfac39f19058