### PR TITLE
feat(engine): add typed trigger interfaces

### DIFF
--- a/packages/engine/src/content/buildings.ts
+++ b/packages/engine/src/content/buildings.ts
@@ -1,9 +1,10 @@
 import { Registry } from '../registry';
 import { Resource } from '../state';
-import { buildingSchema, type BuildingConfig } from '../config/schema';
+import { buildingSchema } from '../config/schema';
 import { building } from '../config/builders';
+import type { BuildingDef } from './defs';
 
-export type BuildingDef = BuildingConfig;
+export type { BuildingDef } from './defs';
 
 export function createBuildingRegistry() {
   const reg = new Registry<BuildingDef>(buildingSchema);

--- a/packages/engine/src/content/defs.ts
+++ b/packages/engine/src/content/defs.ts
@@ -1,0 +1,18 @@
+import type {
+  BuildingConfig,
+  DevelopmentConfig,
+  PopulationConfig,
+} from '../config/schema';
+import type { EffectDef } from '../effects';
+
+export interface Triggered {
+  onDevelopmentPhase?: EffectDef[];
+  onUpkeepPhase?: EffectDef[];
+  onAttackResolved?: EffectDef[];
+}
+
+export interface PopulationDef extends PopulationConfig, Triggered {}
+export interface DevelopmentDef extends DevelopmentConfig, Triggered {}
+export interface BuildingDef extends BuildingConfig, Triggered {}
+
+export type TriggerKey = keyof Triggered;

--- a/packages/engine/src/content/developments.ts
+++ b/packages/engine/src/content/developments.ts
@@ -1,9 +1,10 @@
 import { Registry } from '../registry';
 import { Resource, Stat } from '../state';
-import { developmentSchema, type DevelopmentConfig } from '../config/schema';
+import { developmentSchema } from '../config/schema';
 import { development } from '../config/builders';
+import type { DevelopmentDef } from './defs';
 
-export type DevelopmentDef = DevelopmentConfig;
+export type { DevelopmentDef } from './defs';
 
 export function createDevelopmentRegistry() {
   const reg = new Registry<DevelopmentDef>(developmentSchema);

--- a/packages/engine/src/content/populations.ts
+++ b/packages/engine/src/content/populations.ts
@@ -1,9 +1,10 @@
 import { Registry } from '../registry';
 import { PopulationRole, Resource, Stat } from '../state';
-import { populationSchema, type PopulationConfig } from '../config/schema';
+import { populationSchema } from '../config/schema';
 import { population } from '../config/builders';
+import type { PopulationDef } from './defs';
 
-export type PopulationDef = PopulationConfig;
+export type { PopulationDef } from './defs';
 
 export function createPopulationRegistry() {
   const reg = new Registry<PopulationDef>(populationSchema);

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -19,6 +19,7 @@ import { createActionRegistry } from './content/actions';
 import { BUILDINGS } from './content/buildings';
 import { DEVELOPMENTS } from './content/developments';
 import { POPULATIONS, PopulationDef } from './content/populations';
+import type { TriggerKey } from './content/defs';
 import { EngineContext } from './context';
 import { runEffects, EFFECTS, registerCoreEffects } from './effects';
 import { EVALUATORS, registerCoreEvaluators } from './evaluators';
@@ -34,7 +35,7 @@ import {
 } from './config/schema';
 
 function runTrigger(
-  trigger: 'onDevelopmentPhase' | 'onUpkeepPhase' | 'onAttackResolved',
+  trigger: TriggerKey,
   ctx: EngineContext,
   player: PlayerState = ctx.activePlayer,
 ) {
@@ -44,14 +45,14 @@ function runTrigger(
 
   for (const [role, count] of Object.entries(player.population)) {
     const def = ctx.populations.get(role);
-    const effects = (def as any)[trigger];
+    const effects = def[trigger];
     if (effects) runEffects(effects, ctx, count as number);
   }
 
   for (const land of player.lands) {
     for (const id of land.developments) {
       const def = ctx.developments.get(id);
-      const effects = (def as any)[trigger];
+      const effects = def[trigger];
       if (!effects) continue;
       runEffects(applyParamsToEffects(effects, { landId: land.id, id }), ctx);
     }
@@ -59,7 +60,7 @@ function runTrigger(
 
   for (const id of player.buildings) {
     const def = ctx.buildings.get(id);
-    const effects = (def as any)[trigger];
+    const effects = def[trigger];
     if (effects) runEffects(effects, ctx);
   }
 


### PR DESCRIPTION
## Summary
- add shared Triggered interfaces for population, development, and building definitions
- refactor runTrigger to use typed triggers instead of `as any`

## Testing
- `npm test`
- `npm run build`
- `npm run e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68af66d7d6ac8325bd53e8a62b4627c8