### PR TITLE
refactor(web): consolidate render helpers under translation

### DIFF
--- a/packages/web/src/components/HoverCard.tsx
+++ b/packages/web/src/components/HoverCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderSummary, renderCosts } from '../render';
+import { renderSummary, renderCosts } from '../translation/render';
 import { useGameEngine } from '../state/GameContext';
 
 type HoverCardData = ReturnType<typeof useGameEngine>['hoverCard'];

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -15,7 +15,7 @@ import {
   summarizeContent,
   type Summary,
 } from '../../translation';
-import { renderSummary, renderCosts } from '../../render';
+import { renderSummary, renderCosts } from '../../translation/render';
 import { useGameEngine } from '../../state/GameContext';
 
 interface Action {

--- a/packages/web/src/translation/index.ts
+++ b/packages/web/src/translation/index.ts
@@ -1,3 +1,4 @@
 export * from './effects';
 export * from './content';
 export * from './log';
+export * from './render';

--- a/packages/web/src/translation/render.tsx
+++ b/packages/web/src/translation/render.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Resource, RESOURCES } from '@kingdom-builder/engine';
 import type { ResourceKey } from '@kingdom-builder/engine';
-import type { Summary } from './translation';
+import type { Summary } from './content';
 
 export function renderSummary(summary: Summary | undefined): React.ReactNode {
   return summary?.map((e, i) =>


### PR DESCRIPTION
## Summary
- move renderSummary and renderCosts into translation module
- update components to import render helpers from translation

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b377a65aa88325aeeab0fe390fd8ec