### PR TITLE
refactor: add typed config builders

### DIFF
--- a/packages/engine/src/config/builders.ts
+++ b/packages/engine/src/config/builders.ts
@@ -3,17 +3,18 @@ import type {
   BuildingConfig,
   DevelopmentConfig,
   PopulationConfig,
+  RequirementFn,
 } from './schema';
 import type { ResourceKey } from '../state';
 import type { EffectConfig } from './schema';
 
 class BaseBuilder<T extends { id: string; name: string }> {
-  protected cfg: any;
-  constructor(id: string, name: string, base: any) {
-    this.cfg = { id, name, ...base };
+  protected cfg: T;
+  constructor(id: string, name: string, base: Omit<T, 'id' | 'name'>) {
+    this.cfg = { id, name, ...base } as T;
   }
   build(): T {
-    return this.cfg as T;
+    return this.cfg;
   }
 }
 
@@ -23,10 +24,10 @@ export class ActionBuilder extends BaseBuilder<ActionConfig> {
   }
   cost(key: ResourceKey, amount: number) {
     this.cfg.baseCosts = this.cfg.baseCosts || {};
-    this.cfg.baseCosts[key] = amount;
+    this.cfg.baseCosts![key] = amount;
     return this;
   }
-  requirement(req: (ctx: any) => any) {
+  requirement(req: RequirementFn) {
     this.cfg.requirements = this.cfg.requirements || [];
     this.cfg.requirements.push(req);
     return this;
@@ -46,7 +47,7 @@ export class BuildingBuilder extends BaseBuilder<BuildingConfig> {
     return this;
   }
   onBuild(effect: EffectConfig) {
-    this.cfg.onBuild.push(effect);
+    this.cfg.onBuild!.push(effect);
     return this;
   }
   onDevelopmentPhase(effect: EffectConfig) {

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -1,13 +1,21 @@
 import { z } from 'zod';
 import { Resource } from '../state';
 import type { EffectDef } from '../effects';
+import { EngineContext } from '../context';
+
+export type RequirementFn = (ctx: EngineContext) => true | string;
+
+const requirementSchema: z.ZodType<RequirementFn> = z
+  .function()
+  .args(z.instanceof(EngineContext))
+  .returns(z.union([z.literal(true), z.string()]));
 
 // Basic schemas
 const costBagSchema = z.record(z.nativeEnum(Resource), z.number());
 
 const evaluatorSchema = z.object({
   type: z.string(),
-  params: z.record(z.any()).optional(),
+  params: z.record(z.unknown()).optional(),
 });
 
 // Effect
@@ -15,7 +23,7 @@ export const effectSchema: z.ZodType<EffectDef> = z.lazy(() =>
   z.object({
     type: z.string().optional(),
     method: z.string().optional(),
-    params: z.record(z.any()).optional(),
+    params: z.record(z.unknown()).optional(),
     effects: z.array(effectSchema).optional(),
     evaluator: evaluatorSchema.optional(),
     round: z.enum(['up', 'down']).optional(),
@@ -29,7 +37,7 @@ export const actionSchema = z.object({
   id: z.string(),
   name: z.string(),
   baseCosts: costBagSchema.optional(),
-  requirements: z.array(z.any()).optional(),
+  requirements: z.array(requirementSchema).optional(),
   effects: z.array(effectSchema),
 });
 


### PR DESCRIPTION
## Summary
- introduce generic BaseBuilder and typed requirement functions for config builders
- tighten config schemas with explicit RequirementFn validation and unknown params

## Testing
- `npx playwright install-deps chromium`
- `npx playwright install chromium` *(fails: Download failed: server returned code 403)*
- `npm test`
- `npm run e2e` *(fails: executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af6900f9a08325ba7ccc72ac06a9a3