### PR TITLE
Fix additive strength scaling with multiple leaders

### DIFF
--- a/packages/engine/src/context.ts
+++ b/packages/engine/src/context.ts
@@ -19,6 +19,11 @@ export class EngineContext {
     public phases: PhaseDef[],
   ) {}
   recentResourceGains: { key: ResourceKey; amount: number }[] = [];
+  // Cache base values for stat:add_pct per turn/phase/step to ensure
+  // additive scaling when effects are evaluated multiple times in the
+  // same step (e.g. multiple leaders raising strength).
+  statAddPctBases: Record<string, number> = {};
+  statAddPctAccums: Record<string, number> = {};
   get activePlayer() {
     return this.game.active;
   }

--- a/packages/engine/src/effects/stat_add_pct.ts
+++ b/packages/engine/src/effects/stat_add_pct.ts
@@ -4,7 +4,17 @@ import type { StatKey } from '../state';
 export const statAddPct: EffectHandler = (effect, ctx, mult = 1) => {
   const key = effect.params!['key'] as StatKey;
   const pct = effect.params!['percent'] as number;
-  const current = ctx.activePlayer.stats[key] || 0;
-  const delta = current * (pct / 100) * mult;
-  ctx.activePlayer.stats[key] = current + delta;
+
+  // Use a cache keyed by turn/phase/step so multiple evaluations in the
+  // same step (e.g. multiple commanders) scale additively from the
+  // original stat value rather than compounding.
+  const cacheKey = `${ctx.game.turn}:${ctx.game.currentPhase}:${ctx.game.currentStep}:${key}`;
+  if (!(cacheKey in ctx.statAddPctBases)) {
+    ctx.statAddPctBases[cacheKey] = ctx.activePlayer.stats[key] || 0;
+    ctx.statAddPctAccums[cacheKey] = 0;
+  }
+
+  const base = ctx.statAddPctBases[cacheKey]!;
+  ctx.statAddPctAccums[cacheKey]! += base * (pct / 100) * mult;
+  ctx.activePlayer.stats[key] = base + ctx.statAddPctAccums[cacheKey]!;
 };


### PR DESCRIPTION
## Summary
- prevent commander/fortifier bonuses from compounding by caching base stat per turn step
- add context fields to support additive stat percentage effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3209da67483259b53832c4013fff8