### PR TITLE
Prebuild contents before dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ below.
 - 2025-08-31: Use `rg` for code searches; `grep -R` and `ls -R` are discouraged for performance.
 - 2025-08-31: Registries can validate entries with Zod schemas; invalid data will throw during `add`.
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
+- 2025-08-31: `npm run dev` prebuilds `@kingdom-builder/contents` via a `predev` script to avoid missing dist files.
 
 # Core Agent principles
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 1. Install [Node.js](https://nodejs.org/) (v18+ recommended).
 2. Install dependencies: `npm install` (uses npm workspaces to link local packages)
-3. Start the development server: `npm run dev`
+3. Start the development server: `npm run dev` (automatically builds `@kingdom-builder/contents`)
 4. Build for production: `npm run build`
 
 Default game content (actions, buildings, etc.) lives in `packages/contents`.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/*"
   ],
   "scripts": {
+    "predev": "npm run build --workspace @kingdom-builder/contents",
     "dev": "vite",
     "build": "tsc -b && vite build packages/web",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- build contents workspace before running dev server so source is available
- document automatic contents build when starting dev
- record discovery about the new predev script

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b429d304508325a6bebab80d28392e