### PR TITLE
chore: enforce no-explicit-any

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,6 +28,6 @@ module.exports = {
         argsIgnorePattern: '^_',
       },
     ],
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': 'error',
   },
 };

--- a/packages/engine/src/config/builders.ts
+++ b/packages/engine/src/config/builders.ts
@@ -6,10 +6,11 @@ import type {
 } from './schema';
 import type { ResourceKey } from '../state';
 import type { EffectConfig } from './schema';
+import type { EngineContext } from '../context';
 
 class BaseBuilder<T extends { id: string; name: string }> {
-  protected cfg: any;
-  constructor(id: string, name: string, base: any) {
+  protected cfg: Partial<T>;
+  constructor(id: string, name: string, base: Partial<T>) {
     this.cfg = { id, name, ...base };
   }
   build(): T {
@@ -22,17 +23,19 @@ export class ActionBuilder extends BaseBuilder<ActionConfig> {
     super(id, name, { effects: [] });
   }
   cost(key: ResourceKey, amount: number) {
-    this.cfg.baseCosts = this.cfg.baseCosts || {};
-    this.cfg.baseCosts[key] = amount;
+    const cfg = this.cfg as ActionConfig;
+    cfg.baseCosts = cfg.baseCosts || {};
+    cfg.baseCosts[key] = amount;
     return this;
   }
-  requirement(req: (ctx: any) => any) {
-    this.cfg.requirements = this.cfg.requirements || [];
-    this.cfg.requirements.push(req);
+  requirement(req: (ctx: EngineContext) => unknown) {
+    const cfg = this.cfg as ActionConfig;
+    cfg.requirements = cfg.requirements || [];
+    cfg.requirements.push(req);
     return this;
   }
   effect(effect: EffectConfig) {
-    this.cfg.effects.push(effect);
+    (this.cfg as ActionConfig).effects.push(effect);
     return this;
   }
 }
@@ -42,26 +45,31 @@ export class BuildingBuilder extends BaseBuilder<BuildingConfig> {
     super(id, name, { costs: {}, onBuild: [] });
   }
   cost(key: ResourceKey, amount: number) {
-    this.cfg.costs[key] = amount;
+    (this.cfg as BuildingConfig).costs[key] = amount;
     return this;
   }
   onBuild(effect: EffectConfig) {
-    this.cfg.onBuild.push(effect);
+    const cfg = this.cfg as BuildingConfig;
+    cfg.onBuild = cfg.onBuild || [];
+    cfg.onBuild.push(effect);
     return this;
   }
   onDevelopmentPhase(effect: EffectConfig) {
-    this.cfg.onDevelopmentPhase = this.cfg.onDevelopmentPhase || [];
-    this.cfg.onDevelopmentPhase.push(effect);
+    const cfg = this.cfg as BuildingConfig;
+    cfg.onDevelopmentPhase = cfg.onDevelopmentPhase || [];
+    cfg.onDevelopmentPhase.push(effect);
     return this;
   }
   onUpkeepPhase(effect: EffectConfig) {
-    this.cfg.onUpkeepPhase = this.cfg.onUpkeepPhase || [];
-    this.cfg.onUpkeepPhase.push(effect);
+    const cfg = this.cfg as BuildingConfig;
+    cfg.onUpkeepPhase = cfg.onUpkeepPhase || [];
+    cfg.onUpkeepPhase.push(effect);
     return this;
   }
   onAttackResolved(effect: EffectConfig) {
-    this.cfg.onAttackResolved = this.cfg.onAttackResolved || [];
-    this.cfg.onAttackResolved.push(effect);
+    const cfg = this.cfg as BuildingConfig;
+    cfg.onAttackResolved = cfg.onAttackResolved || [];
+    cfg.onAttackResolved.push(effect);
     return this;
   }
 }
@@ -71,18 +79,21 @@ export class DevelopmentBuilder extends BaseBuilder<DevelopmentConfig> {
     super(id, name, {});
   }
   onBuild(effect: EffectConfig) {
-    this.cfg.onBuild = this.cfg.onBuild || [];
-    this.cfg.onBuild.push(effect);
+    const cfg = this.cfg as DevelopmentConfig;
+    cfg.onBuild = cfg.onBuild || [];
+    cfg.onBuild.push(effect);
     return this;
   }
   onDevelopmentPhase(effect: EffectConfig) {
-    this.cfg.onDevelopmentPhase = this.cfg.onDevelopmentPhase || [];
-    this.cfg.onDevelopmentPhase.push(effect);
+    const cfg = this.cfg as DevelopmentConfig;
+    cfg.onDevelopmentPhase = cfg.onDevelopmentPhase || [];
+    cfg.onDevelopmentPhase.push(effect);
     return this;
   }
   onAttackResolved(effect: EffectConfig) {
-    this.cfg.onAttackResolved = this.cfg.onAttackResolved || [];
-    this.cfg.onAttackResolved.push(effect);
+    const cfg = this.cfg as DevelopmentConfig;
+    cfg.onAttackResolved = cfg.onAttackResolved || [];
+    cfg.onAttackResolved.push(effect);
     return this;
   }
 }
@@ -92,13 +103,15 @@ export class PopulationBuilder extends BaseBuilder<PopulationConfig> {
     super(id, name, {});
   }
   onDevelopmentPhase(effect: EffectConfig) {
-    this.cfg.onDevelopmentPhase = this.cfg.onDevelopmentPhase || [];
-    this.cfg.onDevelopmentPhase.push(effect);
+    const cfg = this.cfg as PopulationConfig;
+    cfg.onDevelopmentPhase = cfg.onDevelopmentPhase || [];
+    cfg.onDevelopmentPhase.push(effect);
     return this;
   }
   onUpkeepPhase(effect: EffectConfig) {
-    this.cfg.onUpkeepPhase = this.cfg.onUpkeepPhase || [];
-    this.cfg.onUpkeepPhase.push(effect);
+    const cfg = this.cfg as PopulationConfig;
+    cfg.onUpkeepPhase = cfg.onUpkeepPhase || [];
+    cfg.onUpkeepPhase.push(effect);
     return this;
   }
 }

