### PR TITLE
feat(engine): add mill building passive effects

### DIFF
--- a/packages/engine/src/content/buildings.ts
+++ b/packages/engine/src/content/buildings.ts
@@ -39,7 +39,39 @@ export function createBuildingRegistry() {
   );
 
   // TODO: remaining buildings from original manual config
-  registry.add('mill', building('mill', 'Mill').cost(Resource.gold, 7).build());
+  registry.add(
+    'mill',
+    building('mill', 'Mill')
+      .cost(Resource.gold, 7)
+      .onBuild({
+        type: 'result_mod',
+        method: 'add',
+        params: { id: 'mill_overwork_bonus', actionId: 'overwork' },
+        effects: [
+          {
+            evaluator: { type: 'development', params: { id: 'farm' } },
+            effects: [
+              {
+                type: 'resource',
+                method: 'add',
+                params: { key: Resource.gold, amount: 1 },
+              },
+            ],
+          },
+        ],
+      })
+      .onDevelopmentPhase({
+        evaluator: { type: 'development', params: { id: 'farm' } },
+        effects: [
+          {
+            type: 'resource',
+            method: 'add',
+            params: { key: Resource.gold, amount: 1 },
+          },
+        ],
+      })
+      .build(),
+  );
   registry.add(
     'raiders_guild',
     building('raiders_guild', "Raider's Guild").cost(Resource.gold, 8).build(),

--- a/packages/engine/src/effects/cost_mod.ts
+++ b/packages/engine/src/effects/cost_mod.ts
@@ -15,8 +15,9 @@ export const costMod: EffectHandler<CostModParams> = (effect, ctx) => {
     throw new Error('cost_mod requires id, actionId, key, amount');
   }
   if (effect.method === 'add') {
-    ctx.passives.registerCostModifier(id, (targetActionId, costs) => {
-      if (targetActionId === actionId) {
+    const ownerId = ctx.activePlayer.id;
+    ctx.passives.registerCostModifier(id, (targetActionId, costs, innerCtx) => {
+      if (targetActionId === actionId && innerCtx.activePlayer.id === ownerId) {
         const current = costs[key] || 0;
         return { ...costs, [key]: current + amount };
       }

--- a/packages/engine/src/effects/result_mod.ts
+++ b/packages/engine/src/effects/result_mod.ts
@@ -12,10 +12,14 @@ export const resultMod: EffectHandler<ResultModParams> = (effect, ctx) => {
   if (!id || !actionId) throw new Error('result_mod requires id and actionId');
   if (effect.method === 'add') {
     const effects = effect.effects || [];
+    const ownerId = ctx.activePlayer.id;
     ctx.passives.registerResultModifier(
       id,
       (executedActionId, innerContext) => {
-        if (executedActionId === actionId) {
+        if (
+          executedActionId === actionId &&
+          innerContext.activePlayer.id === ownerId
+        ) {
           runEffects(effects, innerContext);
         }
       },

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -125,11 +125,11 @@ export class PassiveManager {
 }
 
 function reverseEffect(effect: EffectDef): EffectDef {
-  if (effect.effects)
-    return { ...effect, effects: effect.effects.map(reverseEffect) };
-  if (effect.method === 'add') return { ...effect, method: 'remove' };
-  if (effect.method === 'remove') return { ...effect, method: 'add' };
-  return { ...effect };
+  const reversed: EffectDef = { ...effect };
+  if (effect.effects) reversed.effects = effect.effects.map(reverseEffect);
+  if (effect.method === 'add') reversed.method = 'remove';
+  else if (effect.method === 'remove') reversed.method = 'add';
+  return reversed;
 }
 
 export class Services {

--- a/packages/engine/tests/buildings/mill.test.ts
+++ b/packages/engine/tests/buildings/mill.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEngine,
+  runDevelopment,
+  performAction,
+  Resource,
+  EVALUATORS,
+  type EngineContext,
+} from '../../src/index.ts';
+import { runEffects } from '../../src/effects/index.ts';
+import type { EvaluatorDef } from '../../src/evaluators/index.ts';
+
+function countFarms(ctx: EngineContext) {
+  const evaluator: EvaluatorDef = {
+    type: 'development',
+    params: { id: 'farm' },
+  };
+  return EVALUATORS.get(evaluator.type)(evaluator, ctx) as number;
+}
+
+function getFarmIncome(ctx: EngineContext) {
+  const farm = ctx.developments.get('farm');
+  const effect = farm.onDevelopmentPhase?.find(
+    (e) => e.type === 'resource' && e.params?.key === Resource.gold,
+  ) as { params: { amount: number } } | undefined;
+  const amount = effect?.params.amount ?? 0;
+  return amount * countFarms(ctx);
+}
+
+function getOverworkBaseGold(ctx: EngineContext) {
+  const overwork = ctx.actions.get('overwork');
+  const container = overwork.effects?.[0];
+  if (!container) return 0;
+  const evaluator = container.evaluator;
+  const count = evaluator
+    ? (EVALUATORS.get(evaluator.type)(evaluator, ctx) as number)
+    : 0;
+  const resource = container.effects?.find(
+    (e) =>
+      e.type === 'resource' &&
+      e.method === 'add' &&
+      e.params?.key === Resource.gold,
+  ) as { params: { amount: number } } | undefined;
+  const amount = resource?.params.amount ?? 0;
+  return amount * count;
+}
+
+function getMillDevelopmentBonus(ctx: EngineContext) {
+  const mill = ctx.buildings.get('mill');
+  const container = mill.onDevelopmentPhase?.[0];
+  if (!container) return 0;
+  const evaluator = container.evaluator;
+  const count = evaluator
+    ? (EVALUATORS.get(evaluator.type)(evaluator, ctx) as number)
+    : 0;
+  const resource = container.effects?.find(
+    (e) =>
+      e.type === 'resource' &&
+      e.method === 'add' &&
+      e.params?.key === Resource.gold,
+  ) as { params: { amount: number } } | undefined;
+  const amount = resource?.params.amount ?? 0;
+  return amount * count;
+}
+
+function getMillOverworkBonus(ctx: EngineContext) {
+  const mill = ctx.buildings.get('mill');
+  const mod = mill.onBuild?.find(
+    (e) => e.type === 'result_mod' && e.params?.actionId === 'overwork',
+  );
+  const container = mod?.effects?.[0];
+  if (!container) return 0;
+  const evaluator = container.evaluator;
+  const count = evaluator
+    ? (EVALUATORS.get(evaluator.type)(evaluator, ctx) as number)
+    : 0;
+  const resource = container.effects?.find(
+    (e) =>
+      e.type === 'resource' &&
+      e.method === 'add' &&
+      e.params?.key === Resource.gold,
+  ) as { params: { amount: number } } | undefined;
+  const amount = resource?.params.amount ?? 0;
+  return amount * count;
+}
+
+describe('Mill building', () => {
+  it('without mill, development and overwork yield base gold', () => {
+    const ctx = createEngine();
+
+    const devBase = getFarmIncome(ctx);
+    const beforeDev = ctx.activePlayer.gold;
+    runDevelopment(ctx);
+    expect(ctx.activePlayer.gold - beforeDev).toBe(devBase);
+
+    const overworkBase = getOverworkBaseGold(ctx);
+    const beforeOw = ctx.activePlayer.gold;
+    performAction('overwork', ctx);
+    expect(ctx.activePlayer.gold - beforeOw).toBe(overworkBase);
+  });
+
+  it('grants additional gold during development for each farm until removed', () => {
+    const ctx = createEngine();
+    runDevelopment(ctx);
+
+    performAction('build', ctx, { id: 'mill' });
+
+    const base = getFarmIncome(ctx);
+    const bonus = getMillDevelopmentBonus(ctx);
+    const before = ctx.activePlayer.gold;
+    runDevelopment(ctx);
+    expect(ctx.activePlayer.gold - before).toBe(base + bonus);
+
+    runEffects(
+      [{ type: 'building', method: 'remove', params: { id: 'mill' } }],
+      ctx,
+    );
+    const before2 = ctx.activePlayer.gold;
+    runDevelopment(ctx);
+    expect(ctx.activePlayer.gold - before2).toBe(base);
+  });
+
+  it('adds gold when overworking farms until removed', () => {
+    const ctx = createEngine();
+    runDevelopment(ctx);
+    performAction('build', ctx, { id: 'mill' });
+    ctx.activePlayer.ap += 1;
+    const base = getOverworkBaseGold(ctx);
+    const bonus = getMillOverworkBonus(ctx);
+    const before = ctx.activePlayer.gold;
+    performAction('overwork', ctx);
+    expect(ctx.activePlayer.gold - before).toBe(base + bonus);
+
+    runEffects(
+      [{ type: 'building', method: 'remove', params: { id: 'mill' } }],
+      ctx,
+    );
+    ctx.activePlayer.ap += 1;
+    const before2 = ctx.activePlayer.gold;
+    performAction('overwork', ctx);
+    expect(ctx.activePlayer.gold - before2).toBe(base);
+  });
+
+  it('does not grant bonuses to the opponent', () => {
+    const ctx = createEngine();
+    runDevelopment(ctx);
+    performAction('build', ctx, { id: 'mill' });
+
+    ctx.game.currentPlayerIndex = 1;
+    const devBase = getFarmIncome(ctx);
+    const beforeDev = ctx.activePlayer.gold;
+    runDevelopment(ctx);
+    expect(ctx.activePlayer.gold - beforeDev).toBe(devBase);
+
+    const overworkBase = getOverworkBaseGold(ctx);
+    const beforeOw = ctx.activePlayer.gold;
+    performAction('overwork', ctx);
+    expect(ctx.activePlayer.gold - beforeOw).toBe(overworkBase);
+  });
+});


### PR DESCRIPTION
## Summary
- implement Mill building with farm income and Overwork gold bonuses
- fix passive modifiers to apply only to the owning player and reverse correctly
- test Mill edge cases for opponents, removal, and no-building scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d2212d888325b45ba398dc9191a8