### PR TITLE
Align modifier translations and disable unfinished actions

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -550,6 +550,14 @@ export default function Game({
         const devIcon = developmentInfo[devId]?.icon || '';
         const devLabel = developmentInfo[devId]?.label || devId;
         message += ` - ${devIcon}${devLabel}`;
+      } else if (
+        action.id === 'build' &&
+        params &&
+        typeof (params as { id?: string }).id === 'string'
+      ) {
+        const bId = (params as { id: string }).id;
+        const bLabel = ctx.buildings.get(bId)?.name || bId;
+        message += ` - ${buildingIcon}${bLabel}`;
       }
       addLog([message, ...changes.map((c) => `  ${c}`)]);
     } catch (e) {
@@ -830,15 +838,22 @@ export default function Game({
                       ] >= v,
                   );
                   const meetsReq = requirements.length === 0;
+                  const summary = actionSummaries.get(action.id);
+                  const implemented = (summary?.length ?? 0) > 0; // TODO: implement action effects
                   const enabled =
-                    canPay && meetsReq && ctx.game.currentPhase === Phase.Main;
-                  const title = !meetsReq
-                    ? requirements.join(', ')
-                    : !canPay
-                      ? 'Cannot pay costs'
-                      : ctx.game.currentPhase !== Phase.Main
-                        ? 'Not in Main phase'
-                        : undefined;
+                    canPay &&
+                    meetsReq &&
+                    ctx.game.currentPhase === Phase.Main &&
+                    implemented;
+                  const title = !implemented
+                    ? 'Not implemented yet'
+                    : !meetsReq
+                      ? requirements.join(', ')
+                      : !canPay
+                        ? 'Cannot pay costs'
+                        : ctx.game.currentPhase !== Phase.Main
+                          ? 'Not in Main phase'
+                          : undefined;
                   return (
                     <button
                       key={action.id}
@@ -870,7 +885,13 @@ export default function Game({
                         {renderCosts(costs, ctx.activePlayer.resources)}
                       </span>
                       <ul className="text-sm list-disc pl-4 text-left">
-                        {renderSummary(actionSummaries.get(action.id))}
+                        {implemented ? (
+                          renderSummary(summary)
+                        ) : (
+                          <li className="italic text-red-600">
+                            Not implemented yet
+                          </li>
+                        )}
                       </ul>
                       {requirements.length > 0 && (
                         <div className="text-sm text-red-600 text-left">
@@ -1020,15 +1041,21 @@ export default function Game({
                               k as keyof typeof ctx.activePlayer.resources
                             ] >= v,
                         );
+                      const summary = developmentSummaries.get(d.id);
+                      const implemented = (summary?.length ?? 0) > 0; // TODO: implement development effects
                       const enabled =
-                        canPay && ctx.game.currentPhase === Phase.Main;
-                      const title = !hasDevelopLand
-                        ? 'No land with free development slot'
-                        : !canPay
-                          ? 'Cannot pay costs'
-                          : ctx.game.currentPhase !== Phase.Main
-                            ? 'Not in Main phase'
-                            : undefined;
+                        canPay &&
+                        ctx.game.currentPhase === Phase.Main &&
+                        implemented;
+                      const title = !implemented
+                        ? 'Not implemented yet'
+                        : !hasDevelopLand
+                          ? 'No land with free development slot'
+                          : !canPay
+                            ? 'Cannot pay costs'
+                            : ctx.game.currentPhase !== Phase.Main
+                              ? 'Not in Main phase'
+                              : undefined;
                       return (
                         <button
                           key={d.id}
@@ -1068,7 +1095,13 @@ export default function Game({
                             {renderCosts(costs, ctx.activePlayer.resources)}
                           </span>
                           <ul className="text-sm list-disc pl-4 text-left">
-                            {renderSummary(developmentSummaries.get(d.id))}
+                            {implemented ? (
+                              renderSummary(summary)
+                            ) : (
+                              <li className="italic text-red-600">
+                                Not implemented yet
+                              </li>
+                            )}
                           </ul>
                           {requirements.length > 0 && (
                             <div className="text-sm text-red-600 text-left">
@@ -1102,13 +1135,19 @@ export default function Game({
                             k as keyof typeof ctx.activePlayer.resources
                           ] >= v,
                       );
+                      const summary = buildingSummaries.get(b.id);
+                      const implemented = (summary?.length ?? 0) > 0; // TODO: implement building effects
                       const enabled =
-                        canPay && ctx.game.currentPhase === Phase.Main;
-                      const title = !canPay
-                        ? 'Cannot pay costs'
-                        : ctx.game.currentPhase !== Phase.Main
-                          ? 'Not in Main phase'
-                          : undefined;
+                        canPay &&
+                        ctx.game.currentPhase === Phase.Main &&
+                        implemented;
+                      const title = !implemented
+                        ? 'Not implemented yet'
+                        : !canPay
+                          ? 'Cannot pay costs'
+                          : ctx.game.currentPhase !== Phase.Main
+                            ? 'Not in Main phase'
+                            : undefined;
                       return (
                         <button
                           key={b.id}
@@ -1138,7 +1177,13 @@ export default function Game({
                             {renderCosts(costs, ctx.activePlayer.resources)}
                           </span>
                           <ul className="text-sm list-disc pl-4 text-left">
-                            {renderSummary(buildingSummaries.get(b.id))}
+                            {implemented ? (
+                              renderSummary(summary)
+                            ) : (
+                              <li className="italic text-red-600">
+                                Not implemented yet
+                              </li>
+                            )}
                           </ul>
                         </button>
                       );

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -69,6 +69,7 @@ interface PlayerPanelProps {
     requirements: string[];
     costs: Record<string, number>;
     description?: string;
+    descriptionClass?: string;
     effectsTitle?: string;
   }) => void;
   clearHoverCard: () => void;
@@ -402,6 +403,7 @@ export default function Game({
     requirements: string[];
     costs: Record<string, number>;
     description?: string;
+    descriptionClass?: string;
     effectsTitle?: string;
   } | null>(null);
   const hoverTimeout = useRef<number>();
@@ -444,6 +446,7 @@ export default function Game({
     requirements: string[];
     costs: Record<string, number>;
     description?: string;
+    descriptionClass?: string;
     effectsTitle?: string;
   }) {
     if (hoverTimeout.current) window.clearTimeout(hoverTimeout.current);
@@ -855,6 +858,10 @@ export default function Game({
                           effects: describeContent('action', action.id, ctx),
                           requirements,
                           costs,
+                          ...(!implemented && {
+                            description: 'Not implemented yet',
+                            descriptionClass: 'italic text-red-600',
+                          }),
                         })
                       }
                       onMouseLeave={clearHoverCard}
@@ -1066,6 +1073,10 @@ export default function Game({
                               ),
                               requirements,
                               costs,
+                              ...(!implemented && {
+                                description: 'Not implemented yet',
+                                descriptionClass: 'italic text-red-600',
+                              }),
                             })
                           }
                           onMouseLeave={clearHoverCard}
@@ -1148,6 +1159,10 @@ export default function Game({
                               effects: describeContent('building', b.id, ctx),
                               requirements,
                               costs,
+                              ...(!implemented && {
+                                description: 'Not implemented yet',
+                                descriptionClass: 'italic text-red-600',
+                              }),
                             })
                           }
                           onMouseLeave={clearHoverCard}
@@ -1276,7 +1291,11 @@ export default function Game({
                 </div>
               )}
               {hoverCard.description && (
-                <div className="mb-2 text-sm">{hoverCard.description}</div>
+                <div
+                  className={`mb-2 text-sm ${hoverCard.descriptionClass ?? ''}`}
+                >
+                  {hoverCard.description}
+                </div>
               )}
               {hoverCard.effects.length > 0 && (
                 <div>

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -27,6 +27,7 @@ import {
   describeContent,
   snapshotPlayer,
   diffSnapshots,
+  logContent,
   type Summary,
 } from './translation';
 
@@ -539,27 +540,8 @@ export default function Game({
       performAction(action.id, ctx, params as ActionParams<string>);
       const after = snapshotPlayer(ctx.activePlayer);
       const changes = diffSnapshots(before, after, ctx);
-      const icon = actionInfo[action.id as keyof typeof actionInfo]?.icon || '';
-      let message = `Played ${icon} ${action.name}`;
-      if (
-        action.id === 'develop' &&
-        params &&
-        typeof (params as { id?: string }).id === 'string'
-      ) {
-        const devId = (params as { id: string }).id;
-        const devIcon = developmentInfo[devId]?.icon || '';
-        const devLabel = developmentInfo[devId]?.label || devId;
-        message += ` - ${devIcon}${devLabel}`;
-      } else if (
-        action.id === 'build' &&
-        params &&
-        typeof (params as { id?: string }).id === 'string'
-      ) {
-        const bId = (params as { id: string }).id;
-        const bLabel = ctx.buildings.get(bId)?.name || bId;
-        message += ` - ${buildingIcon}${bLabel}`;
-      }
-      addLog([message, ...changes.map((c) => `  ${c}`)]);
+      const messages = logContent('action', action.id, ctx, params);
+      addLog([...messages, ...changes.map((c) => `  ${c}`)]);
     } catch (e) {
       const icon = actionInfo[action.id as keyof typeof actionInfo]?.icon || '';
       addLog(`Failed to play ${icon} ${action.name}: ${(e as Error).message}`);

--- a/packages/web/src/translation/content/action.ts
+++ b/packages/web/src/translation/content/action.ts
@@ -1,10 +1,12 @@
 import type { EngineContext } from '@kingdom-builder/engine';
-import { phaseInfo } from '../../icons';
+import { phaseInfo, actionInfo } from '../../icons';
 import { summarizeEffects, describeEffects } from '../effects';
-import { registerContentTranslator } from './factory';
+import { registerContentTranslator, logContent } from './factory';
 import type { ContentTranslator, Summary } from './types';
 
-class ActionTranslator implements ContentTranslator<string> {
+class ActionTranslator
+  implements ContentTranslator<string, Record<string, unknown>>
+{
   summarize(id: string, ctx: EngineContext): Summary {
     const def = ctx.actions.get(id);
     const eff = summarizeEffects(def.effects, ctx);
@@ -26,6 +28,41 @@ class ActionTranslator implements ContentTranslator<string> {
         items: eff,
       },
     ];
+  }
+  private logHandlers: Record<
+    string,
+    (ctx: EngineContext, params?: Record<string, unknown>) => string
+  > = {
+    develop: (ctx, params) => {
+      const id =
+        typeof (params as { id?: string })?.id === 'string'
+          ? (params as { id: string }).id
+          : undefined;
+      if (!id) return '';
+      const target = logContent('development', id, ctx)[0];
+      return target ? ` - ${target}` : '';
+    },
+    build: (ctx, params) => {
+      const id =
+        typeof (params as { id?: string })?.id === 'string'
+          ? (params as { id: string }).id
+          : undefined;
+      if (!id) return '';
+      const target = logContent('building', id, ctx)[0];
+      return target ? ` - ${target}` : '';
+    },
+  };
+  log(
+    id: string,
+    ctx: EngineContext,
+    params?: Record<string, unknown>,
+  ): string[] {
+    const def = ctx.actions.get(id);
+    const icon = actionInfo[id as keyof typeof actionInfo]?.icon || '';
+    let message = `Played ${icon} ${def.name}`;
+    const extra = this.logHandlers[id]?.(ctx, params);
+    if (extra) message += extra;
+    return [message];
   }
 }
 

--- a/packages/web/src/translation/content/building.ts
+++ b/packages/web/src/translation/content/building.ts
@@ -3,6 +3,7 @@ import { registerContentTranslator } from './factory';
 import type { ContentTranslator, Summary } from './types';
 import { PhasedTranslator } from './phased';
 import { withInstallation } from './decorators';
+import { buildingIcon } from '../../icons';
 
 class BuildingCore implements ContentTranslator<string> {
   private phased = new PhasedTranslator();
@@ -13,6 +14,10 @@ class BuildingCore implements ContentTranslator<string> {
   describe(id: string, ctx: EngineContext): Summary {
     const def = ctx.buildings.get(id);
     return this.phased.describe(def, ctx);
+  }
+  log(id: string, ctx: EngineContext): string[] {
+    const def = ctx.buildings.get(id);
+    return [`${buildingIcon}${def.name}`];
   }
 }
 

--- a/packages/web/src/translation/content/decorators.ts
+++ b/packages/web/src/translation/content/decorators.ts
@@ -30,5 +30,12 @@ export function withInstallation<T>(
         : `${phaseInfo.onBuild.icon} On build, ${phaseInfo.onBuild.future.toLowerCase()}`;
       return [{ title, items: inner }];
     },
+    log(
+      target: T,
+      ctx: EngineContext,
+      opts?: { installed?: boolean },
+    ): string[] {
+      return translator.log ? translator.log(target, ctx, opts) : [];
+    },
   };
 }

--- a/packages/web/src/translation/content/development.ts
+++ b/packages/web/src/translation/content/development.ts
@@ -3,6 +3,7 @@ import { registerContentTranslator } from './factory';
 import type { ContentTranslator, Summary } from './types';
 import { PhasedTranslator } from './phased';
 import { withInstallation } from './decorators';
+import { developmentInfo } from '../../icons';
 
 class DevelopmentCore implements ContentTranslator<string> {
   private phased = new PhasedTranslator();
@@ -13,6 +14,11 @@ class DevelopmentCore implements ContentTranslator<string> {
   describe(id: string, ctx: EngineContext): Summary {
     const def = ctx.developments.get(id);
     return this.phased.describe(def, ctx);
+  }
+  log(id: string, ctx: EngineContext): string[] {
+    const def = ctx.developments.get(id);
+    const icon = developmentInfo[id]?.icon || '';
+    return [`${icon}${def.name}`];
   }
 }
 

--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -14,7 +14,7 @@ registerEffectFormatter('cost_mod', 'add', {
     const actionId = eff.params?.['actionId'] as string;
     const actionIcon =
       actionInfo[actionId as keyof typeof actionInfo]?.icon || actionId;
-    return `${modifierInfo.cost.icon} ${actionIcon} cost ${icon}${signed(amount)}${amount}`;
+    return `${modifierInfo.cost.icon} ${actionIcon}: ${icon}${signed(amount)}${amount}`;
   },
   describe: (eff) => {
     const key = eff.params?.['key'] as string;
@@ -23,7 +23,7 @@ registerEffectFormatter('cost_mod', 'add', {
     const actionId = eff.params?.['actionId'] as string;
     const actionIcon =
       actionInfo[actionId as keyof typeof actionInfo]?.icon || actionId;
-    return `${modifierInfo.cost.label}: ${increaseOrDecrease(amount)} ${actionIcon} cost by ${icon}${Math.abs(amount)}`;
+    return `${modifierInfo.cost.label} on ${actionIcon}: ${increaseOrDecrease(amount)} cost by ${icon}${Math.abs(amount)}`;
   },
 });
 

--- a/packages/web/src/translation/effects/formatters/resource.ts
+++ b/packages/web/src/translation/effects/formatters/resource.ts
@@ -1,5 +1,5 @@
 import { resourceInfo } from '../../../icons';
-import { gainOrLose, signed } from '../helpers';
+import { signed } from '../helpers';
 import { registerEffectFormatter } from '../factory';
 
 registerEffectFormatter('resource', 'add', {
@@ -14,8 +14,8 @@ registerEffectFormatter('resource', 'add', {
     const key = eff.params?.['key'] as string;
     const res = resourceInfo[key as keyof typeof resourceInfo];
     const label = res?.label || key;
-    const icon = res?.icon || '';
+    const icon = res?.icon || key;
     const amount = Number(eff.params?.['amount']);
-    return `${gainOrLose(amount)} ${Math.abs(amount)} ${icon} ${label}`;
+    return `${icon}${signed(amount)}${amount} ${label}`;
   },
 });

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -1,12 +1,6 @@
 import type { EngineContext } from '@kingdom-builder/engine';
-import {
-  resourceInfo,
-  statInfo,
-  developmentInfo,
-  landIcon,
-  buildingIcon,
-} from '../icons';
-import type { Land } from './content';
+import { resourceInfo, statInfo, landIcon } from '../icons';
+import { logContent, type Land } from './content';
 
 export interface PlayerSnapshot {
   resources: Record<string, number>;
@@ -84,13 +78,8 @@ export function diffSnapshots(
   const afterB = new Set(after.buildings);
   for (const id of afterB)
     if (!beforeB.has(id)) {
-      let name = id;
-      try {
-        name = ctx.buildings.get(id).name;
-      } catch {
-        // use id if lookup fails
-      }
-      changes.push(`${buildingIcon} ${name} built`);
+      const label = logContent('building', id, ctx)[0] ?? id;
+      changes.push(`${label} built`);
     }
   for (const land of after.lands) {
     const prev = before.lands.find((l) => l.id === land.id);
@@ -100,8 +89,8 @@ export function diffSnapshots(
     }
     for (const dev of land.developments)
       if (!prev.developments.includes(dev)) {
-        const icon = developmentInfo[dev]?.icon || dev;
-        changes.push(`${landIcon} +${icon}`);
+        const label = logContent('development', dev, ctx)[0] ?? dev;
+        changes.push(`${landIcon} +${label}`);
       }
   }
   return changes;


### PR DESCRIPTION
## Summary
- streamline cost modifier text and unify modifier descriptions
- show building details in Build log entries
- disable unimplemented actions and mark them as not implemented

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e56b4e3c83259870f77e2ac317cd