### PR TITLE
Move upkeep costs into phase config and add trigger resolution step

### DIFF
--- a/packages/engine/src/content/README.md
+++ b/packages/engine/src/content/README.md
@@ -6,5 +6,22 @@ frequently during playtesting or balancing. Only the _structure_ of the objects 
 engine schemas; the actual values, triggers and effects may change freely without impacting
 the core engine.
 
+## Phases & Steps
+
+Turn flow is fully data‑driven through `phases.ts`. Each phase lists an ordered set of
+steps. A step may define a `title`, optional `effects` and optional `triggers`:
+
+- **effects** – resolved immediately when the step runs. Complex behaviour is composed
+  with nested effects and `evaluator` helpers. For example, the `pay-upkeep` step removes
+  gold per population role by using the `population` evaluator.
+- **triggers** – collect matching `onXPhase` effects from all active content (population,
+  developments, buildings). These are resolved in a dedicated `Resolve dynamic triggers`
+  step at the start of each phase so additional phase‑based rules can be added without
+  touching engine code.
+
+By editing the phase configuration you can add, remove or reorder phases and steps, adjust
+upkeep costs or introduce entirely new mechanics. The engine and frontend consume this
+configuration dynamically.
+
 To add new content or adjust existing entries, edit the files here or copy them as a starting
 point for your own configuration set.

--- a/packages/engine/src/content/phases.ts
+++ b/packages/engine/src/content/phases.ts
@@ -20,6 +20,11 @@ export const PHASES: PhaseDef[] = [
     id: 'development',
     steps: [
       {
+        id: 'resolve-dynamic-triggers',
+        title: 'Resolve dynamic triggers',
+        triggers: ['onDevelopmentPhase'],
+      },
+      {
         id: 'gain-income',
         title: 'Gain Income',
         effects: [
@@ -34,7 +39,6 @@ export const PHASES: PhaseDef[] = [
             ],
           },
         ],
-        triggers: ['onDevelopmentPhase'],
       },
       {
         id: 'gain-ap',
@@ -93,9 +97,54 @@ export const PHASES: PhaseDef[] = [
     id: 'upkeep',
     steps: [
       {
+        id: 'resolve-dynamic-triggers',
+        title: 'Resolve dynamic triggers',
+        triggers: ['onUpkeepPhase'],
+      },
+      {
         id: 'pay-upkeep',
         title: 'Pay Upkeep',
-        triggers: ['onUpkeepPhase'],
+        effects: [
+          {
+            evaluator: {
+              type: 'population',
+              params: { role: PopulationRole.Council },
+            },
+            effects: [
+              {
+                type: 'resource',
+                method: 'remove',
+                params: { key: Resource.gold, amount: 2 },
+              },
+            ],
+          },
+          {
+            evaluator: {
+              type: 'population',
+              params: { role: PopulationRole.Commander },
+            },
+            effects: [
+              {
+                type: 'resource',
+                method: 'remove',
+                params: { key: Resource.gold, amount: 1 },
+              },
+            ],
+          },
+          {
+            evaluator: {
+              type: 'population',
+              params: { role: PopulationRole.Fortifier },
+            },
+            effects: [
+              {
+                type: 'resource',
+                method: 'remove',
+                params: { key: Resource.gold, amount: 1 },
+              },
+            ],
+          },
+        ],
       },
     ],
   },

--- a/packages/engine/src/content/populations.ts
+++ b/packages/engine/src/content/populations.ts
@@ -22,11 +22,6 @@ export function createPopulationRegistry() {
         method: 'remove',
         params: { key: Resource.ap, amount: 1 },
       })
-      .onUpkeepPhase({
-        type: 'resource',
-        method: 'remove',
-        params: { key: Resource.gold, amount: 2 },
-      })
       .build(),
   );
 
@@ -50,11 +45,6 @@ export function createPopulationRegistry() {
         method: 'remove',
         params: { id: 'commander_$player_$index' },
       })
-      .onUpkeepPhase({
-        type: 'resource',
-        method: 'remove',
-        params: { key: Resource.gold, amount: 1 },
-      })
       .build(),
   );
 
@@ -77,11 +67,6 @@ export function createPopulationRegistry() {
         type: 'passive',
         method: 'remove',
         params: { id: 'fortifier_$player_$index' },
-      })
-      .onUpkeepPhase({
-        type: 'resource',
-        method: 'remove',
-        params: { key: Resource.gold, amount: 1 },
       })
       .build(),
   );

--- a/packages/engine/tests/phases/development.test.ts
+++ b/packages/engine/tests/phases/development.test.ts
@@ -76,4 +76,19 @@ describe('Development phase', () => {
     expect(player.stats[Stat.armyStrength]).toBeCloseTo(expectedArmy);
     expect(player.stats[Stat.fortificationStrength]).toBeCloseTo(expectedFort);
   });
+
+  it('scales strength additively with multiple leaders', () => {
+    const ctx = createEngine();
+    ctx.activePlayer.population[PopulationRole.Commander] = 2;
+    ctx.activePlayer.population[PopulationRole.Fortifier] = 2;
+    ctx.activePlayer.stats[Stat.armyStrength] = 10;
+    ctx.activePlayer.stats[Stat.fortificationStrength] = 10;
+    while (ctx.game.currentPhase === 'development') advance(ctx);
+    const expectedArmy = 10 + 10 * (commanderPct / 100) * 2;
+    const expectedFort = 10 + 10 * (fortifierPct / 100) * 2;
+    expect(ctx.activePlayer.stats[Stat.armyStrength]).toBeCloseTo(expectedArmy);
+    expect(ctx.activePlayer.stats[Stat.fortificationStrength]).toBeCloseTo(
+      expectedFort,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- run phase transition triggers in a dedicated "Resolve dynamic triggers" step
- make upkeep payments configurable via phase step instead of population defs
- test additive strength scaling with multiple commanders or fortifiers
- document how phase/step/effect configuration works

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30ff5c73483259001575d06c11a3f