--- a/packages/engine/src/effects/cost_mod.ts
+++ b/packages/engine/src/effects/cost_mod.ts
@@ -1,8 +1,16 @@
 import type { EffectHandler } from '.';
 import type { ResourceKey } from '../state';
 
+interface CostModParams {
+  id: string;
+  actionId: string;
+  key: string;
+  amount: number;
+}
+
 export const costMod: EffectHandler = (effect, ctx) => {
-  const { id, actionId, key, amount } = effect.params || {};
+  const { id, actionId, key, amount } =
+    (effect.params as Partial<CostModParams>) || {};
   if (!id || !actionId || !key || amount === undefined) {
     throw new Error('cost_mod requires id, actionId, key, amount');
   }
@@ -11,7 +19,7 @@ export const costMod: EffectHandler = (effect, ctx) => {
       if (act === actionId) {
         const k = key as ResourceKey;
         const current = costs[k] || 0;
-        return { ...costs, [k]: current + (amount as number) };
+        return { ...costs, [k]: current + amount };
       }
       return costs;
     });

--- a/packages/engine/src/effects/index.ts
+++ b/packages/engine/src/effects/index.ts
@@ -19,7 +19,7 @@ import { resultMod } from './result_mod';
 export interface EffectDef {
   type?: string;
   method?: string;
-  params?: Record<string, any>;
+  params?: Record<string, unknown>;
   effects?: EffectDef[];
   evaluator?: import('../evaluators').EvaluatorDef;
   round?: 'up' | 'down';

--- a/packages/engine/src/effects/land_add.ts
+++ b/packages/engine/src/effects/land_add.ts
@@ -2,7 +2,9 @@ import { Land } from '../state';
 import type { EffectHandler } from '.';
 
 export const landAdd: EffectHandler = (effect, ctx, mult = 1) => {
-  const count = Math.floor((effect.params?.count ?? 1) * mult);
+  const count = Math.floor(
+    ((effect.params?.count as number | undefined) ?? 1) * mult,
+  );
   for (let i = 0; i < count; i++) {
     const land = new Land(
       `${ctx.activePlayer.id}-L${ctx.activePlayer.lands.length + 1}`,

--- a/packages/engine/src/effects/result_mod.ts
+++ b/packages/engine/src/effects/result_mod.ts
@@ -1,8 +1,13 @@
 import type { EffectHandler } from '.';
 import { runEffects } from '.';
 
+interface ResultModParams {
+  id: string;
+  actionId: string;
+}
+
 export const resultMod: EffectHandler = (effect, ctx) => {
-  const { id, actionId } = effect.params || {};
+  const { id, actionId } = (effect.params as Partial<ResultModParams>) || {};
   if (!id || !actionId) throw new Error('result_mod requires id and actionId');
   if (effect.method === 'add') {
     const effects = effect.effects || [];

--- a/packages/engine/src/evaluators/development.ts
+++ b/packages/engine/src/evaluators/development.ts
@@ -9,7 +9,9 @@ export const developmentEvaluator: EvaluatorHandler<number> = (
   def: EvaluatorDef,
   ctx: EngineContext,
 ) => {
-  const { id } = def.params as DevelopmentEvaluatorParams;
+  const params = def.params as Partial<DevelopmentEvaluatorParams> | undefined;
+  if (!params?.id) throw new Error('development evaluator requires id param');
+  const { id } = params;
   return ctx.activePlayer.lands.reduce(
     (total, land) => total + land.developments.filter((d) => d === id).length,
     0,

--- a/packages/engine/src/evaluators/index.ts
+++ b/packages/engine/src/evaluators/index.ts
@@ -4,10 +4,10 @@ import type { EngineContext } from '../context';
 import { developmentEvaluator } from './development';
 export interface EvaluatorDef {
   type: string;
-  params?: Record<string, any>;
+  params?: Record<string, unknown>;
 }
 
-export interface EvaluatorHandler<R = any> {
+export interface EvaluatorHandler<R = unknown> {
   (def: EvaluatorDef, ctx: EngineContext): R;
 }
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -103,12 +103,12 @@ function pay(costs: CostBag, player: PlayerState) {
 
 type ActionParamMap = {
   develop: { id: string; landId: string };
-  [key: string]: Record<string, any>;
+  [key: string]: Record<string, unknown>;
 };
 
 export type ActionParams<T extends string> = T extends keyof ActionParamMap
   ? ActionParamMap[T]
-  : Record<string, any>;
+  : Record<string, unknown>;
 
 export function performAction<T extends string>(
   actionId: T,

--- a/packages/engine/src/utils.ts
+++ b/packages/engine/src/utils.ts
@@ -2,9 +2,9 @@ import type { EffectDef } from './effects';
 
 export function applyParamsToEffects(
   effects: EffectDef[],
-  params: Record<string, any>,
+  params: Record<string, unknown>,
 ): EffectDef[] {
-  const replace = (val: any) =>
+  const replace = (val: unknown) =>
     typeof val === 'string' && val.startsWith('$') ? params[val.slice(1)] : val;
   const mapEffect = (e: EffectDef): EffectDef => ({
     ...e,


### PR DESCRIPTION
## Summary
- enable `@typescript-eslint/no-explicit-any` rule
- replace `any` usages with stricter typings across engine

## Testing
- `npx playwright install-deps chromium`
- `npx playwright install chromium`
- `npm test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af69162abc83258c65ddc21814e7a2