### PR TITLE
feat(engine): add build plow workshop action

### DIFF
--- a/packages/engine/src/content/actions.ts
+++ b/packages/engine/src/content/actions.ts
@@ -135,6 +135,18 @@ export function createActionRegistry() {
   );
 
   registry.add(
+    'build_plow_workshop',
+    action('build_plow_workshop', 'Build - Plow Workshop')
+      .cost(Resource.ap, 1)
+      .effect({
+        type: 'building',
+        method: 'add',
+        params: { id: 'plow_workshop' },
+      })
+      .build(),
+  );
+
+  registry.add(
     'plow',
     action('plow', 'Plow')
       .system()
@@ -174,6 +186,10 @@ export const ACTION_INFO: Record<string, { icon: string; label: string }> = {
   royal_decree: { icon: '📜', label: ACTIONS.get('royal_decree').name },
   army_attack: { icon: '🗡️', label: ACTIONS.get('army_attack').name },
   hold_festival: { icon: '🎉', label: ACTIONS.get('hold_festival').name },
+  build_plow_workshop: {
+    icon: '🚜',
+    label: ACTIONS.get('build_plow_workshop').name,
+  },
   plow: { icon: '🚜', label: ACTIONS.get('plow').name },
   build: { icon: '🏛️', label: ACTIONS.get('build').name },
 } as const;

--- a/packages/engine/tests/actions/build_plow_workshop.test.ts
+++ b/packages/engine/tests/actions/build_plow_workshop.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEngine,
+  performAction,
+  getActionCosts,
+  Resource,
+  advance,
+} from '../../src/index.ts';
+
+describe('Build - Plow Workshop action', () => {
+  it('builds the Plow Workshop and unlocks Plow', () => {
+    const ctx = createEngine();
+    while (ctx.game.currentPhase !== 'main') advance(ctx);
+    const cost = getActionCosts('build_plow_workshop', ctx);
+    const buildingCost =
+      ctx.buildings.get('plow_workshop').costs[Resource.gold];
+    expect(cost[Resource.gold]).toBe(buildingCost);
+    performAction('build_plow_workshop', ctx);
+    expect(ctx.activePlayer.buildings.has('plow_workshop')).toBe(true);
+    expect(ctx.activePlayer.actions.has('plow')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Build - Plow Workshop action and metadata
- derive building costs for any action that adds buildings
- test building Plow Workshop unlocks Plow action

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b36d2dd4a08325bec8b55d1c80c2cb