### PR TITLE
refactor: extract timer circle component

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -14,6 +14,7 @@ import type { ResourceKey } from '@kingdom-builder/engine';
 import { summarizeContent, describeContent, type Summary } from './translation';
 import { GameProvider, useGameEngine } from './state/GameContext';
 import PlayerPanel from './components/player/PlayerPanel';
+import TimerCircle from './components/TimerCircle';
 
 interface Action {
   id: string;
@@ -67,46 +68,6 @@ function renderCosts(
         </span>
       ))}
     </>
-  );
-}
-
-function TimerCircle({
-  progress,
-  paused = false,
-}: {
-  progress: number;
-  paused?: boolean;
-}) {
-  const radius = 12;
-  const circumference = 2 * Math.PI * radius;
-  if (paused)
-    return (
-      <svg width={24} height={24} viewBox="0 0 24 24">
-        <rect x="6" y="4" width="4" height="16" fill="#10b981" />
-        <rect x="14" y="4" width="4" height="16" fill="#10b981" />
-      </svg>
-    );
-  return (
-    <svg width={24} height={24}>
-      <circle
-        cx="12"
-        cy="12"
-        r={radius}
-        stroke="#e5e7eb"
-        strokeWidth="2"
-        fill="none"
-      />
-      <circle
-        cx="12"
-        cy="12"
-        r={radius}
-        stroke="#10b981"
-        strokeWidth="2"
-        fill="none"
-        strokeDasharray={circumference}
-        strokeDashoffset={(1 - progress) * circumference}
-      />
-    </svg>
   );
 }
 

--- a/packages/web/src/components/TimerCircle.tsx
+++ b/packages/web/src/components/TimerCircle.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+interface TimerCircleProps {
+  progress: number;
+  paused?: boolean;
+}
+
+const TimerCircle: React.FC<TimerCircleProps> = ({
+  progress,
+  paused = false,
+}) => {
+  const radius = 12;
+  const circumference = 2 * Math.PI * radius;
+
+  if (paused)
+    return (
+      <svg width={24} height={24} viewBox="0 0 24 24">
+        <rect x="6" y="4" width="4" height="16" fill="#10b981" />
+        <rect x="14" y="4" width="4" height="16" fill="#10b981" />
+      </svg>
+    );
+
+  return (
+    <svg width={24} height={24}>
+      <circle
+        cx="12"
+        cy="12"
+        r={radius}
+        stroke="#e5e7eb"
+        strokeWidth="2"
+        fill="none"
+      />
+      <circle
+        cx="12"
+        cy="12"
+        r={radius}
+        stroke="#10b981"
+        strokeWidth="2"
+        fill="none"
+        strokeDasharray={circumference}
+        strokeDashoffset={(1 - progress) * circumference}
+      />
+    </svg>
+  );
+};
+
+export default TimerCircle;


### PR DESCRIPTION
## Summary
- extract TimerCircle to its own component and wire into Game

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b36e5dc09c8325ad02d4377226d7f1