### PR TITLE
Refine web UI and unify build action

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,10 @@ set -e
 # Run lint-staged on changed files
 npx lint-staged
 
-# Run tests after lint-staged passes
+# Run type checking and linting
+npm run check
+
+# Run tests after check passes
 npm test
 if [ -n "$SONAR_TOKEN" ]; then
   npx sonar-scanner -Dsonar.token=$SONAR_TOKEN

--- a/packages/engine/src/content/actions.ts
+++ b/packages/engine/src/content/actions.ts
@@ -21,19 +21,6 @@ export function createActionRegistry() {
       .build(),
   );
 
-  // A simple build action to acquire Town Charter in tests
-  registry.add(
-    'build_town_charter',
-    action('build_town_charter', 'Build — Town Charter')
-      .cost(Resource.gold, 5)
-      .effect({
-        type: 'building',
-        method: 'add',
-        params: { id: 'town_charter' },
-      })
-      .build(),
-  );
-
   registry.add(
     'overwork',
     action('overwork', 'Overwork')
@@ -99,7 +86,12 @@ export function createActionRegistry() {
 
   registry.add('plow', action('plow', 'Plow').cost(Resource.gold, 6).build());
 
-  registry.add('build', action('build', 'Build').build());
+  registry.add(
+    'build',
+    action('build', 'Build')
+      .effect({ type: 'building', method: 'add', params: { id: '$id' } })
+      .build(),
+  );
 
   return registry;
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -84,7 +84,7 @@ export function getActionCosts<T extends string>(
   const actionDefinition = ctx.actions.get(actionId);
   let base = { ...(actionDefinition.baseCosts || {}) };
   if (actionId === 'build' && params) {
-    const p = params as ActionParams<'build'>;
+    const p = params as unknown as ActionParams<'build'>;
     const building = ctx.buildings.get(p.id);
     base = { ...building.costs, ...base };
   }
@@ -131,7 +131,7 @@ export function performAction<T extends string>(
   }
   let base = { ...(actionDefinition.baseCosts || {}) };
   if (actionId === 'build' && params) {
-    const p = params as ActionParams<'build'>;
+    const p = params as unknown as ActionParams<'build'>;
     const building = ctx.buildings.get(p.id);
     base = { ...building.costs, ...base };
   }

--- a/packages/engine/tests/actions/build.test.ts
+++ b/packages/engine/tests/actions/build.test.ts
@@ -28,13 +28,13 @@ function clonePlayer(player: PlayerState): PlayerState {
   return copy;
 }
 
-describe('Build Town Charter action', () => {
+describe('Build action', () => {
   it('rejects when gold is insufficient', () => {
     const ctx = createEngine();
     runDevelopment(ctx);
-    const cost = getActionCosts('build_town_charter', ctx);
+    const cost = getActionCosts('build', ctx, { id: 'town_charter' });
     ctx.activePlayer.gold = (cost[Resource.gold] || 0) - 1;
-    expect(() => performAction('build_town_charter', ctx)).toThrow(
+    expect(() => performAction('build', ctx, { id: 'town_charter' })).toThrow(
       /Insufficient gold/,
     );
   });
@@ -42,7 +42,7 @@ describe('Build Town Charter action', () => {
   it('adds Town Charter and applies its passive to Expand', () => {
     const ctx = createEngine();
     runDevelopment(ctx);
-    const buildCost = getActionCosts('build_town_charter', ctx);
+    const buildCost = getActionCosts('build', ctx, { id: 'town_charter' });
 
     const game = new GameState();
     game.players[0] = clonePlayer(ctx.activePlayer);
@@ -59,12 +59,15 @@ describe('Build Town Charter action', () => {
     for (const [resourceKey, cost] of Object.entries(buildCost)) {
       sim.activePlayer.resources[resourceKey as ResourceKey] -= cost;
     }
-    const actionDefinition = ctx.actions.get('build_town_charter');
-    runEffects(applyParamsToEffects(actionDefinition.effects, {}), sim);
+    const actionDefinition = ctx.actions.get('build');
+    runEffects(
+      applyParamsToEffects(actionDefinition.effects, { id: 'town_charter' }),
+      sim,
+    );
 
     const expectedCost = getActionCosts('expand', sim);
 
-    performAction('build_town_charter', ctx);
+    performAction('build', ctx, { id: 'town_charter' });
     expect(ctx.activePlayer.buildings.has('town_charter')).toBe(true);
     expect(ctx.activePlayer.gold).toBe(sim.activePlayer.gold);
     expect(ctx.activePlayer.ap).toBe(sim.activePlayer.ap);

--- a/packages/engine/tests/actions/expand.test.ts
+++ b/packages/engine/tests/actions/expand.test.ts
@@ -62,7 +62,7 @@ describe('Expand action', () => {
   it('includes Town Charter modifiers when present', () => {
     const ctx = createEngine();
     runDevelopment(ctx);
-    performAction('build_town_charter', ctx);
+    performAction('build', ctx, { id: 'town_charter' });
     ctx.activePlayer.ap += 1; // allow another action
     const goldBefore = ctx.activePlayer.gold;
     const actionPointsBefore = ctx.activePlayer.ap;
@@ -83,7 +83,7 @@ describe('Expand action', () => {
   it('applies modifiers consistently across multiple expansions', () => {
     const ctx = createEngine();
     runDevelopment(ctx);
-    performAction('build_town_charter', ctx);
+    performAction('build', ctx, { id: 'town_charter' });
     ctx.activePlayer.ap += 2; // allow two expands
     ctx.activePlayer.gold += 10; // top-up to afford two expands
     const goldBefore = ctx.activePlayer.gold;

--- a/packages/web/tests/App.test.tsx
+++ b/packages/web/tests/App.test.tsx
@@ -3,22 +3,41 @@ import { renderToString } from 'react-dom/server';
 import React from 'react';
 import App from '../src/App';
 
-vi.mock('@kingdom-builder/engine', () => ({
-  createEngine: () => ({
-    activePlayer: { resources: {}, stats: {}, buildings: new Set(), lands: [] },
-    actions: { map: new Map() },
-    developments: { map: new Map() },
-    game: { currentPhase: 'development' },
-  }),
-  performAction: () => {},
-  runDevelopment: () => {},
-  runUpkeep: () => {},
-  Phase: { Development: 'development', Upkeep: 'upkeep', Main: 'main' },
-}));
+vi.mock('@kingdom-builder/engine', () => {
+  const player = {
+    id: 'A',
+    name: 'A',
+    resources: {} as Record<string, number>,
+    stats: { maxPopulation: 0 } as Record<string, number>,
+    population: {} as Record<string, number>,
+    buildings: new Set<string>(),
+    lands: [] as unknown[],
+  };
+  return {
+    createEngine: () => ({
+      activePlayer: player,
+      actions: { map: new Map() },
+      developments: { map: new Map() },
+      buildings: { map: new Map() },
+      game: { currentPhase: 'development', players: [player] },
+    }),
+    performAction: () => {},
+    runDevelopment: () => {},
+    runUpkeep: () => {},
+    getActionCosts: () => ({}),
+    Phase: { Development: 'development', Upkeep: 'upkeep', Main: 'main' },
+    Resource: {
+      gold: 'gold',
+      ap: 'ap',
+      happiness: 'happiness',
+      castleHP: 'castleHP',
+    },
+  };
+});
 
 describe('<App />', () => {
-  it('renders testlab header', () => {
+  it('renders Kingdom Builder header', () => {
     const html = renderToString(<App />);
-    expect(html).toContain('testlab');
+    expect(html).toContain('Kingdom Builder');
   });
 });

--- a/tests/integration/building-placement.test.ts
+++ b/tests/integration/building-placement.test.ts
@@ -10,10 +10,10 @@ describe('Building placement integration', () => {
     const ctx = createTestContext();
     ctx.activePlayer.ap = ctx.services.rules.defaultActionAPCost * 2;
     const expandBefore = getActionOutcome('expand', ctx);
-    const buildCosts = getActionCosts('build_town_charter', ctx);
+    const buildCosts = getActionCosts('build', ctx, { id: 'town_charter' });
     const resBefore = { ...ctx.activePlayer.resources };
 
-    performAction('build_town_charter', ctx);
+    performAction('build', ctx, { id: 'town_charter' });
 
     expect(ctx.activePlayer.buildings.has('town_charter')).toBe(true);
     for (const [key, cost] of Object.entries(buildCosts)) {


### PR DESCRIPTION
## Summary
- Replace standalone Town Charter action with parameterized Build action
- Revamp web UI: rename to Kingdom Builder, show both players, phases, costs, and selectors
- Display resources/stats with icons and dynamic population summary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09da057a08325afa53e43706d7bef