### PR TITLE
Compact player panel layout

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -78,6 +78,7 @@ interface PlayerPanelProps {
     bgClass?: string;
   }) => void;
   clearHoverCard: () => void;
+  className?: string;
 }
 
 const PlayerPanel: React.FC<PlayerPanelProps> = ({
@@ -85,6 +86,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
   ctx,
   handleHoverCard,
   clearHoverCard,
+  className = '',
 }) => {
   const popEntries = Object.entries(player.population).filter(([, v]) => v > 0);
   const currentPop = popEntries.reduce((sum, [, v]) => sum + v, 0);
@@ -108,7 +110,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
     });
 
   return (
-    <div className="space-y-1 w-fit">
+    <div className={`space-y-1 w-fit ${className}`}>
       <h3 className="font-semibold">{player.name}</h3>
       <div className="flex flex-wrap items-center gap-2 border p-2 rounded w-fit">
         {Object.entries(player.resources).map(([k, v]) => {
@@ -803,15 +805,22 @@ export default function Game({
             ref={playerBoxRef}
             className="border rounded p-4 bg-white dark:bg-gray-800 shadow"
           >
-            <div className="flex flex-col items-start gap-4">
-              {ctx.game.players.map((p) => (
-                <PlayerPanel
-                  key={p.id}
-                  player={p}
-                  ctx={ctx}
-                  handleHoverCard={handleHoverCard}
-                  clearHoverCard={clearHoverCard}
-                />
+            <div className="flex items-start gap-4">
+              {ctx.game.players.map((p, i) => (
+                <React.Fragment key={p.id}>
+                  {i > 0 && <div className="w-px bg-gray-300 self-stretch" />}
+                  <PlayerPanel
+                    player={p}
+                    ctx={ctx}
+                    handleHoverCard={handleHoverCard}
+                    clearHoverCard={clearHoverCard}
+                    className={`p-2 rounded ${
+                      i === 0
+                        ? 'bg-blue-50 dark:bg-blue-900/40'
+                        : 'bg-red-50 dark:bg-red-900/40'
+                    }`}
+                  />
+                </React.Fragment>
               ))}
             </div>
           </section>

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -108,9 +108,9 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
     });
 
   return (
-    <div className="space-y-1">
+    <div className="space-y-1 w-fit">
       <h3 className="font-semibold">{player.name}</h3>
-      <div className="flex flex-wrap items-center gap-2 border p-2 rounded">
+      <div className="flex flex-wrap items-center gap-2 border p-2 rounded w-fit">
         {Object.entries(player.resources).map(([k, v]) => {
           const info = RESOURCES[k as keyof typeof RESOURCES];
           return (
@@ -205,7 +205,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
           })}
       </div>
       {player.lands.length > 0 && (
-        <div className="grid grid-cols-4 gap-2 mt-2">
+        <div className="flex flex-wrap gap-2 mt-2 w-fit">
           {player.lands.map((land, idx) => {
             const showLandCard = () =>
               handleHoverCard({
@@ -265,11 +265,11 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
                     return (
                       <span
                         key={i}
-                        className="border p-1 text-xs transition-colors transition-transform duration-150 hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-105 cursor-help"
+                        className="border p-1 text-xs transition-colors transition-transform duration-150 hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-105 cursor-help whitespace-nowrap"
                         onMouseEnter={(e) => {
                           e.stopPropagation();
                           handleHoverCard({
-                            title: `${slotIcon} Empty development slot`,
+                            title: `${slotIcon} Development Slot (empty)`,
                             effects: [],
                             description: `Use ${actionInfo.develop.icon} Develop to build here`,
                             requirements: [],
@@ -282,7 +282,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
                           handleLeave();
                         }}
                       >
-                        {slotIcon}
+                        {slotIcon} Development Slot (empty)
                       </span>
                     );
                   })}
@@ -293,7 +293,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
         </div>
       )}
       {player.buildings.size > 0 && (
-        <div className="grid grid-cols-4 gap-2 mt-2">
+        <div className="flex flex-wrap gap-2 mt-2 w-fit">
           {Array.from(player.buildings).map((b) => {
             const name = ctx.buildings.get(b)?.name || b;
             const title = `${buildingIcon} ${name}`;
@@ -803,7 +803,7 @@ export default function Game({
             ref={playerBoxRef}
             className="border rounded p-4 bg-white dark:bg-gray-800 shadow"
           >
-            <div className="flex flex-col gap-4">
+            <div className="flex flex-col items-start gap-4">
               {ctx.game.players.map((p) => (
                 <PlayerPanel
                   key={p.id}

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -110,7 +110,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
     });
 
   return (
-    <div className={`space-y-1 w-fit ${className}`}>
+    <div className={`space-y-1 h-full ${className}`}>
       <h3 className="font-semibold">{player.name}</h3>
       <div className="flex flex-wrap items-center gap-2 border p-2 rounded w-fit">
         {Object.entries(player.resources).map(([k, v]) => {
@@ -805,22 +805,20 @@ export default function Game({
             ref={playerBoxRef}
             className="border rounded p-4 bg-white dark:bg-gray-800 shadow"
           >
-            <div className="flex items-start gap-4">
+            <div className="flex items-stretch rounded overflow-hidden divide-x divide-gray-300">
               {ctx.game.players.map((p, i) => (
-                <React.Fragment key={p.id}>
-                  {i > 0 && <div className="w-px bg-gray-300 self-stretch" />}
-                  <PlayerPanel
-                    player={p}
-                    ctx={ctx}
-                    handleHoverCard={handleHoverCard}
-                    clearHoverCard={clearHoverCard}
-                    className={`p-2 rounded ${
-                      i === 0
-                        ? 'bg-blue-50 dark:bg-blue-900/40'
-                        : 'bg-red-50 dark:bg-red-900/40'
-                    }`}
-                  />
-                </React.Fragment>
+                <PlayerPanel
+                  key={p.id}
+                  player={p}
+                  ctx={ctx}
+                  handleHoverCard={handleHoverCard}
+                  clearHoverCard={clearHoverCard}
+                  className={`flex-1 p-2 ${
+                    i === 0
+                      ? 'bg-blue-50 dark:bg-blue-900/20'
+                      : 'bg-red-50 dark:bg-red-900/20'
+                  }`}
+                />
               ))}
             </div>
           </section>

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -803,7 +803,7 @@ export default function Game({
         >
           <section
             ref={playerBoxRef}
-            className="border rounded p-4 bg-white dark:bg-gray-800 shadow"
+            className="border rounded bg-white dark:bg-gray-800 shadow"
           >
             <div className="flex items-stretch rounded overflow-hidden divide-x divide-gray-300">
               {ctx.game.players.map((p, i) => (
@@ -813,10 +813,10 @@ export default function Game({
                   ctx={ctx}
                   handleHoverCard={handleHoverCard}
                   clearHoverCard={clearHoverCard}
-                  className={`flex-1 p-2 ${
+                  className={`flex-1 p-4 ${
                     i === 0
-                      ? 'bg-blue-50 dark:bg-blue-900/20'
-                      : 'bg-red-50 dark:bg-red-900/20'
+                      ? 'bg-blue-50 dark:bg-blue-900/20 pr-6'
+                      : 'bg-red-50 dark:bg-red-900/20 pl-6'
                   }`}
                 />
               ))}


### PR DESCRIPTION
## Summary
- shrink player resource bar and panel width to fit content
- compress land and building grids; label empty development slot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2fc0bbe1c8325851cf36b637e6e90