### PR TITLE
Scale Tax action by population and translate

### DIFF
--- a/packages/engine/tests/actions/tax.test.ts
+++ b/packages/engine/tests/actions/tax.test.ts
@@ -4,6 +4,8 @@ import {
   runDevelopment,
   performAction,
   Resource,
+  PopulationRole,
+  runEffects,
   EVALUATORS,
 } from '../../src';
 import type { EffectDef } from '../../src/effects';
@@ -36,6 +38,17 @@ describe('Tax action', () => {
   it('grants gold and loses happiness for each population', () => {
     const ctx = createEngine();
     runDevelopment(ctx);
+    runEffects(
+      [
+        {
+          type: 'population',
+          method: 'add',
+          params: { role: PopulationRole.Citizen },
+        },
+      ],
+      ctx,
+      2,
+    );
     const actionDefinition = ctx.actions.get('tax');
     const apBefore = ctx.activePlayer.ap;
     const goldBefore = ctx.activePlayer.gold;

--- a/packages/web/src/translation/effects/evaluators/population.ts
+++ b/packages/web/src/translation/effects/evaluators/population.ts
@@ -1,0 +1,20 @@
+import { populationInfo } from '../../../icons';
+import { registerEvaluatorFormatter } from '../factory';
+
+registerEvaluatorFormatter('population', {
+  summarize: (ev, sub) => {
+    const role = (ev.params as Record<string, string>)?.['role'];
+    const icon = role ? populationInfo[role]?.icon || role : '👥';
+    return sub.map((s) => `${s} per ${icon}`);
+  },
+  describe: (ev, sub) => {
+    const role = (ev.params as Record<string, string>)?.['role'];
+    if (role) {
+      const info = populationInfo[role];
+      return sub.map((s) =>
+        `${s} for each ${info?.icon || ''}${info?.label || role}`.trim(),
+      );
+    }
+    return sub.map((s) => `${s} for each population`);
+  },
+});

--- a/packages/web/src/translation/effects/index.ts
+++ b/packages/web/src/translation/effects/index.ts
@@ -13,3 +13,4 @@ import './formatters/building';
 import './formatters/modifier';
 import './formatters/passive';
 import './evaluators/development';
+import './evaluators/population';

--- a/tests/integration/tax-translation.test.ts
+++ b/tests/integration/tax-translation.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { createEngine } from '../../packages/engine/src';
+import { summarizeContent } from '../../packages/web/src/translation/content';
+
+describe('Tax action translation', () => {
+  it('mentions population scaling', () => {
+    const ctx = createEngine();
+    const summary = summarizeContent('action', 'tax', ctx) as {
+      title: string;
+      items: string[];
+    }[];
+    const items = summary[0]?.items || [];
+    expect(items.some((i) => i.includes('per 👥'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure Tax action multiplies resource effects for each population
- render population-based effects on the frontend
- test Tax action scaling and translation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ddd0733083259b5ad02a97aac7e9