### PR TITLE
docs: clarify package separation and use aliases

### DIFF
--- a/docs/architecture/AGENTS.md
+++ b/docs/architecture/AGENTS.md
@@ -79,8 +79,11 @@ testing, prefer overriding registries instead of stubbing modules.
 
 The repository uses a monorepo under `packages/`:
 
-- `packages/engine` – game rules, registries, effect handlers and tests.
-- `packages/web` – Vite + React client consuming the engine.
+- `packages/contents` – default game configuration edited by live-ops. Contains
+  no logic; only data such as actions, buildings, phases and translations.
+- `packages/engine` – game rules, registries, effect handlers and tests. The
+  engine consumes configuration and never hard codes content.
+- `packages/web` – Vite + React client consuming the engine and content.
 
 Shared configuration files live at the repository root. Adding a new package or
 library should follow the same structure so shared tooling continues to work.

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,0 +1,16 @@
+# Package Overview
+
+This directory houses the monorepo packages:
+
+- **engine** – core game logic, effect handlers and registries. No game content
+  or hardcoded values live here; behaviour derives entirely from supplied
+  configuration.
+- **contents** – default game data such as actions, buildings, phases and
+  starting setup. It contains no processing logic and is intended to be tweaked
+  by non‑technical contributors.
+- **web** – React frontend that renders the game. It queries the engine and, when
+  needed, reads data directly from the contents package.
+
+Keep configuration files inside `contents` and runtime logic inside `engine` or
+`web`. Tests should derive expectations from the active configuration rather
+than hardcoded numbers so that content tweaks do not invalidate tests.

--- a/tests/integration/building-placement.test.ts
+++ b/tests/integration/building-placement.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  performAction,
-  getActionCosts,
-} from '../../packages/engine/src/index.ts';
+import { performAction, getActionCosts } from '@kingdom-builder/engine';
 import { createTestContext, getActionOutcome } from './fixtures';
 
 describe('Building placement integration', () => {

--- a/tests/integration/edge-cases.test.ts
+++ b/tests/integration/edge-cases.test.ts
@@ -4,7 +4,7 @@ import {
   Resource,
   getActionCosts,
   type ResourceKey,
-} from '../../packages/engine/src/index.ts';
+} from '@kingdom-builder/engine';
 import { createTestContext } from './fixtures';
 
 describe('Action edge cases', () => {

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -1,7 +1,4 @@
-import {
-  createEngine,
-  getActionCosts,
-} from '../../packages/engine/src/index.ts';
+import { createEngine, getActionCosts } from '@kingdom-builder/engine';
 import {
   ACTIONS,
   BUILDINGS,
@@ -9,13 +6,10 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
-} from '../../packages/contents/src/index.ts';
-import type {
-  EngineContext,
-  EffectDef,
-} from '../../packages/engine/src/index.ts';
-import { PlayerState, Land } from '../../packages/engine/src/state/index.ts';
-import { runEffects } from '../../packages/engine/src/effects/index.ts';
+} from '@kingdom-builder/contents';
+import type { EngineContext, EffectDef } from '@kingdom-builder/engine';
+import { PlayerState, Land } from '@kingdom-builder/engine/state';
+import { runEffects } from '@kingdom-builder/engine/effects';
 
 function deepClone<T>(value: T): T {
   return structuredClone(value);

--- a/tests/integration/tax-translation.test.ts
+++ b/tests/integration/tax-translation.test.ts
@@ -1,10 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
-vi.mock(
-  '@kingdom-builder/engine',
-  async () => import('../../packages/engine/src'),
-);
-import { createEngine } from '../../packages/engine/src';
-import { summarizeContent } from '../../packages/web/src/translation/content';
+import { describe, it, expect } from 'vitest';
+import { createEngine } from '@kingdom-builder/engine';
+import { summarizeContent } from '@kingdom-builder/web/translation/content';
 import {
   ACTIONS,
   BUILDINGS,
@@ -12,7 +8,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
-} from '../../packages/contents/src';
+} from '@kingdom-builder/contents';
 
 describe('Tax action translation', () => {
   it('mentions population scaling', () => {
@@ -24,6 +20,7 @@ describe('Tax action translation', () => {
       phases: PHASES,
       start: GAME_START,
     });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     const summary = summarizeContent('action', 'tax', ctx) as {
       title: string;
       items: string[];

--- a/tests/integration/turn-cycle.test.ts
+++ b/tests/integration/turn-cycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createEngine, advance } from '../../packages/engine/src';
+import { createEngine, advance } from '@kingdom-builder/engine';
 import {
   ACTIONS,
   BUILDINGS,
@@ -7,7 +7,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
-} from '../../packages/contents/src';
+} from '@kingdom-builder/contents';
 
 describe('Turn cycle integration', () => {
   it('advances players through all phases sequentially', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
         __dirname,
         'packages/contents/src',
       ),
+      '@kingdom-builder/web': path.resolve(__dirname, 'packages/web/src'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- document engine, contents, and web responsibilities under `packages`
- mention new `contents` package in architecture overview
- use `@kingdom-builder/*` aliases in integration tests and Vitest config

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b41ee01c948325ad712d2360f71de2