### PR TITLE
test(engine): add resource effect tests

### DIFF
--- a/packages/engine/tests/effects/resource-add.test.ts
+++ b/packages/engine/tests/effects/resource-add.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEngine,
+  runDevelopment,
+  performAction,
+  createActionRegistry,
+  Resource,
+} from '../../src/index.ts';
+
+describe('resource:add effect', () => {
+  it('increments a resource via action effect', () => {
+    const actions = createActionRegistry();
+    actions.add('grant_gold', {
+      id: 'grant_gold',
+      name: 'Grant Gold',
+      baseCosts: { [Resource.ap]: 0 },
+      effects: [
+        { type: 'resource', method: 'add', params: { key: Resource.gold, amount: 3 } },
+      ],
+    });
+    const ctx = createEngine({ actions });
+    runDevelopment(ctx);
+    const before = ctx.activePlayer.gold;
+    const def = actions.get('grant_gold');
+    const amt = def.effects.find(
+      (e) =>
+        e.type === 'resource' &&
+        e.method === 'add' &&
+        e.params?.key === Resource.gold,
+    )?.params?.amount as number;
+    performAction('grant_gold', ctx);
+    expect(ctx.activePlayer.gold).toBe(before + amt);
+  });
+
+  it('rounds fractional amounts according to round setting', () => {
+    const actions = createActionRegistry();
+    actions.add('round_up', {
+      id: 'round_up',
+      name: 'Round Up',
+      baseCosts: { [Resource.ap]: 0 },
+      effects: [
+        {
+          type: 'resource',
+          method: 'add',
+          params: { key: Resource.gold, amount: 1.2 },
+          round: 'up',
+        },
+      ],
+    });
+    actions.add('round_down', {
+      id: 'round_down',
+      name: 'Round Down',
+      baseCosts: { [Resource.ap]: 0 },
+      effects: [
+        {
+          type: 'resource',
+          method: 'add',
+          params: { key: Resource.gold, amount: 1.8 },
+          round: 'down',
+        },
+      ],
+    });
+    const ctx = createEngine({ actions });
+    runDevelopment(ctx);
+
+    let before = ctx.activePlayer.gold;
+    let effect = actions.get('round_up').effects.find(
+      (e) =>
+        e.type === 'resource' &&
+        e.method === 'add' &&
+        e.params?.key === Resource.gold,
+    );
+    let total = (effect?.params?.amount as number) || 0;
+    if (effect?.round === 'up')
+      total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+    else if (effect?.round === 'down')
+      total = total >= 0 ? Math.floor(total) : Math.ceil(total);
+    performAction('round_up', ctx);
+    expect(ctx.activePlayer.gold).toBe(before + total);
+
+    before = ctx.activePlayer.gold;
+    effect = actions.get('round_down').effects.find(
+      (e) =>
+        e.type === 'resource' &&
+        e.method === 'add' &&
+        e.params?.key === Resource.gold,
+    );
+    total = (effect?.params?.amount as number) || 0;
+    if (effect?.round === 'up')
+      total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+    else if (effect?.round === 'down')
+      total = total >= 0 ? Math.floor(total) : Math.ceil(total);
+    performAction('round_down', ctx);
+    expect(ctx.activePlayer.gold).toBe(before + total);
+  });
+});
+

--- a/packages/engine/tests/effects/resource-remove.test.ts
+++ b/packages/engine/tests/effects/resource-remove.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEngine,
+  runDevelopment,
+  performAction,
+  createActionRegistry,
+  Resource,
+} from '../../src/index.ts';
+
+describe('resource:remove effect', () => {
+  it('decrements a resource via action effect', () => {
+    const actions = createActionRegistry();
+    actions.add('pay_gold', {
+      id: 'pay_gold',
+      name: 'Pay Gold',
+      baseCosts: { [Resource.ap]: 0 },
+      effects: [
+        {
+          type: 'resource',
+          method: 'remove',
+          params: { key: Resource.gold, amount: 3 },
+        },
+      ],
+    });
+    const ctx = createEngine({ actions });
+    runDevelopment(ctx);
+    const before = ctx.activePlayer.gold;
+    const def = actions.get('pay_gold');
+    const amt = def.effects.find(
+      (e) =>
+        e.type === 'resource' &&
+        e.method === 'remove' &&
+        e.params?.key === Resource.gold,
+    )?.params?.amount as number;
+    performAction('pay_gold', ctx);
+    expect(ctx.activePlayer.gold).toBe(before - amt);
+  });
+
+  it('rounds fractional amounts according to round setting', () => {
+    const actions = createActionRegistry();
+    actions.add('round_up_remove', {
+      id: 'round_up_remove',
+      name: 'Round Up Remove',
+      baseCosts: { [Resource.ap]: 0 },
+      effects: [
+        {
+          type: 'resource',
+          method: 'remove',
+          params: { key: Resource.gold, amount: 1.2 },
+          round: 'up',
+        },
+      ],
+    });
+    actions.add('round_down_remove', {
+      id: 'round_down_remove',
+      name: 'Round Down Remove',
+      baseCosts: { [Resource.ap]: 0 },
+      effects: [
+        {
+          type: 'resource',
+          method: 'remove',
+          params: { key: Resource.gold, amount: 1.8 },
+          round: 'down',
+        },
+      ],
+    });
+    const ctx = createEngine({ actions });
+    runDevelopment(ctx);
+
+    let before = ctx.activePlayer.gold;
+    let effect = actions.get('round_up_remove').effects.find(
+      (e) =>
+        e.type === 'resource' &&
+        e.method === 'remove' &&
+        e.params?.key === Resource.gold,
+    );
+    let total = (effect?.params?.amount as number) || 0;
+    if (effect?.round === 'up')
+      total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+    else if (effect?.round === 'down')
+      total = total >= 0 ? Math.floor(total) : Math.ceil(total);
+    performAction('round_up_remove', ctx);
+    expect(ctx.activePlayer.gold).toBe(before - total);
+
+    before = ctx.activePlayer.gold;
+    effect = actions.get('round_down_remove').effects.find(
+      (e) =>
+        e.type === 'resource' &&
+        e.method === 'remove' &&
+        e.params?.key === Resource.gold,
+    );
+    total = (effect?.params?.amount as number) || 0;
+    if (effect?.round === 'up')
+      total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+    else if (effect?.round === 'down')
+      total = total >= 0 ? Math.floor(total) : Math.ceil(total);
+    performAction('round_down_remove', ctx);
+    expect(ctx.activePlayer.gold).toBe(before - total);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for resource add effect including rounding
- add tests for resource remove effect including rounding

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68af4852bd80832586a74e576a594650