### PR TITLE
feat(web): add start screen and overview

### DIFF
--- a/packages/web/game.html
+++ b/packages/web/game.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KB Game</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,10 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>KB Game</title>
+    <title>Kingdom Builder</title>
+    <style>
+      body { display: flex; height: 100vh; margin: 0; align-items: center; justify-content: center; font-family: sans-serif; }
+      .menu { display: flex; flex-direction: column; gap: 1rem; align-items: center; }
+      button { padding: 0.5rem 1rem; font-size: 1rem; cursor: pointer; }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <div class="menu">
+      <h1>Kingdom Builder</h1>
+      <button onclick="window.location.href='game.html'">Start New Game</button>
+      <button onclick="window.location.href='overview.html'">Game Overview</button>
+    </div>
   </body>
 </html>

--- a/packages/web/overview.html
+++ b/packages/web/overview.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kingdom Builder - Overview</title>
+    <style>
+      body { max-width: 800px; margin: 2rem auto; font-family: sans-serif; line-height: 1.5; padding: 0 1rem; }
+      h1 { text-align: center; }
+    </style>
+  </head>
+  <body>
+    <h1>Game Overview</h1>
+    <p>Kingdom Builder is a turn-based duel where you grow your realm and attempt to outmaneuver your rival. Protect your castle, expand your lands, and manage your resources to prevail.</p>
+    <h2>Goal</h2>
+    <p>Outlast or conquer your opponent. A game can end when a castle falls, when a player can no longer sustain their realm, or when the final round ends with one ruler holding the advantage.</p>
+    <h2>Phases</h2>
+    <p>Each turn flows through three phases:</p>
+    <ul>
+      <li><strong>Development</strong> – your realm produces resources and triggered effects take place.</li>
+      <li><strong>Upkeep</strong> – maintain your population and resolve ongoing effects.</li>
+      <li><strong>Main</strong> – both players secretly choose actions and then resolve them in turn.</li>
+    </ul>
+    <h2>Core Mechanics</h2>
+    <p>Actions may require resources or other prerequisites and grant various effects, such as gaining resources, building structures, developing land, or hindering your opponent. Buildings provide passive bonuses, while land around your castle holds developments that yield benefits. Resources like Gold, Action Points, Happiness, and Castle Health are spent and gained throughout the game.</p>
+    <p><a href="index.html">Back to Start</a></p>
+  </body>
+</html>

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -13,4 +13,13 @@ export default defineConfig({
       '@kingdom-builder/engine': path.resolve(rootDir, '../engine/src'),
     },
   },
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(rootDir, 'index.html'),
+        game: path.resolve(rootDir, 'game.html'),
+        overview: path.resolve(rootDir, 'overview.html'),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- add start screen with links to new game and overview
- provide overview page explaining goals, phases and core mechanics
- configure Vite to build multiple entry HTML files

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0a73865688325bf0290ad839bc336