### PR TITLE
feat(engine): type-safe effect params

### DIFF
--- a/packages/engine/src/effects/index.ts
+++ b/packages/engine/src/effects/index.ts
@@ -16,17 +16,19 @@ import { passiveRemove } from './passive_remove';
 import { costMod } from './cost_mod';
 import { resultMod } from './result_mod';
 
-export interface EffectDef {
+export interface EffectDef<
+  P extends Record<string, unknown> = Record<string, unknown>,
+> {
   type?: string;
   method?: string;
-  params?: Record<string, any>;
+  params?: P;
   effects?: EffectDef[];
   evaluator?: import('../evaluators').EvaluatorDef;
   round?: 'up' | 'down';
 }
 
-export interface EffectHandler {
-  (effect: EffectDef, ctx: EngineContext, mult: number): void;
+export interface EffectHandler<P extends Record<string, unknown> = any> {
+  (effect: EffectDef<P>, ctx: EngineContext, mult: number): void;
 }
 
 export class EffectRegistry extends Registry<EffectHandler> {}

--- a/packages/engine/src/utils.ts
+++ b/packages/engine/src/utils.ts
@@ -1,17 +1,17 @@
 import type { EffectDef } from './effects';
 
-export function applyParamsToEffects(
-  effects: EffectDef[],
-  params: Record<string, any>,
-): EffectDef[] {
-  const replace = (val: any) =>
+export function applyParamsToEffects<E extends EffectDef>(
+  effects: E[],
+  params: Record<string, unknown>,
+): E[] {
+  const replace = (val: unknown): unknown =>
     typeof val === 'string' && val.startsWith('$') ? params[val.slice(1)] : val;
-  const mapEffect = (e: EffectDef): EffectDef => ({
+  const mapEffect = (e: E): E => ({
     ...e,
     params: e.params
-      ? Object.fromEntries(
+      ? (Object.fromEntries(
           Object.entries(e.params).map(([k, v]) => [k, replace(v)]),
-        )
+        ) as E['params'])
       : undefined,
     evaluator: e.evaluator
       ? {


### PR DESCRIPTION
## Summary
- add generic `EffectDef<P>` to carry typed params
- refactor `applyParamsToEffects` to use generics and remove `any`

## Testing
- `npx playwright install-deps chromium` *(failed: Invalid response from proxy)*
- `npx playwright install chromium` *(failed: Download failed: server returned code 403)*
- `npm test`
- `npm run e2e` *(failed: missing browser dependencies)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af69223f3083258ba1e9d5797616f7