### PR TITLE
Fix population icon and surface farm income effects

### DIFF
--- a/packages/engine/src/content/stats.ts
+++ b/packages/engine/src/content/stats.ts
@@ -11,7 +11,7 @@ export interface StatInfo {
 export const STATS: Record<StatKey, StatInfo> = {
   [Stat.maxPopulation]: {
     key: Stat.maxPopulation,
-    icon: '🏘️',
+    icon: '👥',
     label: 'Max Population',
     description:
       'Max Population determines how many subjects your kingdom can sustain. Expand infrastructure or build houses to increase it.',

--- a/packages/web/src/translation/content/development.ts
+++ b/packages/web/src/translation/content/development.ts
@@ -1,19 +1,103 @@
-import type { EngineContext } from '@kingdom-builder/engine';
+import type { EffectDef, EngineContext } from '@kingdom-builder/engine';
 import { registerContentTranslator } from './factory';
 import type { ContentTranslator, Summary } from './types';
 import { PhasedTranslator } from './phased';
 import { withInstallation } from './decorators';
 import { developmentInfo } from '../../icons';
 
+interface PhaseEffects {
+  onDevelopmentPhase?: EffectDef[];
+  onUpkeepPhase?: EffectDef[];
+  onAttackResolved?: EffectDef[];
+}
+
+function gatherEffects(
+  effects: EffectDef[] | undefined,
+  id: string,
+  out: EffectDef[],
+): void {
+  if (!effects) return;
+  for (const eff of effects) {
+    if (
+      eff.evaluator?.type === 'development' &&
+      (eff.evaluator.params as Record<string, string> | undefined)?.['id'] ===
+        id
+    ) {
+      out.push(eff);
+    }
+    if (eff.effects) gatherEffects(eff.effects, id, out);
+  }
+}
+
+function collectPhaseEffects(id: string, ctx: EngineContext): PhaseEffects {
+  const result: PhaseEffects = {};
+  const phaseMap: Record<string, keyof PhaseEffects> = {
+    development: 'onDevelopmentPhase',
+    upkeep: 'onUpkeepPhase',
+  };
+  for (const phase of ctx.phases) {
+    const key = phaseMap[phase.id];
+    if (!key) continue;
+    for (const step of phase.steps) {
+      const bucket: EffectDef[] = [];
+      gatherEffects(step.effects, id, bucket);
+      if (bucket.length) {
+        result[key] = [...(result[key] ?? []), ...bucket];
+      }
+    }
+  }
+  return result;
+}
+
 class DevelopmentCore implements ContentTranslator<string> {
   private phased = new PhasedTranslator();
   summarize(id: string, ctx: EngineContext): Summary {
     const def = ctx.developments.get(id);
-    return this.phased.summarize(def, ctx);
+    if (!def) return [];
+    const phases = collectPhaseEffects(id, ctx);
+    const merged = {
+      ...def,
+      ...(phases.onDevelopmentPhase && {
+        onDevelopmentPhase: [
+          ...(def.onDevelopmentPhase ?? []),
+          ...phases.onDevelopmentPhase,
+        ],
+      }),
+      ...(phases.onUpkeepPhase && {
+        onUpkeepPhase: [...(def.onUpkeepPhase ?? []), ...phases.onUpkeepPhase],
+      }),
+      ...(phases.onAttackResolved && {
+        onAttackResolved: [
+          ...(def.onAttackResolved ?? []),
+          ...phases.onAttackResolved,
+        ],
+      }),
+    };
+    return this.phased.summarize(merged, ctx);
   }
   describe(id: string, ctx: EngineContext): Summary {
     const def = ctx.developments.get(id);
-    return this.phased.describe(def, ctx);
+    if (!def) return [];
+    const phases = collectPhaseEffects(id, ctx);
+    const merged = {
+      ...def,
+      ...(phases.onDevelopmentPhase && {
+        onDevelopmentPhase: [
+          ...(def.onDevelopmentPhase ?? []),
+          ...phases.onDevelopmentPhase,
+        ],
+      }),
+      ...(phases.onUpkeepPhase && {
+        onUpkeepPhase: [...(def.onUpkeepPhase ?? []), ...phases.onUpkeepPhase],
+      }),
+      ...(phases.onAttackResolved && {
+        onAttackResolved: [
+          ...(def.onAttackResolved ?? []),
+          ...phases.onAttackResolved,
+        ],
+      }),
+    };
+    return this.phased.describe(merged, ctx);
   }
   log(id: string, ctx: EngineContext): string[] {
     const def = ctx.developments.get(id);

--- a/packages/web/tests/development-summary.test.ts
+++ b/packages/web/tests/development-summary.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { summarizeContent } from '../src/translation/content';
+import type { Summary } from '../src/translation/content';
+import { createEngine } from '@kingdom-builder/engine';
+
+vi.mock('@kingdom-builder/engine', async () => {
+  return await import('../../engine/src');
+});
+
+function flatten(summary: Summary): string[] {
+  const result: string[] = [];
+  for (const entry of summary) {
+    if (typeof entry === 'string') {
+      result.push(entry);
+    } else {
+      result.push(...flatten(entry.items));
+    }
+  }
+  return result;
+}
+
+describe('development translation', () => {
+  it('includes phase effects for farm', () => {
+    const ctx = createEngine();
+    const summary = summarizeContent('development', 'farm', ctx);
+    const flat = flatten(summary);
+    expect(flat).toContain('🪙+2 per 🌾');
+  });
+});


### PR DESCRIPTION
## Summary
- use player population icon for Max Population stat
- aggregate phase-based effects so Farm grants 2 gold each development phase
- test farm translation to ensure phase-defined effects appear

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3132fa028832583a583e799467c2c