### PR TITLE
feat: implement tax action

### DIFF
--- a/packages/engine/src/content/actions.ts
+++ b/packages/engine/src/content/actions.ts
@@ -57,7 +57,28 @@ export function createActionRegistry() {
       .build(),
   );
 
-  registry.add('tax', action('tax', 'Tax').cost(Resource.ap, 0).build());
+  registry.add(
+    'tax',
+    action('tax', 'Tax')
+      .cost(Resource.ap, 1)
+      .effect({
+        evaluator: { type: 'population' },
+        effects: [
+          {
+            type: 'resource',
+            method: 'add',
+            params: { key: Resource.gold, amount: 4 },
+          },
+          {
+            type: 'resource',
+            method: 'add',
+            round: 'up',
+            params: { key: Resource.happiness, amount: -0.5 },
+          },
+        ],
+      })
+      .build(),
+  );
 
   registry.add(
     'reallocate',

--- a/packages/engine/src/evaluators/index.ts
+++ b/packages/engine/src/evaluators/index.ts
@@ -2,6 +2,7 @@ import { Registry } from '../registry';
 import type { EngineContext } from '../context';
 
 import { developmentEvaluator } from './development';
+import { populationEvaluator } from './population';
 export interface EvaluatorDef<
   P extends Record<string, unknown> = Record<string, unknown>,
 > {
@@ -24,6 +25,8 @@ export function registerCoreEvaluators(
   registry: EvaluatorRegistry = EVALUATORS,
 ) {
   registry.add('development', developmentEvaluator);
+  registry.add('population', populationEvaluator);
 }
 
 export { developmentEvaluator } from './development';
+export { populationEvaluator } from './population';

--- a/packages/engine/src/evaluators/population.ts
+++ b/packages/engine/src/evaluators/population.ts
@@ -1,0 +1,19 @@
+import type { EvaluatorHandler } from './index';
+import type { EngineContext } from '../context';
+import type { PopulationRoleId } from '../state';
+
+export interface PopulationEvaluatorParams extends Record<string, unknown> {
+  role?: PopulationRoleId;
+}
+
+export const populationEvaluator: EvaluatorHandler<
+  number,
+  PopulationEvaluatorParams
+> = (definition, ctx: EngineContext) => {
+  const role = definition.params?.role;
+  if (role) return ctx.activePlayer.population[role] || 0;
+  return Object.values(ctx.activePlayer.population).reduce(
+    (total, count) => total + Number(count || 0),
+    0,
+  );
+};

--- a/packages/engine/tests/actions/tax.test.ts
+++ b/packages/engine/tests/actions/tax.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEngine,
+  runDevelopment,
+  performAction,
+  Resource,
+  EVALUATORS,
+} from '../../src';
+import type { EffectDef } from '../../src/effects';
+import type { EvaluatorDef } from '../../src/evaluators';
+import type { EngineContext } from '../../src';
+
+function getTaxExpectations(ctx: EngineContext) {
+  const actionDefinition = ctx.actions.get('tax');
+  const container = actionDefinition.effects[0];
+  const evaluator = container.evaluator as EvaluatorDef;
+  const count = EVALUATORS.get(evaluator.type)(evaluator, ctx) as number;
+  const deltas: Record<string, number> = {};
+  const subEffects = container.effects as (EffectDef & {
+    round?: 'up' | 'down';
+  })[];
+  for (const subEffect of subEffects) {
+    const key = subEffect.params!.key as string;
+    let total = (subEffect.params!.amount as number) * count;
+    const rounding = subEffect.round;
+    if (rounding === 'up')
+      total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+    else if (rounding === 'down')
+      total = total >= 0 ? Math.floor(total) : Math.ceil(total);
+    deltas[key] = total;
+  }
+  return deltas;
+}
+
+describe('Tax action', () => {
+  it('grants gold and loses happiness for each population', () => {
+    const ctx = createEngine();
+    runDevelopment(ctx);
+    const actionDefinition = ctx.actions.get('tax');
+    const apBefore = ctx.activePlayer.ap;
+    const goldBefore = ctx.activePlayer.gold;
+    const hapBefore = ctx.activePlayer.happiness;
+    const expected = getTaxExpectations(ctx);
+    performAction('tax', ctx);
+    expect(ctx.activePlayer.gold).toBe(
+      goldBefore + (expected[Resource.gold] || 0),
+    );
+    expect(ctx.activePlayer.happiness).toBe(
+      hapBefore + (expected[Resource.happiness] || 0),
+    );
+    const cost = actionDefinition.baseCosts?.[Resource.ap] ?? 0;
+    expect(ctx.activePlayer.ap).toBe(apBefore - cost);
+  });
+});


### PR DESCRIPTION
## Summary
- add population evaluator for per-citizen effects
- wire population evaluator into registry
- implement Tax action to grant gold and reduce happiness per population
- test Tax action behaviour
- set Tax action cost to 1 AP

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0acfb72d08325a42ffb729945a9ff