### PR TITLE
feat: ensure unique icons across content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ below.
 - 2025-08-31: Run tests with `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`; avoid running extra test commands.
 - 2025-08-31: `git commit` triggers a Husky pre-commit hook running lint-staged, type checking, linting and tests.
 - 2025-08-31: Use `rg` for code searches; `grep -R` and `ls -R` are discouraged for performance.
+- 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
 
 # Core Agent principles
 

--- a/SAMPLE_CONFIG/AGENTS.md
+++ b/SAMPLE_CONFIG/AGENTS.md
@@ -6,13 +6,13 @@
 - 🏚️Development — a built feature occupying a 🧩Development Slot
 - 👥Population — citizens (roles below)
   - ⚖️Council — each grants 1 ⚡Action Point at the start of your turn
-  - 🎖️Army Commander — **+1 🗡️Army Strength (flat)** & contributes +25% 📈🗡️Growth each 📈Development Phase
-  - 🧱Fortifier — **+1 🛡️Fortification Strength (flat)** & contributes +25% 📈🛡️Growth each 📈Development Phase
+  - 🎖️Army Commander — **+1 ⚔️Army Strength (flat)** & contributes +25% 📈⚔️Growth each 📈Development Phase
+  - 🔧Fortifier — **+1 🛡️Fortification Strength (flat)** & contributes +25% 📈🛡️Growth each 📈Development Phase
   - 👤Citizen — unassigned; no benefits until assigned (upkeep 0🪙)
 - ⚡Action Point (AP) — each Action costs 1⚡
-- 🗡️Army Strength — total offensive strength
+- ⚔️Army Strength — total offensive strength
 - 🛡️Fortification Strength — total defensive strength
-- 📈🗡️/📈🛡️ Growth — % increase applied during 📈Development
+- 📈⚔️/📈🛡️ Growth — % increase applied during 📈Development
 - 😊Happiness — morale (–10 … +10)
 - 🏰Castle HP — starts at 10
 - 🧑‍🌾Till — add +1 🧩Development Slot to an 🗺️Land (max 2 🧩)
@@ -39,14 +39,14 @@
 - **Gain 💹Income**: resolve sources that trigger now (e.g., 🌾, 🌿, Temple).
 - **Generate ⚡**: +1⚡ per ⚖️Council; Player B gets +1⚡ in their first 📈Development only.
 - **Grow Strengths**:
-  - 🗡️ increases by +25% per 🎖️ (rounded up), applied to current 🗡️ which already includes +1 per 🎖️.
-  - 🛡️ increases by +25% per 🧱 (rounded up), applied to current 🛡️ which already includes +1 per 🧱.
+  - ⚔️ increases by +25% per 🎖️ (rounded up), applied to current ⚔️ which already includes +1 per 🎖️.
+  - 🛡️ increases by +25% per 🔧 (rounded up), applied to current 🛡️ which already includes +1 per 🔧.
   - If a 😊 threshold says no growth, skip both increases.
 
 ### 2.2 🧾Upkeep Phase
 
-- Pay: 2🪙/⚖️, 1🪙/🎖️, 1🪙/🧱, 0🪙/👤.
-- If short: Liquidation → recheck → Desertion (🎖️→🧱→⚖️; keep ≥1 ⚖️) → Bankruptcy.
+- Pay: 2🪙/⚖️, 1🪙/🎖️, 1🪙/🔧, 0🪙/👤.
+- If short: Liquidation → recheck → Desertion (🎖️→🔧→⚖️; keep ≥1 ⚖️) → Bankruptcy.
 - End-of-Upkeep triggers: resolve one at a time; owner chooses order.
 
 ### 2.3 🎯Main Phase
@@ -69,7 +69,7 @@
 - Place on 🗺️ with available 🧩:
   - 🏠House — +1 pop cap
   - 🌾Farm — +2🪙 at 💹
-  - 🛡️Outpost — +1🗡️, +1🛡️
+  - 🏹Outpost — +1⚔️, +1🛡️
   - 🗼Watchtower — +2🛡️; **+50% Absorption**; _after an enemy 🗡️Army Attack against you is fully resolved (damage & triggers), remove this 🗼Watchtower (free the 🧩 slot)_
 
 ### 3.4 Tax 💰 — Free
