### PR TITLE
fix: set playwright download host

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+playwright_download_host=https://playwright.download.prss.microsoft.com/dbazure/download/playwright

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Tests live in:
 - `tests/integration` for integration tests
 - `e2e` for end-to-end tests using Playwright
 
-Always run all tests before making a PR. Install the Playwright Chromium browser (Linux users run `install-deps` once) and run all checks:
+Always run all tests before making a PR. Install the Playwright Chromium browser (Linux users run `install-deps` once) and run all checks. The repository configures an alternate Playwright download host via `.npmrc` to work behind restricted networks:
 
 ```bash
 npx playwright install-deps chromium  # Linux only, run once


### PR DESCRIPTION
## Summary
- allow Playwright to download browsers from alternate domain accessible behind proxy
- clarify testing instructions with note about alternate download host

## Testing
- `npm test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af6aac42fc8325b1ded7bcf84ec48b