### PR TITLE
Condense action timing notes into category headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-08-31: `npm run dev` prebuilds `@kingdom-builder/contents` via a `predev` script to avoid missing dist files.
 - 2025-08-31: Action/development summaries include trigger headers as the first element; render `summary?.[0]?.items` to skip these when a parent header already conveys timing.
 - 2025-08-31: `summarizeContent` returns a trigger header even when there are no items; tests should check `summary[0]?.items` length for empties instead of array length.
+- 2025-08-31: Removing `auto-rows-fr` from action grids lets each row size to its own tallest card rather than the tallest card in the entire grid.
 
 # Core Agent principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
 - 2025-08-31: Buildings that unlock actions require an `action` effect formatter so they aren't marked as unimplemented in the UI.
 - 2025-08-31: `npm run dev` prebuilds `@kingdom-builder/contents` via a `predev` script to avoid missing dist files.
+- 2025-08-31: Action/development summaries include trigger headers as the first element; render `summary?.[0]?.items` to skip these when a parent header already conveys timing.
 
 # Core Agent principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-08-31: Buildings that unlock actions require an `action` effect formatter so they aren't marked as unimplemented in the UI.
 - 2025-08-31: `npm run dev` prebuilds `@kingdom-builder/contents` via a `predev` script to avoid missing dist files.
 - 2025-08-31: Action/development summaries include trigger headers as the first element; render `summary?.[0]?.items` to skip these when a parent header already conveys timing.
+- 2025-08-31: `summarizeContent` returns a trigger header even when there are no items; tests should check `summary[0]?.items` length for empties instead of array length.
 
 # Core Agent principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-08-31: Action/development summaries include trigger headers as the first element; render `summary?.[0]?.items` to skip these when a parent header already conveys timing.
 - 2025-08-31: `summarizeContent` returns a trigger header even when there are no items; tests should check `summary[0]?.items` length for empties instead of array length.
 - 2025-08-31: Removing `auto-rows-fr` from action grids lets each row size to its own tallest card rather than the tallest card in the entire grid.
+- 2025-09-24: Generic population icon lives at `POPULATION_ROLES[PopulationRole.Citizen].icon` for requirement displays.
 
 # Core Agent principles
 

--- a/packages/web/src/components/HoverCard.tsx
+++ b/packages/web/src/components/HoverCard.tsx
@@ -23,28 +23,24 @@ export default function HoverCard() {
           {data.description}
         </div>
       )}
