### PR TITLE
feat(web): translate population effects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ below.
 - 2025-08-31: Registries can validate entries with Zod schemas; invalid data will throw during `add`.
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
 - 2025-08-31: Buildings that unlock actions require an `action` effect formatter so they aren't marked as unimplemented in the UI.
+- 2025-08-31: `summarizeContent` and `describeContent` for actions can accept params; `applyParamsToEffects` resolves placeholders for dynamic summaries.
 
 # Core Agent principles
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1942,6 +1942,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
       "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@bcoe/v8-coverage": "^1.0.2",

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -166,16 +166,10 @@ function RaisePopOptions({
             : !canPay
               ? 'Cannot pay costs'
               : undefined;
-          const summary = describeContent('action', 'raise_pop', ctx);
-          const shortSummary = summarizeContent('action', 'raise_pop', ctx);
-          const first = summary[0];
-          if (first && typeof first !== 'string') {
-            first.items.push(`👥(${POPULATION_ROLES[role]?.icon}) +1`);
-          }
-          const shortFirst = shortSummary[0];
-          if (shortFirst && typeof shortFirst !== 'string') {
-            shortFirst.items.push(`👥(${POPULATION_ROLES[role]?.icon}) +1`);
-          }
+          const summary = describeContent('action', 'raise_pop', ctx, { role });
+          const shortSummary = summarizeContent('action', 'raise_pop', ctx, {
+            role,
+          });
           return (
             <button
               key={role}

--- a/packages/web/src/translation/content/action.ts
+++ b/packages/web/src/translation/content/action.ts
@@ -4,15 +4,23 @@ import {
   ACTION_INFO as actionInfo,
 } from '@kingdom-builder/contents';
 import { summarizeEffects, describeEffects } from '../effects';
+import { applyParamsToEffects } from '@kingdom-builder/engine';
 import { registerContentTranslator, logContent } from './factory';
 import type { ContentTranslator, Summary } from './types';
 
 class ActionTranslator
   implements ContentTranslator<string, Record<string, unknown>>
 {
-  summarize(id: string, ctx: EngineContext): Summary {
+  summarize(
+    id: string,
+    ctx: EngineContext,
+    opts?: Record<string, unknown>,
+  ): Summary {
     const def = ctx.actions.get(id);
-    const eff = summarizeEffects(def.effects, ctx);
+    const effects = opts
+      ? applyParamsToEffects(def.effects, opts)
+      : def.effects;
+    const eff = summarizeEffects(effects, ctx);
     if (!eff.length) return [];
     return [
       {
@@ -21,9 +29,16 @@ class ActionTranslator
       },
     ];
   }
-  describe(id: string, ctx: EngineContext): Summary {
+  describe(
+    id: string,
+    ctx: EngineContext,
+    opts?: Record<string, unknown>,
+  ): Summary {
     const def = ctx.actions.get(id);
-    const eff = describeEffects(def.effects, ctx);
+    const effects = opts
+      ? applyParamsToEffects(def.effects, opts)
+      : def.effects;
+    const eff = describeEffects(effects, ctx);
     if (!eff.length) return [];
     return [
       {

--- a/packages/web/src/translation/effects/formatters/population.ts
+++ b/packages/web/src/translation/effects/formatters/population.ts
@@ -1,0 +1,40 @@
+import { POPULATION_ROLES } from '@kingdom-builder/contents';
+import { registerEffectFormatter } from '../factory';
+
+registerEffectFormatter('population', 'add', {
+  summarize: (eff) => {
+    const role = eff.params?.['role'] as
+      | keyof typeof POPULATION_ROLES
+      | undefined;
+    const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
+    return `👥(${icon}) +1`;
+  },
+  describe: (eff) => {
+    const role = eff.params?.['role'] as
+      | keyof typeof POPULATION_ROLES
+      | undefined;
+    const info = role ? POPULATION_ROLES[role] : undefined;
+    const label = info?.label || role || 'population';
+    const icon = info?.icon || '';
+    return `Add ${icon} ${label}`;
+  },
+});
+
+registerEffectFormatter('population', 'remove', {
+  summarize: (eff) => {
+    const role = eff.params?.['role'] as
+      | keyof typeof POPULATION_ROLES
+      | undefined;
+    const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
+    return `👥(${icon}) -1`;
+  },
+  describe: (eff) => {
+    const role = eff.params?.['role'] as
+      | keyof typeof POPULATION_ROLES
+      | undefined;
+    const info = role ? POPULATION_ROLES[role] : undefined;
+    const label = info?.label || role || 'population';
+    const icon = info?.icon || '';
+    return `Remove ${icon} ${label}`;
+  },
+});

--- a/packages/web/src/translation/effects/index.ts
+++ b/packages/web/src/translation/effects/index.ts
@@ -13,5 +13,6 @@ import './formatters/building';
 import './formatters/modifier';
 import './formatters/action';
 import './formatters/passive';
+import './formatters/population';
 import './evaluators/development';
 import './evaluators/population';

--- a/packages/web/tests/population-summary.test.ts
+++ b/packages/web/tests/population-summary.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  summarizeContent,
+  summarizeEffects,
+  describeEffects,
+  type Summary,
+} from '../src/translation';
+import { createEngine, PopulationRole } from '@kingdom-builder/engine';
+import {
+  ACTIONS,
+  BUILDINGS,
+  DEVELOPMENTS,
+  POPULATIONS,
+  PHASES,
+  GAME_START,
+  POPULATION_ROLES,
+} from '@kingdom-builder/contents';
+
+vi.mock('@kingdom-builder/engine', async () => {
+  return await import('../../engine/src');
+});
+
+function flatten(summary: Summary): string[] {
+  const result: string[] = [];
+  for (const entry of summary) {
+    if (typeof entry === 'string') {
+      result.push(entry);
+    } else {
+      result.push(...flatten(entry.items));
+    }
+  }
+  return result;
+}
+
+describe('population effect translation', () => {
+  const ctx = createEngine({
+    actions: ACTIONS,
+    buildings: BUILDINGS,
+    developments: DEVELOPMENTS,
+    populations: POPULATIONS,
+    phases: PHASES,
+    start: GAME_START,
+  });
+
+  it('summarizes raise_pop action for specific role', () => {
+    const summary = summarizeContent('action', 'raise_pop', ctx, {
+      role: PopulationRole.Council,
+    });
+    const flat = flatten(summary);
+    expect(flat).toContain(
+      `👥(${POPULATION_ROLES[PopulationRole.Council].icon}) +1`,
+    );
+  });
+
+  it('handles population removal effect', () => {
+    const summary = summarizeEffects(
+      [
+        {
+          type: 'population',
+          method: 'remove',
+          params: { role: PopulationRole.Council },
+        },
+      ],
+      ctx,
+    );
+    const desc = describeEffects(
+      [
+        {
+          type: 'population',
+          method: 'remove',
+          params: { role: PopulationRole.Council },
+        },
+      ],
+      ctx,
+    );
+    expect(summary).toContain(
+      `👥(${POPULATION_ROLES[PopulationRole.Council].icon}) -1`,
+    );
+    expect(desc).toContain(
+      `Remove ${POPULATION_ROLES[PopulationRole.Council].icon} ${POPULATION_ROLES[PopulationRole.Council].label}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add population effect formatter with add/remove support
- plug formatter into translation system and apply action params for role-aware summaries
- remove hard-coded population summary in actions panel
- test population effect summaries

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b42bf858d08325a7fea291856eb8bb