### PR TITLE
feat: implement till system action and land tilling

### DIFF
--- a/packages/engine/src/config/builders.ts
+++ b/packages/engine/src/config/builders.ts
@@ -36,6 +36,10 @@ export class ActionBuilder extends BaseBuilder<ActionConfig> {
     this.config.effects.push(effect);
     return this;
   }
+  system(flag = true) {
+    this.config.system = flag;
+    return this;
+  }
 }
 
 export class BuildingBuilder extends BaseBuilder<BuildingConfig> {

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -40,6 +40,7 @@ export const actionSchema = z.object({
   baseCosts: costBagSchema.optional(),
   requirements: z.array(requirementSchema).optional(),
   effects: z.array(effectSchema),
+  system: z.boolean().optional(),
 });
 
 export type ActionConfig = z.infer<typeof actionSchema>;
@@ -85,6 +86,7 @@ const landStartSchema = z.object({
   developments: z.array(z.string()).optional(),
   slotsMax: z.number().optional(),
   slotsUsed: z.number().optional(),
+  tilled: z.boolean().optional(),
 });
 
 const playerStartSchema = z.object({

--- a/packages/engine/src/content/actions.ts
+++ b/packages/engine/src/content/actions.ts
@@ -140,6 +140,14 @@ export function createActionRegistry() {
   );
 
   registry.add(
+    'till',
+    action('till', 'Till')
+      .system()
+      .effect({ type: 'land', method: 'till' })
+      .build(),
+  );
+
+  registry.add(
     'build',
     action('build', 'Build')
       .cost(Resource.ap, 1)

--- a/packages/engine/src/effects/land_till.ts
+++ b/packages/engine/src/effects/land_till.ts
@@ -1,14 +1,15 @@
 import type { EffectHandler } from '.';
 
 export const landTill: EffectHandler = (effect, ctx, mult = 1) => {
-  const landId = effect.params?.['landId'] as string;
-  if (!landId) throw new Error('land:till requires landId');
-  const land = ctx.activePlayer.lands.find(
-    (landState) => landState.id === landId,
-  );
-  if (!land) throw new Error(`Land ${landId} not found`);
   const max = ctx.services.rules.maxSlotsPerLand;
   for (let index = 0; index < Math.floor(mult); index++) {
+    const landId = effect.params?.['landId'] as string | undefined;
+    const land = landId
+      ? ctx.activePlayer.lands.find((l) => l.id === landId)
+      : ctx.activePlayer.lands.find((l) => !l.tilled && l.slotsMax < max);
+    if (!land) throw new Error('No tillable land available');
+    if (land.tilled) throw new Error(`Land ${land.id} already tilled`);
     land.slotsMax = Math.min(land.slotsMax + 1, max);
+    land.tilled = true;
   }
 };

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -113,8 +113,11 @@ function applyCostsWithPassives(
   ctx: EngineContext,
 ): CostBag {
   const withDefaultAP = { ...base };
+  const definition = ctx.actions.get(actionId);
   if (withDefaultAP[Resource.ap] === undefined)
-    withDefaultAP[Resource.ap] = ctx.services.rules.defaultActionAPCost;
+    withDefaultAP[Resource.ap] = definition.system
+      ? 0
+      : ctx.services.rules.defaultActionAPCost;
   return ctx.passives.applyCostMods(actionId, withDefaultAP, ctx);
 }
 
@@ -246,6 +249,7 @@ function applyPlayerStart(
       const land = new Land(
         `${player.id}-L${idx + 1}`,
         landCfg.slotsMax ?? rules.slotsPerNewLand,
+        landCfg.tilled ?? false,
       );
       if (landCfg.developments) land.developments.push(...landCfg.developments);
       land.slotsUsed = landCfg.slotsUsed ?? land.developments.length;

--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -37,9 +37,11 @@ export class Land {
   slotsMax: number;
   slotsUsed = 0;
   developments: string[] = [];
-  constructor(id: string, slotsMax: number) {
+  tilled = false;
+  constructor(id: string, slotsMax: number, tilled = false) {
     this.id = id;
     this.slotsMax = slotsMax;
+    this.tilled = tilled;
   }
   get slotsFree() {
     return this.slotsMax - this.slotsUsed;

--- a/packages/engine/tests/actions/build.test.ts
+++ b/packages/engine/tests/actions/build.test.ts
@@ -19,7 +19,7 @@ function clonePlayer(player: PlayerState): PlayerState {
   copy.stats = { ...player.stats };
   copy.population = { ...player.population };
   copy.lands = player.lands.map((landState) => {
-    const land = new Land(landState.id, landState.slotsMax);
+    const land = new Land(landState.id, landState.slotsMax, landState.tilled);
     land.slotsUsed = landState.slotsUsed;
     land.developments = [...landState.developments];
     return land;

--- a/packages/engine/tests/actions/develop.test.ts
+++ b/packages/engine/tests/actions/develop.test.ts
@@ -19,7 +19,7 @@ function clonePlayer(player: PlayerState): PlayerState {
   copy.stats = { ...player.stats };
   copy.population = { ...player.population };
   copy.lands = player.lands.map((landState) => {
-    const land = new Land(landState.id, landState.slotsMax);
+    const land = new Land(landState.id, landState.slotsMax, landState.tilled);
     land.slotsUsed = landState.slotsUsed;
     land.developments = [...landState.developments];
     return land;

--- a/packages/engine/tests/actions/till.test.ts
+++ b/packages/engine/tests/actions/till.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEngine,
+  performAction,
+  getActionCosts,
+  Resource,
+} from '../../src/index.ts';
+
+describe('Till action', () => {
+  it('tills an available land for free', () => {
+    const ctx = createEngine();
+    ctx.activePlayer.ap = 5;
+    const target = ctx.activePlayer.lands.find((l) => !l.tilled)!;
+    const before = target.slotsMax;
+    const costs = getActionCosts('till', ctx);
+    performAction('till', ctx);
+    expect(costs[Resource.ap]).toBe(0);
+    expect(target.tilled).toBe(true);
+    expect(target.slotsMax).toBe(
+      Math.min(before + 1, ctx.services.rules.maxSlotsPerLand),
+    );
+    expect(ctx.activePlayer.ap).toBe(5);
+  });
+
+  it('throws when no tillable land exists', () => {
+    const ctx = createEngine();
+    performAction('till', ctx);
+    performAction('till', ctx);
+    expect(() => performAction('till', ctx)).toThrow(/No tillable land/);
+  });
+});

--- a/packages/engine/tests/effects/add_development.test.ts
+++ b/packages/engine/tests/effects/add_development.test.ts
@@ -60,7 +60,7 @@ function clonePlayer(player: PlayerState): PlayerState {
   copy.stats = { ...player.stats };
   copy.population = { ...player.population };
   copy.lands = player.lands.map((landState) => {
-    const land = new Land(landState.id, landState.slotsMax);
+    const land = new Land(landState.id, landState.slotsMax, landState.tilled);
     land.slotsUsed = landState.slotsUsed;
     land.developments = [...landState.developments];
     return land;

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -128,6 +128,7 @@ function diffSnapshots(
 interface Action {
   id: string;
   name: string;
+  system?: boolean;
 }
 interface Development {
   id: string;
@@ -408,7 +409,7 @@ export default function Game({ onExit }: { onExit?: () => void }) {
     () =>
       Array.from(
         (ctx.actions as unknown as { map: Map<string, Action> }).map.values(),
-      ),
+      ).filter((a) => !a.system),
     [ctx],
   );
   const developmentOptions = useMemo<Development[]>(


### PR DESCRIPTION
## Summary
- add system-only action support and register hidden Till action
- track tilled lands and update land:till effect to add one slot once
- ensure system actions skip default AP cost

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0dc0a846c8325b3b479d1ddb8215f