### PR TITLE
fix(web): use auto overflow in phase list

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -1235,7 +1235,7 @@ export default function Game({
             </div>
             <ul
               ref={phaseStepsRef}
-              className="text-sm text-left space-y-1 overflow-y-scroll flex-1"
+              className="text-sm text-left space-y-1 overflow-y-auto flex-1"
             >
               {phaseSteps.map((s, i) => (
                 <li key={i} className={s.active ? 'font-semibold' : ''}>


### PR DESCRIPTION
## Summary
- use `overflow-y-auto` for phase list to avoid always visible scrollbars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fb290a3c8325a0ac848f221302fc