### PR TITLE
use local chrome for e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type-check": "tsc --noEmit",
     "test": "npm run lint && vitest run",
     "test:coverage": "npm run lint && vitest run --coverage",
-    "e2e": "playwright install --with-deps chromium && playwright test",
+    "e2e": "playwright test",
     "format": "prettier .",
     "prepare": "husky install"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { browserName: 'chromium' },
+      use: { browserName: 'chromium', channel: 'chrome' },
     },
   ],
 });


### PR DESCRIPTION
## Summary
- avoid blocked Playwright downloads by removing install step and relying on system Chrome
- configure Playwright to launch Chrome via channel option

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68af470ae24c8325800f086708d67c24