### PR TITLE
feat(ui): soften player panel colors

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -733,11 +733,11 @@ export default function Game({
                 const bgClass =
                   i === 0
                     ? isActive
-                      ? 'bg-blue-200 dark:bg-blue-800 pr-6'
-                      : 'bg-blue-300 dark:bg-blue-900 pr-6'
+                      ? 'bg-[#1f3b99] text-white pr-6'
+                      : 'bg-[#11235f] text-white pr-6'
                     : isActive
-                      ? 'bg-red-200 dark:bg-red-800 pl-6'
-                      : 'bg-red-300 dark:bg-red-900 pl-6';
+                      ? 'bg-[#813939] text-white pl-6'
+                      : 'bg-[#632b2b] text-white pl-6';
                 return (
                   <PlayerPanel
                     key={p.id}

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -733,11 +733,11 @@ export default function Game({
                 const bgClass =
                   i === 0
                     ? isActive
-                      ? 'bg-blue-200 dark:bg-blue-700 pr-6'
-                      : 'bg-blue-500 dark:bg-blue-900 pr-6'
+                      ? 'bg-blue-200 dark:bg-blue-800 pr-6'
+                      : 'bg-blue-300 dark:bg-blue-900 pr-6'
                     : isActive
-                      ? 'bg-red-200 dark:bg-red-700 pl-6'
-                      : 'bg-red-500 dark:bg-red-900 pl-6';
+                      ? 'bg-red-200 dark:bg-red-800 pl-6'
+                      : 'bg-red-300 dark:bg-red-900 pl-6';
                 return (
                   <PlayerPanel
                     key={p.id}


### PR DESCRIPTION
## Summary
- soften player panel colors for both players
- maintain subtle highlight when active

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b32e8390ac8325bef3624c02c18139