### PR TITLE
chore: forbid explicit any

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,6 +28,6 @@ module.exports = {
         argsIgnorePattern: '^_',
       },
     ],
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': 'error',
   },
 };

--- a/packages/engine/src/effects/cost_mod.ts
+++ b/packages/engine/src/effects/cost_mod.ts
@@ -1,8 +1,16 @@
 import type { EffectHandler } from '.';
 import type { ResourceKey } from '../state';
 
-export const costMod: EffectHandler = (effect, ctx) => {
-  const { id, actionId, key, amount } = effect.params || {};
+interface CostModParams extends Record<string, unknown> {
+  id: string;
+  actionId: string;
+  key: ResourceKey;
+  amount: number;
+}
+
+export const costMod: EffectHandler<CostModParams> = (effect, ctx) => {
+  const { id, actionId, key, amount } =
+    (effect.params as CostModParams) || ({} as CostModParams);
   if (!id || !actionId || !key || amount === undefined) {
     throw new Error('cost_mod requires id, actionId, key, amount');
   }

--- a/packages/engine/src/effects/index.ts
+++ b/packages/engine/src/effects/index.ts
@@ -27,7 +27,9 @@ export interface EffectDef<
   round?: 'up' | 'down';
 }
 
-export interface EffectHandler<P extends Record<string, unknown> = any> {
+export interface EffectHandler<
+  P extends Record<string, unknown> = Record<string, unknown>,
+> {
   (effect: EffectDef<P>, ctx: EngineContext, mult: number): void;
 }
 

--- a/packages/engine/src/effects/land_add.ts
+++ b/packages/engine/src/effects/land_add.ts
@@ -1,8 +1,16 @@
 import { Land } from '../state';
 import type { EffectHandler } from '.';
 
-export const landAdd: EffectHandler = (effect, ctx, mult = 1) => {
-  const count = Math.floor((effect.params?.['count'] ?? 1) * mult);
+interface LandAddParams extends Record<string, unknown> {
+  count?: number;
+}
+
+export const landAdd: EffectHandler<LandAddParams> = (
+  effect,
+  ctx,
+  mult = 1,
+) => {
+  const count = Math.floor((effect.params?.count ?? 1) * mult);
   for (let i = 0; i < count; i++) {
     const land = new Land(
       `${ctx.activePlayer.id}-L${ctx.activePlayer.lands.length + 1}`,

--- a/packages/engine/src/effects/result_mod.ts
+++ b/packages/engine/src/effects/result_mod.ts
@@ -1,8 +1,13 @@
 import type { EffectHandler } from '.';
 import { runEffects } from '.';
 
-export const resultMod: EffectHandler = (effect, ctx) => {
-  const { id, actionId } = effect.params || {};
+interface ResultModParams extends Record<string, unknown> {
+  id: string;
+  actionId: string;
+}
+
+export const resultMod: EffectHandler<ResultModParams> = (effect, ctx) => {
+  const { id, actionId } = (effect.params as ResultModParams) || {};
   if (!id || !actionId) throw new Error('result_mod requires id and actionId');
   if (effect.method === 'add') {
     const effects = effect.effects || [];

--- a/packages/engine/src/evaluators/development.ts
+++ b/packages/engine/src/evaluators/development.ts
@@ -9,7 +9,8 @@ export const developmentEvaluator: EvaluatorHandler<number> = (
   def: EvaluatorDef,
   ctx: EngineContext,
 ) => {
-  const { id } = def.params as DevelopmentEvaluatorParams;
+  const params = def.params as unknown as DevelopmentEvaluatorParams;
+  const { id } = params;
   return ctx.activePlayer.lands.reduce(
     (total, land) => total + land.developments.filter((d) => d === id).length,
     0,

--- a/packages/engine/src/evaluators/index.ts
+++ b/packages/engine/src/evaluators/index.ts
@@ -4,10 +4,10 @@ import type { EngineContext } from '../context';
 import { developmentEvaluator } from './development';
 export interface EvaluatorDef {
   type: string;
-  params?: Record<string, any>;
+  params?: Record<string, unknown>;
 }
 
-export interface EvaluatorHandler<R = any> {
+export interface EvaluatorHandler<R = unknown> {
   (def: EvaluatorDef, ctx: EngineContext): R;
 }
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -103,12 +103,12 @@ function pay(costs: CostBag, player: PlayerState) {
 
 type ActionParamMap = {
   develop: { id: string; landId: string };
-  [key: string]: Record<string, any>;
+  [key: string]: Record<string, unknown>;
 };
 
 export type ActionParams<T extends string> = T extends keyof ActionParamMap
   ? ActionParamMap[T]
-  : Record<string, any>;
+  : Record<string, unknown>;
 
 export function performAction<T extends string>(
   actionId: T,

--- a/packages/engine/tests/actions/build_town_charter.test.ts
+++ b/packages/engine/tests/actions/build_town_charter.test.ts
@@ -14,9 +14,9 @@ import { applyParamsToEffects } from '../../src/utils.ts';
 
 function clonePlayer(p: PlayerState): PlayerState {
   const copy = new PlayerState(p.id, p.name);
-  copy.resources = { ...p.resources } as any;
-  copy.stats = { ...p.stats } as any;
-  copy.population = { ...p.population } as any;
+  copy.resources = { ...p.resources };
+  copy.stats = { ...p.stats };
+  copy.population = { ...p.population };
   copy.lands = p.lands.map((l) => {
     const land = new Land(l.id, l.slotsMax);
     land.slotsUsed = l.slotsUsed;

--- a/packages/engine/tests/actions/develop.test.ts
+++ b/packages/engine/tests/actions/develop.test.ts
@@ -15,9 +15,9 @@ import { applyParamsToEffects } from '../../src/utils.ts';
 
 function clonePlayer(p: PlayerState): PlayerState {
   const copy = new PlayerState(p.id, p.name);
-  copy.resources = { ...p.resources } as any;
-  copy.stats = { ...p.stats } as any;
-  copy.population = { ...p.population } as any;
+  copy.resources = { ...p.resources };
+  copy.stats = { ...p.stats };
+  copy.population = { ...p.population };
   copy.lands = p.lands.map((l) => {
     const land = new Land(l.id, l.slotsMax);
     land.slotsUsed = l.slotsUsed;

--- a/packages/engine/tests/effects/add_development.test.ts
+++ b/packages/engine/tests/effects/add_development.test.ts
@@ -56,9 +56,9 @@ actions.add('build_house_full', {
 
 function clonePlayer(p: PlayerState): PlayerState {
   const copy = new PlayerState(p.id, p.name);
-  copy.resources = { ...p.resources } as any;
-  copy.stats = { ...p.stats } as any;
-  copy.population = { ...p.population } as any;
+  copy.resources = { ...p.resources };
+  copy.stats = { ...p.stats };
+  copy.population = { ...p.population };
   copy.lands = p.lands.map((l) => {
     const land = new Land(l.id, l.slotsMax);
     land.slotsUsed = l.slotsUsed;


### PR DESCRIPTION
## Summary
- enable `@typescript-eslint/no-explicit-any` rule
- replace `any` with stricter types across engine and tests

## Testing
- `npx playwright install-deps chromium`
- `npx playwright install chromium` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `npm test`
- `npm run e2e` *(fails: Executable doesn't exist at chromium_headless_shell; run `npx playwright install`)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af6b5b2e408325aa095c892c119b27