### PR TITLE
refactor Game component to compose panels via provider

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -32,40 +32,40 @@ function GameLayout() {
         )}
       </div>
 
-      <div className="flex gap-4">
-        <div
-          className="flex-1 space-y-6"
-          style={{ maxWidth: 'calc(100% - 31rem)' }}
-        >
-          <section className="border rounded bg-white dark:bg-gray-800 shadow flex">
-            <div className="flex flex-1 items-stretch rounded overflow-hidden divide-x divide-black/10 dark:divide-white/10">
-              {ctx.game.players.map((p, i) => {
-                const isActive = p.id === ctx.activePlayer.id;
-                const bgClass =
-                  i === 0
-                    ? isActive
-                      ? 'player-bg player-bg-blue-active pr-6'
-                      : 'player-bg player-bg-blue pr-6'
-                    : isActive
-                      ? 'player-bg player-bg-red-active pl-6'
-                      : 'player-bg player-bg-red pl-6';
-                return (
-                  <PlayerPanel
-                    key={p.id}
-                    player={p}
-                    className={`flex-1 p-4 ${bgClass}`}
-                  />
-                );
-              })}
-            </div>
-          </section>
+      <div
+        className="grid gap-x-4 gap-y-6"
+        style={{ gridTemplateColumns: 'minmax(0,1fr) 30rem' }}
+      >
+        <section className="border rounded bg-white dark:bg-gray-800 shadow flex min-h-[275px]">
+          <div className="flex flex-1 items-stretch rounded overflow-hidden divide-x divide-black/10 dark:divide-white/10">
+            {ctx.game.players.map((p, i) => {
+              const isActive = p.id === ctx.activePlayer.id;
+              const bgClass =
+                i === 0
+                  ? isActive
+                    ? 'player-bg player-bg-blue-active pr-6'
+                    : 'player-bg player-bg-blue pr-6'
+                  : isActive
+                    ? 'player-bg player-bg-red-active pl-6'
+                    : 'player-bg player-bg-red pl-6';
+              return (
+                <PlayerPanel
+                  key={p.id}
+                  player={p}
+                  className={`flex-1 p-4 ${bgClass}`}
+                />
+              );
+            })}
+          </div>
+        </section>
+        <PhasePanel />
+        <div className="col-start-1 row-start-2">
           <ActionsPanel />
         </div>
-        <section className="w-[30rem] self-start flex flex-col gap-6">
-          <PhasePanel />
+        <div className="col-start-2 row-start-2 w-[30rem] flex flex-col gap-6">
           <LogPanel />
           <HoverCard />
-        </section>
+        </div>
       </div>
     </div>
   );

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { summarizeContent, describeContent, type Summary } from './translation';
+import React from 'react';
 import { GameProvider, useGameEngine } from './state/GameContext';
 import PlayerPanel from './components/player/PlayerPanel';
 import HoverCard from './components/HoverCard';
@@ -7,179 +6,8 @@ import ActionsPanel from './components/actions/ActionsPanel';
 import PhasePanel from './components/phases/PhasePanel';
 import LogPanel from './components/LogPanel';
 
