### PR TITLE
refactor: clarify naming and document code standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Full game information can be read below.
 
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- [CODE_STANDARDS.md](docs/CODE_STANDARDS.md)
 
 # Abstraction guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 Thanks for your interest in improving Kingdom Builder! This guide describes the
 workflow for contributors so that changes remain consistent and easy to review.
 
+Please also review our [Code Standards](docs/CODE_STANDARDS.md) for naming and
+style conventions used throughout the repository.
+
 ## Development Setup
 
 1. Install [Node.js](https://nodejs.org/) **18 or newer**.

--- a/docs/CODE_STANDARDS.md
+++ b/docs/CODE_STANDARDS.md
@@ -1,0 +1,27 @@
+# Code Standards
+
+This project follows a few simple conventions to keep the codebase readable and
+maintainable.
+
+## Naming
+
+- Use **descriptive names** for variables, functions, classes and files.
+  - Avoid one-letter identifiers except for well known generic type parameters.
+  - Abbreviations should be expanded (`populationDefinition` instead of `def`).
+- Variables and functions use `camelCase`; classes and types use `PascalCase`.
+
+## Style
+
+- The repository is formatted with Prettier; run `npm run lint` to format code.
+- Prefer clarity over brevity and keep functions focused on a single task.
+- Derive values from configuration or registries rather than hard coding
+  numbers in tests.
+
+## Testing
+
+- Unit tests live under `packages/engine/tests`.
+- Integration tests live under `tests/integration`.
+- End-to-end tests live under `e2e`.
+- Run `npm test`, `npm run e2e` and `npm run build` before committing.
+
+These standards help ensure consistent contributions across the repository.

--- a/packages/engine/src/config/builders.ts
+++ b/packages/engine/src/config/builders.ts
@@ -9,12 +9,12 @@ import type {
 import type { ResourceKey } from '../state';
 
 class BaseBuilder<T extends { id: string; name: string }> {
-  protected cfg: T;
+  protected config: T;
   constructor(id: string, name: string, base: Omit<T, 'id' | 'name'>) {
-    this.cfg = { id, name, ...base } as T;
+    this.config = { id, name, ...base } as T;
   }
   build(): T {
-    return this.cfg;
+    return this.config;
   }
 }
 
@@ -23,17 +23,17 @@ export class ActionBuilder extends BaseBuilder<ActionConfig> {
     super(id, name, { effects: [] });
   }
   cost(key: ResourceKey, amount: number) {
-    this.cfg.baseCosts = this.cfg.baseCosts || {};
-    this.cfg.baseCosts[key] = amount;
+    this.config.baseCosts = this.config.baseCosts || {};
+    this.config.baseCosts[key] = amount;
     return this;
   }
   requirement(req: RequirementFn) {
-    this.cfg.requirements = this.cfg.requirements || [];
-    this.cfg.requirements.push(req);
+    this.config.requirements = this.config.requirements || [];
+    this.config.requirements.push(req);
     return this;
   }
   effect(effect: EffectConfig) {
-    this.cfg.effects.push(effect);
+    this.config.effects.push(effect);
     return this;
   }
 }
@@ -43,26 +43,26 @@ export class BuildingBuilder extends BaseBuilder<BuildingConfig> {
     super(id, name, { costs: {}, onBuild: [] });
   }
   cost(key: ResourceKey, amount: number) {
-    this.cfg.costs[key] = amount;
+    this.config.costs[key] = amount;
     return this;
   }
   onBuild(effect: EffectConfig) {
-    this.cfg.onBuild!.push(effect);
+    this.config.onBuild!.push(effect);
     return this;
   }
   onDevelopmentPhase(effect: EffectConfig) {
-    this.cfg.onDevelopmentPhase = this.cfg.onDevelopmentPhase || [];
-    this.cfg.onDevelopmentPhase.push(effect);
+    this.config.onDevelopmentPhase = this.config.onDevelopmentPhase || [];
+    this.config.onDevelopmentPhase.push(effect);
     return this;
   }
   onUpkeepPhase(effect: EffectConfig) {
-    this.cfg.onUpkeepPhase = this.cfg.onUpkeepPhase || [];
-    this.cfg.onUpkeepPhase.push(effect);
+    this.config.onUpkeepPhase = this.config.onUpkeepPhase || [];
+    this.config.onUpkeepPhase.push(effect);
     return this;
   }
   onAttackResolved(effect: EffectConfig) {
-    this.cfg.onAttackResolved = this.cfg.onAttackResolved || [];
-    this.cfg.onAttackResolved.push(effect);
+    this.config.onAttackResolved = this.config.onAttackResolved || [];
+    this.config.onAttackResolved.push(effect);
     return this;
   }
 }
@@ -72,18 +72,18 @@ export class DevelopmentBuilder extends BaseBuilder<DevelopmentConfig> {
     super(id, name, {});
   }
   onBuild(effect: EffectConfig) {
-    this.cfg.onBuild = this.cfg.onBuild || [];
-    this.cfg.onBuild.push(effect);
+    this.config.onBuild = this.config.onBuild || [];
+    this.config.onBuild.push(effect);
     return this;
   }
   onDevelopmentPhase(effect: EffectConfig) {
-    this.cfg.onDevelopmentPhase = this.cfg.onDevelopmentPhase || [];
-    this.cfg.onDevelopmentPhase.push(effect);
+    this.config.onDevelopmentPhase = this.config.onDevelopmentPhase || [];
+    this.config.onDevelopmentPhase.push(effect);
     return this;
   }
   onAttackResolved(effect: EffectConfig) {
-    this.cfg.onAttackResolved = this.cfg.onAttackResolved || [];
-    this.cfg.onAttackResolved.push(effect);
+    this.config.onAttackResolved = this.config.onAttackResolved || [];
+    this.config.onAttackResolved.push(effect);
     return this;
   }
 }
@@ -93,13 +93,13 @@ export class PopulationBuilder extends BaseBuilder<PopulationConfig> {
     super(id, name, {});
   }
   onDevelopmentPhase(effect: EffectConfig) {
-    this.cfg.onDevelopmentPhase = this.cfg.onDevelopmentPhase || [];
-    this.cfg.onDevelopmentPhase.push(effect);
+    this.config.onDevelopmentPhase = this.config.onDevelopmentPhase || [];
+    this.config.onDevelopmentPhase.push(effect);
     return this;
   }
   onUpkeepPhase(effect: EffectConfig) {
-    this.cfg.onUpkeepPhase = this.cfg.onUpkeepPhase || [];
-    this.cfg.onUpkeepPhase.push(effect);
+    this.config.onUpkeepPhase = this.config.onUpkeepPhase || [];
+    this.config.onUpkeepPhase.push(effect);
     return this;
   }
 }

