### PR TITLE
fix: delay action UI until phase transition completes

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -437,7 +437,9 @@ export default function Game({
     () => ctx.phases.find((p) => p.action)?.id,
     [ctx],
   );
-  const isActionPhase = Boolean(ctx.phases[ctx.game.phaseIndex]?.action);
+  const isActionPhase =
+    tabsEnabled &&
+    Boolean(ctx.phases.find((p) => p.id === displayPhase)?.action);
 
   useEffect(() => {
     const pEl = playerBoxRef.current;


### PR DESCRIPTION
## Summary
- gate action phase UI on `tabsEnabled` and displayed phase so Next Turn appears only after phase transition

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b33ac91f8883258c936f3f9a408a69