-      <div className="flex gap-2">
-        {data.effects.length > 0 && (
-          <div className="flex-1">
-            <div className="font-semibold">
-              {data.effectsTitle ?? 'Effects'}
-            </div>
-            <ul className="list-disc pl-4 text-sm">
-              {renderSummary(data.effects)}
-            </ul>
-          </div>
-        )}
-        {data.requirements.length > 0 && (
-          <div className="text-sm text-red-600 mt-4 w-1/3">
-            <div className="font-semibold text-red-600">Requirements</div>
-            <ul className="list-disc pl-4">
-              {data.requirements.map((r, i) => (
-                <li key={i}>{r}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </div>
+      {data.effects.length > 0 && (
+        <div className="mb-2">
+          <div className="font-semibold">{data.effectsTitle ?? 'Effects'}</div>
+          <ul className="list-disc pl-4 text-sm">
+            {renderSummary(data.effects)}
+          </ul>
+        </div>
+      )}
+      {data.requirements.length > 0 && (
+        <div className="text-sm text-red-600 mt-2">
+          <div className="font-semibold text-red-600">Requirements</div>
+          <ul className="list-disc pl-4">
+            {data.requirements.map((r, i) => (
+              <li key={i}>{r}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/HoverCard.tsx
+++ b/packages/web/src/components/HoverCard.tsx
@@ -18,29 +18,33 @@ export default function HoverCard() {
           {renderCosts(data.costs, ctx.activePlayer.resources)}
         </span>
       </div>
-      {data.requirements.length > 0 && (
-        <div className="mb-2">
-          <div className="font-semibold text-red-600">Requirements</div>
-          <ul className="list-disc pl-4 text-sm text-red-600">
-            {data.requirements.map((r, i) => (
-              <li key={i}>{r}</li>
-            ))}
-          </ul>
-        </div>
-      )}
       {data.description && (
         <div className={`mb-2 text-sm ${data.descriptionClass ?? ''}`}>
           {data.description}
         </div>
       )}
-      {data.effects.length > 0 && (
-        <div>
-          <div className="font-semibold">{data.effectsTitle ?? 'Effects'}</div>
-          <ul className="list-disc pl-4 text-sm">
-            {renderSummary(data.effects)}
-          </ul>
-        </div>
-      )}
+      <div className="flex gap-2">
+        {data.effects.length > 0 && (
+          <div className="flex-1">
+            <div className="font-semibold">
+              {data.effectsTitle ?? 'Effects'}
+            </div>
+            <ul className="list-disc pl-4 text-sm">
+              {renderSummary(data.effects)}
+            </ul>
+          </div>
+        )}
+        {data.requirements.length > 0 && (
+          <div className="text-sm text-red-600 mt-4 w-1/3">
+            <div className="font-semibold text-red-600">Requirements</div>
+            <ul className="list-disc pl-4">
+              {data.requirements.map((r, i) => (
+                <li key={i}>{r}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -109,23 +109,25 @@ function GenericActions({
             <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
               {renderCosts(costs, ctx.activePlayer.resources)}
             </span>
-            <ul className="text-sm list-disc pl-4 text-left">
-              {implemented ? (
-                renderSummary(stripSummary(summary))
-              ) : (
-                <li className="italic text-red-600">Not implemented yet</li>
+            <div className="flex w-full gap-2">
+              <ul className="text-sm list-disc pl-4 text-left flex-1">
+                {implemented ? (
+                  renderSummary(stripSummary(summary))
+                ) : (
+                  <li className="italic text-red-600">Not implemented yet</li>
+                )}
+              </ul>
+              {requirements.length > 0 && (
+                <div className="text-sm text-red-600 text-left mt-4 w-1/3">
+                  <span className="font-semibold">Requirements</span>
+                  <ul className="list-disc pl-4">
+                    {requirements.map((r, i) => (
+                      <li key={i}>{r}</li>
+                    ))}
+                  </ul>
+                </div>
               )}
-            </ul>
-            {requirements.length > 0 && (
-              <div className="text-sm text-red-600 text-left">
-                <span className="font-semibold">Requirements</span>
-                <ul className="list-disc pl-4">
-                  {requirements.map((r, i) => (
-                    <li key={i}>{r}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
+            </div>
           </button>
         );
       })}
@@ -183,11 +185,9 @@ function RaisePopOptions({
             onClick={() => enabled && handlePerform(action, { role })}
             onMouseEnter={() =>
               handleHoverCard({
-                title: `${actionInfo['raise_pop']?.icon ?? ''} ${
-                  actionInfo['raise_pop']?.label ?? ''
-                } - ${POPULATION_ROLES[role]?.icon} ${
-                  POPULATION_ROLES[role]?.label || ''
-                }`,
+                title: `${actionInfo['raise_pop']?.icon ?? ''}${
+                  POPULATION_ROLES[role]?.icon
+                } - Hire ${POPULATION_ROLES[role]?.label || ''}`,
                 effects: summary,
                 requirements,
                 costs,
@@ -197,26 +197,28 @@ function RaisePopOptions({
             onMouseLeave={clearHoverCard}
           >
             <span className="text-base font-medium">
-              {actionInfo['raise_pop']?.icon ?? ''}{' '}
-              {actionInfo['raise_pop']?.label ?? ''} -{' '}
-              {POPULATION_ROLES[role]?.icon} {POPULATION_ROLES[role]?.label}
+              {actionInfo['raise_pop']?.icon ?? ''}
+              {POPULATION_ROLES[role]?.icon} - Hire{' '}
+              {POPULATION_ROLES[role]?.label}
             </span>
             <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
               {renderCosts(costs, ctx.activePlayer.resources)}
             </span>
-            <ul className="text-sm list-disc pl-4 text-left">
-              {renderSummary(stripSummary(shortSummary))}
-            </ul>
-            {requirements.length > 0 && (
-              <div className="text-sm text-red-600 text-left">
-                <span className="font-semibold">Requirements</span>
-                <ul className="list-disc pl-4">
-                  {requirements.map((r, i) => (
-                    <li key={i}>{r}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
+            <div className="flex w-full gap-2">
+              <ul className="text-sm list-disc pl-4 text-left flex-1">
+                {renderSummary(stripSummary(shortSummary))}
+              </ul>
+              {requirements.length > 0 && (
+                <div className="text-sm text-red-600 text-left mt-4 w-1/3">
+                  <span className="font-semibold">Requirements</span>
+                  <ul className="list-disc pl-4">
+                    {requirements.map((r, i) => (
+                      <li key={i}>{r}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
           </button>
         );
       })}
@@ -243,7 +245,7 @@ function BasicOptions({
           (Effects take place immediately, unless stated otherwise)
         </span>
       </h3>
-      <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">
+      <div className="grid grid-cols-4 gap-2 mt-1">
         <GenericActions
           actions={actions}
           summaries={summaries}
@@ -283,7 +285,7 @@ function DevelopOptions({
           (Effects take place on build and last until development is removed)
         </span>
       </h3>
-      <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">
+      <div className="grid grid-cols-4 gap-2 mt-1">
         {developments.map((d) => {
           const landIdForCost = ctx.activePlayer.lands[0]?.id as string;
           const costs = getActionCosts('develop', ctx, {
@@ -350,13 +352,25 @@ function DevelopOptions({
               <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
                 {renderCosts(costs, ctx.activePlayer.resources)}
               </span>
-              <ul className="text-sm list-disc pl-4 text-left">
-                {implemented ? (
-                  renderSummary(stripSummary(summary))
-                ) : (
-                  <li className="italic text-red-600">Not implemented yet</li>
+              <div className="flex w-full gap-2">
+                <ul className="text-sm list-disc pl-4 text-left flex-1">
+                  {implemented ? (
+                    renderSummary(stripSummary(summary))
+                  ) : (
+                    <li className="italic text-red-600">Not implemented yet</li>
+                  )}
+                </ul>
+                {requirements.length > 0 && (
+                  <div className="text-sm text-red-600 text-left mt-4 w-1/3">
+                    <span className="font-semibold">Requirements</span>
+                    <ul className="list-disc pl-4">
+                      {requirements.map((r, i) => (
+                        <li key={i}>{r}</li>
+                      ))}
+                    </ul>
+                  </div>
                 )}
-              </ul>
+              </div>
             </button>
           );
         })}
@@ -388,7 +402,7 @@ function BuildOptions({
           (Effects take place on build and last until building is removed)
         </span>
       </h3>
-      <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">
+      <div className="grid grid-cols-4 gap-2 mt-1">
         {buildings.map((b) => {
           const costs = getActionCosts('build', ctx, { id: b.id });
           const requirements: string[] = [];
@@ -440,13 +454,25 @@ function BuildOptions({
               <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
                 {renderCosts(costs, ctx.activePlayer.resources)}
               </span>
-              <ul className="text-sm list-disc pl-4 text-left">
-                {implemented ? (
-                  renderSummary(stripSummary(summary))
-                ) : (
-                  <li className="italic text-red-600">Not implemented yet</li>
+              <div className="flex w-full gap-2">
+                <ul className="text-sm list-disc pl-4 text-left flex-1">
+                  {implemented ? (
+                    renderSummary(stripSummary(summary))
+                  ) : (
+                    <li className="italic text-red-600">Not implemented yet</li>
+                  )}
+                </ul>
+                {requirements.length > 0 && (
+                  <div className="text-sm text-red-600 text-left mt-4 w-1/3">
+                    <span className="font-semibold">Requirements</span>
+                    <ul className="list-disc pl-4">
+                      {requirements.map((r, i) => (
+                        <li key={i}>{r}</li>
+                      ))}
+                    </ul>
+                  </div>
                 )}
-              </ul>
+              </div>
             </button>
           );
         })}

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -109,25 +109,18 @@ function GenericActions({
             <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
               {renderCosts(costs, ctx.activePlayer.resources)}
             </span>
-            <div className="flex w-full gap-2">
-              <ul className="text-sm list-disc pl-4 text-left flex-1">
-                {implemented ? (
-                  renderSummary(stripSummary(summary))
-                ) : (
-                  <li className="italic text-red-600">Not implemented yet</li>
-                )}
-              </ul>
-              {requirements.length > 0 && (
-                <div className="text-sm text-red-600 text-left mt-4 w-1/3">
-                  <span className="font-semibold">Requirements</span>
-                  <ul className="list-disc pl-4">
-                    {requirements.map((r, i) => (
-                      <li key={i}>{r}</li>
-                    ))}
-                  </ul>
-                </div>
+            {requirements.length > 0 && (
+              <span className="absolute top-7 right-2 text-xs text-red-600">
+                Req {POPULATION_ROLES[PopulationRole.Citizen]?.icon}
+              </span>
+            )}
+            <ul className="text-sm list-disc pl-4 text-left">
+              {implemented ? (
+                renderSummary(stripSummary(summary))
+              ) : (
+                <li className="italic text-red-600">Not implemented yet</li>
               )}
-            </div>
+            </ul>
           </button>
         );
       })}
@@ -204,21 +197,14 @@ function RaisePopOptions({
             <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
               {renderCosts(costs, ctx.activePlayer.resources)}
             </span>
-            <div className="flex w-full gap-2">
-              <ul className="text-sm list-disc pl-4 text-left flex-1">
-                {renderSummary(stripSummary(shortSummary))}
-              </ul>
-              {requirements.length > 0 && (
-                <div className="text-sm text-red-600 text-left mt-4 w-1/3">
-                  <span className="font-semibold">Requirements</span>
-                  <ul className="list-disc pl-4">
-                    {requirements.map((r, i) => (
-                      <li key={i}>{r}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </div>
+            {requirements.length > 0 && (
+              <span className="absolute top-7 right-2 text-xs text-red-600">
+                Req {POPULATION_ROLES[PopulationRole.Citizen]?.icon}
+              </span>
+            )}
+            <ul className="text-sm list-disc pl-4 text-left">
+              {renderSummary(stripSummary(shortSummary))}
+            </ul>
           </button>
         );
       })}
@@ -352,25 +338,18 @@ function DevelopOptions({
               <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
                 {renderCosts(costs, ctx.activePlayer.resources)}
               </span>
-              <div className="flex w-full gap-2">
-                <ul className="text-sm list-disc pl-4 text-left flex-1">
-                  {implemented ? (
-                    renderSummary(stripSummary(summary))
-                  ) : (
-                    <li className="italic text-red-600">Not implemented yet</li>
-                  )}
-                </ul>
-                {requirements.length > 0 && (
-                  <div className="text-sm text-red-600 text-left mt-4 w-1/3">
-                    <span className="font-semibold">Requirements</span>
-                    <ul className="list-disc pl-4">
-                      {requirements.map((r, i) => (
-                        <li key={i}>{r}</li>
-                      ))}
-                    </ul>
-                  </div>
+              {requirements.length > 0 && (
+                <span className="absolute top-7 right-2 text-xs text-red-600">
+                  Req {POPULATION_ROLES[PopulationRole.Citizen]?.icon}
+                </span>
+              )}
+              <ul className="text-sm list-disc pl-4 text-left">
+                {implemented ? (
+                  renderSummary(stripSummary(summary))
+                ) : (
+                  <li className="italic text-red-600">Not implemented yet</li>
                 )}
-              </div>
+              </ul>
             </button>
           );
         })}
@@ -454,25 +433,18 @@ function BuildOptions({
               <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
                 {renderCosts(costs, ctx.activePlayer.resources)}
               </span>
-              <div className="flex w-full gap-2">
-                <ul className="text-sm list-disc pl-4 text-left flex-1">
-                  {implemented ? (
-                    renderSummary(stripSummary(summary))
-                  ) : (
-                    <li className="italic text-red-600">Not implemented yet</li>
-                  )}
-                </ul>
-                {requirements.length > 0 && (
-                  <div className="text-sm text-red-600 text-left mt-4 w-1/3">
-                    <span className="font-semibold">Requirements</span>
-                    <ul className="list-disc pl-4">
-                      {requirements.map((r, i) => (
-                        <li key={i}>{r}</li>
-                      ))}
-                    </ul>
-                  </div>
+              {requirements.length > 0 && (
+                <span className="absolute top-7 right-2 text-xs text-red-600">
+                  Req {POPULATION_ROLES[PopulationRole.Citizen]?.icon}
+                </span>
+              )}
+              <ul className="text-sm list-disc pl-4 text-left">
+                {implemented ? (
+                  renderSummary(stripSummary(summary))
+                ) : (
+                  <li className="italic text-red-600">Not implemented yet</li>
                 )}
-              </div>
+              </ul>
             </button>
           );
         })}

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -55,7 +55,7 @@ function GenericActions({
     useGameEngine();
   const formatRequirement = (req: string) => req;
   return (
-    <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">
+    <>
       {actions.map((action) => {
         const costs = getActionCosts(action.id, ctx);
         const requirements = getActionRequirements(action.id, ctx).map(
@@ -129,7 +129,7 @@ function GenericActions({
           </button>
         );
       })}
-    </div>
+    </>
   );
 }
 
@@ -144,7 +144,7 @@ function RaisePopOptions({
     useGameEngine();
   const formatRequirement = (req: string) => req;
   return (
-    <div className="grid grid-cols-3 gap-2 mt-1 auto-rows-fr">
+    <>
       {[
         PopulationRole.Council,
         PopulationRole.Commander,
@@ -220,7 +220,7 @@ function RaisePopOptions({
           </button>
         );
       })}
-    </div>
+    </>
   );
 }
 
@@ -243,19 +243,19 @@ function BasicOptions({
           (Effects take place immediately, unless stated otherwise)
         </span>
       </h3>
-      {actions.length > 0 && (
+      <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">
         <GenericActions
           actions={actions}
           summaries={summaries}
           isActionPhase={isActionPhase}
         />
-      )}
-      {raisePopAction && (
-        <RaisePopOptions
-          action={raisePopAction}
-          isActionPhase={isActionPhase}
-        />
-      )}
+        {raisePopAction && (
+          <RaisePopOptions
+            action={raisePopAction}
+            isActionPhase={isActionPhase}
+          />
+        )}
+      </div>
     </div>
   );
 }
@@ -280,7 +280,7 @@ function DevelopOptions({
       <h3 className="font-medium">
         {actionInfo['develop']?.icon ?? ''} {actionInfo['develop']?.label ?? ''}{' '}
         <span className="italic text-sm font-normal">
-          (On build, until removed)
+          (Effects take place on build and last until development is removed)
         </span>
       </h3>
       <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">
@@ -385,7 +385,7 @@ function BuildOptions({
       <h3 className="font-medium">
         {actionInfo['build']?.icon ?? ''} {actionInfo['build']?.label ?? ''}{' '}
         <span className="italic text-sm font-normal">
-          (On build, until removed)
+          (Effects take place on build and last until building is removed)
         </span>
       </h3>
       <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -21,6 +21,12 @@ import { renderSummary, renderCosts } from '../../translation/render';
 import { useGameEngine } from '../../state/GameContext';
 import { isActionPhaseActive } from '../../utils/isActionPhaseActive';
 
+function stripSummary(summary: Summary | undefined): Summary | undefined {
+  const first = summary?.[0];
+  if (!first) return summary;
+  return typeof first === 'string' ? summary : first.items;
+}
+
 interface Action {
   id: string;
   name: string;
@@ -49,7 +55,7 @@ function GenericActions({
     useGameEngine();
   const formatRequirement = (req: string) => req;
   return (
-    <div className="grid grid-cols-4 gap-2 auto-rows-fr">
+    <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">
       {actions.map((action) => {
         const costs = getActionCosts(action.id, ctx);
         const requirements = getActionRequirements(action.id, ctx).map(
@@ -105,7 +111,7 @@ function GenericActions({
             </span>
             <ul className="text-sm list-disc pl-4 text-left">
               {implemented ? (
-                renderSummary(summary)
+                renderSummary(stripSummary(summary))
               ) : (
                 <li className="italic text-red-600">Not implemented yet</li>
               )}
@@ -138,86 +144,118 @@ function RaisePopOptions({
     useGameEngine();
   const formatRequirement = (req: string) => req;
   return (
+    <div className="grid grid-cols-3 gap-2 mt-1 auto-rows-fr">
+      {[
+        PopulationRole.Council,
+        PopulationRole.Commander,
+        PopulationRole.Fortifier,
+      ].map((role) => {
+        const costs = getActionCosts('raise_pop', ctx);
+        const requirements = getActionRequirements('raise_pop', ctx).map(
+          formatRequirement,
+        );
+        const canPay = Object.entries(costs).every(
+          ([k, v]) =>
+            ctx.activePlayer.resources[
+              k as keyof typeof ctx.activePlayer.resources
+            ] >= v,
+        );
+        const meetsReq = requirements.length === 0;
+        const enabled = canPay && meetsReq && isActionPhase;
+        const title = !meetsReq
+          ? requirements.join(', ')
+          : !canPay
+            ? 'Cannot pay costs'
+            : undefined;
+        const summary = describeContent('action', 'raise_pop', ctx, { role });
+        const shortSummary = summarizeContent('action', 'raise_pop', ctx, {
+          role,
+        });
+        return (
+          <button
+            key={role}
+            className={`relative panel-card border border-black/10 dark:border-white/10 p-2 flex flex-col items-start gap-1 h-full shadow-sm ${
+              enabled
+                ? 'hoverable cursor-pointer'
+                : 'opacity-50 cursor-not-allowed'
+            }`}
+            title={title}
+            onClick={() => enabled && handlePerform(action, { role })}
+            onMouseEnter={() =>
+              handleHoverCard({
+                title: `${actionInfo['raise_pop']?.icon ?? ''} ${
+                  actionInfo['raise_pop']?.label ?? ''
+                } - ${POPULATION_ROLES[role]?.icon} ${
+                  POPULATION_ROLES[role]?.label || ''
+                }`,
+                effects: summary,
+                requirements,
+                costs,
+                bgClass: 'bg-gray-100 dark:bg-gray-700',
+              })
+            }
+            onMouseLeave={clearHoverCard}
+          >
+            <span className="text-base font-medium">
+              {actionInfo['raise_pop']?.icon ?? ''}{' '}
+              {actionInfo['raise_pop']?.label ?? ''} -{' '}
+              {POPULATION_ROLES[role]?.icon} {POPULATION_ROLES[role]?.label}
+            </span>
+            <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
+              {renderCosts(costs, ctx.activePlayer.resources)}
+            </span>
+            <ul className="text-sm list-disc pl-4 text-left">
+              {renderSummary(stripSummary(shortSummary))}
+            </ul>
+            {requirements.length > 0 && (
+              <div className="text-sm text-red-600 text-left">
+                <span className="font-semibold">Requirements</span>
+                <ul className="list-disc pl-4">
+                  {requirements.map((r, i) => (
+                    <li key={i}>{r}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function BasicOptions({
+  actions,
+  raisePopAction,
+  summaries,
+  isActionPhase,
+}: {
+  actions: Action[];
+  raisePopAction: Action | undefined;
+  summaries: Map<string, Summary>;
+  isActionPhase: boolean;
+}) {
+  return (
     <div>
       <h3 className="font-medium">
-        {actionInfo['raise_pop']?.icon ?? ''}{' '}
-        {actionInfo['raise_pop']?.label ?? ''}
+        Basic{' '}
+        <span className="italic text-sm font-normal">
+          (Effects take place immediately, unless stated otherwise)
+        </span>
       </h3>
-      <div className="grid grid-cols-3 gap-2 mt-1 auto-rows-fr">
-        {[
-          PopulationRole.Council,
-          PopulationRole.Commander,
-          PopulationRole.Fortifier,
-        ].map((role) => {
-          const costs = getActionCosts('raise_pop', ctx);
-          const requirements = getActionRequirements('raise_pop', ctx).map(
-            formatRequirement,
-          );
-          const canPay = Object.entries(costs).every(
-            ([k, v]) =>
-              ctx.activePlayer.resources[
-                k as keyof typeof ctx.activePlayer.resources
-              ] >= v,
-          );
-          const meetsReq = requirements.length === 0;
-          const enabled = canPay && meetsReq && isActionPhase;
-          const title = !meetsReq
-            ? requirements.join(', ')
-            : !canPay
-              ? 'Cannot pay costs'
-              : undefined;
-          const summary = describeContent('action', 'raise_pop', ctx, { role });
-          const shortSummary = summarizeContent('action', 'raise_pop', ctx, {
-            role,
-          });
-          return (
-            <button
-              key={role}
-              className={`relative panel-card border border-black/10 dark:border-white/10 p-2 flex flex-col items-start gap-1 h-full shadow-sm ${
-                enabled
-                  ? 'hoverable cursor-pointer'
-                  : 'opacity-50 cursor-not-allowed'
-              }`}
-              title={title}
-              onClick={() => enabled && handlePerform(action, { role })}
-              onMouseEnter={() =>
-                handleHoverCard({
-                  title: `${actionInfo['raise_pop']?.icon ?? ''} ${
-                    actionInfo['raise_pop']?.label ?? ''
-                  } - ${POPULATION_ROLES[role]?.icon} ${
-                    POPULATION_ROLES[role]?.label || ''
-                  }`,
-                  effects: summary,
-                  requirements,
-                  costs,
-                  bgClass: 'bg-gray-100 dark:bg-gray-700',
-                })
-              }
-              onMouseLeave={clearHoverCard}
-            >
-              <span className="text-base font-medium">
-                {POPULATION_ROLES[role]?.icon} {POPULATION_ROLES[role]?.label}
-              </span>
-              <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
-                {renderCosts(costs, ctx.activePlayer.resources)}
-              </span>
-              <ul className="text-sm list-disc pl-4 text-left">
-                {renderSummary(shortSummary)}
-              </ul>
-              {requirements.length > 0 && (
-                <div className="text-sm text-red-600 text-left">
-                  <span className="font-semibold">Requirements</span>
-                  <ul className="list-disc pl-4">
-                    {requirements.map((r, i) => (
-                      <li key={i}>{r}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </button>
-          );
-        })}
-      </div>
+      {actions.length > 0 && (
+        <GenericActions
+          actions={actions}
+          summaries={summaries}
+          isActionPhase={isActionPhase}
+        />
+      )}
+      {raisePopAction && (
+        <RaisePopOptions
+          action={raisePopAction}
+          isActionPhase={isActionPhase}
+        />
+      )}
     </div>
   );
 }
@@ -240,7 +278,10 @@ function DevelopOptions({
   return (
     <div>
       <h3 className="font-medium">
-        {actionInfo['develop']?.icon ?? ''} {actionInfo['develop']?.label ?? ''}
+        {actionInfo['develop']?.icon ?? ''} {actionInfo['develop']?.label ?? ''}{' '}
+        <span className="italic text-sm font-normal">
+          (On build, until removed)
+        </span>
       </h3>
       <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">
         {developments.map((d) => {
@@ -311,7 +352,7 @@ function DevelopOptions({
               </span>
               <ul className="text-sm list-disc pl-4 text-left">
                 {implemented ? (
-                  renderSummary(summary)
+                  renderSummary(stripSummary(summary))
                 ) : (
                   <li className="italic text-red-600">Not implemented yet</li>
                 )}
@@ -342,7 +383,10 @@ function BuildOptions({
   return (
     <div>
       <h3 className="font-medium">
-        {actionInfo['build']?.icon ?? ''} {actionInfo['build']?.label ?? ''}
+        {actionInfo['build']?.icon ?? ''} {actionInfo['build']?.label ?? ''}{' '}
+        <span className="italic text-sm font-normal">
+          (On build, until removed)
+        </span>
       </h3>
       <div className="grid grid-cols-4 gap-2 mt-1 auto-rows-fr">
         {buildings.map((b) => {
@@ -398,7 +442,7 @@ function BuildOptions({
               </span>
               <ul className="text-sm list-disc pl-4 text-left">
                 {implemented ? (
-                  renderSummary(summary)
+                  renderSummary(stripSummary(summary))
                 ) : (
                   <li className="italic text-red-600">Not implemented yet</li>
                 )}
@@ -511,14 +555,11 @@ export default function ActionsPanel() {
         )}
       </div>
       <div className="space-y-3">
-        <GenericActions
-          actions={otherActions}
-          summaries={actionSummaries}
-          isActionPhase={isActionPhase}
-        />
-        {raisePopAction && (
-          <RaisePopOptions
-            action={raisePopAction}
+        {(otherActions.length > 0 || raisePopAction) && (
+          <BasicOptions
+            actions={otherActions}
+            raisePopAction={raisePopAction}
+            summaries={actionSummaries}
             isActionPhase={isActionPhase}
           />
         )}

--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -70,7 +70,7 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
                 return (
                   <span
                     key={i}
-                    className="panel-card p-1 text-xs hoverable cursor-help whitespace-nowrap"
+                    className="panel-card p-1 text-xs hoverable cursor-help italic"
                     onMouseEnter={(e) => {
                       e.stopPropagation();
                       handleHoverCard({
@@ -88,7 +88,7 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
                       handleLeave();
                     }}
                   >
-                    {slotIcon} Development Slot (empty)
+                    empty
                   </span>
                 );
               })}

--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -88,7 +88,7 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
                       handleLeave();
                     }}
                   >
-                    empty
+                    {slotIcon} empty
                   </span>
                 );
               })}

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -4,7 +4,11 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import ActionsPanel from '../src/components/actions/ActionsPanel';
-import { createEngine, Resource } from '@kingdom-builder/engine';
+import {
+  createEngine,
+  Resource,
+  PopulationRole,
+} from '@kingdom-builder/engine';
 import {
   RESOURCES,
   ACTION_INFO,
@@ -14,6 +18,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  POPULATION_ROLES,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -64,5 +69,11 @@ describe('<ActionsPanel />', () => {
     const developName = ctx.actions.get('develop')?.name || '';
     const developLabel = `${ACTION_INFO['develop'].icon} ${developName}`;
     expect(screen.getByText(developLabel)).toBeInTheDocument();
+  });
+
+  it('shows short requirement indicator when unmet', () => {
+    render(<ActionsPanel />);
+    const popIcon = POPULATION_ROLES[PopulationRole.Citizen].icon;
+    expect(screen.getAllByText(`Req ${popIcon}`)[0]).toBeInTheDocument();
   });
 });

--- a/packages/web/tests/land-till-formatter.test.ts
+++ b/packages/web/tests/land-till-formatter.test.ts
@@ -46,7 +46,11 @@ describe('land till formatter', () => {
 
   it('handles plow action with no summary', () => {
     const ctx = createCtx();
-    const summary = summarizeContent('action', 'plow', ctx);
-    expect(summary).toHaveLength(0);
+    const summary = summarizeContent('action', 'plow', ctx) as {
+      title: string;
+      items: string[];
+    }[];
+    const items = summary?.[0]?.items || [];
+    expect(items).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- group actions into Basic, Develop and Build with single italic timing notes
- drop Raise Population category, prefix population actions with 👶 Raise Population
- show "empty" in player panel slots instead of full Development Slot label

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b43484add88325a065719b00429949