### PR TITLE
feat(engine): add typed action params

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -100,10 +100,19 @@ function pay(costs: CostBag, player: PlayerState) {
   }
 }
 
-export function performAction(
-  actionId: string,
+type ActionParamMap = {
+  develop: { id: string; landId: string };
+  [key: string]: Record<string, any>;
+};
+
+export type ActionParams<T extends string> = T extends keyof ActionParamMap
+  ? ActionParamMap[T]
+  : Record<string, any>;
+
+export function performAction<T extends string>(
+  actionId: T,
   ctx: EngineContext,
-  params?: Record<string, any>,
+  params?: ActionParams<T>,
 ) {
   const def = ctx.actions.get(actionId);
   for (const req of def.requirements || []) {


### PR DESCRIPTION
## Summary
- add generic action parameter map
- type `performAction` to use mapped params

## Testing
- `npm test`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist; attempted `npx playwright install` but download failed with 403)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af66e8230883258277dfd2449c05b2