### PR TITLE
chore(ci): speed up playwright setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
       - run: npm test
 
       - run: npm run test:coverage
-      - run: npx playwright install --with-deps chromium
+      # Install only the Chrome browser. Dependencies are already present on
+      # the GitHub runner, so we skip the slow `--with-deps` flag.
+      - run: npx playwright install chrome
       - run: npm run e2e
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Run unit and integration tests:
 npm test
 ```
 
-Run end-to-end tests (requires Playwright browsers and system deps):
+Run end-to-end tests (requires the Playwright Chrome browser). Install system
+dependencies once on Linux, then install only the browser for faster runs:
 
 ```bash
-npx playwright install
-npx playwright install-deps # required on Linux
+npx playwright install-deps # Linux only, run once
+npx playwright install chrome
 npm run e2e
 ```
 


### PR DESCRIPTION
## Summary
- avoid reinstalling Playwright dependencies on every CI run
- document faster Chrome-only install for e2e tests

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68af4a94b2e48325bf6781f460002604