### PR TITLE
feat(web): add dark mode with toggle

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kingdom Builder</title>
   </head>
-  <body class="bg-gradient-to-b from-green-50 to-slate-200 text-gray-900">
+  <body class="bg-slate-100 dark:bg-slate-900 text-gray-900 dark:text-gray-100">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,6 +6,11 @@ type Screen = 'menu' | 'overview' | 'game';
 export default function App() {
   const [screen, setScreen] = useState<Screen>('menu');
   const [gameKey, setGameKey] = useState(0);
+  const [darkMode, setDarkMode] = useState(true);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode]);
 
   useEffect(() => {
     if (window.location.pathname !== '/') {
@@ -61,7 +66,14 @@ export default function App() {
   }
 
   if (screen === 'game') {
-    return <Game key={gameKey} onExit={() => setScreen('menu')} />;
+    return (
+      <Game
+        key={gameKey}
+        onExit={() => setScreen('menu')}
+        darkMode={darkMode}
+        onToggleDark={() => setDarkMode((d) => !d)}
+      />
+    );
   }
 
   return (

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -542,7 +542,9 @@ function renderCosts(
 ) {
   const entries = Object.entries(costs).filter(([k]) => k !== Resource.ap);
   if (entries.length === 0)
-    return <span className="mr-1 text-gray-400 italic">Free</span>;
+    return (
+      <span className="mr-1 text-gray-400 dark:text-gray-500 italic">Free</span>
+    );
   return (
     <>
       {entries.map(([k, v]) => (
@@ -585,7 +587,15 @@ function TimerCircle({ progress }: { progress: number }) {
   );
 }
 
-export default function Game({ onExit }: { onExit?: () => void }) {
+export default function Game({
+  onExit,
+  darkMode = true,
+  onToggleDark = () => {},
+}: {
+  onExit?: () => void;
+  darkMode?: boolean;
+  onToggleDark?: () => void;
+}) {
   const ctx = useMemo<EngineContext>(() => {
     const c = createEngine();
     return c;
@@ -1094,20 +1104,31 @@ export default function Game({ onExit }: { onExit?: () => void }) {
   }
 
   return (
-    <div className="p-4 flex gap-4 w-full bg-slate-100 text-gray-900 min-h-screen">
+    <div className="p-4 flex gap-4 w-full bg-slate-100 text-gray-900 dark:bg-slate-900 dark:text-gray-100 min-h-screen">
       <div className="flex-1 space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold text-center flex-1">
             Kingdom Builder
           </h1>
           {onExit && (
-            <button className="border px-2 py-1 ml-4" onClick={onExit}>
-              Back to Menu
-            </button>
+            <div className="flex items-center gap-2 ml-4">
+              <button
+                className="px-3 py-1 bg-gray-600 text-white rounded hover:bg-gray-700"
+                onClick={onToggleDark}
+              >
+                {darkMode ? 'Light Mode' : 'Dark Mode'}
+              </button>
+              <button
+                className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700"
+                onClick={onExit}
+              >
+                Quit
+              </button>
+            </div>
           )}
         </div>
 
-        <section className="border rounded p-4 bg-white shadow">
+        <section className="border rounded p-4 bg-white dark:bg-gray-800 shadow">
           <div className="flex flex-col gap-4">
             {ctx.game.players.map((p) => (
               <PlayerPanel key={p.id} player={p} />
@@ -1116,7 +1137,7 @@ export default function Game({ onExit }: { onExit?: () => void }) {
         </section>
 
         <section
-          className="border rounded p-4 bg-white shadow relative w-full max-w-md"
+          className="border rounded p-4 bg-white dark:bg-gray-800 shadow relative w-full max-w-md"
           onMouseEnter={() =>
             ctx.game.currentPhase !== Phase.Main && setPaused(true)
           }
@@ -1181,13 +1202,13 @@ export default function Game({ onExit }: { onExit?: () => void }) {
             </div>
           )}
           {phasePaused && (
-            <div className="absolute inset-0 bg-white bg-opacity-50 flex items-center justify-center text-sm">
+            <div className="absolute inset-0 bg-white dark:bg-gray-900 bg-opacity-50 flex items-center justify-center text-sm">
               Paused
             </div>
           )}
         </section>
 
-        <section className="border rounded p-4 bg-white shadow">
+        <section className="border rounded p-4 bg-white dark:bg-gray-800 shadow">
           <div className="flex items-center justify-between mb-2">
             <h2 className="text-xl font-semibold">
               Actions (1 {resourceInfo[Resource.ap].icon} each)
@@ -1243,7 +1264,7 @@ export default function Game({ onExit }: { onExit?: () => void }) {
                       {actionInfo[action.id as keyof typeof actionInfo]?.icon}{' '}
                       {action.name}
                     </span>
-                    <span className="absolute top-2 right-2 text-sm text-gray-600">
+                    <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
                       {renderCosts(costs, ctx.activePlayer.resources)}
                     </span>
                     <ul className="text-sm list-disc pl-4 text-left">
@@ -1329,7 +1350,7 @@ export default function Game({ onExit }: { onExit?: () => void }) {
                           {populationInfo[role]?.icon}{' '}
                           {populationInfo[role]?.label}
                         </span>
-                        <span className="absolute top-2 right-2 text-sm text-gray-600">
+                        <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
                           {renderCosts(costs, ctx.activePlayer.resources)}
                         </span>
                         <ul className="text-sm list-disc list-inside text-left">
@@ -1419,7 +1440,7 @@ export default function Game({ onExit }: { onExit?: () => void }) {
                         <span className="text-base font-medium">
                           {developmentInfo[d.id]?.icon} {d.name}
                         </span>
-                        <span className="absolute top-2 right-2 text-sm text-gray-600">
+                        <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
                           {renderCosts(costs, ctx.activePlayer.resources)}
                         </span>
                         <ul className="text-sm list-disc pl-4 text-left">
@@ -1485,7 +1506,7 @@ export default function Game({ onExit }: { onExit?: () => void }) {
                         onMouseLeave={clearHoverCard}
                       >
                         <span className="text-base font-medium">{b.name}</span>
-                        <span className="absolute top-2 right-2 text-sm text-gray-600">
+                        <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
                           {renderCosts(costs, ctx.activePlayer.resources)}
                         </span>
                         <ul className="text-sm list-disc pl-4 text-left">
@@ -1501,7 +1522,7 @@ export default function Game({ onExit }: { onExit?: () => void }) {
         </section>
       </div>
       <section className="w-96 sticky top-4 self-start flex flex-col gap-4">
-        <div className="border rounded p-4 overflow-y-auto max-h-80 bg-white shadow">
+        <div className="border rounded p-4 overflow-y-auto max-h-80 bg-white dark:bg-gray-800 shadow">
           <h2 className="text-xl font-semibold mb-2">Log</h2>
           <ul className="mt-2 space-y-1">
             {log.map((entry, idx) => (
@@ -1512,10 +1533,10 @@ export default function Game({ onExit }: { onExit?: () => void }) {
           </ul>
         </div>
         {hoverCard && (
-          <div className="border rounded p-4 bg-white shadow relative">
+          <div className="border rounded p-4 bg-white dark:bg-gray-800 shadow relative">
             <div className="font-semibold mb-2">
               {hoverCard.title}
-              <span className="absolute top-2 right-2 text-sm text-gray-600">
+              <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
                 {renderCosts(hoverCard.costs, ctx.activePlayer.resources)}
               </span>
             </div>

--- a/packages/web/tailwind.config.cjs
+++ b/packages/web/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: { extend: {} },
   plugins: [],


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind and set default theme to dark
- add dark/light toggle and red Quit button in game header
- apply dark styling across game sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b206a083408325ab19b3ef0f4c6d49