-interface Action {
-  id: string;
-  name: string;
-  system?: boolean;
-}
-interface Development {
-  id: string;
-  name: string;
-  system?: boolean;
-}
-interface Building {
-  id: string;
-  name: string;
-}
-
-export function isActionPhaseActive(
-  currentPhase: string,
-  actionPhaseId: string | undefined,
-  tabsEnabled: boolean,
-): boolean {
-  return tabsEnabled && currentPhase === actionPhaseId;
-}
-
-function GameInner({
-  onExit,
-  darkMode = true,
-  onToggleDark = () => {},
-}: {
-  onExit?: () => void;
-  darkMode?: boolean;
-  onToggleDark?: () => void;
-}) {
-  const {
-    ctx,
-    log,
-    hoverCard,
-    phaseSteps,
-    setPhaseSteps,
-    phaseTimer,
-    phasePaused,
-    setPaused,
-    mainApStart,
-    displayPhase,
-    setDisplayPhase,
-    phaseHistories,
-    tabsEnabled,
-    runUntilActionPhase,
-    handleEndTurn,
-    updateMainPhaseStep,
-  } = useGameEngine();
-
-  const playerBoxRef = useRef<HTMLDivElement>(null);
-  const phaseBoxRef = useRef<HTMLDivElement>(null);
-  const [playerBoxHeight, setPlayerBoxHeight] = useState(0);
-  const [phaseBoxHeight, setPhaseBoxHeight] = useState(0);
-  const actionPhaseId = useMemo(
-    () => ctx.phases.find((p) => p.action)?.id,
-    [ctx],
-  );
-  const isActionPhase = isActionPhaseActive(
-    ctx.game.currentPhase,
-    actionPhaseId,
-    tabsEnabled,
-  );
-
-  useEffect(() => {
-    const pEl = playerBoxRef.current;
-    const phEl = phaseBoxRef.current;
-    if (!pEl || !phEl) return;
-    const update = () => {
-      setPlayerBoxHeight(pEl.offsetHeight);
-      setPhaseBoxHeight(phEl.offsetHeight);
-    };
-    update();
-    const ro = new ResizeObserver(update);
-    ro.observe(pEl);
-    ro.observe(phEl);
-    return () => ro.disconnect();
-  }, []);
-
-  const sharedHeight = Math.max(playerBoxHeight, phaseBoxHeight, 275);
-
-  const actions = useMemo<Action[]>(
-    () =>
-      Array.from(
-        (ctx.actions as unknown as { map: Map<string, Action> }).map.values(),
-      ).filter((a) => !a.system || ctx.activePlayer.actions.has(a.id)),
-    [ctx, ctx.activePlayer.actions.size],
-  );
-  const developmentOptions = useMemo<Development[]>(
-    () =>
-      Array.from(
-        (
-          ctx.developments as unknown as { map: Map<string, Development> }
-        ).map.values(),
-      ).filter((d) => !d.system),
-    [ctx],
-  );
-  const developmentOrder = ['house', 'farm', 'outpost', 'watchtower'];
-  const sortedDevelopments = useMemo(
-    () =>
-      developmentOrder
-        .map((id) => developmentOptions.find((d) => d.id === id))
-        .filter(Boolean) as Development[],
-    [developmentOptions],
-  );
-  const buildingOptions = useMemo<Building[]>(
-    () =>
-      Array.from(
-        (
-          ctx.buildings as unknown as { map: Map<string, Building> }
-        ).map.values(),
-      ),
-    [ctx],
-  );
-
-  const actionSummaries = useMemo(() => {
-    const map = new Map<string, Summary>();
-    actions.forEach((a) =>
-      map.set(a.id, summarizeContent('action', a.id, ctx)),
-    );
-    return map;
-  }, [actions, ctx]);
-  const developmentSummaries = useMemo(() => {
-    const map = new Map<string, Summary>();
-    sortedDevelopments.forEach((d) =>
-      map.set(d.id, summarizeContent('development', d.id, ctx)),
-    );
-    return map;
-  }, [sortedDevelopments, ctx]);
-  const buildingSummaries = useMemo(() => {
-    const map = new Map<string, Summary>();
-    buildingOptions.forEach((b) =>
-      map.set(b.id, summarizeContent('building', b.id, ctx)),
-    );
-    return map;
-  }, [buildingOptions, ctx]);
-  const buildingDescriptions = useMemo(() => {
-    const map = new Map<string, Summary>();
-    buildingOptions.forEach((b) =>
-      map.set(b.id, describeContent('building', b.id, ctx)),
-    );
-    return map;
-  }, [buildingOptions, ctx]);
-  const buildingInstalledDescriptions = useMemo(() => {
-    const map = new Map<string, Summary>();
-    buildingOptions.forEach((b) =>
-      map.set(
-        b.id,
-        describeContent('building', b.id, ctx, { installed: true }),
-      ),
-    );
-    return map;
-  }, [buildingOptions, ctx]);
-
-  const hasDevelopLand = ctx.activePlayer.lands.some((l) => l.slotsFree > 0);
-  const developAction = actions.find((a) => a.id === 'develop');
-  const buildAction = actions.find((a) => a.id === 'build');
-  const raisePopAction = actions.find((a) => a.id === 'raise_pop');
-  const otherActions = actions.filter(
-    (a) => a.id !== 'develop' && a.id !== 'build' && a.id !== 'raise_pop',
-  );
-
-  useEffect(() => {
-    void runUntilActionPhase();
-  }, []);
-
-  useEffect(() => {
-    if (isActionPhase && (mainApStart !== 0 || ctx.activePlayer.ap === 0)) {
-      updateMainPhaseStep();
-    }
-  }, [isActionPhase, ctx.activePlayer.ap, mainApStart]);
-
+function GameLayout() {
+  const { ctx, onExit, darkMode, onToggleDark } = useGameEngine();
   return (
     <div className="p-4 w-full bg-slate-100 text-gray-900 dark:bg-slate-900 dark:text-gray-100 min-h-screen">
       <div className="flex items-center justify-between mb-6">
@@ -209,11 +37,7 @@ function GameInner({
           className="flex-1 space-y-6"
           style={{ maxWidth: 'calc(100% - 31rem)' }}
         >
-          <section
-            ref={playerBoxRef}
-            className="border rounded bg-white dark:bg-gray-800 shadow flex"
-            style={{ minHeight: sharedHeight }}
-          >
+          <section className="border rounded bg-white dark:bg-gray-800 shadow flex">
             <div className="flex flex-1 items-stretch rounded overflow-hidden divide-x divide-black/10 dark:divide-white/10">
               {ctx.game.players.map((p, i) => {
                 const isActive = p.id === ctx.activePlayer.id;
@@ -230,63 +54,39 @@ function GameInner({
                     key={p.id}
                     player={p}
                     className={`flex-1 p-4 ${bgClass}`}
-                    buildingDescriptions={buildingInstalledDescriptions}
                   />
                 );
               })}
             </div>
           </section>
-          <ActionsPanel
-            isActionPhase={isActionPhase}
-            otherActions={otherActions}
-            raisePopAction={raisePopAction}
-            developAction={developAction}
-            buildAction={buildAction}
-            hasDevelopLand={hasDevelopLand}
-            sortedDevelopments={sortedDevelopments}
-            buildingOptions={buildingOptions}
-            actionSummaries={actionSummaries}
-            developmentSummaries={developmentSummaries}
-            buildingSummaries={buildingSummaries}
-            buildingDescriptions={buildingDescriptions}
-          />
+          <ActionsPanel />
         </div>
         <section className="w-[30rem] self-start flex flex-col gap-6">
-          <PhasePanel
-            ref={phaseBoxRef}
-            turn={ctx.game.turn}
-            activePlayerName={ctx.activePlayer.name}
-            phases={ctx.phases}
-            phaseSteps={phaseSteps}
-            setPhaseSteps={setPhaseSteps}
-            phaseTimer={phaseTimer}
-            phasePaused={phasePaused}
-            setPaused={setPaused}
-            displayPhase={displayPhase}
-            setDisplayPhase={setDisplayPhase}
-            phaseHistories={phaseHistories}
-            tabsEnabled={tabsEnabled}
-            isActionPhase={isActionPhase}
-            actionPhaseId={actionPhaseId}
-            handleEndTurn={handleEndTurn}
-            sharedHeight={sharedHeight}
-          />
-          <LogPanel entries={log} />
-          <HoverCard data={hoverCard} />
+          <PhasePanel />
+          <LogPanel />
+          <HoverCard />
         </section>
       </div>
     </div>
   );
 }
 
-export default function Game(props: {
+export default function Game({
+  onExit,
+  darkMode = true,
+  onToggleDark = () => {},
+}: {
   onExit?: () => void;
   darkMode?: boolean;
   onToggleDark?: () => void;
 }) {
   return (
-    <GameProvider>
-      <GameInner {...props} />
+    <GameProvider
+      {...(onExit ? { onExit } : {})}
+      darkMode={darkMode}
+      onToggleDark={onToggleDark}
+    >
+      <GameLayout />
     </GameProvider>
   );
 }

--- a/packages/web/src/components/HoverCard.tsx
+++ b/packages/web/src/components/HoverCard.tsx
@@ -2,22 +2,15 @@ import React from 'react';
 import { renderSummary, renderCosts } from '../translation/render';
 import { useGameEngine } from '../state/GameContext';
 
-type HoverCardData = ReturnType<typeof useGameEngine>['hoverCard'];
-
-interface HoverCardProps {
-  data: HoverCardData;
-  onClose?: () => void;
-}
-
-export default function HoverCard({ data, onClose }: HoverCardProps) {
-  const { ctx } = useGameEngine();
+export default function HoverCard() {
+  const { hoverCard: data, clearHoverCard, ctx } = useGameEngine();
   if (!data) return null;
   return (
     <div
       className={`border rounded p-4 shadow relative pointer-events-none w-full ${
         data.bgClass || 'bg-white dark:bg-gray-800'
       }`}
-      onMouseLeave={onClose}
+      onMouseLeave={clearHoverCard}
     >
       <div className="font-semibold mb-2">
         {data.title}

--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -1,11 +1,8 @@
 import React, { useEffect, useRef } from 'react';
-import type { LogEntry } from '../state/GameContext';
+import { useGameEngine } from '../state/GameContext';
 
-interface LogPanelProps {
-  entries: LogEntry[];
-}
-
-export default function LogPanel({ entries }: LogPanelProps) {
+export default function LogPanel() {
+  const { log: entries } = useGameEngine();
   const logRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -1,150 +1,123 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useMemo } from 'react';
 import TimerCircle from '../TimerCircle';
-import type { PhaseStep } from '../../state/GameContext';
+import { useGameEngine } from '../../state/GameContext';
+import { isActionPhaseActive } from '../../utils/isActionPhaseActive';
 
-interface PhaseInfo {
-  id: string;
-  label: string;
-  icon?: React.ReactNode;
-}
+const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
+  const {
+    ctx,
+    phaseSteps,
+    setPhaseSteps,
+    phaseTimer,
+    phasePaused,
+    setPaused,
+    displayPhase,
+    setDisplayPhase,
+    phaseHistories,
+    tabsEnabled,
+    handleEndTurn,
+  } = useGameEngine();
 
-interface PhasePanelProps {
-  turn: number;
-  activePlayerName: string;
-  phases: PhaseInfo[];
-  phaseSteps: PhaseStep[];
-  setPhaseSteps: React.Dispatch<React.SetStateAction<PhaseStep[]>>;
-  phaseTimer: number;
-  phasePaused: boolean;
-  setPaused: (v: boolean) => void;
-  displayPhase: string;
-  setDisplayPhase: (id: string) => void;
-  phaseHistories: Record<string, PhaseStep[]>;
-  tabsEnabled: boolean;
-  isActionPhase: boolean;
-  actionPhaseId?: string | undefined;
-  handleEndTurn: () => void | Promise<void>;
-  sharedHeight: number;
-}
+  const actionPhaseId = useMemo(
+    () => ctx.phases.find((p) => p.action)?.id,
+    [ctx],
+  );
+  const isActionPhase = isActionPhaseActive(
+    ctx.game.currentPhase,
+    actionPhaseId,
+    tabsEnabled,
+  );
 
-const PhasePanel = React.forwardRef<HTMLDivElement, PhasePanelProps>(
-  (
-    {
-      turn,
-      activePlayerName,
-      phases,
-      phaseSteps,
-      setPhaseSteps,
-      phaseTimer,
-      phasePaused,
-      setPaused,
-      displayPhase,
-      setDisplayPhase,
-      phaseHistories,
-      tabsEnabled,
-      isActionPhase,
-      actionPhaseId,
-      handleEndTurn,
-      sharedHeight,
-    },
-    ref,
-  ) => {
-    const phaseStepsRef = useRef<HTMLUListElement>(null);
+  const phaseStepsRef = useRef<HTMLUListElement>(null);
 
-    useEffect(() => {
-      const el = phaseStepsRef.current;
-      if (!el) return;
-      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
-    }, [phaseSteps]);
+  useEffect(() => {
+    const el = phaseStepsRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+  }, [phaseSteps]);
 
-    return (
-      <section
-        ref={ref}
-        className="border rounded p-4 bg-white dark:bg-gray-800 shadow relative w-full flex flex-col"
-        onMouseEnter={() => !isActionPhase && setPaused(true)}
-        onMouseLeave={() => setPaused(false)}
-        style={{
-          cursor: phasePaused && !isActionPhase ? 'pause' : 'auto',
-          minHeight: sharedHeight,
-        }}
-      >
-        <div className="absolute -top-6 left-0 font-semibold">
-          Turn {turn} - {activePlayerName}
-        </div>
-        <div className="flex mb-2 border-b">
-          {phases.map((p) => {
-            const isSelected = displayPhase === p.id;
-            return (
-              <button
-                key={p.id}
-                type="button"
-                disabled={!tabsEnabled}
-                onClick={() => {
-                  if (!tabsEnabled) return;
-                  setDisplayPhase(p.id);
-                  setPhaseSteps(phaseHistories[p.id] ?? []);
-                }}
-                className={`px-3 py-1 text-sm flex items-center gap-1 border-b-2 ${
-                  isSelected
-                    ? 'border-blue-500 font-semibold'
-                    : 'border-transparent text-gray-500'
-                } ${
-                  tabsEnabled
-                    ? 'hover:text-gray-800 dark:hover:text-gray-200'
-                    : ''
-                }`}
-              >
-                {p?.icon} {p?.label}
-              </button>
-            );
-          })}
-        </div>
-        <ul
-          ref={phaseStepsRef}
-          className="text-sm text-left space-y-1 overflow-y-auto flex-1"
-        >
-          {phaseSteps.map((s, i) => (
-            <li key={i} className={s.active ? 'font-semibold' : ''}>
-              <div>{s.title}</div>
-              <ul className="pl-4 list-disc list-inside">
-                {s.items.length > 0 ? (
-                  s.items.map((it, j) => (
-                    <li key={j} className={it.italic ? 'italic' : ''}>
-                      {it.text}
-                      {it.done && (
-                        <span className="text-green-600 ml-1">✔️</span>
-                      )}
-                    </li>
-                  ))
-                ) : (
-                  <li>...</li>
-                )}
-              </ul>
-            </li>
-          ))}
-        </ul>
-        {(!isActionPhase || phaseTimer > 0) && (
-          <div className="absolute top-2 right-2">
-            <TimerCircle progress={phaseTimer} paused={phasePaused} />
-          </div>
-        )}
-        {isActionPhase && (
-          <div className="mt-2 text-right">
+  return (
+    <section
+      ref={ref}
+      className="border rounded p-4 bg-white dark:bg-gray-800 shadow relative w-full flex flex-col"
+      onMouseEnter={() => !isActionPhase && setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      style={{ cursor: phasePaused && !isActionPhase ? 'pause' : 'auto' }}
+    >
+      <div className="absolute -top-6 left-0 font-semibold">
+        Turn {ctx.game.turn} - {ctx.activePlayer.name}
+      </div>
+      <div className="flex mb-2 border-b">
+        {ctx.phases.map((p) => {
+          const isSelected = displayPhase === p.id;
+          return (
             <button
-              className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
-              disabled={Boolean(
-                actionPhaseId &&
-                  phaseHistories[actionPhaseId]?.some((s) => s.active),
-              )}
-              onClick={() => void handleEndTurn()}
+              key={p.id}
+              type="button"
+              disabled={!tabsEnabled}
+              onClick={() => {
+                if (!tabsEnabled) return;
+                setDisplayPhase(p.id);
+                setPhaseSteps(phaseHistories[p.id] ?? []);
+              }}
+              className={`px-3 py-1 text-sm flex items-center gap-1 border-b-2 ${
+                isSelected
+                  ? 'border-blue-500 font-semibold'
+                  : 'border-transparent text-gray-500'
+              } ${
+                tabsEnabled
+                  ? 'hover:text-gray-800 dark:hover:text-gray-200'
+                  : ''
+              }`}
             >
-              Next Turn
+              {p?.icon} {p?.label}
             </button>
-          </div>
-        )}
-      </section>
-    );
-  },
-);
+          );
+        })}
+      </div>
+      <ul
+        ref={phaseStepsRef}
+        className="text-sm text-left space-y-1 overflow-y-auto flex-1"
+      >
+        {phaseSteps.map((s, i) => (
+          <li key={i} className={s.active ? 'font-semibold' : ''}>
+            <div>{s.title}</div>
+            <ul className="pl-4 list-disc list-inside">
+              {s.items.length > 0 ? (
+                s.items.map((it, j) => (
+                  <li key={j} className={it.italic ? 'italic' : ''}>
+                    {it.text}
+                    {it.done && <span className="text-green-600 ml-1">✔️</span>}
+                  </li>
+                ))
+              ) : (
+                <li>...</li>
+              )}
+            </ul>
+          </li>
+        ))}
+      </ul>
+      {(!isActionPhase || phaseTimer > 0) && (
+        <div className="absolute top-2 right-2">
+          <TimerCircle progress={phaseTimer} paused={phasePaused} />
+        </div>
+      )}
+      {isActionPhase && (
+        <div className="mt-2 text-right">
+          <button
+            className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+            disabled={Boolean(
+              actionPhaseId &&
+                phaseHistories[actionPhaseId]?.some((s) => s.active),
+            )}
+            onClick={() => void handleEndTurn()}
+          >
+            Next Turn
+          </button>
+        </div>
+      )}
+    </section>
+  );
+});
 
 export default PhasePanel;

--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -39,7 +39,7 @@ const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
   return (
     <section
       ref={ref}
-      className="border rounded p-4 bg-white dark:bg-gray-800 shadow relative w-full flex flex-col"
+      className="border rounded p-4 bg-white dark:bg-gray-800 shadow relative w-full flex flex-col h-full min-h-[275px]"
       onMouseEnter={() => !isActionPhase && setPaused(true)}
       onMouseLeave={() => setPaused(false)}
       style={{ cursor: phasePaused && !isActionPhase ? 'pause' : 'auto' }}

--- a/packages/web/src/components/player/BuildingDisplay.tsx
+++ b/packages/web/src/components/player/BuildingDisplay.tsx
@@ -4,18 +4,14 @@ import {
   BUILDING_INFO as buildingInfo,
 } from '@kingdom-builder/engine';
 import type { EngineContext } from '@kingdom-builder/engine';
-import type { Summary } from '../../translation';
+import { describeContent } from '../../translation';
 import { useGameEngine } from '../../state/GameContext';
 
 interface BuildingDisplayProps {
   player: EngineContext['activePlayer'];
-  buildingDescriptions: Map<string, Summary>;
 }
 
-const BuildingDisplay: React.FC<BuildingDisplayProps> = ({
-  player,
-  buildingDescriptions,
-}) => {
+const BuildingDisplay: React.FC<BuildingDisplayProps> = ({ player }) => {
   const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
   if (player.buildings.size === 0) return null;
   return (
@@ -31,7 +27,9 @@ const BuildingDisplay: React.FC<BuildingDisplayProps> = ({
             onMouseEnter={() =>
               handleHoverCard({
                 title,
-                effects: buildingDescriptions.get(b) ?? [],
+                effects: describeContent('building', b, ctx, {
+                  installed: true,
+                }),
                 requirements: [],
                 bgClass: 'bg-gray-100 dark:bg-gray-700',
               })

--- a/packages/web/src/components/player/PlayerPanel.tsx
+++ b/packages/web/src/components/player/PlayerPanel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { EngineContext } from '@kingdom-builder/engine';
-import type { Summary } from '../../translation';
 import ResourceBar from './ResourceBar';
 import PopulationInfo from './PopulationInfo';
 import LandDisplay from './LandDisplay';
@@ -9,13 +8,11 @@ import BuildingDisplay from './BuildingDisplay';
 interface PlayerPanelProps {
   player: EngineContext['activePlayer'];
   className?: string;
-  buildingDescriptions: Map<string, Summary>;
 }
 
 const PlayerPanel: React.FC<PlayerPanelProps> = ({
   player,
   className = '',
-  buildingDescriptions,
 }) => {
   return (
     <div className={`h-full flex flex-col space-y-1 ${className}`}>
@@ -25,10 +22,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
         <PopulationInfo player={player} />
       </div>
       <LandDisplay player={player} />
-      <BuildingDisplay
-        player={player}
-        buildingDescriptions={buildingDescriptions}
-      />
+      <BuildingDisplay player={player} />
     </div>
   );
 };

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -4,6 +4,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  useEffect,
 } from 'react';
 import {
   createEngine,
@@ -257,6 +258,10 @@ export function GameProvider({
     setPhaseHistories({});
     await runUntilActionPhase();
   }
+
+  useEffect(() => {
+    void runUntilActionPhase();
+  }, []);
 
   const value: GameEngineContextValue = {
     ctx,

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -259,6 +259,14 @@ export function GameProvider({
     await runUntilActionPhase();
   }
 
+  // Update main phase steps once action phase becomes active
+  useEffect(() => {
+    if (ctx.phases[ctx.game.phaseIndex]?.action) {
+      setMainApStart(ctx.activePlayer.ap);
+      updateMainPhaseStep(ctx.activePlayer.ap);
+    }
+  }, [ctx.game.phaseIndex]);
+
   useEffect(() => {
     void runUntilActionPhase();
   }, []);

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -71,11 +71,24 @@ interface GameEngineContextValue {
   runUntilActionPhase: () => Promise<void>;
   handleEndTurn: () => Promise<void>;
   updateMainPhaseStep: (apStartOverride?: number) => void;
+  onExit?: () => void;
+  darkMode: boolean;
+  onToggleDark: () => void;
 }
 
 const GameEngineContext = createContext<GameEngineContextValue | null>(null);
 
-export function GameProvider({ children }: { children: React.ReactNode }) {
+export function GameProvider({
+  children,
+  onExit,
+  darkMode = true,
+  onToggleDark = () => {},
+}: {
+  children: React.ReactNode;
+  onExit?: () => void;
+  darkMode?: boolean;
+  onToggleDark?: () => void;
+}) {
   const ctx = useMemo<EngineContext>(() => createEngine(), []);
   const [, setTick] = useState(0);
   const refresh = () => setTick((t) => t + 1);
@@ -265,6 +278,9 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     runUntilActionPhase,
     handleEndTurn,
     updateMainPhaseStep,
+    darkMode,
+    onToggleDark,
+    ...(onExit ? { onExit } : {}),
   };
 
   return (

--- a/packages/web/src/utils/isActionPhaseActive.ts
+++ b/packages/web/src/utils/isActionPhaseActive.ts
@@ -1,0 +1,7 @@
+export function isActionPhaseActive(
+  currentPhase: string,
+  actionPhaseId: string | undefined,
+  tabsEnabled: boolean,
+): boolean {
+  return tabsEnabled && currentPhase === actionPhaseId;
+}

--- a/packages/web/tests/phase-history.test.ts
+++ b/packages/web/tests/phase-history.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { isActionPhaseActive } from '../src/Game';
+import { isActionPhaseActive } from '../src/utils/isActionPhaseActive';
 
 vi.mock('@kingdom-builder/engine', async () => {
   return await import('../../engine/src');


### PR DESCRIPTION
## Summary
- simplify Game component to just compose panels and wrap in GameProvider
- expose dark mode toggle and exit handlers through GameProvider context
- move isActionPhaseActive helper to a shared utils module

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b378c109c483259898bb739fa6c651