### PR TITLE
refactor(action-panel): modernize layout

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -804,8 +804,8 @@ export default function Game({
                 </span>
               )}
             </div>
-            <div className="space-y-4">
-              <div className="grid grid-cols-4 gap-2">
+            <div className="space-y-3">
+              <div className="grid grid-cols-4 gap-2 auto-rows-fr">
                 {otherActions.map((action) => {
                   const costs = getActionCosts(action.id, ctx);
                   const requirements = getActionRequirements(
@@ -833,8 +833,10 @@ export default function Game({
                   return (
                     <button
                       key={action.id}
-                      className={`relative border p-3 flex flex-col items-start gap-2 h-full transition-colors transition-transform duration-150 hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-105 hover:cursor-help ${
-                        enabled ? '' : 'opacity-50 cursor-not-allowed'
+                      className={`relative panel-card border border-black/10 dark:border-white/10 p-2 flex flex-col items-start gap-1 h-full shadow-sm ${
+                        enabled
+                          ? 'hoverable cursor-pointer'
+                          : 'opacity-50 cursor-not-allowed'
                       }`}
                       title={title}
                       onClick={() => enabled && handlePerform(action)}
@@ -889,7 +891,7 @@ export default function Game({
                     {actionInfo['raise_pop']?.icon ?? ''}{' '}
                     {actionInfo['raise_pop']?.label ?? ''}
                   </h3>
-                  <div className="grid grid-cols-3 gap-2 mt-1">
+                  <div className="grid grid-cols-3 gap-2 mt-1 auto-rows-fr">
                     {[
                       PopulationRole.Council,
                       PopulationRole.Commander,
@@ -938,8 +940,10 @@ export default function Game({
                       return (
                         <button
                           key={role}
-                          className={`relative border p-3 flex flex-col items-start gap-2 h-full transition-colors transition-transform duration-150 hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-105 hover:cursor-help ${
-                            enabled ? '' : 'opacity-50 cursor-not-allowed'
+                          className={`relative panel-card border border-black/10 dark:border-white/10 p-2 flex flex-col items-start gap-1 h-full shadow-sm ${
+                            enabled
+                              ? 'hoverable cursor-pointer'
+                              : 'opacity-50 cursor-not-allowed'
                           }`}
                           title={title}
                           onClick={() =>
@@ -993,7 +997,7 @@ export default function Game({
                     {actionInfo['develop']?.icon ?? ''}{' '}
                     {actionInfo['develop']?.label ?? ''}
                   </h3>
-                  <div className="grid grid-cols-4 gap-2 mt-1">
+                  <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">
                     {sortedDevelopments.map((d) => {
                       const landIdForCost = ctx.activePlayer.lands[0]
                         ?.id as string;
@@ -1025,8 +1029,10 @@ export default function Game({
                       return (
                         <button
                           key={d.id}
-                          className={`relative border p-3 flex flex-col items-start gap-2 h-full transition-colors transition-transform duration-150 hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-105 hover:cursor-help ${
-                            enabled ? '' : 'opacity-50 cursor-not-allowed'
+                          className={`relative panel-card border border-black/10 dark:border-white/10 p-2 flex flex-col items-start gap-1 h-full shadow-sm ${
+                            enabled
+                              ? 'hoverable cursor-pointer'
+                              : 'opacity-50 cursor-not-allowed'
                           }`}
                           title={title}
                           onClick={() => {
@@ -1097,7 +1103,7 @@ export default function Game({
                     {actionInfo['build']?.icon ?? ''}{' '}
                     {actionInfo['build']?.label ?? ''}
                   </h3>
-                  <div className="grid grid-cols-4 gap-2 mt-1">
+                  <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">
                     {buildingOptions.map((b) => {
                       const costs = getActionCosts('build', ctx, { id: b.id });
                       const requirements: string[] = [];
@@ -1118,8 +1124,10 @@ export default function Game({
                       return (
                         <button
                           key={b.id}
-                          className={`relative border p-3 flex flex-col items-start gap-2 h-full transition-colors transition-transform duration-150 hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-105 hover:cursor-help ${
-                            enabled ? '' : 'opacity-50 cursor-not-allowed'
+                          className={`relative panel-card border border-black/10 dark:border-white/10 p-2 flex flex-col items-start gap-1 h-full shadow-sm ${
+                            enabled
+                              ? 'hoverable cursor-pointer'
+                              : 'opacity-50 cursor-not-allowed'
                           }`}
                           title={title}
                           onClick={() =>


### PR DESCRIPTION
## Summary
- restyle action buttons with compact panel cards while retaining full bullet summaries
- restore effect overviews for population, development, and building options

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b36c2828b48325a7e220590ca6ede8