### PR TITLE
fix: fill player panel background

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -109,7 +109,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
     });
 
   return (
-    <div className={`flex flex-col space-y-1 ${className}`}>
+    <div className={`h-full flex flex-col space-y-1 ${className}`}>
       <h3 className="font-semibold">{player.name}</h3>
       <div className="flex flex-wrap items-center gap-2 border p-2 rounded w-fit">
         {Object.entries(player.resources).map(([k, v]) => {

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -715,10 +715,10 @@ export default function Game({
         >
           <section
             ref={playerBoxRef}
-            className="border rounded bg-white dark:bg-gray-800 shadow"
+            className="border rounded bg-white dark:bg-gray-800 shadow flex"
             style={{ minHeight: sharedHeight }}
           >
-            <div className="flex items-stretch rounded overflow-hidden divide-x divide-gray-300 h-full">
+            <div className="flex flex-1 items-stretch rounded overflow-hidden divide-x divide-gray-300">
               {ctx.game.players.map((p, i) => (
                 <PlayerPanel
                   key={p.id}


### PR DESCRIPTION
## Summary
- ensure player panel backgrounds cover available vertical space

## Testing
- `npm test` *(fails: Development phase > scales strength additively with multiple leaders)*

------
https://chatgpt.com/codex/tasks/task_e_68b321fdebc88325ba24b56b8f19c089