### PR TITLE
fix: reconcile population evaluator and add tax translation test

### DIFF
--- a/packages/engine/tests/actions/tax.test.ts
+++ b/packages/engine/tests/actions/tax.test.ts
@@ -4,6 +4,8 @@ import {
   runDevelopment,
   performAction,
   Resource,
+  PopulationRole,
+  runEffects,
   EVALUATORS,
 } from '../../src';
 import type { EffectDef } from '../../src/effects';
@@ -36,6 +38,17 @@ describe('Tax action', () => {
   it('grants gold and loses happiness for each population', () => {
     const ctx = createEngine();
     runDevelopment(ctx);
+    runEffects(
+      [
+        {
+          type: 'population',
+          method: 'add',
+          params: { role: PopulationRole.Citizen },
+        },
+      ],
+      ctx,
+      2,
+    );
     const actionDefinition = ctx.actions.get('tax');
     const apBefore = ctx.activePlayer.ap;
     const goldBefore = ctx.activePlayer.gold;

--- a/tests/integration/tax-translation.test.ts
+++ b/tests/integration/tax-translation.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createEngine } from '../../packages/engine/src';
+
+vi.mock(
+  '@kingdom-builder/engine',
+  async () => await import('../../packages/engine/src'),
+);
+
+import { summarizeContent } from '../../packages/web/src/translation/content';
+
+describe('Tax action translation', () => {
+  it('mentions population scaling', () => {
+    const ctx = createEngine();
+    const summary = summarizeContent('action', 'tax', ctx) as {
+      title: string;
+      items: string[];
+    }[];
+    const items = summary[0]?.items || [];
+    expect(items.some((i) => i.includes('per 👥'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- resolve population evaluator import conflict by standardizing on engine icons
- add integration test to ensure tax translation scales with population

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ed9631248325869a5620812e4278