### PR TITLE
Fix population icon and mill farm bonus handling

### DIFF
--- a/packages/engine/src/content/buildings.ts
+++ b/packages/engine/src/content/buildings.ts
@@ -60,8 +60,10 @@ export function createBuildingRegistry() {
           },
         ],
       })
-      .onDevelopmentPhase({
-        evaluator: { type: 'development', params: { id: 'farm' } },
+      .onBuild({
+        type: 'result_mod',
+        method: 'add',
+        params: { id: 'mill_farm_bonus', actionId: 'development:farm' },
         effects: [
           {
             type: 'resource',

--- a/packages/engine/src/content/stats.ts
+++ b/packages/engine/src/content/stats.ts
@@ -11,7 +11,7 @@ export interface StatInfo {
 export const STATS: Record<StatKey, StatInfo> = {
   [Stat.maxPopulation]: {
     key: Stat.maxPopulation,
-    icon: '🏘️',
+    icon: '👥',
     label: 'Max Population',
     description:
       'Max Population determines how many subjects your kingdom can sustain. Expand infrastructure or build houses to increase it.',

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -53,7 +53,10 @@ function runTrigger(
   for (const [role, count] of Object.entries(player.population)) {
     const populationDefinition = ctx.populations.get(role);
     const effects = populationDefinition[trigger];
-    if (effects) runEffects(effects, ctx, Number(count));
+    if (effects) {
+      runEffects(effects, ctx, Number(count));
+      ctx.passives.runResultMods(`population:${role}`, ctx);
+    }
   }
 
   for (const land of player.lands) {
@@ -62,13 +65,17 @@ function runTrigger(
       const effects = developmentDefinition[trigger];
       if (!effects) continue;
       runEffects(applyParamsToEffects(effects, { landId: land.id, id }), ctx);
+      ctx.passives.runResultMods(`development:${id}`, ctx);
     }
   }
 
   for (const id of player.buildings) {
     const buildingDefinition = ctx.buildings.get(id);
     const effects = buildingDefinition[trigger];
-    if (effects) runEffects(effects, ctx);
+    if (effects) {
+      runEffects(effects, ctx);
+      ctx.passives.runResultMods(`building:${id}`, ctx);
+    }
   }
 
   ctx.game.currentPlayerIndex = original;

--- a/packages/engine/tests/buildings/mill.test.ts
+++ b/packages/engine/tests/buildings/mill.test.ts
@@ -47,20 +47,17 @@ function getOverworkBaseGold(ctx: EngineContext) {
 
 function getMillDevelopmentBonus(ctx: EngineContext) {
   const mill = ctx.buildings.get('mill');
-  const container = mill.onDevelopmentPhase?.[0];
-  if (!container) return 0;
-  const evaluator = container.evaluator;
-  const count = evaluator
-    ? (EVALUATORS.get(evaluator.type)(evaluator, ctx) as number)
-    : 0;
-  const resource = container.effects?.find(
+  const mod = mill.onBuild?.find(
+    (e) => e.type === 'result_mod' && e.params?.actionId === 'development:farm',
+  );
+  const resource = mod?.effects?.find(
     (e) =>
       e.type === 'resource' &&
       e.method === 'add' &&
       e.params?.key === Resource.gold,
   ) as { params: { amount: number } } | undefined;
   const amount = resource?.params.amount ?? 0;
-  return amount * count;
+  return amount * countFarms(ctx);
 }
 
 function getMillOverworkBonus(ctx: EngineContext) {

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -655,6 +655,9 @@ export default function Game({
     for (const effect of effects) {
       const before = snapshotPlayer(player);
       runEffects([effect], ctx);
+      const id = (effect.params ?? ({} as Record<string, unknown>))['id'];
+      if (typeof id === 'string')
+        ctx.passives.runResultMods(`development:${id}`, ctx);
       const after = snapshotPlayer(player);
       const changes = diffSnapshots(before, after, ctx);
       phaseChanges.push(...changes);

--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -1,4 +1,4 @@
-import { actionInfo, modifierInfo } from '../../../icons';
+import { actionInfo, modifierInfo, developmentInfo } from '../../../icons';
 import { RESOURCES } from '@kingdom-builder/engine';
 import type { ResourceKey } from '@kingdom-builder/engine';
 import { increaseOrDecrease, signed } from '../helpers';
@@ -34,19 +34,30 @@ registerEffectFormatter('result_mod', 'add', {
   summarize: (eff, ctx) => {
     const sub = summarizeEffects(eff.effects || [], ctx);
     const actionId = eff.params?.['actionId'] as string;
-    const actionIcon =
-      actionInfo[actionId as keyof typeof actionInfo]?.icon || actionId;
-    return sub.map((s) => `${modifierInfo.result.icon} ${actionIcon}: ${s}`);
+    let actionIcon: string | undefined =
+      actionInfo[actionId as keyof typeof actionInfo]?.icon;
+    if (!actionIcon && actionId.startsWith('development:')) {
+      const dev = actionId.split(':')[1]!;
+      actionIcon = developmentInfo[dev]?.icon || actionId;
+    }
+    return sub.map(
+      (s) => `${modifierInfo.result.icon} ${actionIcon || actionId}: ${s}`,
+    );
   },
   describe: (eff, ctx) => {
     const sub = describeEffects(eff.effects || [], ctx);
     const actionId = eff.params?.['actionId'] as string;
-    const actionIcon =
-      actionInfo[actionId as keyof typeof actionInfo]?.icon || actionId;
-    const actionName = ctx.actions.get(actionId)?.name || actionId;
+    let actionIcon: string | undefined =
+      actionInfo[actionId as keyof typeof actionInfo]?.icon;
+    let actionName: string | undefined = ctx.actions.get(actionId)?.name;
+    if (!actionIcon && actionId.startsWith('development:')) {
+      const devId = actionId.split(':')[1]!;
+      actionIcon = developmentInfo[devId]?.icon || actionId;
+      actionName = ctx.developments.get(devId)?.name || devId;
+    }
     return sub.map(
       (s) =>
-        `${modifierInfo.result.icon} ${modifierInfo.result.label} on ${actionIcon} ${actionName}: ${s}`,
+        `${modifierInfo.result.icon} ${modifierInfo.result.label} on ${actionIcon || actionId} ${actionName || actionId}: ${s}`,
     );
   },
 });


### PR DESCRIPTION
## Summary
- use population icon for max population stat
- treat Mill's farm income bonus as a result modifier
- support development-specific result modifiers in engine, UI, and translations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3076137e8832585e4efd2d1bffdca