### PR TITLE
Clarify discovery log guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ may include repository structure tips, tricky commands, or environment quirks
 that required some investigation. Maintain this list during your work and, when
 submitting a pull request, append your findings to the **Agent discovery log**
 below.
+Avoid logging the routine steps you performed; use the discovery log only for
+non-obvious insights that will help future agents work more efficiently.
 
 ## Agent discovery log
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ may include repository structure tips, tricky commands, or environment quirks
 that required some investigation. Maintain this list during your work and, when
 submitting a pull request, append your findings to the **Agent discovery log**
 below.
-Avoid logging the routine steps you performed; use the discovery log only for
+Avoid logging the routine steps you performed, avoid logging updates related to your implementation; use the discovery log only for
 non-obvious insights that will help future agents work more efficiently.
 
 ## Agent discovery log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ that required some investigation. Maintain this list during your work and, when
 submitting a pull request, append your findings to the **Agent discovery log**
 below.
 Avoid logging the routine steps you performed, avoid logging updates related to your implementation; use the discovery log only for
-non-obvious insights that will help future agents work more efficiently.
+non-obvious insights that will help future agents work more efficiently. Any updates or documentation related to your implementation should be plaecd in architectural/system design/system config documentation elsewhere.
 
 ## Agent discovery log
 


### PR DESCRIPTION
## Summary
- Clarify that the discovery log should exclude routine work logs and focus on non-obvious findings

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b42d5d4ba08325824d659fb6cb7841