### PR TITLE
chore: add sonar scanner configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,15 @@ jobs:
       # the GitHub runner, so we skip the slow `--with-deps` flag.
       - run: npx playwright install chromium
       - run: npm run e2e
+      - name: SonarQube Scan
+        run: |
+          if [ -n "$SONAR_TOKEN" ]; then
+            npx sonar-scanner -Dsonar.token=$SONAR_TOKEN
+          else
+            npx sonar-scanner -Dsonar.scanner.skip=true
+          fi
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,3 +10,8 @@ npx lint-staged
 npm run lint
 npm run type-check
 npm test
+if [ -n "$SONAR_TOKEN" ]; then
+  npx sonar-scanner -Dsonar.token=$SONAR_TOKEN
+else
+  npx sonar-scanner -Dsonar.scanner.skip=true
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "lint-staged": "^16.1.5",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
+        "sonar-scanner": "^3.1.0",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.5.4",
         "vite": "^5.4.0",
@@ -4599,6 +4600,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sonar-scanner": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sonar-scanner/-/sonar-scanner-3.1.0.tgz",
+      "integrity": "sha512-KD7W3wHCKJKAakhn8ckxNYTxkdb1cnJa3ot0NVvO8CCeJjb0yvF0fW2yGdI09zMHsqxCRsl4dLtyCL2SUv47WA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "sonar-scanner": "index.js"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8376,6 +8388,12 @@
           "dev": true
         }
       }
+    },
+    "sonar-scanner": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sonar-scanner/-/sonar-scanner-3.1.0.tgz",
+      "integrity": "sha512-KD7W3wHCKJKAakhn8ckxNYTxkdb1cnJa3ot0NVvO8CCeJjb0yvF0fW2yGdI09zMHsqxCRsl4dLtyCL2SUv47WA==",
+      "dev": true
     },
     "source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint-staged": "^16.1.5",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
+    "sonar-scanner": "^3.1.0",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.5.4",
     "vite": "^5.4.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.projectKey=kingdom-builder-game
+sonar.projectName=Kingdom Builder Game
+sonar.organization=kingdom-builder
+sonar.host.url=https://sonarcloud.io
+sonar.sourceEncoding=UTF-8
+sonar.sources=packages
+sonar.tests=tests,e2e
+sonar.test.inclusions=tests/**/*.test.ts,e2e/**/*.ts
+sonar.typescript.tsconfigPath=tsconfig.json
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## Summary
- configure sonar scanner for TypeScript project and coverage reporting
- ensure sonar scan runs in CI and pre-commit hooks
- skip scan locally when SONAR_TOKEN is absent

## Testing
- `npm test`
- `npm run test:coverage`
- `npx playwright install chromium` *(fails: server returned code 403)*
- `npm run e2e` *(fails: missing browser dependencies)*
- `npm run build`
- `npx sonar-scanner -Dsonar.scanner.skip=true`


------
https://chatgpt.com/codex/tasks/task_e_68af6415f7b4832598ee13fff830790d