### PR TITLE
docs: streamline testing instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,27 @@ Tests live in:
 - `packages/engine/tests` for unit tests
 - `tests/integration` for integration tests
 
-The pre-commit hook runs lint-staged, type checking, linting, and `npm run test:coverage` automatically. GitHub
-Actions executes `npm run test:coverage` and `npm run build` for each pull
-request. Run these scripts locally only when debugging or when changes could
-affect them. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+To run the test suite and capture a reliable summary without redundant
+checks, execute:
+
+```sh
+npm run test:coverage >/tmp/unit.log 2>&1; tail -n 100 /tmp/unit.log
+```
+
+This command runs the tests with coverage and saves the output to
+`/tmp/unit.log`. The `tail` command prints the final portion of the log so
+you can quickly confirm whether tests passed or inspect any failures.
+
+**Run no additional manual tests.** Execute only the command above,
+verify the tail output looks correct, and proceed without running any
+extra test or build commands.
+
+The pre-commit hook already runs `lint-staged`, type checking, linting, and
+`npm test` (which triggers a `pretest` step). Running `npm test` manually
+would repeat those checks. GitHub Actions executes `npm run test:coverage`
+and `npm run build` for each pull request. Run these scripts locally only
+when debugging or when changes could affect them. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 # Game overview
 


### PR DESCRIPTION
## Summary
- streamline testing guidelines to run only the coverage test suite and log tail output
- note that npm test triggers pretest and pre-commit already runs linting/type checks, so using test:coverage avoids duplicate work

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1; tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b3496445b88325bd1524e1721d65b5