### PR TITLE
feat: add configurable phase step system

### DIFF
--- a/packages/engine/src/content/phases.ts
+++ b/packages/engine/src/content/phases.ts
@@ -1,0 +1,26 @@
+import type { TriggerKey } from './defs';
+
+export interface StepDef {
+  id: string;
+  trigger?: TriggerKey;
+}
+
+export interface PhaseDef {
+  id: string;
+  steps: StepDef[];
+}
+
+export const PHASES: PhaseDef[] = [
+  {
+    id: 'development',
+    steps: [{ id: 'default', trigger: 'onDevelopmentPhase' }],
+  },
+  {
+    id: 'upkeep',
+    steps: [{ id: 'default', trigger: 'onUpkeepPhase' }],
+  },
+  {
+    id: 'main',
+    steps: [{ id: 'default' }],
+  },
+];

--- a/packages/engine/src/context.ts
+++ b/packages/engine/src/context.ts
@@ -5,6 +5,7 @@ import type { ActionDef } from './content/actions';
 import type { BuildingDef } from './content/buildings';
 import type { DevelopmentDef } from './content/developments';
 import type { PopulationDef } from './content/populations';
+import type { PhaseDef } from './content/phases';
 
 export class EngineContext {
   constructor(
@@ -15,6 +16,7 @@ export class EngineContext {
     public developments: Registry<DevelopmentDef>,
     public populations: Registry<PopulationDef>,
     public passives: PassiveManager,
+    public phases: PhaseDef[],
   ) {}
   get activePlayer() {
     return this.game.active;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -30,6 +30,7 @@ import { EVALUATORS, registerCoreEvaluators } from './evaluators';
 import { runRequirement, registerCoreRequirements } from './requirements';
 import { Registry } from './registry';
 import { applyParamsToEffects } from './utils';
+import { PHASES, type PhaseDef } from './content/phases';
 import {
   validateGameConfig,
   type GameConfig,
@@ -205,14 +206,44 @@ export function performAction<T extends string>(
   ctx.passives.runResultMods(actionDefinition.id, ctx);
 }
 
-export function runDevelopment(ctx: EngineContext) {
-  ctx.game.currentPhase = Phase.Development;
-  runTrigger('onDevelopmentPhase', ctx);
+export interface AdvanceResult {
+  phase: string;
+  step: string;
+  effects: EffectDef[];
+  player: PlayerState;
 }
 
-export function runUpkeep(ctx: EngineContext) {
-  ctx.game.currentPhase = Phase.Upkeep;
-  runTrigger('onUpkeepPhase', ctx);
+export function advance(ctx: EngineContext): AdvanceResult {
+  const phase = ctx.phases[ctx.game.phaseIndex]!;
+  const step = phase.steps[ctx.game.stepIndex];
+  const player = ctx.activePlayer;
+  let effects: EffectDef[] = [];
+  if (step?.trigger) {
+    effects = collectTriggerEffects(step.trigger, ctx, player);
+    runEffects(effects, ctx);
+  }
+
+  ctx.game.stepIndex += 1;
+  if (ctx.game.stepIndex >= phase.steps.length) {
+    ctx.game.stepIndex = 0;
+    if (ctx.game.currentPlayerIndex === ctx.game.players.length - 1) {
+      ctx.game.currentPlayerIndex = 0;
+      ctx.game.phaseIndex += 1;
+      if (ctx.game.phaseIndex >= ctx.phases.length) {
+        ctx.game.phaseIndex = 0;
+        ctx.game.turn += 1;
+      }
+    } else {
+      ctx.game.currentPlayerIndex += 1;
+    }
+  }
+
+  const nextPhase = ctx.phases[ctx.game.phaseIndex]!;
+  const nextStep = nextPhase.steps[ctx.game.stepIndex];
+  ctx.game.currentPhase = nextPhase.id;
+  ctx.game.currentStep = nextStep ? nextStep.id : '';
+
+  return { phase: phase.id, step: step?.id || '', effects, player };
 }
 
 export function resolveAttack(
@@ -264,6 +295,7 @@ export function createEngine(overrides?: {
   populations?: Registry<PopulationDef>;
   rules?: RuleSet;
   config?: GameConfig;
+  phases?: PhaseDef[];
 }) {
   registerCoreEffects();
   registerCoreEvaluators();
@@ -279,6 +311,7 @@ export function createEngine(overrides?: {
   let developments = overrides?.developments;
   let populations = overrides?.populations;
   let start = GAME_START;
+  let phases = overrides?.phases || PHASES;
 
   if (overrides?.config) {
     const config = validateGameConfig(overrides.config);
@@ -312,6 +345,7 @@ export function createEngine(overrides?: {
   buildings = buildings || BUILDINGS;
   developments = developments || DEVELOPMENTS;
   populations = populations || POPULATIONS;
+  phases = phases || PHASES;
 
   const ctx = new EngineContext(
     game,
@@ -321,6 +355,7 @@ export function createEngine(overrides?: {
     developments,
     populations,
     passives,
+    phases,
   );
   const playerA = ctx.game.players[0]!;
   const playerB = ctx.game.players[1]!;
@@ -328,6 +363,8 @@ export function createEngine(overrides?: {
   applyPlayerStart(playerA, start.player, rules);
   applyPlayerStart(playerB, start.player, rules);
   ctx.game.currentPlayerIndex = 0;
+  ctx.game.currentPhase = phases[0]?.id || '';
+  ctx.game.currentStep = phases[0]?.steps[0]?.id || '';
 
   return ctx;
 }
@@ -347,6 +384,7 @@ export {
   Services,
   PassiveManager,
   DefaultRules,
+  PHASES,
 };
 
 export type { RuleSet, ResourceKey };

--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -122,7 +122,10 @@ export class PlayerState {
 export class GameState {
   turn = 1;
   currentPlayerIndex = 0; // multi-player friendly
-  currentPhase: PhaseId = Phase.Development;
+  currentPhase = '';
+  currentStep = '';
+  phaseIndex = 0;
+  stepIndex = 0;
   players: PlayerState[];
   constructor(aName = 'Player A', bName = 'Player B') {
     this.players = [new PlayerState('A', aName), new PlayerState('B', bName)];

--- a/packages/engine/tests/actions/action-config.test.ts
+++ b/packages/engine/tests/actions/action-config.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runDevelopment,
   performAction,
   Resource,
   createActionRegistry,
   getActionCosts,
   type EngineContext,
+  collectTriggerEffects,
+  runEffects,
 } from '../../src/index.ts';
 
 function getExpandExpectations(ctx: EngineContext) {
@@ -43,7 +44,7 @@ describe('Action configuration overrides', () => {
       },
     ];
     const ctx = createEngine({ actions });
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const goldBefore = ctx.activePlayer.gold;
     const landsBefore = ctx.activePlayer.lands.length;
     const hapBefore = ctx.activePlayer.happiness;

--- a/packages/engine/tests/actions/build.test.ts
+++ b/packages/engine/tests/actions/build.test.ts
@@ -1,17 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runDevelopment,
   performAction,
   Resource,
   getActionCosts,
+  collectTriggerEffects,
+  runEffects,
 } from '../../src/index.ts';
 import { runEffects } from '../../src/effects/index.ts';
 
 describe('Build action', () => {
   it('rejects when gold is insufficient', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const cost = getActionCosts('build', ctx, { id: 'town_charter' });
     ctx.activePlayer.gold = (cost[Resource.gold] || 0) - 1;
     expect(() => performAction('build', ctx, { id: 'town_charter' })).toThrow(
@@ -21,7 +22,7 @@ describe('Build action', () => {
 
   it('adds Town Charter modifying Expand until removed', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
 
     const baseCost = getActionCosts('expand', ctx);
     performAction('build', ctx, { id: 'town_charter' });

--- a/packages/engine/tests/actions/develop.test.ts
+++ b/packages/engine/tests/actions/develop.test.ts
@@ -3,11 +3,12 @@ import {
   createEngine,
   performAction,
   resolveAttack,
-  runDevelopment,
   EngineContext,
   PassiveManager,
   getActionCosts,
   type ResourceKey,
+  collectTriggerEffects,
+  runEffects,
 } from '../../src/index.ts';
 import { PlayerState, Land, GameState } from '../../src/state/index.ts';
 import { runEffects } from '../../src/effects/index.ts';
@@ -73,7 +74,7 @@ function expectState(actual: PlayerState, expected: PlayerState) {
 describe('Develop action', () => {
   it('places a Farm applying its configured effects', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const land = ctx.activePlayer.lands[1];
     const slotsBefore = land.slotsUsed;
     const expected = simulateBuild(ctx, 'farm', land.id);
@@ -85,7 +86,7 @@ describe('Develop action', () => {
 
   it('places a House applying its configured effects', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const land = ctx.activePlayer.lands[1];
     const slotsBefore = land.slotsUsed;
     const expected = simulateBuild(ctx, 'house', land.id);
@@ -97,7 +98,7 @@ describe('Develop action', () => {
 
   it('places an Outpost applying its configured effects', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const land = ctx.activePlayer.lands[1];
     const slotsBefore = land.slotsUsed;
     const expected = simulateBuild(ctx, 'outpost', land.id);
@@ -109,7 +110,7 @@ describe('Develop action', () => {
 
   it('applies development effects and cleans up after attack', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const land = ctx.activePlayer.lands[1];
 
     const expectedBuild = simulateBuild(ctx, 'watchtower', land.id);
@@ -127,7 +128,7 @@ describe('Develop action', () => {
 
   it('removing a development reverts its on-build effects', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const land = ctx.activePlayer.lands[1];
 
     const def = ctx.developments.get('house');

--- a/packages/engine/tests/actions/expand.test.ts
+++ b/packages/engine/tests/actions/expand.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runDevelopment,
   performAction,
   Resource,
   getActionCosts,
   type EngineContext,
+  collectTriggerEffects,
+  runEffects,
 } from '../../src/index.ts';
 import { PlayerState } from '../../src/state/index.ts';
 
@@ -40,7 +41,7 @@ function getExpandExpectations(ctx: EngineContext) {
 describe('Expand action', () => {
   it('costs gold and AP while granting land and happiness without Town Charter', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const goldBefore = ctx.activePlayer.gold;
     const actionPointsBefore = ctx.activePlayer.ap;
     const landsBefore = ctx.activePlayer.lands.length;
@@ -61,7 +62,7 @@ describe('Expand action', () => {
 
   it('includes Town Charter modifiers when present', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     performAction('build', ctx, { id: 'town_charter' });
     ctx.activePlayer.ap += 1; // allow another action
     const goldBefore = ctx.activePlayer.gold;
@@ -82,7 +83,7 @@ describe('Expand action', () => {
 
   it('applies modifiers consistently across multiple expansions', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     performAction('build', ctx, { id: 'town_charter' });
     ctx.activePlayer.ap += 2; // allow two expands
     ctx.activePlayer.gold += 10; // top-up to afford two expands
@@ -109,7 +110,7 @@ describe('Expand action', () => {
 
   it('rejects expand when gold is insufficient', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const cost = getActionCosts('expand', ctx);
     ctx.activePlayer.gold = (cost[Resource.gold] || 0) - 1;
     expect(() => performAction('expand', ctx)).toThrow(/Insufficient gold/);

--- a/packages/engine/tests/actions/multi_cost.test.ts
+++ b/packages/engine/tests/actions/multi_cost.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runDevelopment,
   performAction,
   getActionCosts,
   Resource,
+  collectTriggerEffects,
+  runEffects,
 } from '../../src/index.ts';
 import { action, building } from '../../src/config/builders.ts';
 
@@ -21,7 +22,7 @@ describe('multi-cost content', () => {
       .build();
 
     const ctx = createEngine({ config: { actions: [multiCostAction] } });
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
 
     ctx.activePlayer.gold = 5;
     ctx.activePlayer.happiness = 3;
@@ -63,7 +64,7 @@ describe('multi-cost content', () => {
         buildings: [multiCostBuildingDefinition],
       },
     });
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
 
     ctx.activePlayer.gold = 10;
     ctx.activePlayer.happiness = 2;

--- a/packages/engine/tests/actions/overwork.test.ts
+++ b/packages/engine/tests/actions/overwork.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runDevelopment,
   performAction,
   Resource,
   EVALUATORS,
+  collectTriggerEffects,
+  runEffects,
 } from '../../src';
 import type { EffectDef } from '../../src/effects';
 import type { EvaluatorDef } from '../../src/evaluators';
@@ -35,7 +36,7 @@ function getOverworkExpectations(ctx: EngineContext) {
 describe('Overwork action', () => {
   it('grants gold and loses happiness for each Farm', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const goldBefore = ctx.activePlayer.gold;
     const hapBefore = ctx.activePlayer.happiness;
     const expected = getOverworkExpectations(ctx);

--- a/packages/engine/tests/actions/raise_pop.test.ts
+++ b/packages/engine/tests/actions/raise_pop.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   createEngine,
   performAction,
-  runDevelopment,
   runEffects,
   getActionCosts,
+  collectTriggerEffects,
 } from '../../src';
 import { PopulationRole, Resource } from '../../src/state';
 import type { EffectDef } from '../../src/effects';
@@ -21,7 +21,7 @@ describe('Raise Population action', () => {
   it('assigns a Council and applies effects', () => {
     const ctx = createEngine();
     ctx.activePlayer.maxPopulation = 2;
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const costs = getActionCosts('raise_pop', ctx);
     const goldBefore = ctx.activePlayer.gold;
     const apBefore = ctx.activePlayer.ap;
@@ -46,7 +46,7 @@ describe('Raise Population action', () => {
   it('assigns a Commander and grants army strength', () => {
     const ctx = createEngine();
     ctx.activePlayer.maxPopulation = 2;
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const commanderDef = ctx.populations.get(PopulationRole.Commander);
     const passive = commanderDef.onAssigned![0];
     const statGain = (
@@ -60,7 +60,7 @@ describe('Raise Population action', () => {
 
   it('enforces population cap requirement', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     expect(() =>
       performAction('raise_pop', ctx, { role: PopulationRole.Council }),
     ).toThrow();
@@ -69,7 +69,7 @@ describe('Raise Population action', () => {
   it('removes commander passive when unassigned', () => {
     const ctx = createEngine();
     ctx.activePlayer.maxPopulation = 2;
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     performAction('raise_pop', ctx, { role: PopulationRole.Commander });
     const afterAdd = ctx.activePlayer.armyStrength;
     runEffects(
@@ -89,7 +89,7 @@ describe('Raise Population action', () => {
   it('removes council AP when unassigned', () => {
     const ctx = createEngine();
     ctx.activePlayer.maxPopulation = 2;
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     performAction('raise_pop', ctx, { role: PopulationRole.Council });
     runEffects(
       [

--- a/packages/engine/tests/actions/tax.test.ts
+++ b/packages/engine/tests/actions/tax.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runDevelopment,
   performAction,
   Resource,
   PopulationRole,
   runEffects,
   EVALUATORS,
+  collectTriggerEffects,
 } from '../../src';
 import type { EffectDef } from '../../src/effects';
 import type { EvaluatorDef } from '../../src/evaluators';
@@ -37,7 +37,7 @@ function getTaxExpectations(ctx: EngineContext) {
 describe('Tax action', () => {
   it('grants gold and loses happiness for each population', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     runEffects(
       [
         {

--- a/packages/engine/tests/buildings/mill.test.ts
+++ b/packages/engine/tests/buildings/mill.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runDevelopment,
   performAction,
   Resource,
   EVALUATORS,
   type EngineContext,
+  collectTriggerEffects,
+  runEffects,
 } from '../../src/index.ts';
-import { runEffects } from '../../src/effects/index.ts';
 import type { EvaluatorDef } from '../../src/evaluators/index.ts';
 
 function countFarms(ctx: EngineContext) {
@@ -90,7 +90,7 @@ describe('Mill building', () => {
 
     const devBase = getFarmIncome(ctx);
     const beforeDev = ctx.activePlayer.gold;
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     expect(ctx.activePlayer.gold - beforeDev).toBe(devBase);
 
     const overworkBase = getOverworkBaseGold(ctx);
@@ -101,14 +101,14 @@ describe('Mill building', () => {
 
   it('grants additional gold during development for each farm until removed', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
 
     performAction('build', ctx, { id: 'mill' });
 
     const base = getFarmIncome(ctx);
     const bonus = getMillDevelopmentBonus(ctx);
     const before = ctx.activePlayer.gold;
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     expect(ctx.activePlayer.gold - before).toBe(base + bonus);
 
     runEffects(
@@ -116,13 +116,13 @@ describe('Mill building', () => {
       ctx,
     );
     const before2 = ctx.activePlayer.gold;
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     expect(ctx.activePlayer.gold - before2).toBe(base);
   });
 
   it('adds gold when overworking farms until removed', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     performAction('build', ctx, { id: 'mill' });
     ctx.activePlayer.ap += 1;
     const base = getOverworkBaseGold(ctx);
@@ -143,13 +143,13 @@ describe('Mill building', () => {
 
   it('does not grant bonuses to the opponent', () => {
     const ctx = createEngine();
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     performAction('build', ctx, { id: 'mill' });
 
     ctx.game.currentPlayerIndex = 1;
     const devBase = getFarmIncome(ctx);
     const beforeDev = ctx.activePlayer.gold;
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     expect(ctx.activePlayer.gold - beforeDev).toBe(devBase);
 
     const overworkBase = getOverworkBaseGold(ctx);

--- a/packages/engine/tests/effects/add_stat.test.ts
+++ b/packages/engine/tests/effects/add_stat.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runDevelopment,
   performAction,
   Resource,
   Stat,
   createActionRegistry,
+  collectTriggerEffects,
+  runEffects,
 } from '../../src/index.ts';
 
 describe('stat:add effect', () => {
@@ -24,7 +25,7 @@ describe('stat:add effect', () => {
       ],
     });
     const ctx = createEngine({ actions });
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const before = ctx.activePlayer.armyStrength;
     const actionDefinition = actions.get('train_army');
     const amount = actionDefinition.effects.find(

--- a/packages/engine/tests/effects/resource-add.test.ts
+++ b/packages/engine/tests/effects/resource-add.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runDevelopment,
   performAction,
   createActionRegistry,
   Resource,
+  collectTriggerEffects,
+  runEffects,
 } from '../../src/index.ts';
 
 describe('resource:add effect', () => {
@@ -23,7 +24,7 @@ describe('resource:add effect', () => {
       ],
     });
     const ctx = createEngine({ actions });
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const before = ctx.activePlayer.gold;
     const actionDefinition = actions.get('grant_gold');
     const amount = actionDefinition.effects.find(
@@ -65,7 +66,7 @@ describe('resource:add effect', () => {
       ],
     });
     const ctx = createEngine({ actions });
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
 
     let before = ctx.activePlayer.gold;
     let foundEffect = actions

--- a/packages/engine/tests/effects/resource-remove.test.ts
+++ b/packages/engine/tests/effects/resource-remove.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runDevelopment,
   performAction,
   createActionRegistry,
   Resource,
+  collectTriggerEffects,
+  runEffects,
 } from '../../src/index.ts';
 
 describe('resource:remove effect', () => {
@@ -23,7 +24,7 @@ describe('resource:remove effect', () => {
       ],
     });
     const ctx = createEngine({ actions });
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
     const before = ctx.activePlayer.gold;
     const actionDefinition = actions.get('pay_gold');
     const amount = actionDefinition.effects.find(
@@ -65,7 +66,7 @@ describe('resource:remove effect', () => {
       ],
     });
     const ctx = createEngine({ actions });
-    runDevelopment(ctx);
+    runEffects(collectTriggerEffects('onDevelopmentPhase', ctx), ctx);
 
     let before = ctx.activePlayer.gold;
     let foundEffect = actions

--- a/packages/engine/tests/phases/development.test.ts
+++ b/packages/engine/tests/phases/development.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runDevelopment,
+  advance,
   PopulationRole,
   Stat,
   Resource,
@@ -49,12 +49,13 @@ const fortifierPct = Number(
 describe('Development phase', () => {
   it('triggers population and development effects', () => {
     const ctx = createEngine();
-    const apBefore = ctx.activePlayer.ap;
-    const goldBefore = ctx.activePlayer.gold;
-    runDevelopment(ctx);
-    const councils = ctx.activePlayer.population[PopulationRole.Council];
-    expect(ctx.activePlayer.ap).toBe(apBefore + councilApGain * councils);
-    expect(ctx.activePlayer.gold).toBe(goldBefore + farmGoldGain);
+    const player = ctx.activePlayer;
+    const apBefore = player.ap;
+    const goldBefore = player.gold;
+    advance(ctx);
+    const councils = player.population[PopulationRole.Council];
+    expect(player.ap).toBe(apBefore + councilApGain * councils);
+    expect(player.gold).toBe(goldBefore + farmGoldGain);
   });
 
   it('grows commander and fortifier stats', () => {
@@ -63,12 +64,11 @@ describe('Development phase', () => {
     ctx.activePlayer.population[PopulationRole.Fortifier] = 1;
     ctx.activePlayer.stats[Stat.armyStrength] = 8;
     ctx.activePlayer.stats[Stat.fortificationStrength] = 4;
-    runDevelopment(ctx);
+    const player = ctx.activePlayer;
+    advance(ctx);
     const expectedArmy = 8 + 8 * (commanderPct / 100);
     const expectedFort = 4 + 4 * (fortifierPct / 100);
-    expect(ctx.activePlayer.stats[Stat.armyStrength]).toBeCloseTo(expectedArmy);
-    expect(ctx.activePlayer.stats[Stat.fortificationStrength]).toBeCloseTo(
-      expectedFort,
-    );
+    expect(player.stats[Stat.armyStrength]).toBeCloseTo(expectedArmy);
+    expect(player.stats[Stat.fortificationStrength]).toBeCloseTo(expectedFort);
   });
 });

--- a/packages/engine/tests/phases/upkeep.test.ts
+++ b/packages/engine/tests/phases/upkeep.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEngine,
-  runUpkeep,
+  advance,
   PopulationRole,
   Resource,
   POPULATIONS,
+  PHASES,
 } from '../../src';
 
 const councilUpkeep = Number(
@@ -35,24 +36,32 @@ const fortifierUpkeep = Number(
 describe('Upkeep phase', () => {
   it('charges gold per population role', () => {
     const ctx = createEngine();
+    ctx.game.phaseIndex = 1;
+    ctx.game.currentPhase = PHASES[1]!.id;
+    ctx.game.currentStep = PHASES[1]!.steps[0]!.id;
     ctx.activePlayer.population[PopulationRole.Commander] = 1;
     ctx.activePlayer.population[PopulationRole.Fortifier] = 1;
     const startGold = 5;
     ctx.activePlayer.gold = startGold;
     const councils = ctx.activePlayer.population[PopulationRole.Council];
-    runUpkeep(ctx);
+    const player = ctx.activePlayer;
+    advance(ctx);
+    ctx.game.currentPlayerIndex = 0;
     const expectedGold =
       startGold -
       (councilUpkeep * councils + commanderUpkeep + fortifierUpkeep);
-    expect(ctx.activePlayer.gold).toBe(expectedGold);
+    expect(player.gold).toBe(expectedGold);
   });
 
   it('throws if upkeep cannot be paid', () => {
     const ctx = createEngine();
+    ctx.game.phaseIndex = 1;
+    ctx.game.currentPhase = PHASES[1]!.id;
+    ctx.game.currentStep = PHASES[1]!.steps[0]!.id;
     ctx.activePlayer.population[PopulationRole.Commander] = 1;
     const councils = ctx.activePlayer.population[PopulationRole.Council];
     const totalCost = councilUpkeep * councils + commanderUpkeep;
     ctx.activePlayer.gold = totalCost - 1;
-    expect(() => runUpkeep(ctx)).toThrow();
+    expect(() => advance(ctx)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- model phases/steps via content definitions
- add generic `advance` state machine and phase tracking
- update tests for new turn progression

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68b2f9d93abc832585badc4bfd552b6a