### PR TITLE
feat(web): add till land formatter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ below.
 - 2025-08-31: Registries can validate entries with Zod schemas; invalid data will throw during `add`.
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
 - 2025-08-31: Buildings that unlock actions require an `action` effect formatter so they aren't marked as unimplemented in the UI.
+- 2025-08-31: `land:till` unlocks a 🧩 slot on the targeted 🗺️ and marks it tilled; actions without effects like `plow` produce no summary.
 
 # Core Agent principles
 

--- a/packages/web/src/translation/effects/formatters/land.ts
+++ b/packages/web/src/translation/effects/formatters/land.ts
@@ -1,4 +1,7 @@
-import { LAND_ICON as landIcon } from '@kingdom-builder/contents';
+import {
+  LAND_ICON as landIcon,
+  SLOT_ICON as slotIcon,
+} from '@kingdom-builder/contents';
 import { gainOrLose, signed } from '../helpers';
 import { registerEffectFormatter } from '../factory';
 
@@ -11,4 +14,9 @@ registerEffectFormatter('land', 'add', {
     const count = Number(eff.params?.['count'] ?? 1);
     return `${gainOrLose(count)} ${count} ${landIcon} Land`;
   },
+});
+
+registerEffectFormatter('land', 'till', {
+  summarize: () => `${slotIcon}+1`,
+  describe: () => `Till ${landIcon} to unlock ${slotIcon} slot`,
 });

--- a/packages/web/tests/land-till-formatter.test.ts
+++ b/packages/web/tests/land-till-formatter.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { summarizeEffects } from '../src/translation/effects';
+import { summarizeContent } from '../src/translation/content';
+import { createEngine } from '@kingdom-builder/engine';
+import {
+  ACTIONS,
+  BUILDINGS,
+  DEVELOPMENTS,
+  POPULATIONS,
+  PHASES,
+  GAME_START,
+  SLOT_ICON as slotIcon,
+} from '@kingdom-builder/contents';
+
+vi.mock('@kingdom-builder/engine', async () => {
+  return await import('../../engine/src');
+});
+
+function createCtx() {
+  return createEngine({
+    actions: ACTIONS,
+    buildings: BUILDINGS,
+    developments: DEVELOPMENTS,
+    populations: POPULATIONS,
+    phases: PHASES,
+    start: GAME_START,
+  });
+}
+
+describe('land till formatter', () => {
+  it('summarizes till effect', () => {
+    const ctx = createCtx();
+    const summary = summarizeEffects([{ type: 'land', method: 'till' }], ctx);
+    expect(summary).toContain(`${slotIcon}+1`);
+  });
+
+  it('summarizes till action', () => {
+    const ctx = createCtx();
+    const summary = summarizeContent('action', 'till', ctx) as {
+      title: string;
+      items: string[];
+    }[];
+    const items = summary[0]?.items || [];
+    expect(items.some((i) => i.includes(slotIcon))).toBe(true);
+  });
+
+  it('handles plow action with no summary', () => {
+    const ctx = createCtx();
+    const summary = summarizeContent('action', 'plow', ctx);
+    expect(summary).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add effect formatter for land:till to summarize +1 slot and describe tilled land
- test translations for land tilling and related actions
- document land:till behavior in discovery log

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b42c0c4db0832586ca61c72ffe6a26