@@ -78,7 +78,7 @@
 
 ### 3.5 Reallocate 🔄 — 5🪙
 
-- Move 1 👥 between ⚖️/🎖️/🧱 (keep ≥1 ⚖️)
+- Move 1 👥 between ⚖️/🎖️/🔧 (keep ≥1 ⚖️)
 - –1😊
 - If assigned to ⚖️: +1⚡ immediately
 - If removed from ⚖️: –1⚡ immediately (floor 0 this turn)
@@ -92,12 +92,12 @@
 
 ### 3.7 Royal Decree 📜 — 12🪙
 
-- 🌱Expand → 🧑‍🌾Till → 🏗️Develop (🏠/🌾/🛡️/🗼), then –3😊
+- 🌱Expand → 🧑‍🌾Till → 🏗️Develop (🏠/🌾/🏹/🗼), then –3😊
 
 ### 3.8 🗡️Army Attack — Free
 
 - Limit: ≤ number of 🎖️
-- Attack Power = current 🗡️
+- Attack Power = current ⚔️
 - Apply **Absorption** (see Section 6)
 - Damage: reduce 🛡️ first; overflow damages 🏰
 - On 🏰 damage: defender –1😊, attacker +1😊, plunder 25% (50% with Raider’s Guild)
@@ -107,7 +107,7 @@
 - +2😊; you cannot Attack this turn
 - Attacks against you: **double attacker’s damage before Absorption**, then apply Absorption (Section 6)
 
-### 3.10 🚜Plow — 6🪙 (requires 🚜Plow Workshop)
+### 3.10 🚜Plow — 6🪙 (requires 🏭Plow Workshop)
 
 - 🌱Expand; 🧑‍🌾Till
 - Your next Action this turn costs +2🪙 (token queue)
@@ -117,10 +117,10 @@
 - **5🪙 — Town Charter**: 🌱Expand costs +2🪙; grants +1 extra 😊
 - **7🪙 — Mill**: whenever you gain resources from a 🌾, gain +1 more of that resource
 - **8🪙 — Raider’s Guild**: Plunder 50%
-- **10🪙 — 🚜Plow Workshop**: gain 🚜Plow
+- **10🪙 — 🏭Plow Workshop**: gain 🚜Plow
 - **10🪙 — Market**: Tax +1🪙/👥
-- **12🪙 — Barracks**: each 🎖️ gives **+1 additional** 🗡️; 📈🗡️ +10% per 🎖️
-- **12🪙 — Citadel**: +5🛡️; 📈🛡️ +15% per 🧱; +1🏠
+- **12🪙 — Barracks**: each 🎖️ gives **+1 additional** ⚔️; 📈⚔️ +10% per 🎖️
+- **12🪙 — Citadel**: +5🛡️; 📈🛡️ +15% per 🔧; +1🏠
 - **14🪙 — Castle Walls**: +5🛡️; **Absorption 20%**
 - **15🪙 — Castle Gardens**: on build → 🌱×2, 🧑‍🌾×2, 🏗️🌿×2; 🌿: +1🪙 at 💹; end of 🧾Upkeep if 😊<0: +1😊
 - **16🪙 — Temple**: whenever 😊 increases, gain +1 extra 😊; +1🏠; +1🪙 at 💹
@@ -129,7 +129,7 @@
 
 ## 4) 😊Happiness — Threshold Effects
 
-- +10 → +50% 💹; Buildings –20% (rounded up); 📈🗡️/📈🛡️ +20%
+- +10 → +50% 💹; Buildings –20% (rounded up); 📈⚔️/📈🛡️ +20%
 - +8 → +50% 💹; Buildings –20% (rounded up)
 - +5 → +25% 💹; Buildings –20% (rounded up)
 - +3 → +25% 💹
@@ -143,5 +143,5 @@
 
 - 🪙 10; 🗺️ 2 (one has 🌾); 🏰 10 (with +1 🏠)
 - 👥 1 (in ⚖️)
