### PR TITLE
feat: implement plow action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ below.
 - 2025-08-31: Registries can validate entries with Zod schemas; invalid data will throw during `add`.
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
 - 2025-08-31: Buildings that unlock actions require an `action` effect formatter so they aren't marked as unimplemented in the UI.
+- 2025-08-31: Passives can schedule phase triggers via `onUpkeepPhase` and are stored per-player in `PassiveManager`.
 
 # Core Agent principles
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1942,6 +1942,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
       "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@bcoe/v8-coverage": "^1.0.2",

--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -143,6 +143,33 @@ export function createActionRegistry() {
       .system()
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 6)
+      .effect({ type: 'action', method: 'perform', params: { id: 'expand' } })
+      .effect({ type: 'action', method: 'perform', params: { id: 'till' } })
+      .effect({
+        type: 'passive',
+        method: 'add',
+        params: {
+          id: 'plow_cost_mod',
+          onUpkeepPhase: [
+            {
+              type: 'passive',
+              method: 'remove',
+              params: { id: 'plow_cost_mod' },
+            },
+          ],
+        },
+        effects: [
+          {
+            type: 'cost_mod',
+            method: 'add',
+            params: {
+              id: 'plow_cost_all',
+              key: Resource.gold,
+              amount: 2,
+            },
+          },
+        ],
+      })
       .build(),
   );
 

--- a/packages/engine/src/effects/action_perform.ts
+++ b/packages/engine/src/effects/action_perform.ts
@@ -1,0 +1,15 @@
+import type { EffectHandler } from '.';
+import { applyParamsToEffects } from '../utils';
+import { runEffects } from '.';
+
+export const actionPerform: EffectHandler = (effect, ctx, mult = 1) => {
+  const id = effect.params?.['id'] as string;
+  if (!id) throw new Error('action:perform requires id');
+  const params = effect.params as Record<string, unknown>;
+  for (let i = 0; i < Math.floor(mult); i++) {
+    const def = ctx.actions.get(id);
+    const resolved = applyParamsToEffects(def.effects, params);
+    runEffects(resolved, ctx);
+    ctx.passives.runResultMods(def.id, ctx);
+  }
+};

