### PR TITLE
Improve PlayerPanel readability

### DIFF
--- a/packages/web/src/components/player/PlayerPanel.tsx
+++ b/packages/web/src/components/player/PlayerPanel.tsx
@@ -18,7 +18,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
   buildingDescriptions,
 }) => {
   return (
-    <div className={`h-full flex flex-col space-y-1 ${className}`}>
+    <div className={`player-panel h-full flex flex-col space-y-1 ${className}`}>
       <h3 className="font-semibold">{player.name}</h3>
       <div className="panel-card flex flex-wrap items-center gap-2 px-3 py-2 w-fit">
         <ResourceBar player={player} />

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -25,6 +25,9 @@
   .panel-card {
     @apply rounded-md bg-black/5 dark:bg-white/10;
   }
+  .player-panel .panel-card {
+    @apply bg-gray-50/40 dark:bg-gray-700/40;
+  }
   .player-bg {
     @apply relative overflow-hidden text-gray-900 dark:text-white;
     --stripe-color: rgba(0, 0, 0, 0.03);


### PR DESCRIPTION
## Summary
- lighten PlayerPanel sub-card backgrounds with subtler translucent gray for better default contrast
- add wrapper class to scope new styles
- dial back default PlayerPanel card background to lighter semi-transparent gray for contrast with hover state

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b376c28c4c8325b9c5bab08fcdc11c