### PR TITLE
fix: show phase list bullets fully

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -1192,7 +1192,7 @@ export default function Game({
               {phaseSteps.map((s, i) => (
                 <li key={i} className={s.active ? 'font-semibold' : ''}>
                   <div>{s.title}</div>
-                  <ul className="pl-4 list-disc">
+                  <ul className="pl-4 list-disc list-inside">
                     {s.items.length > 0 ? (
                       s.items.map((it, j) => (
                         <li key={j} className={it.italic ? 'italic' : ''}>


### PR DESCRIPTION
## Summary
- ensure phase list bullets are fully visible by using inside bullet positioning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b336045d0c832593e012e44f581e01