--- a/packages/engine/src/effects/cost_mod.ts
+++ b/packages/engine/src/effects/cost_mod.ts
@@ -3,7 +3,7 @@ import type { ResourceKey } from '../state';
 
 interface CostModParams {
   id: string;
-  actionId: string;
+  actionId?: string;
   key: ResourceKey;
   amount: number;
   [key: string]: unknown;
@@ -11,8 +11,8 @@ interface CostModParams {
 
 export const costMod: EffectHandler<CostModParams> = (effect, ctx) => {
   const { id, actionId, key, amount } = effect.params || ({} as CostModParams);
-  if (!id || !actionId || !key || amount === undefined) {
-    throw new Error('cost_mod requires id, actionId, key, amount');
+  if (!id || !key || amount === undefined) {
+    throw new Error('cost_mod requires id, key, amount');
   }
   const ownerId = ctx.activePlayer.id;
   const modId = `${id}_${ownerId}`;
@@ -21,8 +21,8 @@ export const costMod: EffectHandler<CostModParams> = (effect, ctx) => {
       modId,
       (targetActionId, costs, innerCtx) => {
         if (
-          targetActionId === actionId &&
-          innerCtx.activePlayer.id === ownerId
+          innerCtx.activePlayer.id === ownerId &&
+          (!actionId || targetActionId === actionId)
         ) {
           const current = costs[key] || 0;
           return { ...costs, [key]: current + amount };

--- a/packages/engine/src/effects/index.ts
+++ b/packages/engine/src/effects/index.ts
@@ -21,6 +21,7 @@ import { populationAdd } from './population_add';
 import { populationRemove } from './population_remove';
 import { actionAdd } from './action_add';
 import { actionRemove } from './action_remove';
+import { actionPerform } from './action_perform';
 
 export interface EffectDef<
   P extends Record<string, unknown> = Record<string, unknown>,
@@ -64,6 +65,7 @@ export function registerCoreEffects(registry: EffectRegistry = EFFECTS) {
   registry.add('population:remove', populationRemove);
   registry.add('action:add', actionAdd);
   registry.add('action:remove', actionRemove);
+  registry.add('action:perform', actionPerform);
 }
 
 export function runEffects(effects: EffectDef[], ctx: EngineContext, mult = 1) {
@@ -110,4 +112,5 @@ export {
   populationRemove,
   actionAdd,
   actionRemove,
+  actionPerform,
 };

--- a/packages/engine/src/effects/passive_add.ts
+++ b/packages/engine/src/effects/passive_add.ts
@@ -1,9 +1,31 @@
-import type { EffectHandler } from '.';
+import type { EffectHandler, EffectDef } from '.';
 
-export const passiveAdd: EffectHandler = (effect, ctx, mult = 1) => {
-  const id = effect.params?.['id'] as string;
+interface PassiveParams {
+  id: string;
+  onDevelopmentPhase?: EffectDef[];
+  onUpkeepPhase?: EffectDef[];
+  onAttackResolved?: EffectDef[];
+  [key: string]: unknown;
+}
+
+export const passiveAdd: EffectHandler<PassiveParams> = (
+  effect,
+  ctx,
+  mult = 1,
+) => {
+  const params = effect.params || ({} as PassiveParams);
+  const { id, onDevelopmentPhase, onUpkeepPhase, onAttackResolved } = params;
   if (!id) throw new Error('passive:add requires id');
-  const passive = { id, effects: effect.effects || [] };
+  const passive: {
+    id: string;
+    effects: EffectDef[];
+    onDevelopmentPhase?: EffectDef[];
+    onUpkeepPhase?: EffectDef[];
+    onAttackResolved?: EffectDef[];
+  } = { id, effects: effect.effects || [] };
+  if (onDevelopmentPhase) passive.onDevelopmentPhase = onDevelopmentPhase;
+  if (onUpkeepPhase) passive.onUpkeepPhase = onUpkeepPhase;
+  if (onAttackResolved) passive.onAttackResolved = onAttackResolved;
   for (let index = 0; index < Math.floor(mult); index++) {
     ctx.passives.addPassive(passive, ctx);
   }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -74,6 +74,11 @@ function runTrigger(
     if (effects) runEffects(effects, ctx);
   }
 
+  for (const passive of ctx.passives.values(player.id)) {
+    const effects = getEffects(passive, trigger);
+    if (effects) runEffects(effects, ctx);
+  }
+
   ctx.game.currentPlayerIndex = original;
 }
 
@@ -105,6 +110,10 @@ export function collectTriggerEffects(
   for (const id of player.buildings) {
     const buildingDefinition = ctx.buildings.get(id);
     const list = getEffects(buildingDefinition, trigger);
+    if (list) effects.push(...list.map((e) => ({ ...e })));
+  }
+  for (const passive of ctx.passives.values(player.id)) {
+    const list = getEffects(passive, trigger);
     if (list) effects.push(...list.map((e) => ({ ...e })));
   }
   return effects;

--- a/packages/engine/tests/actions/plow.test.ts
+++ b/packages/engine/tests/actions/plow.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import {
+  performAction,
+  getActionCosts,
+  Resource,
+  collectTriggerEffects,
+  runEffects,
+  advance,
+  type EngineContext,
+} from '../../src/index.ts';
+import { createTestEngine } from '../helpers.ts';
+
+function countTilled(ctx: EngineContext): number {
+  return ctx.activePlayer.lands.filter((l) => l.tilled).length;
+}
+
+describe('Plow action', () => {
+  it('expands, tills and adds temporary cost modifier', () => {
+    const ctx = createTestEngine();
+    while (ctx.game.currentPhase !== 'main') advance(ctx);
+    ctx.activePlayer.gold += 20;
+    const baseCost = getActionCosts('expand', ctx);
+    performAction('build', ctx, { id: 'plow_workshop' });
+    ctx.activePlayer.ap += 1;
+    const landsBefore = ctx.activePlayer.lands.length;
+    const tilledBefore = countTilled(ctx);
+    performAction('plow', ctx);
+    expect(ctx.activePlayer.lands.length).toBe(landsBefore + 1);
+    expect(countTilled(ctx)).toBe(tilledBefore + 1);
+    const modified = getActionCosts('expand', ctx);
+    expect(modified[Resource.gold]).toBe((baseCost[Resource.gold] || 0) + 2);
+    runEffects(collectTriggerEffects('onUpkeepPhase', ctx), ctx);
+    const reverted = getActionCosts('expand', ctx);
+    expect(reverted[Resource.gold]).toBe(baseCost[Resource.gold] || 0);
+  });
+});

--- a/packages/engine/tests/services/rules.test.ts
+++ b/packages/engine/tests/services/rules.test.ts
@@ -62,10 +62,10 @@ describe('PassiveManager', () => {
     };
     const before = ctx.activePlayer.gold;
     ctx.passives.addPassive(passive, ctx);
-    expect(ctx.passives.list()).toContain('shiny');
+    expect(ctx.passives.list(ctx.activePlayer.id)).toContain('shiny');
     expect(ctx.activePlayer.gold).toBe(before + 2);
     ctx.passives.removePassive('shiny', ctx);
-    expect(ctx.passives.list()).not.toContain('shiny');
+    expect(ctx.passives.list(ctx.activePlayer.id)).not.toContain('shiny');
     expect(ctx.activePlayer.gold).toBe(before);
     // removing non-existent passive is a no-op
     ctx.passives.removePassive('unknown', ctx);

--- a/packages/web/src/translation/effects/formatters/action.ts
+++ b/packages/web/src/translation/effects/formatters/action.ts
@@ -54,3 +54,18 @@ registerEffectFormatter('action', 'remove', {
     return `Lost ${icon} ${name}`;
   },
 });
+
+registerEffectFormatter('action', 'perform', {
+  summarize: (eff, ctx) => {
+    const id = eff.params?.['id'] as string;
+    if (!id) return null;
+    const { icon, name } = getActionLabel(id, ctx);
+    return `${icon} ${name}`;
+  },
+  describe: (eff, ctx) => {
+    const id = eff.params?.['id'] as string;
+    if (!id) return null;
+    const { icon, name } = getActionLabel(id, ctx);
+    return `Perform action ${icon}${name}`;
+  },
+});

--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -17,18 +17,48 @@ registerEffectFormatter('cost_mod', 'add', {
     const key = eff.params?.['key'] as string;
     const icon = RESOURCES[key as ResourceKey]?.icon || key;
     const amount = Number(eff.params?.['amount']);
-    const actionId = eff.params?.['actionId'] as string;
-    const actionIcon = actionInfo[actionId]?.icon || actionId;
-    return `${modifierInfo.cost.icon} ${actionIcon}: ${icon}${signed(amount)}${amount}`;
+    const actionId = eff.params?.['actionId'] as string | undefined;
+    const actionIcon = actionId ? actionInfo[actionId]?.icon || actionId : '';
+    const target = actionId ? `${actionIcon}` : 'All actions';
+    return `${modifierInfo.cost.icon} ${target}: ${icon}${signed(amount)}${amount}`;
   },
   describe: (eff, ctx) => {
     const key = eff.params?.['key'] as string;
     const icon = RESOURCES[key as ResourceKey]?.icon || key;
     const amount = Number(eff.params?.['amount']);
-    const actionId = eff.params?.['actionId'] as string;
-    const actionIcon = actionInfo[actionId]?.icon || actionId;
-    const actionName = ctx.actions.get(actionId)?.name || actionId;
-    return `${modifierInfo.cost.icon} ${modifierInfo.cost.label} on ${actionIcon} ${actionName}: ${increaseOrDecrease(amount)} cost by ${icon}${Math.abs(amount)}`;
+    const actionId = eff.params?.['actionId'] as string | undefined;
+    const actionIcon = actionId ? actionInfo[actionId]?.icon || actionId : '';
+    const actionName = actionId
+      ? ctx.actions.get(actionId)?.name || actionId
+      : 'all actions';
+    const target = actionId ? `${actionIcon} ${actionName}` : actionName;
+    return `${modifierInfo.cost.icon} ${modifierInfo.cost.label} on ${target}: ${increaseOrDecrease(amount)} cost by ${icon}${Math.abs(amount)}`;
+  },
+});
+
+registerEffectFormatter('cost_mod', 'remove', {
+  summarize: (eff, _ctx) => {
+    const key = eff.params?.['key'] as string;
+    const icon = RESOURCES[key as ResourceKey]?.icon || key;
+    const amount = Number(eff.params?.['amount']);
+    const actionId = eff.params?.['actionId'] as string | undefined;
+    const actionIcon = actionId ? actionInfo[actionId]?.icon || actionId : '';
+    const target = actionId ? `${actionIcon}` : 'All actions';
+    const delta = -amount;
+    const sign = delta >= 0 ? '+' : '-';
+    return `${modifierInfo.cost.icon} ${target}: ${icon}${sign}${Math.abs(delta)}`;
+  },
+  describe: (eff, ctx) => {
+    const key = eff.params?.['key'] as string;
+    const icon = RESOURCES[key as ResourceKey]?.icon || key;
+    const amount = Number(eff.params?.['amount']);
+    const actionId = eff.params?.['actionId'] as string | undefined;
+    const actionIcon = actionId ? actionInfo[actionId]?.icon || actionId : '';
+    const actionName = actionId
+      ? ctx.actions.get(actionId)?.name || actionId
+      : 'all actions';
+    const target = actionId ? `${actionIcon} ${actionName}` : actionName;
+    return `${modifierInfo.cost.icon} ${modifierInfo.cost.label} on ${target}: ${increaseOrDecrease(-amount)} cost by ${icon}${Math.abs(amount)}`;
   },
 });
 


### PR DESCRIPTION
## Summary
- implement Plow action that expands, tills and temporarily increases all action gold costs
- support player-scoped passive triggers and global cost modifiers
- add action performer effect and update translations for modifiers and actions

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b42b368380832585a1b82a12c97eb2