### PR TITLE
chore: enforce lint and type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
             ${{ runner.os }}-playwright-
       - run: npm ci
       - run: npm run format --check
+      - run: npm run lint
       - run: npm run type-check
       - run: npm test
 
@@ -54,6 +55,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run format --check
-      - run: npm test
+      - run: npm run lint
       - run: npm run type-check
+      - run: npm test
       - run: npm run build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,9 +6,7 @@ set -e
 # Run lint-staged on changed files
 npx lint-staged
 
-# Run project-wide checks
-npm run lint
-npm run type-check
+# Run tests after lint-staged passes
 npm test
 if [ -n "$SONAR_TOKEN" ]; then
   npx sonar-scanner -Dsonar.token=$SONAR_TOKEN

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx",
     "type-check": "tsc --noEmit",
-    "test": "npm run lint && vitest run",
-    "test:coverage": "npm run lint && vitest run --coverage",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "e2e": "playwright test",
     "format": "prettier .",
     "prepare": "husky install"
@@ -42,6 +42,8 @@
     "vitest": "^3.2.4"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,json,md}": "prettier --write"
+    "*.{js,jsx,ts,tsx,json,md}": "prettier --write",
+    "*.{js,jsx,ts,tsx}": "eslint --max-warnings=0",
+    "*.{ts,tsx}": "bash -c 'tsc --noEmit'"
   }
 }


### PR DESCRIPTION
## Summary
- run ESLint and type checking as part of lint-staged and pre-commit
- verify CI runs lint, type-check, tests and e2e suite

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af70733c988325abd84ea4a7503795