### PR TITLE
Enforce no-explicit-any rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,6 +28,6 @@ module.exports = {
         argsIgnorePattern: '^_',
       },
     ],
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': 'error',
   },
 };

--- a/packages/engine/src/effects/cost_mod.ts
+++ b/packages/engine/src/effects/cost_mod.ts
@@ -1,17 +1,24 @@
 import type { EffectHandler } from '.';
 import type { ResourceKey } from '../state';
 
-export const costMod: EffectHandler = (effect, ctx) => {
-  const { id, actionId, key, amount } = effect.params || {};
+interface CostModParams {
+  id: string;
+  actionId: string;
+  key: ResourceKey;
+  amount: number;
+  [key: string]: unknown;
+}
+
+export const costMod: EffectHandler<CostModParams> = (effect, ctx) => {
+  const { id, actionId, key, amount } = effect.params || ({} as CostModParams);
   if (!id || !actionId || !key || amount === undefined) {
     throw new Error('cost_mod requires id, actionId, key, amount');
   }
   if (effect.method === 'add') {
     ctx.passives.registerCostModifier(id, (act, costs) => {
       if (act === actionId) {
-        const k = key as ResourceKey;
-        const current = costs[k] || 0;
-        return { ...costs, [k]: current + (amount as number) };
+        const current = costs[key] || 0;
+        return { ...costs, [key]: current + amount };
       }
       return costs;
     });

--- a/packages/engine/src/effects/index.ts
+++ b/packages/engine/src/effects/index.ts
@@ -27,7 +27,9 @@ export interface EffectDef<
   round?: 'up' | 'down';
 }
 
-export interface EffectHandler<P extends Record<string, unknown> = any> {
+export interface EffectHandler<
+  P extends Record<string, unknown> = Record<string, unknown>,
+> {
   (effect: EffectDef<P>, ctx: EngineContext, mult: number): void;
 }
 

--- a/packages/engine/src/effects/land_add.ts
+++ b/packages/engine/src/effects/land_add.ts
@@ -1,8 +1,17 @@
 import { Land } from '../state';
 import type { EffectHandler } from '.';
 
-export const landAdd: EffectHandler = (effect, ctx, mult = 1) => {
-  const count = Math.floor((effect.params?.['count'] ?? 1) * mult);
+interface LandAddParams {
+  count?: number;
+  [key: string]: unknown;
+}
+
+export const landAdd: EffectHandler<LandAddParams> = (
+  effect,
+  ctx,
+  mult = 1,
+) => {
+  const count = Math.floor(((effect.params?.count ?? 1) as number) * mult);
   for (let i = 0; i < count; i++) {
     const land = new Land(
       `${ctx.activePlayer.id}-L${ctx.activePlayer.lands.length + 1}`,

--- a/packages/engine/src/effects/result_mod.ts
+++ b/packages/engine/src/effects/result_mod.ts
@@ -1,8 +1,14 @@
 import type { EffectHandler } from '.';
 import { runEffects } from '.';
 
-export const resultMod: EffectHandler = (effect, ctx) => {
-  const { id, actionId } = effect.params || {};
+interface ResultModParams {
+  id: string;
+  actionId: string;
+  [key: string]: unknown;
+}
+
+export const resultMod: EffectHandler<ResultModParams> = (effect, ctx) => {
+  const { id, actionId } = effect.params || ({} as ResultModParams);
   if (!id || !actionId) throw new Error('result_mod requires id and actionId');
   if (effect.method === 'add') {
     const effects = effect.effects || [];

--- a/packages/engine/src/evaluators/index.ts
+++ b/packages/engine/src/evaluators/index.ts
@@ -10,7 +10,7 @@ export interface EvaluatorDef<
 }
 
 export interface EvaluatorHandler<
-  R = any,
+  R = unknown,
   P extends Record<string, unknown> = Record<string, unknown>,
 > {
   (def: EvaluatorDef<P>, ctx: EngineContext): R;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -103,12 +103,12 @@ function pay(costs: CostBag, player: PlayerState) {
 
 type ActionParamMap = {
   develop: { id: string; landId: string };
-  [key: string]: Record<string, any>;
+  [key: string]: Record<string, unknown>;
 };
 
 export type ActionParams<T extends string> = T extends keyof ActionParamMap
   ? ActionParamMap[T]
-  : Record<string, any>;
+  : Record<string, unknown>;
 
 export function performAction<T extends string>(
   actionId: T,

--- a/packages/engine/tests/actions/build_town_charter.test.ts
+++ b/packages/engine/tests/actions/build_town_charter.test.ts
@@ -14,9 +14,9 @@ import { applyParamsToEffects } from '../../src/utils.ts';
 
 function clonePlayer(p: PlayerState): PlayerState {
   const copy = new PlayerState(p.id, p.name);
-  copy.resources = { ...p.resources } as any;
-  copy.stats = { ...p.stats } as any;
-  copy.population = { ...p.population } as any;
+  copy.resources = { ...p.resources };
+  copy.stats = { ...p.stats };
+  copy.population = { ...p.population };
   copy.lands = p.lands.map((l) => {
     const land = new Land(l.id, l.slotsMax);
     land.slotsUsed = l.slotsUsed;

--- a/packages/engine/tests/actions/develop.test.ts
+++ b/packages/engine/tests/actions/develop.test.ts
@@ -15,9 +15,9 @@ import { applyParamsToEffects } from '../../src/utils.ts';
 
 function clonePlayer(p: PlayerState): PlayerState {
   const copy = new PlayerState(p.id, p.name);
-  copy.resources = { ...p.resources } as any;
-  copy.stats = { ...p.stats } as any;
-  copy.population = { ...p.population } as any;
+  copy.resources = { ...p.resources };
+  copy.stats = { ...p.stats };
+  copy.population = { ...p.population };
   copy.lands = p.lands.map((l) => {
     const land = new Land(l.id, l.slotsMax);
     land.slotsUsed = l.slotsUsed;

--- a/packages/engine/tests/effects/add_development.test.ts
+++ b/packages/engine/tests/effects/add_development.test.ts
@@ -56,9 +56,9 @@ actions.add('build_house_full', {
 
 function clonePlayer(p: PlayerState): PlayerState {
   const copy = new PlayerState(p.id, p.name);
-  copy.resources = { ...p.resources } as any;
-  copy.stats = { ...p.stats } as any;
-  copy.population = { ...p.population } as any;
+  copy.resources = { ...p.resources };
+  copy.stats = { ...p.stats };
+  copy.population = { ...p.population };
   copy.lands = p.lands.map((l) => {
     const land = new Land(l.id, l.slotsMax);
     land.slotsUsed = l.slotsUsed;


### PR DESCRIPTION
## Summary
- enable `@typescript-eslint/no-explicit-any` and fix all violations
- tighten effect and evaluator typings
- remove `any` casts in tests and engine helpers

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af6d1c95948325be6a46d17d356b2e