### PR TITLE
feat(ui): enhance log with phase and source details

### DIFF
--- a/packages/engine/src/content/buildings.ts
+++ b/packages/engine/src/content/buildings.ts
@@ -50,6 +50,7 @@ export function createBuildingRegistry() {
           id: 'mill_farm_bonus',
           evaluation: { type: 'development', id: 'farm' },
           amount: 1,
+          source: 'building:mill',
         },
       })
       .build(),

--- a/packages/engine/src/context.ts
+++ b/packages/engine/src/context.ts
@@ -19,6 +19,15 @@ export class EngineContext {
     public phases: PhaseDef[],
   ) {}
   recentResourceGains: { key: ResourceKey; amount: number }[] = [];
+  recentEvaluations: {
+    target: string;
+    base: { key: ResourceKey; amount: number }[];
+    gains: { key: ResourceKey; amount: number }[];
+    modifiers: {
+      source: string;
+      gains: { key: ResourceKey; amount: number }[];
+    }[];
+  }[] = [];
   get activePlayer() {
     return this.game.active;
   }

--- a/packages/engine/src/effects/resource_remove.ts
+++ b/packages/engine/src/effects/resource_remove.ts
@@ -13,4 +13,5 @@ export const resourceRemove: EffectHandler = (effect, ctx, mult = 1) => {
   if (have < total)
     throw new Error(`Insufficient ${key}: need ${total}, have ${have}`);
   ctx.activePlayer.resources[key] = have - total;
+  if (total > 0) ctx.recentResourceGains.push({ key, amount: -total });
 };

--- a/packages/engine/src/effects/result_mod.ts
+++ b/packages/engine/src/effects/result_mod.ts
@@ -6,6 +6,7 @@ interface ResultModParams {
   actionId?: string;
   evaluation?: { type: string; id: string };
   amount?: number;
+  source?: string;
   [key: string]: unknown;
 }
 
@@ -53,6 +54,7 @@ export const resultMod: EffectHandler<ResultModParams> = (effect, ctx) => {
                   innerContext,
                 );
         },
+        effect.params?.source,
       );
     }
   } else if (effect.method === 'remove') {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -12,8 +12,14 @@ import type {
   StatKey,
   PopulationRoleId,
 } from './state';
-import { Services, PassiveManager, DefaultRules } from './services';
-import type { CostBag, RuleSet } from './services';
+import {
+  Services,
+  PassiveManager,
+  DefaultRules,
+  type CostBag,
+  type RuleSet,
+  type EvaluationLog,
+} from './services';
 import { createActionRegistry } from './content/actions';
 import { BUILDINGS } from './content/buildings';
 import { DEVELOPMENTS } from './content/developments';
@@ -210,6 +216,7 @@ export interface AdvanceResult {
   phase: string;
   step: string;
   effects: EffectDef[];
+  evaluations: EvaluationLog[];
   player: PlayerState;
 }
 
@@ -217,6 +224,7 @@ export function advance(ctx: EngineContext): AdvanceResult {
   const phase = ctx.phases[ctx.game.phaseIndex]!;
   const step = phase.steps[ctx.game.stepIndex];
   const player = ctx.activePlayer;
+  ctx.recentEvaluations = [];
   const effects: EffectDef[] = [];
   if (step?.triggers) {
     for (const trig of step.triggers) {
@@ -254,7 +262,13 @@ export function advance(ctx: EngineContext): AdvanceResult {
   ctx.game.currentPhase = nextPhase.id;
   ctx.game.currentStep = nextStep ? nextStep.id : '';
 
-  return { phase: phase.id, step: step?.id || '', effects, player };
+  return {
+    phase: phase.id,
+    step: step?.id || '',
+    effects,
+    evaluations: ctx.recentEvaluations,
+    player,
+  };
 }
 
 export function resolveAttack(
@@ -398,7 +412,8 @@ export {
   PHASES,
 };
 
-export type { RuleSet, ResourceKey };
+export type { RuleSet, ResourceGain, EvaluationLog } from './services';
+export type { ResourceKey } from './state';
 
 export { createActionRegistry } from './content/actions';
 export { createBuildingRegistry } from './content/buildings';

--- a/packages/web/src/icons.ts
+++ b/packages/web/src/icons.ts
@@ -25,6 +25,9 @@ export const developmentInfo: Record<string, { icon: string; label: string }> =
 export const landIcon = '🗺️';
 export const slotIcon = '🧩';
 export const buildingIcon = '🏛️';
+export const buildingInfo: Record<string, { icon: string; label: string }> = {
+  mill: { icon: '⚙️', label: 'Mill' },
+};
 
 export const modifierInfo = {
   cost: { icon: '💲', label: 'Cost Modifier' },


### PR DESCRIPTION
## Summary
- display phase and step names along with detailed breakdowns for resource changes
- track evaluation sources and modifiers to show where gains and losses come from
- add minimal building icon data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b320a600cc8325bc66d75105358a5f