### PR TITLE
feat(engine): add generic evaluator types

### DIFF
--- a/packages/engine/src/evaluators/development.ts
+++ b/packages/engine/src/evaluators/development.ts
@@ -1,15 +1,15 @@
-import type { EvaluatorHandler, EvaluatorDef } from './index';
+import type { EvaluatorHandler } from './index';
 import type { EngineContext } from '../context';
 
-export interface DevelopmentEvaluatorParams {
+export interface DevelopmentEvaluatorParams extends Record<string, unknown> {
   id: string;
 }
 
-export const developmentEvaluator: EvaluatorHandler<number> = (
-  def: EvaluatorDef,
-  ctx: EngineContext,
-) => {
-  const { id } = def.params as DevelopmentEvaluatorParams;
+export const developmentEvaluator: EvaluatorHandler<
+  number,
+  DevelopmentEvaluatorParams
+> = (def, ctx: EngineContext) => {
+  const { id } = def.params!;
   return ctx.activePlayer.lands.reduce(
     (total, land) => total + land.developments.filter((d) => d === id).length,
     0,

--- a/packages/engine/src/evaluators/index.ts
+++ b/packages/engine/src/evaluators/index.ts
@@ -2,13 +2,18 @@ import { Registry } from '../registry';
 import type { EngineContext } from '../context';
 
 import { developmentEvaluator } from './development';
-export interface EvaluatorDef {
+export interface EvaluatorDef<
+  P extends Record<string, unknown> = Record<string, unknown>,
+> {
   type: string;
-  params?: Record<string, any>;
+  params?: P;
 }
 
-export interface EvaluatorHandler<R = any> {
-  (def: EvaluatorDef, ctx: EngineContext): R;
+export interface EvaluatorHandler<
+  R = any,
+  P extends Record<string, unknown> = Record<string, unknown>,
+> {
+  (def: EvaluatorDef<P>, ctx: EngineContext): R;
 }
 
 export class EvaluatorRegistry extends Registry<EvaluatorHandler> {}


### PR DESCRIPTION
## Summary
- make EvaluatorDef and EvaluatorHandler generics to type params
- type built-in development evaluator with its specific params

## Testing
- `npm test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af6b6581c083258dbf34d581985c3f