### PR TITLE
Keep actions available when viewing past phases

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -385,6 +385,14 @@ function TimerCircle({
   );
 }
 
+export function isActionPhaseActive(
+  currentPhase: string,
+  actionPhaseId: string | undefined,
+  tabsEnabled: boolean,
+): boolean {
+  return tabsEnabled && currentPhase === actionPhaseId;
+}
+
 export default function Game({
   onExit,
   darkMode = true,
@@ -438,9 +446,11 @@ export default function Game({
     () => ctx.phases.find((p) => p.action)?.id,
     [ctx],
   );
-  const isActionPhase =
-    tabsEnabled &&
-    Boolean(ctx.phases.find((p) => p.id === displayPhase)?.action);
+  const isActionPhase = isActionPhaseActive(
+    ctx.game.currentPhase,
+    actionPhaseId,
+    tabsEnabled,
+  );
 
   useEffect(() => {
     const pEl = playerBoxRef.current;

--- a/packages/web/tests/phase-history.test.ts
+++ b/packages/web/tests/phase-history.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+import { isActionPhaseActive } from '../src/Game';
+
+vi.mock('@kingdom-builder/engine', async () => {
+  return await import('../../engine/src');
+});
+
+// Ensure actions remain enabled when viewing previous phase history.
+// Specifically, current phase is main, but tabs display a prior phase.
+
+describe('isActionPhaseActive', () => {
+  it('returns true when game is in action phase regardless of display phase', () => {
+    expect(isActionPhaseActive('main', 'main', true)).toBe(true);
+  });
+
+  it('returns false when not in action phase', () => {
+    expect(isActionPhaseActive('development', 'main', true)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- compute action-phase status from the game's current phase
- ensure viewing past phases doesn't disable actions or show phase warnings
- add tests for action phase calculation

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b362743fd08325a33dd4d66bdb9ef0