--- a/packages/engine/src/content/actions.ts
+++ b/packages/engine/src/content/actions.ts
@@ -6,9 +6,9 @@ import { action } from '../config/builders';
 export type ActionDef = ActionConfig;
 
 export function createActionRegistry() {
-  const reg = new Registry<ActionDef>(actionSchema);
+  const registry = new Registry<ActionDef>(actionSchema);
 
-  reg.add(
+  registry.add(
     'expand',
     action('expand', 'Expand')
       .cost(Resource.gold, 2)
@@ -22,7 +22,7 @@ export function createActionRegistry() {
   );
 
   // A simple build action to acquire Town Charter in tests
-  reg.add(
+  registry.add(
     'build_town_charter',
     action('build_town_charter', 'Build — Town Charter')
       .cost(Resource.gold, 5)
@@ -34,7 +34,7 @@ export function createActionRegistry() {
       .build(),
   );
 
-  reg.add(
+  registry.add(
     'overwork',
     action('overwork', 'Overwork')
       .cost(Resource.ap, 0)
@@ -58,7 +58,7 @@ export function createActionRegistry() {
       .build(),
   );
 
-  reg.add(
+  registry.add(
     'develop',
     action('develop', 'Develop')
       .cost(Resource.gold, 3)
@@ -70,38 +70,38 @@ export function createActionRegistry() {
       .build(),
   );
 
-  reg.add('tax', action('tax', 'Tax').cost(Resource.ap, 0).build());
+  registry.add('tax', action('tax', 'Tax').cost(Resource.ap, 0).build());
 
-  reg.add(
+  registry.add(
     'reallocate',
     action('reallocate', 'Reallocate').cost(Resource.gold, 5).build(),
   );
 
-  reg.add(
+  registry.add(
     'raise_pop',
     action('raise_pop', 'Raise Population').cost(Resource.gold, 5).build(),
   );
 
-  reg.add(
+  registry.add(
     'royal_decree',
     action('royal_decree', 'Royal Decree').cost(Resource.gold, 12).build(),
   );
 
-  reg.add(
+  registry.add(
     'army_attack',
     action('army_attack', 'Army Attack').cost(Resource.ap, 0).build(),
   );
 
-  reg.add(
+  registry.add(
     'hold_festival',
     action('hold_festival', 'Hold Festival').cost(Resource.gold, 3).build(),
   );
 
-  reg.add('plow', action('plow', 'Plow').cost(Resource.gold, 6).build());
+  registry.add('plow', action('plow', 'Plow').cost(Resource.gold, 6).build());
 
-  reg.add('build', action('build', 'Build').build());
+  registry.add('build', action('build', 'Build').build());
 
-  return reg;
+  return registry;
 }
 
 export const ACTIONS = createActionRegistry();

--- a/packages/engine/src/content/buildings.ts
+++ b/packages/engine/src/content/buildings.ts
@@ -7,9 +7,9 @@ import type { BuildingDef } from './defs';
 export type { BuildingDef } from './defs';
 
 export function createBuildingRegistry() {
-  const reg = new Registry<BuildingDef>(buildingSchema);
+  const registry = new Registry<BuildingDef>(buildingSchema);
 
-  reg.add(
+  registry.add(
     'town_charter',
     building('town_charter', 'Town Charter')
       .cost(Resource.gold, 5)
@@ -46,51 +46,51 @@ export function createBuildingRegistry() {
   );
 
   // TODO: remaining buildings from original manual config
-  reg.add('mill', building('mill', 'Mill').cost(Resource.gold, 7).build());
-  reg.add(
+  registry.add('mill', building('mill', 'Mill').cost(Resource.gold, 7).build());
+  registry.add(
     'raiders_guild',
     building('raiders_guild', "Raider's Guild").cost(Resource.gold, 8).build(),
   );
-  reg.add(
+  registry.add(
     'plow_workshop',
     building('plow_workshop', 'Plow Workshop').cost(Resource.gold, 10).build(),
   );
-  reg.add(
+  registry.add(
     'market',
     building('market', 'Market').cost(Resource.gold, 10).build(),
   );
-  reg.add(
+  registry.add(
     'barracks',
     building('barracks', 'Barracks').cost(Resource.gold, 12).build(),
   );
-  reg.add(
+  registry.add(
     'citadel',
     building('citadel', 'Citadel').cost(Resource.gold, 12).build(),
   );
-  reg.add(
+  registry.add(
     'castle_walls',
     building('castle_walls', 'Castle Walls').cost(Resource.gold, 14).build(),
   );
-  reg.add(
+  registry.add(
     'castle_gardens',
     building('castle_gardens', 'Castle Gardens')
       .cost(Resource.gold, 15)
       .build(),
   );
-  reg.add(
+  registry.add(
     'temple',
     building('temple', 'Temple').cost(Resource.gold, 16).build(),
   );
-  reg.add(
+  registry.add(
     'palace',
     building('palace', 'Palace').cost(Resource.gold, 20).build(),
   );
-  reg.add(
+  registry.add(
     'great_hall',
     building('great_hall', 'Great Hall').cost(Resource.gold, 22).build(),
   );
 
-  return reg;
+  return registry;
 }
 
 export const BUILDINGS = createBuildingRegistry();

--- a/packages/engine/src/content/developments.ts
+++ b/packages/engine/src/content/developments.ts
@@ -7,9 +7,9 @@ import type { DevelopmentDef } from './defs';
 export type { DevelopmentDef } from './defs';
 
 export function createDevelopmentRegistry() {
-  const reg = new Registry<DevelopmentDef>(developmentSchema);
+  const registry = new Registry<DevelopmentDef>(developmentSchema);
 
-  reg.add(
+  registry.add(
     'farm',
     development('farm', 'Farm')
       .onDevelopmentPhase({
@@ -20,7 +20,7 @@ export function createDevelopmentRegistry() {
       .build(),
   );
 
-  reg.add(
+  registry.add(
     'house',
     development('house', 'House')
       .onBuild({
@@ -31,7 +31,7 @@ export function createDevelopmentRegistry() {
       .build(),
   );
 
-  reg.add(
+  registry.add(
     'outpost',
     development('outpost', 'Outpost')
       .onBuild({
@@ -47,7 +47,7 @@ export function createDevelopmentRegistry() {
       .build(),
   );
 
-  reg.add(
+  registry.add(
     'watchtower',
     development('watchtower', 'Watchtower')
       .onBuild({
@@ -80,7 +80,7 @@ export function createDevelopmentRegistry() {
       .build(),
   );
 
-  return reg;
+  return registry;
 }
 
 export const DEVELOPMENTS = createDevelopmentRegistry();

--- a/packages/engine/src/content/populations.ts
+++ b/packages/engine/src/content/populations.ts
@@ -7,9 +7,9 @@ import type { PopulationDef } from './defs';
 export type { PopulationDef } from './defs';
 
 export function createPopulationRegistry() {
-  const reg = new Registry<PopulationDef>(populationSchema);
+  const registry = new Registry<PopulationDef>(populationSchema);
 
-  reg.add(
+  registry.add(
     PopulationRole.Council,
     population(PopulationRole.Council, 'Council')
       .onDevelopmentPhase({
@@ -25,7 +25,7 @@ export function createPopulationRegistry() {
       .build(),
   );
 
-  reg.add(
+  registry.add(
     PopulationRole.Commander,
     population(PopulationRole.Commander, 'Army Commander')
       .onDevelopmentPhase({
@@ -41,7 +41,7 @@ export function createPopulationRegistry() {
       .build(),
   );
 
-  reg.add(
+  registry.add(
     PopulationRole.Fortifier,
     population(PopulationRole.Fortifier, 'Fortifier')
       .onDevelopmentPhase({
@@ -57,12 +57,12 @@ export function createPopulationRegistry() {
       .build(),
   );
 
-  reg.add(
+  registry.add(
     PopulationRole.Citizen,
     population(PopulationRole.Citizen, 'Citizen').build(),
   );
 
-  return reg;
+  return registry;
 }
 
 export const POPULATIONS = createPopulationRegistry();

--- a/packages/engine/src/effects/building_add.ts
+++ b/packages/engine/src/effects/building_add.ts
@@ -3,9 +3,9 @@ import { runEffects } from '.';
 
 export const buildingAdd: EffectHandler = (effect, ctx, mult = 1) => {
   const id = effect.params!['id'] as string;
-  for (let i = 0; i < Math.floor(mult); i++) {
+  for (let index = 0; index < Math.floor(mult); index++) {
     ctx.activePlayer.buildings.add(id);
-    const b = ctx.buildings.get(id);
-    if (b.onBuild) runEffects(b.onBuild, ctx);
+    const building = ctx.buildings.get(id);
+    if (building.onBuild) runEffects(building.onBuild, ctx);
   }
 };

--- a/packages/engine/src/effects/cost_mod.ts
+++ b/packages/engine/src/effects/cost_mod.ts
@@ -15,8 +15,8 @@ export const costMod: EffectHandler<CostModParams> = (effect, ctx) => {
     throw new Error('cost_mod requires id, actionId, key, amount');
   }
   if (effect.method === 'add') {
-    ctx.passives.registerCostModifier(id, (act, costs) => {
-      if (act === actionId) {
+    ctx.passives.registerCostModifier(id, (targetActionId, costs) => {
+      if (targetActionId === actionId) {
         const current = costs[key] || 0;
         return { ...costs, [key]: current + amount };
       }

--- a/packages/engine/src/effects/development_add.ts
+++ b/packages/engine/src/effects/development_add.ts
@@ -6,16 +6,21 @@ export const developmentAdd: EffectHandler = (effect, ctx, mult = 1) => {
   const id = effect.params?.['id'] as string;
   const landId = effect.params?.['landId'] as string;
   if (!id || !landId) throw new Error('development:add requires id and landId');
-  const land = ctx.activePlayer.lands.find((l) => l.id === landId);
+  const land = ctx.activePlayer.lands.find(
+    (landItem) => landItem.id === landId,
+  );
   if (!land) throw new Error(`Land ${landId} not found`);
   const iterations = Math.floor(mult);
-  for (let i = 0; i < iterations; i++) {
+  for (let index = 0; index < iterations; index++) {
     if (land.slotsUsed >= land.slotsMax)
       throw new Error(`No free slots on land ${landId}`);
     land.developments.push(id);
     land.slotsUsed += 1;
-    const def = ctx.developments.get(id);
-    if (def?.onBuild)
-      runEffects(applyParamsToEffects(def.onBuild, { landId, id }), ctx);
+    const developmentDefinition = ctx.developments.get(id);
+    if (developmentDefinition?.onBuild)
+      runEffects(
+        applyParamsToEffects(developmentDefinition.onBuild, { landId, id }),
+        ctx,
+      );
   }
 };

--- a/packages/engine/src/effects/development_remove.ts
+++ b/packages/engine/src/effects/development_remove.ts
@@ -5,13 +5,15 @@ export const developmentRemove: EffectHandler = (effect, ctx, mult = 1) => {
   const landId = effect.params?.['landId'] as string;
   if (!id || !landId)
     throw new Error('development:remove requires id and landId');
-  const land = ctx.activePlayer.lands.find((l) => l.id === landId);
+  const land = ctx.activePlayer.lands.find(
+    (landState) => landState.id === landId,
+  );
   if (!land) throw new Error(`Land ${landId} not found`);
   const iterations = Math.floor(mult);
-  for (let i = 0; i < iterations; i++) {
-    const idx = land.developments.indexOf(id);
-    if (idx === -1) break;
-    land.developments.splice(idx, 1);
+  for (let index = 0; index < iterations; index++) {
+    const developmentIndex = land.developments.indexOf(id);
+    if (developmentIndex === -1) break;
+    land.developments.splice(developmentIndex, 1);
     land.slotsUsed = Math.max(0, land.slotsUsed - 1);
   }
 };

--- a/packages/engine/src/effects/index.ts
+++ b/packages/engine/src/effects/index.ts
@@ -57,14 +57,14 @@ export function registerCoreEffects(registry: EffectRegistry = EFFECTS) {
 }
 
 export function runEffects(effects: EffectDef[], ctx: EngineContext, mult = 1) {
-  for (const e of effects) {
-    if (e.evaluator) {
-      const ev = EVALUATORS.get(e.evaluator.type);
-      const count = ev(e.evaluator, ctx);
-      runEffects(e.effects || [], ctx, mult * (count as number));
-    } else if (e.type && e.method) {
-      const handler = EFFECTS.get(`${e.type}:${e.method}`);
-      handler(e, ctx, mult);
+  for (const effect of effects) {
+    if (effect.evaluator) {
+      const evaluatorHandler = EVALUATORS.get(effect.evaluator.type);
+      const count = evaluatorHandler(effect.evaluator, ctx);
+      runEffects(effect.effects || [], ctx, mult * (count as number));
+    } else if (effect.type && effect.method) {
+      const handler = EFFECTS.get(`${effect.type}:${effect.method}`);
+      handler(effect, ctx, mult);
     }
   }
 }

--- a/packages/engine/src/effects/land_add.ts
+++ b/packages/engine/src/effects/land_add.ts
@@ -12,7 +12,7 @@ export const landAdd: EffectHandler<LandAddParams> = (
   mult = 1,
 ) => {
   const count = Math.floor(Number(effect.params?.count ?? 1) * mult);
-  for (let i = 0; i < count; i++) {
+  for (let index = 0; index < count; index++) {
     const land = new Land(
       `${ctx.activePlayer.id}-L${ctx.activePlayer.lands.length + 1}`,
       ctx.services.rules.slotsPerNewLand,

--- a/packages/engine/src/effects/land_till.ts
+++ b/packages/engine/src/effects/land_till.ts
@@ -3,10 +3,12 @@ import type { EffectHandler } from '.';
 export const landTill: EffectHandler = (effect, ctx, mult = 1) => {
   const landId = effect.params?.['landId'] as string;
   if (!landId) throw new Error('land:till requires landId');
-  const land = ctx.activePlayer.lands.find((l) => l.id === landId);
+  const land = ctx.activePlayer.lands.find(
+    (landState) => landState.id === landId,
+  );
   if (!land) throw new Error(`Land ${landId} not found`);
   const max = ctx.services.rules.maxSlotsPerLand;
-  for (let i = 0; i < Math.floor(mult); i++) {
+  for (let index = 0; index < Math.floor(mult); index++) {
     land.slotsMax = Math.min(land.slotsMax + 1, max);
   }
 };

--- a/packages/engine/src/effects/passive_add.ts
+++ b/packages/engine/src/effects/passive_add.ts
@@ -4,7 +4,7 @@ export const passiveAdd: EffectHandler = (effect, ctx, mult = 1) => {
   const id = effect.params?.['id'] as string;
   if (!id) throw new Error('passive:add requires id');
   const passive = { id, effects: effect.effects || [] };
-  for (let i = 0; i < Math.floor(mult); i++) {
+  for (let index = 0; index < Math.floor(mult); index++) {
     ctx.passives.addPassive(passive, ctx);
   }
 };

--- a/packages/engine/src/effects/passive_remove.ts
+++ b/packages/engine/src/effects/passive_remove.ts
@@ -3,7 +3,7 @@ import type { EffectHandler } from '.';
 export const passiveRemove: EffectHandler = (effect, ctx, mult = 1) => {
   const id = effect.params?.['id'] as string;
   if (!id) throw new Error('passive:remove requires id');
-  for (let i = 0; i < Math.floor(mult); i++) {
+  for (let index = 0; index < Math.floor(mult); index++) {
     ctx.passives.removePassive(id, ctx);
   }
 };

--- a/packages/engine/src/effects/result_mod.ts
+++ b/packages/engine/src/effects/result_mod.ts
@@ -12,11 +12,14 @@ export const resultMod: EffectHandler<ResultModParams> = (effect, ctx) => {
   if (!id || !actionId) throw new Error('result_mod requires id and actionId');
   if (effect.method === 'add') {
     const effects = effect.effects || [];
-    ctx.passives.registerResultModifier(id, (act, innerCtx) => {
-      if (act === actionId) {
-        runEffects(effects, innerCtx);
-      }
-    });
+    ctx.passives.registerResultModifier(
+      id,
+      (executedActionId, innerContext) => {
+        if (executedActionId === actionId) {
+          runEffects(effects, innerContext);
+        }
+      },
+    );
   } else if (effect.method === 'remove') {
     ctx.passives.unregisterResultModifier(id);
   }

--- a/packages/engine/src/evaluators/development.ts
+++ b/packages/engine/src/evaluators/development.ts
@@ -8,10 +8,12 @@ export interface DevelopmentEvaluatorParams extends Record<string, unknown> {
 export const developmentEvaluator: EvaluatorHandler<
   number,
   DevelopmentEvaluatorParams
-> = (def, ctx: EngineContext) => {
-  const { id } = def.params!;
+> = (definition, ctx: EngineContext) => {
+  const { id } = definition.params!;
   return ctx.activePlayer.lands.reduce(
-    (total, land) => total + land.developments.filter((d) => d === id).length,
+    (total, land) =>
+      total +
+      land.developments.filter((development) => development === id).length,
     0,
   );
 };

--- a/packages/engine/src/evaluators/index.ts
+++ b/packages/engine/src/evaluators/index.ts
@@ -13,7 +13,7 @@ export interface EvaluatorHandler<
   R = unknown,
   P extends Record<string, unknown> = Record<string, unknown>,
 > {
-  (def: EvaluatorDef<P>, ctx: EngineContext): R;
+  (definition: EvaluatorDef<P>, ctx: EngineContext): R;
 }
 
 export class EvaluatorRegistry extends Registry<EvaluatorHandler> {}

--- a/packages/engine/src/registry.ts
+++ b/packages/engine/src/registry.ts
@@ -3,13 +3,13 @@ import type { ZodType } from 'zod';
 export class Registry<T> {
   private map = new Map<string, T>();
   constructor(private schema?: ZodType<T>) {}
-  add(id: string, v: unknown) {
-    const value = this.schema ? this.schema.parse(v) : (v as T);
+  add(id: string, rawValue: unknown) {
+    const value = this.schema ? this.schema.parse(rawValue) : (rawValue as T);
     this.map.set(id, value);
   }
   get(id: string): T {
-    const v = this.map.get(id);
-    if (!v) throw new Error(`Unknown id: ${id}`);
-    return v;
+    const value = this.map.get(id);
+    if (!value) throw new Error(`Unknown id: ${id}`);
+    return value;
   }
 }

--- a/packages/engine/src/utils.ts
+++ b/packages/engine/src/utils.ts
@@ -6,27 +6,32 @@ export function applyParamsToEffects<E extends EffectDef>(
 ): E[] {
   const replace = (val: unknown): unknown =>
     typeof val === 'string' && val.startsWith('$') ? params[val.slice(1)] : val;
-  const mapEffect = (e: E): E => ({
-    ...e,
-    params: e.params
+  const mapEffect = (effect: E): E => ({
+    ...effect,
+    params: effect.params
       ? (Object.fromEntries(
-          Object.entries(e.params).map(([k, v]) => [k, replace(v)]),
+          Object.entries(effect.params).map(([key, value]) => [
+            key,
+            replace(value),
+          ]),
         ) as E['params'])
       : undefined,
-    evaluator: e.evaluator
+    evaluator: effect.evaluator
       ? {
-          ...e.evaluator,
-          params: e.evaluator.params
+          ...effect.evaluator,
+          params: effect.evaluator.params
             ? Object.fromEntries(
-                Object.entries(e.evaluator.params).map(([k, v]) => [
-                  k,
-                  replace(v),
+                Object.entries(effect.evaluator.params).map(([key, value]) => [
+                  key,
+                  replace(value),
                 ]),
               )
             : undefined,
         }
       : undefined,
-    effects: e.effects ? applyParamsToEffects(e.effects, params) : undefined,
+    effects: effect.effects
+      ? applyParamsToEffects(effect.effects, params)
+      : undefined,
   });
   return effects.map(mapEffect);
 }

--- a/packages/engine/tests/actions/action-config.test.ts
+++ b/packages/engine/tests/actions/action-config.test.ts
@@ -13,16 +13,16 @@ function getExpandExpectations(ctx: EngineContext) {
   const expandDef = ctx.actions.get('expand');
   const costs = getActionCosts('expand', ctx);
   const landGain = expandDef.effects
-    .filter((e) => e.type === 'land' && e.method === 'add')
-    .reduce((sum, e) => sum + Number(e.params?.count ?? 0), 0);
+    .filter((effect) => effect.type === 'land' && effect.method === 'add')
+    .reduce((sum, effect) => sum + Number(effect.params?.count ?? 0), 0);
   const baseHappiness = expandDef.effects
     .filter(
-      (e) =>
-        e.type === 'resource' &&
-        e.method === 'add' &&
-        e.params?.key === Resource.happiness,
+      (effect) =>
+        effect.type === 'resource' &&
+        effect.method === 'add' &&
+        effect.params?.key === Resource.happiness,
     )
-    .reduce((sum, e) => sum + Number(e.params?.amount ?? 0), 0);
+    .reduce((sum, effect) => sum + Number(effect.params?.amount ?? 0), 0);
   const dummyCtx = { activePlayer: { happiness: 0 } } as EngineContext;
   ctx.passives.runResultMods(expandDef.id, dummyCtx);
   const extraHappiness = dummyCtx.activePlayer.happiness;

--- a/packages/engine/tests/actions/build_town_charter.test.ts
+++ b/packages/engine/tests/actions/build_town_charter.test.ts
@@ -13,18 +13,18 @@ import { PlayerState, Land, GameState } from '../../src/state/index.ts';
 import { runEffects } from '../../src/effects/index.ts';
 import { applyParamsToEffects } from '../../src/utils.ts';
 
-function clonePlayer(p: PlayerState): PlayerState {
-  const copy = new PlayerState(p.id, p.name);
-  copy.resources = { ...p.resources };
-  copy.stats = { ...p.stats };
-  copy.population = { ...p.population };
-  copy.lands = p.lands.map((l) => {
-    const land = new Land(l.id, l.slotsMax);
-    land.slotsUsed = l.slotsUsed;
-    land.developments = [...l.developments];
+function clonePlayer(player: PlayerState): PlayerState {
+  const copy = new PlayerState(player.id, player.name);
+  copy.resources = { ...player.resources };
+  copy.stats = { ...player.stats };
+  copy.population = { ...player.population };
+  copy.lands = player.lands.map((landState) => {
+    const land = new Land(landState.id, landState.slotsMax);
+    land.slotsUsed = landState.slotsUsed;
+    land.developments = [...landState.developments];
     return land;
   });
-  copy.buildings = new Set(p.buildings);
+  copy.buildings = new Set(player.buildings);
   return copy;
 }
 
@@ -56,11 +56,11 @@ describe('Build Town Charter action', () => {
       ctx.populations,
       new PassiveManager(),
     );
-    for (const [k, v] of Object.entries(buildCost)) {
-      sim.activePlayer.resources[k as ResourceKey] -= v;
+    for (const [resourceKey, cost] of Object.entries(buildCost)) {
+      sim.activePlayer.resources[resourceKey as ResourceKey] -= cost;
     }
-    const def = ctx.actions.get('build_town_charter');
-    runEffects(applyParamsToEffects(def.effects, {}), sim);
+    const actionDefinition = ctx.actions.get('build_town_charter');
+    runEffects(applyParamsToEffects(actionDefinition.effects, {}), sim);
 
     const expectedCost = getActionCosts('expand', sim);
 

--- a/packages/engine/tests/actions/multi_cost.test.ts
+++ b/packages/engine/tests/actions/multi_cost.test.ts
@@ -10,7 +10,7 @@ import { action, building } from '../../src/config/builders.ts';
 
 describe('multi-cost content', () => {
   it('supports actions with multiple costs', () => {
-    const multi = action('multi_cost_action', 'Multi Cost Action')
+    const multiCostAction = action('multi_cost_action', 'Multi Cost Action')
       .cost(Resource.gold, 3)
       .cost(Resource.happiness, 2)
       .effect({
@@ -20,7 +20,7 @@ describe('multi-cost content', () => {
       })
       .build();
 
-    const ctx = createEngine({ config: { actions: [multi] } });
+    const ctx = createEngine({ config: { actions: [multiCostAction] } });
     runDevelopment(ctx);
 
     ctx.activePlayer.gold = 5;
@@ -36,12 +36,18 @@ describe('multi-cost content', () => {
   });
 
   it('supports building actions with multiple costs', () => {
-    const bld = building('multi_cost_building', 'Multi Cost Building')
+    const multiCostBuildingDefinition = building(
+      'multi_cost_building',
+      'Multi Cost Building',
+    )
       .cost(Resource.gold, 4)
       .cost(Resource.happiness, 1)
       .build();
 
-    const act = action('build_multi_cost_building', 'Build Multi Cost Building')
+    const buildAction = action(
+      'build_multi_cost_building',
+      'Build Multi Cost Building',
+    )
       .cost(Resource.gold, 4)
       .cost(Resource.happiness, 1)
       .effect({
@@ -51,7 +57,12 @@ describe('multi-cost content', () => {
       })
       .build();
 
-    const ctx = createEngine({ config: { actions: [act], buildings: [bld] } });
+    const ctx = createEngine({
+      config: {
+        actions: [buildAction],
+        buildings: [multiCostBuildingDefinition],
+      },
+    });
     runDevelopment(ctx);
 
     ctx.activePlayer.gold = 10;
@@ -65,8 +76,8 @@ describe('multi-cost content', () => {
       2 - (costs[Resource.happiness] || 0),
     );
     expect(ctx.activePlayer.buildings.has('multi_cost_building')).toBe(true);
-    const def = ctx.buildings.get('multi_cost_building');
-    expect(def.costs[Resource.gold]).toBe(4);
-    expect(def.costs[Resource.happiness]).toBe(1);
+    const buildingDefinition = ctx.buildings.get('multi_cost_building');
+    expect(buildingDefinition.costs[Resource.gold]).toBe(4);
+    expect(buildingDefinition.costs[Resource.happiness]).toBe(1);
   });
 });

--- a/packages/engine/tests/actions/overwork.test.ts
+++ b/packages/engine/tests/actions/overwork.test.ts
@@ -11,18 +11,21 @@ import type { EvaluatorDef } from '../../src/evaluators';
 import type { EngineContext } from '../../src';
 
 function getOverworkExpectations(ctx: EngineContext) {
-  const def = ctx.actions.get('overwork');
-  const container = def.effects[0];
+  const actionDefinition = ctx.actions.get('overwork');
+  const container = actionDefinition.effects[0];
   const evaluator = container.evaluator as EvaluatorDef;
   const count = EVALUATORS.get(evaluator.type)(evaluator, ctx) as number;
   const deltas: Record<string, number> = {};
-  const sub = container.effects as (EffectDef & { round?: 'up' | 'down' })[];
-  for (const e of sub) {
-    const key = e.params!.key as string;
-    let total = (e.params!.amount as number) * count;
-    const r = e.round;
-    if (r === 'up') total = total >= 0 ? Math.ceil(total) : Math.floor(total);
-    else if (r === 'down')
+  const subEffects = container.effects as (EffectDef & {
+    round?: 'up' | 'down';
+  })[];
+  for (const subEffect of subEffects) {
+    const key = subEffect.params!.key as string;
+    let total = (subEffect.params!.amount as number) * count;
+    const rounding = subEffect.round;
+    if (rounding === 'up')
+      total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+    else if (rounding === 'down')
       total = total >= 0 ? Math.floor(total) : Math.ceil(total);
     deltas[key] = total;
   }

--- a/packages/engine/tests/effects/add_stat.test.ts
+++ b/packages/engine/tests/effects/add_stat.test.ts
@@ -26,14 +26,14 @@ describe('stat:add effect', () => {
     const ctx = createEngine({ actions });
     runDevelopment(ctx);
     const before = ctx.activePlayer.armyStrength;
-    const def = actions.get('train_army');
-    const amt = def.effects.find(
-      (e) =>
-        e.type === 'stat' &&
-        e.method === 'add' &&
-        e.params?.key === Stat.armyStrength,
+    const actionDefinition = actions.get('train_army');
+    const amount = actionDefinition.effects.find(
+      (effect) =>
+        effect.type === 'stat' &&
+        effect.method === 'add' &&
+        effect.params?.key === Stat.armyStrength,
     )?.params?.amount as number;
     performAction('train_army', ctx);
-    expect(ctx.activePlayer.armyStrength).toBe(before + amt);
+    expect(ctx.activePlayer.armyStrength).toBe(before + amount);
   });
 });

--- a/packages/engine/tests/effects/resource-add.test.ts
+++ b/packages/engine/tests/effects/resource-add.test.ts
@@ -15,21 +15,25 @@ describe('resource:add effect', () => {
       name: 'Grant Gold',
       baseCosts: { [Resource.ap]: 0 },
       effects: [
-        { type: 'resource', method: 'add', params: { key: Resource.gold, amount: 3 } },
+        {
+          type: 'resource',
+          method: 'add',
+          params: { key: Resource.gold, amount: 3 },
+        },
       ],
     });
     const ctx = createEngine({ actions });
     runDevelopment(ctx);
     const before = ctx.activePlayer.gold;
-    const def = actions.get('grant_gold');
-    const amt = def.effects.find(
-      (e) =>
-        e.type === 'resource' &&
-        e.method === 'add' &&
-        e.params?.key === Resource.gold,
+    const actionDefinition = actions.get('grant_gold');
+    const amount = actionDefinition.effects.find(
+      (effect) =>
+        effect.type === 'resource' &&
+        effect.method === 'add' &&
+        effect.params?.key === Resource.gold,
     )?.params?.amount as number;
     performAction('grant_gold', ctx);
-    expect(ctx.activePlayer.gold).toBe(before + amt);
+    expect(ctx.activePlayer.gold).toBe(before + amount);
   });
 
   it('rounds fractional amounts according to round setting', () => {
@@ -64,34 +68,37 @@ describe('resource:add effect', () => {
     runDevelopment(ctx);
 
     let before = ctx.activePlayer.gold;
-    let effect = actions.get('round_up').effects.find(
-      (e) =>
-        e.type === 'resource' &&
-        e.method === 'add' &&
-        e.params?.key === Resource.gold,
-    );
-    let total = (effect?.params?.amount as number) || 0;
-    if (effect?.round === 'up')
+    let foundEffect = actions
+      .get('round_up')
+      .effects.find(
+        (effect) =>
+          effect.type === 'resource' &&
+          effect.method === 'add' &&
+          effect.params?.key === Resource.gold,
+      );
+    let total = (foundEffect?.params?.amount as number) || 0;
+    if (foundEffect?.round === 'up')
       total = total >= 0 ? Math.ceil(total) : Math.floor(total);
-    else if (effect?.round === 'down')
+    else if (foundEffect?.round === 'down')
       total = total >= 0 ? Math.floor(total) : Math.ceil(total);
     performAction('round_up', ctx);
     expect(ctx.activePlayer.gold).toBe(before + total);
 
     before = ctx.activePlayer.gold;
-    effect = actions.get('round_down').effects.find(
-      (e) =>
-        e.type === 'resource' &&
-        e.method === 'add' &&
-        e.params?.key === Resource.gold,
-    );
-    total = (effect?.params?.amount as number) || 0;
-    if (effect?.round === 'up')
+    foundEffect = actions
+      .get('round_down')
+      .effects.find(
+        (effect) =>
+          effect.type === 'resource' &&
+          effect.method === 'add' &&
+          effect.params?.key === Resource.gold,
+      );
+    total = (foundEffect?.params?.amount as number) || 0;
+    if (foundEffect?.round === 'up')
       total = total >= 0 ? Math.ceil(total) : Math.floor(total);
-    else if (effect?.round === 'down')
+    else if (foundEffect?.round === 'down')
       total = total >= 0 ? Math.floor(total) : Math.ceil(total);
     performAction('round_down', ctx);
     expect(ctx.activePlayer.gold).toBe(before + total);
   });
 });
-

--- a/packages/engine/tests/effects/resource-remove.test.ts
+++ b/packages/engine/tests/effects/resource-remove.test.ts
@@ -25,15 +25,15 @@ describe('resource:remove effect', () => {
     const ctx = createEngine({ actions });
     runDevelopment(ctx);
     const before = ctx.activePlayer.gold;
-    const def = actions.get('pay_gold');
-    const amt = def.effects.find(
-      (e) =>
-        e.type === 'resource' &&
-        e.method === 'remove' &&
-        e.params?.key === Resource.gold,
+    const actionDefinition = actions.get('pay_gold');
+    const amount = actionDefinition.effects.find(
+      (effect) =>
+        effect.type === 'resource' &&
+        effect.method === 'remove' &&
+        effect.params?.key === Resource.gold,
     )?.params?.amount as number;
     performAction('pay_gold', ctx);
-    expect(ctx.activePlayer.gold).toBe(before - amt);
+    expect(ctx.activePlayer.gold).toBe(before - amount);
   });
 
   it('rounds fractional amounts according to round setting', () => {
@@ -68,34 +68,37 @@ describe('resource:remove effect', () => {
     runDevelopment(ctx);
 
     let before = ctx.activePlayer.gold;
-    let effect = actions.get('round_up_remove').effects.find(
-      (e) =>
-        e.type === 'resource' &&
-        e.method === 'remove' &&
-        e.params?.key === Resource.gold,
-    );
-    let total = (effect?.params?.amount as number) || 0;
-    if (effect?.round === 'up')
+    let foundEffect = actions
+      .get('round_up_remove')
+      .effects.find(
+        (effect) =>
+          effect.type === 'resource' &&
+          effect.method === 'remove' &&
+          effect.params?.key === Resource.gold,
+      );
+    let total = (foundEffect?.params?.amount as number) || 0;
+    if (foundEffect?.round === 'up')
       total = total >= 0 ? Math.ceil(total) : Math.floor(total);
-    else if (effect?.round === 'down')
+    else if (foundEffect?.round === 'down')
       total = total >= 0 ? Math.floor(total) : Math.ceil(total);
     performAction('round_up_remove', ctx);
     expect(ctx.activePlayer.gold).toBe(before - total);
 
     before = ctx.activePlayer.gold;
-    effect = actions.get('round_down_remove').effects.find(
-      (e) =>
-        e.type === 'resource' &&
-        e.method === 'remove' &&
-        e.params?.key === Resource.gold,
-    );
-    total = (effect?.params?.amount as number) || 0;
-    if (effect?.round === 'up')
+    foundEffect = actions
+      .get('round_down_remove')
+      .effects.find(
+        (effect) =>
+          effect.type === 'resource' &&
+          effect.method === 'remove' &&
+          effect.params?.key === Resource.gold,
+      );
+    total = (foundEffect?.params?.amount as number) || 0;
+    if (foundEffect?.round === 'up')
       total = total >= 0 ? Math.ceil(total) : Math.floor(total);
-    else if (effect?.round === 'down')
+    else if (foundEffect?.round === 'down')
       total = total >= 0 ? Math.floor(total) : Math.ceil(total);
     performAction('round_down_remove', ctx);
     expect(ctx.activePlayer.gold).toBe(before - total);
   });
 });
-

--- a/packages/engine/tests/effects/till_land.test.ts
+++ b/packages/engine/tests/effects/till_land.test.ts
@@ -34,7 +34,7 @@ describe('land:till effect', () => {
     const land = ctx.activePlayer.lands[1];
     const max = ctx.services.rules.maxSlotsPerLand;
     const attempts = max - land.slotsMax + 1;
-    for (let i = 0; i < attempts; i++) {
+    for (let iteration = 0; iteration < attempts; iteration++) {
       performAction('till', ctx);
     }
     expect(land.slotsMax).toBe(max);

--- a/packages/engine/tests/phases/development.test.ts
+++ b/packages/engine/tests/phases/development.test.ts
@@ -12,37 +12,37 @@ import {
 const council = POPULATIONS.get(PopulationRole.Council);
 const councilApGain = Number(
   council.onDevelopmentPhase?.find(
-    (e) =>
-      e.type === 'resource' &&
-      e.method === 'add' &&
-      e.params.key === Resource.ap,
+    (effect) =>
+      effect.type === 'resource' &&
+      effect.method === 'add' &&
+      effect.params.key === Resource.ap,
   )?.params.amount ?? 0,
 );
 
 const farm = DEVELOPMENTS.get('farm');
 const farmGoldGain = Number(
   farm.onDevelopmentPhase?.find(
-    (e) =>
-      e.type === 'resource' &&
-      e.method === 'add' &&
-      e.params.key === Resource.gold,
+    (effect) =>
+      effect.type === 'resource' &&
+      effect.method === 'add' &&
+      effect.params.key === Resource.gold,
   )?.params.amount ?? 0,
 );
 
 const commanderPct = Number(
   POPULATIONS.get(PopulationRole.Commander).onDevelopmentPhase?.find(
-    (e) =>
-      e.type === 'stat' &&
-      e.method === 'add_pct' &&
-      e.params.key === Stat.armyStrength,
+    (effect) =>
+      effect.type === 'stat' &&
+      effect.method === 'add_pct' &&
+      effect.params.key === Stat.armyStrength,
   )?.params.percent ?? 0,
 );
 const fortifierPct = Number(
   POPULATIONS.get(PopulationRole.Fortifier).onDevelopmentPhase?.find(
-    (e) =>
-      e.type === 'stat' &&
-      e.method === 'add_pct' &&
-      e.params.key === Stat.fortificationStrength,
+    (effect) =>
+      effect.type === 'stat' &&
+      effect.method === 'add_pct' &&
+      effect.params.key === Stat.fortificationStrength,
   )?.params.percent ?? 0,
 );
 

--- a/packages/engine/tests/phases/population-effects.test.ts
+++ b/packages/engine/tests/phases/population-effects.test.ts
@@ -13,49 +13,49 @@ import {
 const council = POPULATIONS.get(PopulationRole.Council);
 const councilApGain =
   council.onDevelopmentPhase?.find(
-    (e) =>
-      e.type === 'resource' &&
-      e.method === 'add' &&
-      e.params.key === Resource.ap,
+    (effect) =>
+      effect.type === 'resource' &&
+      effect.method === 'add' &&
+      effect.params.key === Resource.ap,
   )?.params.amount ?? 0;
 const councilUpkeep =
   council.onUpkeepPhase?.find(
-    (e) =>
-      e.type === 'resource' &&
-      e.method === 'remove' &&
-      e.params.key === Resource.gold,
+    (effect) =>
+      effect.type === 'resource' &&
+      effect.method === 'remove' &&
+      effect.params.key === Resource.gold,
   )?.params.amount ?? 0;
 
 const commander = POPULATIONS.get(PopulationRole.Commander);
 const commanderUpkeep =
   commander.onUpkeepPhase?.find(
-    (e) =>
-      e.type === 'resource' &&
-      e.method === 'remove' &&
-      e.params.key === Resource.gold,
+    (effect) =>
+      effect.type === 'resource' &&
+      effect.method === 'remove' &&
+      effect.params.key === Resource.gold,
   )?.params.amount ?? 0;
 const commanderPct =
   commander.onDevelopmentPhase?.find(
-    (e) =>
-      e.type === 'stat' &&
-      e.method === 'add_pct' &&
-      e.params.key === Stat.armyStrength,
+    (effect) =>
+      effect.type === 'stat' &&
+      effect.method === 'add_pct' &&
+      effect.params.key === Stat.armyStrength,
   )?.params.percent ?? 0;
 
 const fortifier = POPULATIONS.get(PopulationRole.Fortifier);
 const fortifierUpkeep =
   fortifier.onUpkeepPhase?.find(
-    (e) =>
-      e.type === 'resource' &&
-      e.method === 'remove' &&
-      e.params.key === Resource.gold,
+    (effect) =>
+      effect.type === 'resource' &&
+      effect.method === 'remove' &&
+      effect.params.key === Resource.gold,
   )?.params.amount ?? 0;
 const fortifierPct =
   fortifier.onDevelopmentPhase?.find(
-    (e) =>
-      e.type === 'stat' &&
-      e.method === 'add_pct' &&
-      e.params.key === Stat.fortificationStrength,
+    (effect) =>
+      effect.type === 'stat' &&
+      effect.method === 'add_pct' &&
+      effect.params.key === Stat.fortificationStrength,
   )?.params.percent ?? 0;
 
 function setup({
@@ -247,21 +247,21 @@ describe('population registry overrides', () => {
     ctx.activePlayer.population[PopulationRole.Commander] = 0;
     ctx.activePlayer.population[PopulationRole.Fortifier] = 0;
 
-    const council = populations.get(PopulationRole.Council);
+    const councilDefinition = populations.get(PopulationRole.Council);
     const devGain = Number(
-      council.onDevelopmentPhase?.find(
-        (e) =>
-          e.type === 'resource' &&
-          e.method === 'add' &&
-          e.params.key === Resource.gold,
+      councilDefinition.onDevelopmentPhase?.find(
+        (effect) =>
+          effect.type === 'resource' &&
+          effect.method === 'add' &&
+          effect.params.key === Resource.gold,
       )?.params.amount ?? 0,
     );
     const upkeepCost = Number(
-      council.onUpkeepPhase?.find(
-        (e) =>
-          e.type === 'resource' &&
-          e.method === 'remove' &&
-          e.params.key === Resource.ap,
+      councilDefinition.onUpkeepPhase?.find(
+        (effect) =>
+          effect.type === 'resource' &&
+          effect.method === 'remove' &&
+          effect.params.key === Resource.ap,
       )?.params.amount ?? 0,
     );
 
@@ -306,20 +306,20 @@ describe('population registry overrides', () => {
     ctx.activePlayer.population[PopulationRole.Council] = 0;
     ctx.activePlayer.population[PopulationRole.Commander] = 1;
 
-    const commander = populations.get(PopulationRole.Commander);
+    const commanderDefinition = populations.get(PopulationRole.Commander);
     const devCost =
-      commander.onDevelopmentPhase?.find(
-        (e) =>
-          e.type === 'resource' &&
-          e.method === 'remove' &&
-          e.params.key === Resource.gold,
+      commanderDefinition.onDevelopmentPhase?.find(
+        (effect) =>
+          effect.type === 'resource' &&
+          effect.method === 'remove' &&
+          effect.params.key === Resource.gold,
       )?.params.amount ?? 0;
     const upkeepPct =
-      commander.onUpkeepPhase?.find(
-        (e) =>
-          e.type === 'stat' &&
-          e.method === 'add_pct' &&
-          e.params.key === Stat.armyStrength,
+      commanderDefinition.onUpkeepPhase?.find(
+        (effect) =>
+          effect.type === 'stat' &&
+          effect.method === 'add_pct' &&
+          effect.params.key === Stat.armyStrength,
       )?.params.percent ?? 0;
 
     runDevelopment(ctx);
@@ -364,20 +364,20 @@ describe('population registry overrides', () => {
     ctx.activePlayer.population[PopulationRole.Council] = 0;
     ctx.activePlayer.population[PopulationRole.Fortifier] = 1;
 
-    const fortifier = populations.get(PopulationRole.Fortifier);
+    const fortifierDefinition = populations.get(PopulationRole.Fortifier);
     const devCost =
-      fortifier.onDevelopmentPhase?.find(
-        (e) =>
-          e.type === 'resource' &&
-          e.method === 'remove' &&
-          e.params.key === Resource.gold,
+      fortifierDefinition.onDevelopmentPhase?.find(
+        (effect) =>
+          effect.type === 'resource' &&
+          effect.method === 'remove' &&
+          effect.params.key === Resource.gold,
       )?.params.amount ?? 0;
     const upkeepPct =
-      fortifier.onUpkeepPhase?.find(
-        (e) =>
-          e.type === 'stat' &&
-          e.method === 'add_pct' &&
-          e.params.key === Stat.fortificationStrength,
+      fortifierDefinition.onUpkeepPhase?.find(
+        (effect) =>
+          effect.type === 'stat' &&
+          effect.method === 'add_pct' &&
+          effect.params.key === Stat.fortificationStrength,
       )?.params.percent ?? 0;
 
     runDevelopment(ctx);

--- a/packages/engine/tests/phases/upkeep.test.ts
+++ b/packages/engine/tests/phases/upkeep.test.ts
@@ -9,26 +9,26 @@ import {
 
 const councilUpkeep = Number(
   POPULATIONS.get(PopulationRole.Council).onUpkeepPhase?.find(
-    (e) =>
-      e.type === 'resource' &&
-      e.method === 'remove' &&
-      e.params.key === Resource.gold,
+    (effect) =>
+      effect.type === 'resource' &&
+      effect.method === 'remove' &&
+      effect.params.key === Resource.gold,
   )?.params.amount ?? 0,
 );
 const commanderUpkeep = Number(
   POPULATIONS.get(PopulationRole.Commander).onUpkeepPhase?.find(
-    (e) =>
-      e.type === 'resource' &&
-      e.method === 'remove' &&
-      e.params.key === Resource.gold,
+    (effect) =>
+      effect.type === 'resource' &&
+      effect.method === 'remove' &&
+      effect.params.key === Resource.gold,
   )?.params.amount ?? 0,
 );
 const fortifierUpkeep = Number(
   POPULATIONS.get(PopulationRole.Fortifier).onUpkeepPhase?.find(
-    (e) =>
-      e.type === 'resource' &&
-      e.method === 'remove' &&
-      e.params.key === Resource.gold,
+    (effect) =>
+      effect.type === 'resource' &&
+      effect.method === 'remove' &&
+      effect.params.key === Resource.gold,
   )?.params.amount ?? 0,
 );
 

--- a/tests/integration/edge-cases.test.ts
+++ b/tests/integration/edge-cases.test.ts
@@ -17,15 +17,15 @@ describe('Action edge cases', () => {
     const ctx = createTestContext();
     const costs = getActionCosts('expand', ctx);
     const entries = Object.entries(costs).filter(
-      ([k]) => k !== Resource.ap,
+      ([key]) => key !== Resource.ap,
     ) as [ResourceKey, number][];
     if (entries.length === 0) return; // no non-AP cost to exhaust
-    const [key, amount]: [ResourceKey, number] = entries[0];
-    ctx.activePlayer.resources[key] = (amount ?? 0) - 1;
+    const [resourceKey, amount]: [ResourceKey, number] = entries[0];
+    ctx.activePlayer.resources[resourceKey] = (amount ?? 0) - 1;
     expect(() => performAction('expand', ctx)).toThrow(
-      new RegExp(`Insufficient ${key}`),
+      new RegExp(`Insufficient ${resourceKey}`),
     );
-    expect(ctx.activePlayer.resources[key]).toBe((amount ?? 0) - 1);
+    expect(ctx.activePlayer.resources[resourceKey]).toBe((amount ?? 0) - 1);
   });
 
   it('rejects actions when action points are exhausted', () => {

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -13,19 +13,19 @@ function deepClone<T>(value: T): T {
   return structuredClone(value);
 }
 
-function clonePlayer(p: PlayerState) {
-  const c = new PlayerState(p.id, p.name);
-  c.resources = deepClone(p.resources);
-  c.stats = deepClone(p.stats);
-  c.population = deepClone(p.population);
-  c.lands = p.lands.map((l) => {
-    const nl = new Land(l.id, l.slotsMax);
-    nl.slotsUsed = l.slotsUsed;
-    nl.developments = [...l.developments];
-    return nl;
+function clonePlayer(player: PlayerState) {
+  const copy = new PlayerState(player.id, player.name);
+  copy.resources = deepClone(player.resources);
+  copy.stats = deepClone(player.stats);
+  copy.population = deepClone(player.population);
+  copy.lands = player.lands.map((landState) => {
+    const newLand = new Land(landState.id, landState.slotsMax);
+    newLand.slotsUsed = landState.slotsUsed;
+    newLand.developments = [...landState.developments];
+    return newLand;
   });
-  c.buildings = new Set([...p.buildings]);
-  return c;
+  copy.buildings = new Set([...player.buildings]);
+  return copy;
 }
 
 export function createTestContext(overrides?: { gold?: number; ap?: number }) {
@@ -67,8 +67,12 @@ export function simulateEffects(
 }
 
 export function getActionOutcome(id: string, ctx: EngineContext) {
-  const def = ctx.actions.get(id);
+  const actionDefinition = ctx.actions.get(id);
   const costs = getActionCosts(id, ctx);
-  const results = simulateEffects(def.effects, ctx, def.id);
+  const results = simulateEffects(
+    actionDefinition.effects,
+    ctx,
+    actionDefinition.id,
+  );
   return { costs, results };
 }


### PR DESCRIPTION
## Summary
- replace single-letter identifiers with descriptive names across engine and tests
- introduce repository code standards and reference them in docs

## Testing
- `npm test`
- `npm run e2e` *(fails: browser dependencies missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b080cb03a883259fe18968ed6f63b5