### PR TITLE
Refine phase transition timer and layout

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -560,9 +560,22 @@ function renderCosts(
   );
 }
 
-function TimerCircle({ progress }: { progress: number }) {
+function TimerCircle({
+  progress,
+  paused = false,
+}: {
+  progress: number;
+  paused?: boolean;
+}) {
   const radius = 12;
   const circumference = 2 * Math.PI * radius;
+  if (paused)
+    return (
+      <svg width={24} height={24} viewBox="0 0 24 24">
+        <rect x="6" y="4" width="4" height="16" fill="#10b981" />
+        <rect x="14" y="4" width="4" height="16" fill="#10b981" />
+      </svg>
+    );
   return (
     <svg width={24} height={24}>
       <circle
@@ -770,12 +783,13 @@ export default function Game({
 
   function updateMainPhaseStep(apStartOverride?: number) {
     const total = apStartOverride ?? mainApStart;
+    const spent = total - ctx.activePlayer.ap;
     setPhaseSteps([
       {
         title: 'Step 1 - Spend all AP',
         items: [
           {
-            text: `${resourceInfo[Resource.ap].icon} ${ctx.activePlayer.ap}/${total} remaining`,
+            text: `${resourceInfo[Resource.ap].icon} ${spent}/${total} spent`,
             done: ctx.activePlayer.ap === 0,
           },
         ],
@@ -898,14 +912,13 @@ export default function Game({
           };
           return next;
         });
-        await runStepDelay();
       }
+      await runStepDelay();
       setPhaseSteps((prev) => {
         const next = [...prev];
         next[i] = { ...next[i]!, active: false };
         return next;
       });
-      await runStepDelay();
     }
   }
 
@@ -1134,78 +1147,6 @@ export default function Game({
               <PlayerPanel key={p.id} player={p} />
             ))}
           </div>
-        </section>
-
-        <section
-          className="border rounded p-4 bg-white dark:bg-gray-800 shadow relative w-full max-w-md"
-          onMouseEnter={() =>
-            ctx.game.currentPhase !== Phase.Main && setPaused(true)
-          }
-          onMouseLeave={() => setPaused(false)}
-          style={{
-            cursor:
-              phasePaused && ctx.game.currentPhase !== Phase.Main
-                ? 'pause'
-                : 'auto',
-          }}
-        >
-          <h2 className="text-xl font-semibold mb-2">
-            Turn {ctx.game.turn} - {ctx.activePlayer.name}
-          </h2>
-          <div className="flex gap-4 mb-2">
-            {[Phase.Development, Phase.Upkeep, Phase.Main].map((p) => (
-              <span
-                key={p}
-                className={
-                  p === ctx.game.currentPhase ? 'font-semibold underline' : ''
-                }
-              >
-                {p.charAt(0).toUpperCase() + p.slice(1)} Phase
-              </span>
-            ))}
-          </div>
-          <ul className="text-sm text-left min-h-[1rem] space-y-1">
-            {phaseSteps.map((s, i) => (
-              <li key={i} className={s.active ? 'font-semibold' : ''}>
-                <div>{s.title}</div>
-                <ul className="pl-4 list-disc">
-                  {s.items.length > 0 ? (
-                    s.items.map((it, j) => (
-                      <li key={j} className={it.italic ? 'italic' : ''}>
-                        {it.text}
-                        {it.done && (
-                          <span className="text-green-600 ml-1">✔️</span>
-                        )}
-                      </li>
-                    ))
-                  ) : (
-                    <li>...</li>
-                  )}
-                </ul>
-              </li>
-            ))}
-          </ul>
-          {ctx.game.currentPhase !== Phase.Main && (
-            <div className="absolute top-2 right-2">
-              <TimerCircle progress={phaseTimer} />
-            </div>
-          )}
-          {ctx.game.currentPhase === Phase.Main && (
-            <div className="mt-2 text-right">
-              <button
-                className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
-                disabled={phaseSteps.some((s) => s.active)}
-                onClick={() => void handleEndTurn()}
-              >
-                Next Turn
-              </button>
-            </div>
-          )}
-          {phasePaused && (
-            <div className="absolute inset-0 bg-white dark:bg-gray-900 bg-opacity-50 flex items-center justify-center text-sm">
-              Paused
-            </div>
-          )}
         </section>
 
         <section className="border rounded p-4 bg-white dark:bg-gray-800 shadow">
@@ -1522,6 +1463,72 @@ export default function Game({
         </section>
       </div>
       <section className="w-96 sticky top-4 self-start flex flex-col gap-4">
+        <section
+          className="border rounded p-4 bg-white dark:bg-gray-800 shadow relative w-full"
+          onMouseEnter={() =>
+            ctx.game.currentPhase !== Phase.Main && setPaused(true)
+          }
+          onMouseLeave={() => setPaused(false)}
+          style={{
+            cursor:
+              phasePaused && ctx.game.currentPhase !== Phase.Main
+                ? 'pause'
+                : 'auto',
+          }}
+        >
+          <h2 className="text-xl font-semibold mb-2">
+            Turn {ctx.game.turn} - {ctx.activePlayer.name}
+          </h2>
+          <div className="flex gap-4 mb-2">
+            {[Phase.Development, Phase.Upkeep, Phase.Main].map((p) => (
+              <span
+                key={p}
+                className={
+                  p === ctx.game.currentPhase ? 'font-semibold underline' : ''
+                }
+              >
+                {p.charAt(0).toUpperCase() + p.slice(1)} Phase
+              </span>
+            ))}
+          </div>
+          <ul className="text-sm text-left min-h-[1rem] space-y-1">
+            {phaseSteps.map((s, i) => (
+              <li key={i} className={s.active ? 'font-semibold' : ''}>
+                <div>{s.title}</div>
+                <ul className="pl-4 list-disc">
+                  {s.items.length > 0 ? (
+                    s.items.map((it, j) => (
+                      <li key={j} className={it.italic ? 'italic' : ''}>
+                        {it.text}
+                        {it.done && (
+                          <span className="text-green-600 ml-1">✔️</span>
+                        )}
+                      </li>
+                    ))
+                  ) : (
+                    <li>...</li>
+                  )}
+                </ul>
+              </li>
+            ))}
+          </ul>
+          {ctx.game.currentPhase !== Phase.Main && (
+            <div className="absolute top-2 right-2">
+              <TimerCircle progress={phaseTimer} paused={phasePaused} />
+            </div>
+          )}
+          {ctx.game.currentPhase === Phase.Main && (
+            <div className="mt-2 text-right">
+              <button
+                className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                disabled={phaseSteps.some((s) => s.active)}
+                onClick={() => void handleEndTurn()}
+              >
+                Next Turn
+              </button>
+            </div>
+          )}
+        </section>
         <div className="border rounded p-4 overflow-y-auto max-h-80 bg-white dark:bg-gray-800 shadow">
           <h2 className="text-xl font-semibold mb-2">Log</h2>
           <ul className="mt-2 space-y-1">


### PR DESCRIPTION
## Summary
- replace pause overlay with pause icon in phase timer
- fix step timer to run once per step
- show AP spent in main phase and relocate phase box beside player with log below

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b21140141c8325b965df65faff6808