### PR TITLE
refactor: centralize game start configuration

### DIFF
--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { Resource } from '../state';
+import { Resource, Stat, PopulationRole } from '../state';
 import type { EffectDef } from '../effects';
 import { EngineContext } from '../context';
 
@@ -78,7 +78,28 @@ export const populationSchema = z.object({
 export type PopulationConfig = z.infer<typeof populationSchema>;
 
 // Game config
+const landStartSchema = z.object({
+  developments: z.array(z.string()).optional(),
+  slotsMax: z.number().optional(),
+  slotsUsed: z.number().optional(),
+});
+
+const playerStartSchema = z.object({
+  resources: z.record(z.nativeEnum(Resource), z.number()).optional(),
+  stats: z.record(z.nativeEnum(Stat), z.number()).optional(),
+  population: z.record(z.nativeEnum(PopulationRole), z.number()).optional(),
+  lands: z.array(landStartSchema).optional(),
+});
+
+export const startConfigSchema = z.object({
+  player: playerStartSchema,
+});
+
+export type PlayerStartConfig = z.infer<typeof playerStartSchema>;
+export type StartConfig = z.infer<typeof startConfigSchema>;
+
 export const gameConfigSchema = z.object({
+  start: startConfigSchema.optional(),
   actions: z.array(actionSchema).optional(),
   buildings: z.array(buildingSchema).optional(),
   developments: z.array(developmentSchema).optional(),

--- a/packages/engine/src/content/game.ts
+++ b/packages/engine/src/content/game.ts
@@ -1,0 +1,26 @@
+import { Resource, Stat, PopulationRole } from '../state';
+import type { StartConfig } from '../config/schema';
+
+export const GAME_START: StartConfig = {
+  player: {
+    resources: {
+      [Resource.gold]: 10,
+      [Resource.ap]: 0,
+      [Resource.happiness]: 0,
+      [Resource.castleHP]: 10,
+    },
+    stats: {
+      [Stat.maxPopulation]: 1,
+      [Stat.armyStrength]: 0,
+      [Stat.fortificationStrength]: 0,
+      [Stat.absorption]: 0,
+    },
+    population: {
+      [PopulationRole.Council]: 1,
+      [PopulationRole.Commander]: 0,
+      [PopulationRole.Fortifier]: 0,
+      [PopulationRole.Citizen]: 0,
+    },
+    lands: [{ developments: ['farm'] }, {}],
+  },
+};

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -130,7 +130,6 @@ function renderCosts(costs: Record<string, number>) {
 export default function App() {
   const ctx = useMemo<EngineContext>(() => {
     const c = createEngine();
-    c.activePlayer.ap = 30;
     return c;
   }, []);
 


### PR DESCRIPTION
## Summary
- move starting resources, stats, lands and population into configurable content
- expose start config schema and apply it to both players during engine creation
- remove debug AP boost from web demo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a52161f083259584ebb123d0c894