### PR TITLE
chore: remove unused actions registry export

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,8 +49,8 @@ for details on built-in handlers and registering custom ones.
 
 Most subsystems rely on lightweight registries. A `Registry` maps string
 identifiers to handler functions and throws if an unknown id is requested. Core
-registries include `EFFECTS`, `EVALUATORS`, `ACTIONS`, `BUILDINGS`,
-`DEVELOPMENTS` and `POPULATIONS`.
+registries include the actions, buildings, developments and populations
+registries alongside `EFFECTS` and `EVALUATORS`.
 
 Registries are intentionally mutable: tests or mods may replace entries or add
 new ones at runtime. This allows contributors to prototype new mechanics simply

--- a/packages/engine/src/content/actions.ts
+++ b/packages/engine/src/content/actions.ts
@@ -134,5 +134,3 @@ export function createActionRegistry() {
 
   return registry;
 }
-
-export const ACTIONS = createActionRegistry();


### PR DESCRIPTION
## Summary
- drop unused `ACTIONS` export and rely on factory for action registry
- document available registries without legacy `ACTIONS` constant

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0cb25d0808325b78f7ab91b0e7ee1