-- 🗡️ 0; 🛡️ 0
+- ⚔️ 0; 🛡️ 0
 - 😊 0

--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -190,7 +190,7 @@ export const ACTION_INFO: Record<string, { icon: string; label: string }> = {
   army_attack: { icon: '🗡️', label: ACTIONS.get('army_attack').name },
   hold_festival: { icon: '🎉', label: ACTIONS.get('hold_festival').name },
   build_plow_workshop: {
-    icon: '🚜',
+    icon: '🏭',
     label: ACTIONS.get('build_plow_workshop').name,
   },
   plow: { icon: '🚜', label: ACTIONS.get('plow').name },

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -108,8 +108,8 @@ export const BUILDINGS = createBuildingRegistry();
 export const BUILDING_INFO: Record<string, { icon: string; label: string }> = {
   town_charter: { icon: '🏘️', label: BUILDINGS.get('town_charter').name },
   mill: { icon: '⚙️', label: BUILDINGS.get('mill').name },
-  raiders_guild: { icon: '⚔️', label: BUILDINGS.get('raiders_guild').name },
-  plow_workshop: { icon: '🚜', label: BUILDINGS.get('plow_workshop').name },
+  raiders_guild: { icon: '🏴‍☠️', label: BUILDINGS.get('raiders_guild').name },
+  plow_workshop: { icon: '🏭', label: BUILDINGS.get('plow_workshop').name },
   market: { icon: '🏪', label: BUILDINGS.get('market').name },
   barracks: { icon: '🪖', label: BUILDINGS.get('barracks').name },
   citadel: { icon: '🏯', label: BUILDINGS.get('citadel').name },

--- a/packages/contents/src/developments.ts
+++ b/packages/contents/src/developments.ts
@@ -70,7 +70,7 @@ export const DEVELOPMENT_INFO: Record<string, { icon: string; label: string }> =
   {
     house: { icon: '🏠', label: DEVELOPMENTS.get('house').name },
     farm: { icon: '🌾', label: DEVELOPMENTS.get('farm').name },
-    outpost: { icon: '🛡️', label: DEVELOPMENTS.get('outpost').name },
+    outpost: { icon: '🏹', label: DEVELOPMENTS.get('outpost').name },
     watchtower: { icon: '🗼', label: DEVELOPMENTS.get('watchtower').name },
     garden: { icon: '🌿', label: DEVELOPMENTS.get('garden').name },
   };

--- a/packages/contents/src/populationRoles.ts
+++ b/packages/contents/src/populationRoles.ts
@@ -25,7 +25,7 @@ export const POPULATION_ROLES: Record<PopulationRoleId, PopulationRoleInfo> = {
   },
   [PopulationRole.Fortifier]: {
     key: PopulationRole.Fortifier,
-    icon: '🧱',
+    icon: '🔧',
     label: 'Fortifier',
     description:
       'Fortifiers reinforce your defenses. They raise Fortification Strength and shore up the castle every Development phase.',

--- a/packages/contents/src/stats.ts
+++ b/packages/contents/src/stats.ts
@@ -18,14 +18,14 @@ export const STATS: Record<StatKey, StatInfo> = {
   },
   [Stat.armyStrength]: {
     key: Stat.armyStrength,
-    icon: '🛡️',
+    icon: '⚔️',
     label: 'Army Strength',
     description:
       'Army Strength reflects the overall power of your military forces. A higher value makes your attacks more formidable.',
   },
   [Stat.fortificationStrength]: {
     key: Stat.fortificationStrength,
-    icon: '🏯',
+    icon: '🛡️',
     label: 'Fortification Strength',
     description:
       'Fortification Strength measures the resilience of your defenses. It reduces damage taken when enemies assault your castle.',


### PR DESCRIPTION
## Summary
- use ⚔️ for Army Strength and 🛡️ for Fortification Strength
- give Fortifier, Raider's Guild and Plow Workshop distinct icons
- document icon updates in sample config and discovery log

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b422ccc35083259d1cbc606654208e