### PR TITLE
refactor: deep clone player state in tests

### DIFF
--- a/packages/engine/tests/actions/expand.test.ts
+++ b/packages/engine/tests/actions/expand.test.ts
@@ -9,6 +9,10 @@ import {
 } from '../../src/index.ts';
 import { PlayerState } from '../../src/state/index.ts';
 
+function deepClone<T>(value: T): T {
+  return structuredClone(value);
+}
+
 function getExpandExpectations(ctx: EngineContext) {
   const expandDef = ctx.actions.get('expand');
   const costs = getActionCosts('expand', ctx);
@@ -24,8 +28,8 @@ function getExpandExpectations(ctx: EngineContext) {
     )
     .reduce((sum, e) => sum + (e.params?.amount ?? 0), 0);
   const dummy = new PlayerState(ctx.activePlayer.id, ctx.activePlayer.name);
-  dummy.resources = { ...ctx.activePlayer.resources } as any;
-  dummy.stats = { ...ctx.activePlayer.stats } as any;
+  dummy.resources = deepClone(ctx.activePlayer.resources);
+  dummy.stats = deepClone(ctx.activePlayer.stats);
   const dummyCtx = { ...ctx, activePlayer: dummy } as EngineContext;
   const before = dummy.happiness;
   ctx.passives.runResultMods(expandDef.id, dummyCtx);

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -7,11 +7,15 @@ import {
 import { PlayerState, Land } from '../../packages/engine/src/state/index.ts';
 import { runEffects } from '../../packages/engine/src/effects/index.ts';
 
+function deepClone<T>(value: T): T {
+  return structuredClone(value);
+}
+
 function clonePlayer(p: PlayerState) {
   const c = new PlayerState(p.id, p.name);
-  c.resources = { ...p.resources } as any;
-  c.stats = { ...p.stats } as any;
-  c.population = { ...p.population } as any;
+  c.resources = deepClone(p.resources);
+  c.stats = deepClone(p.stats);
+  c.population = deepClone(p.population);
   c.lands = p.lands.map((l) => {
     const nl = new Land(l.id, l.slotsMax);
     nl.slotsUsed = l.slotsUsed;


### PR DESCRIPTION
## Summary
- add generic `deepClone` helper using `structuredClone`
- clone player resources, stats, and population without `as any`
- ensure expand action expectations use typed clones

## Testing
- `npm test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af63dc120c832586d19749f8199f5d