### PR TITLE
feat: unlock plow action via workshop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ below.
 - 2025-08-31: Use `rg` for code searches; `grep -R` and `ls -R` are discouraged for performance.
 - 2025-08-31: Registries can validate entries with Zod schemas; invalid data will throw during `add`.
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
+- 2025-08-31: Buildings that unlock actions require an `action` effect formatter so they aren't marked as unimplemented in the UI.
 
 # Core Agent principles
 

--- a/packages/web/src/translation/effects/formatters/action.ts
+++ b/packages/web/src/translation/effects/formatters/action.ts
@@ -1,0 +1,56 @@
+import type { EngineContext } from '@kingdom-builder/engine';
+import { ACTION_INFO as actionInfo } from '@kingdom-builder/contents';
+import { registerEffectFormatter } from '../factory';
+
+function getActionLabel(id: string, ctx: EngineContext) {
+  let name = id;
+  try {
+    name = ctx.actions.get(id).name;
+  } catch {
+    // ignore missing action
+  }
+  const icon = actionInfo[id]?.icon || '';
+  return { icon, name };
+}
+
+registerEffectFormatter('action', 'add', {
+  summarize: (eff, ctx) => {
+    const id = eff.params?.['id'] as string;
+    if (!id) return null;
+    const { icon, name } = getActionLabel(id, ctx);
+    return `Gain ${icon}${name}`;
+  },
+  describe: (eff, ctx) => {
+    const id = eff.params?.['id'] as string;
+    if (!id) return null;
+    const { icon, name } = getActionLabel(id, ctx);
+    return `Gain action ${icon}${name}`;
+  },
+  log: (eff, ctx) => {
+    const id = eff.params?.['id'] as string;
+    if (!id) return null;
+    const { icon, name } = getActionLabel(id, ctx);
+    return `Unlocked ${icon} ${name}`;
+  },
+});
+
+registerEffectFormatter('action', 'remove', {
+  summarize: (eff, ctx) => {
+    const id = eff.params?.['id'] as string;
+    if (!id) return null;
+    const { icon, name } = getActionLabel(id, ctx);
+    return `Lose ${icon}${name}`;
+  },
+  describe: (eff, ctx) => {
+    const id = eff.params?.['id'] as string;
+    if (!id) return null;
+    const { icon, name } = getActionLabel(id, ctx);
+    return `Lose action ${icon}${name}`;
+  },
+  log: (eff, ctx) => {
+    const id = eff.params?.['id'] as string;
+    if (!id) return null;
+    const { icon, name } = getActionLabel(id, ctx);
+    return `Lost ${icon} ${name}`;
+  },
+});

--- a/packages/web/src/translation/effects/index.ts
+++ b/packages/web/src/translation/effects/index.ts
@@ -11,6 +11,7 @@ import './formatters/land';
 import './formatters/development';
 import './formatters/building';
 import './formatters/modifier';
+import './formatters/action';
 import './formatters/passive';
 import './evaluators/development';
 import './evaluators/population';


### PR DESCRIPTION
## Summary
- translate action add/remove effects so buildings can unlock actions
- record discovery about formatter requirement in AGENTS log

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b42919761483258a4bdaedf8b1bad9