### PR TITLE
chore: streamline Playwright setup for e2e tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,9 @@ Tests live in:
 - `tests/integration` for integration tests
 - `e2e` for end-to-end tests using Playwright
 
-Always run all tests before making a PR. Install the Playwright Chromium browser (Linux users run `install-deps` once) and run all checks. The repository configures an alternate Playwright download host via `.npmrc` to work behind restricted networks:
+Always run all tests before making a PR. The Playwright Chromium browser is installed automatically the first time `npm run e2e` is executed (it runs `playwright install --with-deps chromium` under the hood). The repository configures an alternate Playwright download host via `.npmrc` to work behind restricted networks:
 
 ```bash
-npx playwright install-deps chromium  # Linux only, run once
-npx playwright install chromium
 npm test
 npm run e2e
 npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,13 +22,15 @@ style conventions used throughout the repository.
   - **Integration tests** under `tests/integration`.
   - **End-to-end tests** under `e2e` (Playwright).
 - Run unit and integration tests with `npm test`.
-- Run end-to-end tests (requires the Playwright Chromium browser):
+- Run end-to-end tests. The `npm run e2e` script automatically downloads the
+  Playwright Chromium browser and any required Linux dependencies on first run:
 
   ```bash
-  npx playwright install-deps chromium # Linux only, run once
-  npx playwright install chromium
   npm run e2e
   ```
+
+  Some environments may print `403` warnings from `mise.jdx.dev` while installing
+  system packages; these are harmless and can be ignored.
 
 - Always run `npm test`, `npm run e2e`, and `npm run build` before committing.
   The `npm test` script runs ESLint and Vitest for unit/integration tests.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 # 👑 Kingdom Builder v5.11
+
 ## 1) Setup
 
 1. Install [Node.js](https://nodejs.org/) (v18+ recommended).
 2. Install dependencies: `npm install`
 3. Start the development server: `npm run dev`
 4. Build for production: `npm run build`
+
+## 2) Testing
+
+Run tests before committing:
+
+```bash
+npm test
+npm run e2e
+npm run build
+```
+
+`npm run e2e` automatically installs the Playwright Chromium browser and any
+required system dependencies on first run.
 
 ## 3) Game Overview
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check": "npm run typecheck && npm run lint",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "pree2e": "playwright install --with-deps chromium",
     "e2e": "playwright test",
     "format": "prettier .",
     "prepare": "husky install"


### PR DESCRIPTION
## Summary
- auto-install Playwright Chromium and dependencies before running e2e tests
- document new e2e workflow and note harmless 403 warnings
- add testing instructions to README

## Testing
- `npm test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0901893b0832588f3341bbf98052f