### PR TITLE
Handle placeholder building ids in web summary

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -185,7 +185,12 @@ function summarizeEffects(
       case 'building': {
         if (eff.method === 'add' && eff.params) {
           const id = eff.params['id'] as string;
-          const name = ctx.buildings.get(id)?.name || id;
+          let name = id;
+          try {
+            name = ctx.buildings.get(id).name;
+          } catch {
+            // fall back to raw id when the building is not registered yet
+          }
           parts.push(`${buildingIcon}${name}`);
         }
         break;

--- a/packages/web/tests/App.render.test.tsx
+++ b/packages/web/tests/App.render.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import React from 'react';
+import App from '../src/App';
+
+// Render the application with the real engine to ensure that
+// dynamic action effects (e.g. build with "$id") don't crash
+// the rendering pipeline when summarized.
+vi.mock('@kingdom-builder/engine', async () => {
+  // Re-export the actual engine source since vitest doesn't resolve the monorepo alias
+  return await import('../../engine/src');
+});
+describe('<App /> integration', () => {
+  it('renders without crashing', () => {
+    expect(() => renderToString(<App />)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Avoid crashing when summarizing build actions with unresolved building ids
- Add integration test rendering app with real engine to guard against regression

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0b40b51388325829aeaa06c1c8a06