### PR TITLE
Improve turn flow and refine game UI

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -8,6 +8,6 @@
 
 @layer components {
   .bar-item {
-    @apply flex items-center gap-1 w-20 tabular-nums;
+    @apply flex items-center gap-1 tabular-nums whitespace-nowrap;
   }
 }


### PR DESCRIPTION
## Summary
- correct phase sequencing so each player completes all phases before the next
- display current turn, clarify action details, and add icons to actions and references
- streamline player panel and actions layout, hide empty sections, and show log player names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf5e0cfc8325a022d9b1c07e7ebc