### PR TITLE
feat: surface till and plow passives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-08-31: Registries can validate entries with Zod schemas; invalid data will throw during `add`.
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
 - 2025-08-31: `npm run dev` prebuilds `@kingdom-builder/contents` via a `predev` script to avoid missing dist files.
+- 2025-09-01: Player snapshots now require the engine context to include active passive IDs; use `snapshotPlayer(player, ctx)`.
 
 # Core Agent principles
 

--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -205,5 +205,6 @@ export const ACTION_INFO: Record<string, { icon: string; label: string }> = {
   army_attack: { icon: '🗡️', label: ACTIONS.get('army_attack').name },
   hold_festival: { icon: '🎉', label: ACTIONS.get('hold_festival').name },
   plow: { icon: '🚜', label: ACTIONS.get('plow').name },
+  till: { icon: '🧑‍🌾', label: ACTIONS.get('till').name },
   build: { icon: '🏛️', label: ACTIONS.get('build').name },
 } as const;

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { useGameEngine } from '../../state/GameContext';
+import { MODIFIER_INFO as modifierInfo } from '@kingdom-builder/contents';
+import { describeEffects } from '../../translation';
+import type { EffectDef } from '@kingdom-builder/engine';
+
+export default function PassiveDisplay({
+  player,
+}: {
+  player: ReturnType<typeof useGameEngine>['ctx']['activePlayer'];
+}) {
+  const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
+  const ids = ctx.passives.list(player.id);
+  const defs = ctx.passives.values(player.id) as {
+    effects?: EffectDef[];
+    onUpkeepPhase?: EffectDef[];
+  }[];
+  const map = new Map<
+    string,
+    { effects?: EffectDef[]; onUpkeepPhase?: EffectDef[] }
+  >(ids.map((id, i) => [id, defs[i]!]));
+
+  const buildingIds = new Set(player.buildings);
+  const developmentIds = new Set(
+    player.lands.flatMap((l) => l.developments.map((d) => `${d}_${l.id}`)),
+  );
+
+  const entries = Array.from(map.entries()).filter(
+    ([id]) => !buildingIds.has(id) && !developmentIds.has(id),
+  );
+  if (entries.length === 0) return null;
+
+  const getIcon = (effects: EffectDef[] | undefined) => {
+    const first = effects?.[0];
+    if (first?.type === 'cost_mod') return modifierInfo.cost.icon;
+    if (first?.type === 'result_mod') return modifierInfo.result.icon;
+    return '❔';
+  };
+
+  return (
+    <div className="panel-card flex items-center gap-1 px-3 py-2 w-fit">
+      {entries.map(([id, def]) => {
+        const icon = getIcon(def.effects);
+        const items = describeEffects(def.effects || [], ctx);
+        const summary = def.onUpkeepPhase
+          ? [{ title: 'Until your next Upkeep Phase', items }]
+          : items;
+        return (
+          <span
+            key={id}
+            className="hoverable cursor-pointer"
+            onMouseEnter={() =>
+              handleHoverCard({
+                title: `${icon} Passive`,
+                effects: summary,
+                requirements: [],
+                bgClass: 'bg-gray-100 dark:bg-gray-700',
+              })
+            }
+            onMouseLeave={clearHoverCard}
+          >
+            {icon}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/components/player/PlayerPanel.tsx
+++ b/packages/web/src/components/player/PlayerPanel.tsx
@@ -4,6 +4,7 @@ import ResourceBar from './ResourceBar';
 import PopulationInfo from './PopulationInfo';
 import LandDisplay from './LandDisplay';
 import BuildingDisplay from './BuildingDisplay';
+import PassiveDisplay from './PassiveDisplay';
 
 interface PlayerPanelProps {
   player: EngineContext['activePlayer'];
@@ -23,6 +24,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
       </div>
       <LandDisplay player={player} />
       <BuildingDisplay player={player} />
+      <PassiveDisplay player={player} />
     </div>
   );
 };

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -210,7 +210,7 @@ export function GameProvider({
     setPhaseHistories({});
     let lastPhase: string | null = null;
     while (!ctx.phases[ctx.game.phaseIndex]?.action) {
-      const before = snapshotPlayer(ctx.activePlayer);
+      const before = snapshotPlayer(ctx.activePlayer, ctx);
       const { phase, step, player } = advance(ctx);
       const phaseDef = ctx.phases.find((p) => p.id === phase)!;
       const stepDef = phaseDef.steps.find((s) => s.id === step);
@@ -221,7 +221,7 @@ export function GameProvider({
         addLog(`${phaseDef.icon} ${phaseDef.label} Phase`, player.name);
         lastPhase = phase;
       }
-      const after = snapshotPlayer(player);
+      const after = snapshotPlayer(player, ctx);
       const changes = diffStepSnapshots(before, after, stepDef, ctx);
       if (changes.length) {
         addLog(
@@ -253,10 +253,10 @@ export function GameProvider({
   }
 
   function handlePerform(action: Action, params?: Record<string, unknown>) {
-    const before = snapshotPlayer(ctx.activePlayer);
+    const before = snapshotPlayer(ctx.activePlayer, ctx);
     try {
       performAction(action.id, ctx, params as ActionParams<string>);
-      const after = snapshotPlayer(ctx.activePlayer);
+      const after = snapshotPlayer(ctx.activePlayer, ctx);
       const changes = diffSnapshots(before, after, ctx);
       const messages = logContent('action', action.id, ctx, params);
       addLog([...messages, ...changes.map((c) => `  ${c}`)]);

--- a/packages/web/src/translation/effects/evaluators/development.ts
+++ b/packages/web/src/translation/effects/evaluators/development.ts
@@ -5,13 +5,22 @@ registerEvaluatorFormatter('development', {
   summarize: (ev, sub) => {
     const devId = (ev.params as Record<string, string>)['id']!;
     const icon = developmentInfo[devId]?.icon || devId;
-    return sub.map((s) => `${s} per ${icon}`);
+    return sub.map((s) =>
+      typeof s === 'string'
+        ? `${s} per ${icon}`
+        : { ...s, title: `${s.title} per ${icon}` },
+    );
   },
   describe: (ev, sub) => {
     const devId = (ev.params as Record<string, string>)['id']!;
     const info = developmentInfo[devId];
-    return sub.map(
-      (s) => `${s} for each ${info?.icon || ''}${info?.label || devId}`,
+    return sub.map((s) =>
+      typeof s === 'string'
+        ? `${s} for each ${info?.icon || ''}${info?.label || devId}`
+        : {
+            ...s,
+            title: `${s.title} for each ${info?.icon || ''}${info?.label || devId}`,
+          },
     );
   },
 });

--- a/packages/web/src/translation/effects/evaluators/population.ts
+++ b/packages/web/src/translation/effects/evaluators/population.ts
@@ -7,7 +7,11 @@ registerEvaluatorFormatter('population', {
       | keyof typeof POPULATION_ROLES
       | undefined;
     const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
-    return sub.map((s) => `${s} per ${icon}`);
+    return sub.map((s) =>
+      typeof s === 'string'
+        ? `${s} per ${icon}`
+        : { ...s, title: `${s.title} per ${icon}` },
+    );
   },
   describe: (ev, sub) => {
     const role = (ev.params as Record<string, string>)?.['role'] as
@@ -16,9 +20,19 @@ registerEvaluatorFormatter('population', {
     if (role) {
       const info = POPULATION_ROLES[role];
       return sub.map((s) =>
-        `${s} for each ${info?.icon || ''}${info?.label || role}`.trim(),
+        typeof s === 'string'
+          ? `${s} for each ${info?.icon || ''}${info?.label || role}`.trim()
+          : {
+              ...s,
+              title:
+                `${s.title} for each ${info?.icon || ''}${info?.label || role}`.trim(),
+            },
       );
     }
-    return sub.map((s) => `${s} for each population`);
+    return sub.map((s) =>
+      typeof s === 'string'
+        ? `${s} for each population`
+        : { ...s, title: `${s.title} for each population` },
+    );
   },
 });

--- a/packages/web/src/translation/effects/factory.ts
+++ b/packages/web/src/translation/effects/factory.ts
@@ -1,19 +1,20 @@
 import type { EffectDef, EngineContext } from '@kingdom-builder/engine';
+import type { SummaryEntry } from '../content';
 // Effect and evaluator formatter registries drive translation lookups.
 
 export interface EffectFormatter {
   summarize?: (
     effect: EffectDef<Record<string, unknown>>,
     ctx: EngineContext,
-  ) => string | string[] | null;
+  ) => SummaryEntry | SummaryEntry[] | null;
   describe?: (
     effect: EffectDef<Record<string, unknown>>,
     ctx: EngineContext,
-  ) => string | string[] | null;
+  ) => SummaryEntry | SummaryEntry[] | null;
   log?: (
     effect: EffectDef<Record<string, unknown>>,
     ctx: EngineContext,
-  ) => string | string[] | null;
+  ) => SummaryEntry | SummaryEntry[] | null;
 }
 
 const EFFECT_FORMATTERS = new Map<string, EffectFormatter>();
@@ -30,19 +31,19 @@ export function registerEffectFormatter(
 export interface EvaluatorFormatter {
   summarize?: (
     ev: { type: string; params: Record<string, unknown> },
-    sub: string[],
+    sub: SummaryEntry[],
     ctx: EngineContext,
-  ) => string[];
+  ) => SummaryEntry[];
   describe?: (
     ev: { type: string; params: Record<string, unknown> },
-    sub: string[],
+    sub: SummaryEntry[],
     ctx: EngineContext,
-  ) => string[];
+  ) => SummaryEntry[];
   log?: (
     ev: { type: string; params: Record<string, unknown> },
-    sub: string[],
+    sub: SummaryEntry[],
     ctx: EngineContext,
-  ) => string[];
+  ) => SummaryEntry[];
 }
 
 export function registerEvaluatorFormatter(
@@ -56,7 +57,7 @@ function applyFormatter(
   effect: EffectDef<Record<string, unknown>>,
   ctx: EngineContext,
   mode: 'summarize' | 'describe' | 'log',
-): string[] {
+): SummaryEntry[] {
   const key = `${effect.type}:${effect.method ?? ''}`;
   const handler = EFFECT_FORMATTERS.get(key);
   if (!handler) return [];
@@ -70,8 +71,8 @@ function applyFormatter(
 export function summarizeEffects(
   effects: readonly EffectDef<Record<string, unknown>>[] | undefined,
   ctx: EngineContext,
-): string[] {
-  const parts: string[] = [];
+): SummaryEntry[] {
+  const parts: SummaryEntry[] = [];
   for (const eff of effects || []) {
     if (eff.evaluator) {
       const ev = eff.evaluator as {
@@ -89,14 +90,14 @@ export function summarizeEffects(
     }
     parts.push(...applyFormatter(eff, ctx, 'summarize'));
   }
-  return parts.map((p) => p.trim());
+  return parts.map((p) => (typeof p === 'string' ? p.trim() : p));
 }
 
 export function describeEffects(
   effects: readonly EffectDef<Record<string, unknown>>[] | undefined,
   ctx: EngineContext,
-): string[] {
-  const parts: string[] = [];
+): SummaryEntry[] {
+  const parts: SummaryEntry[] = [];
   for (const eff of effects || []) {
     if (eff.evaluator) {
       const ev = eff.evaluator as {
@@ -114,14 +115,14 @@ export function describeEffects(
     }
     parts.push(...applyFormatter(eff, ctx, 'describe'));
   }
-  return parts.map((p) => p.trim());
+  return parts.map((p) => (typeof p === 'string' ? p.trim() : p));
 }
 
 export function logEffects(
   effects: readonly EffectDef<Record<string, unknown>>[] | undefined,
   ctx: EngineContext,
-): string[] {
-  const parts: string[] = [];
+): SummaryEntry[] {
+  const parts: SummaryEntry[] = [];
   for (const eff of effects || []) {
     if (eff.evaluator) {
       const ev = eff.evaluator as {
@@ -139,5 +140,5 @@ export function logEffects(
     }
     parts.push(...applyFormatter(eff, ctx, 'log'));
   }
-  return parts.map((p) => p.trim());
+  return parts.map((p) => (typeof p === 'string' ? p.trim() : p));
 }

--- a/packages/web/src/translation/effects/formatters/action.ts
+++ b/packages/web/src/translation/effects/formatters/action.ts
@@ -1,6 +1,7 @@
 import type { EngineContext } from '@kingdom-builder/engine';
 import { ACTION_INFO as actionInfo } from '@kingdom-builder/contents';
-import { registerEffectFormatter } from '../factory';
+import { summarizeContent, describeContent } from '../../content';
+import { registerEffectFormatter, logEffects } from '../factory';
 
 function getActionLabel(id: string, ctx: EngineContext) {
   let name = id;
@@ -18,13 +19,15 @@ registerEffectFormatter('action', 'add', {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
     const { icon, name } = getActionLabel(id, ctx);
-    return `Gain ${icon}${name}`;
+    const summary = summarizeContent('action', id, ctx);
+    return [{ title: `Gain ${icon}${name}`, items: summary }];
   },
   describe: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
     const { icon, name } = getActionLabel(id, ctx);
-    return `Gain action ${icon}${name}`;
+    const summary = describeContent('action', id, ctx);
+    return [{ title: `Gain action ${icon}${name}`, items: summary }];
   },
   log: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
@@ -60,12 +63,22 @@ registerEffectFormatter('action', 'perform', {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
     const { icon, name } = getActionLabel(id, ctx);
-    return `${icon} ${name}`;
+    const summary = summarizeContent('action', id, ctx);
+    return [{ title: `${icon} ${name}`, items: summary }];
   },
   describe: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
     const { icon, name } = getActionLabel(id, ctx);
-    return `Perform action ${icon}${name}`;
+    const summary = describeContent('action', id, ctx);
+    return [{ title: `Perform action ${icon}${name}`, items: summary }];
+  },
+  log: (eff, ctx) => {
+    const id = eff.params?.['id'] as string;
+    if (!id) return null;
+    const { icon, name } = getActionLabel(id, ctx);
+    const def = ctx.actions.get(id);
+    const sub = logEffects(def.effects, ctx);
+    return [{ title: `${icon} ${name}`, items: sub }];
   },
 });

--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -89,7 +89,14 @@ registerEffectFormatter('result_mod', 'add', {
     }
     const actionId = eff.params?.['actionId'] as string;
     const actionIcon = actionInfo[actionId]?.icon || actionId;
-    return sub.map((s) => `${modifierInfo.result.icon} ${actionIcon}: ${s}`);
+    return sub.map((s) =>
+      typeof s === 'string'
+        ? `${modifierInfo.result.icon} ${actionIcon}: ${s}`
+        : {
+            ...s,
+            title: `${modifierInfo.result.icon} ${actionIcon}: ${s.title}`,
+          },
+    );
   },
   describe: (eff, ctx) => {
     const sub = describeEffects(eff.effects || [], ctx);
@@ -123,9 +130,13 @@ registerEffectFormatter('result_mod', 'add', {
     } catch {
       /* ignore missing action */
     }
-    return sub.map(
-      (s) =>
-        `${modifierInfo.result.icon} ${modifierInfo.result.label} on ${actionIcon} ${actionName}: ${s}`,
+    return sub.map((s) =>
+      typeof s === 'string'
+        ? `${modifierInfo.result.icon} ${modifierInfo.result.label} on ${actionIcon} ${actionName}: ${s}`
+        : {
+            ...s,
+            title: `${modifierInfo.result.icon} ${modifierInfo.result.label} on ${actionIcon} ${actionName}: ${s.title}`,
+          },
     );
   },
 });

--- a/packages/web/src/translation/effects/formatters/passive.ts
+++ b/packages/web/src/translation/effects/formatters/passive.ts
@@ -5,6 +5,16 @@ import {
 } from '../factory';
 
 registerEffectFormatter('passive', 'add', {
-  summarize: (eff, ctx) => summarizeEffects(eff.effects || [], ctx),
-  describe: (eff, ctx) => describeEffects(eff.effects || [], ctx),
+  summarize: (eff, ctx) => {
+    const inner = summarizeEffects(eff.effects || [], ctx);
+    return eff.params?.['onUpkeepPhase']
+      ? [{ title: 'Until your next Upkeep Phase', items: inner }]
+      : inner;
+  },
+  describe: (eff, ctx) => {
+    const inner = describeEffects(eff.effects || [], ctx);
+    return eff.params?.['onUpkeepPhase']
+      ? [{ title: 'Until your next Upkeep Phase', items: inner }]
+      : inner;
+  },
 });

--- a/packages/web/src/translation/effects/index.ts
+++ b/packages/web/src/translation/effects/index.ts
@@ -1,6 +1,7 @@
 export {
   summarizeEffects,
   describeEffects,
+  logEffects,
   registerEffectFormatter,
   registerEvaluatorFormatter,
 } from './factory';

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -29,14 +29,19 @@ export interface PlayerSnapshot {
     slotsUsed: number;
     developments: string[];
   }[];
+  passives: string[];
 }
 
-export function snapshotPlayer(player: {
-  resources: Record<string, number>;
-  stats: Record<string, number>;
-  buildings: Set<string>;
-  lands: Land[];
-}): PlayerSnapshot {
+export function snapshotPlayer(
+  player: {
+    id: string;
+    resources: Record<string, number>;
+    stats: Record<string, number>;
+    buildings: Set<string>;
+    lands: Land[];
+  },
+  ctx: EngineContext,
+): PlayerSnapshot {
   return {
     resources: { ...player.resources },
     stats: { ...player.stats },
@@ -47,6 +52,8 @@ export function snapshotPlayer(player: {
       slotsUsed: l.slotsUsed,
       developments: [...l.developments],
     })),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    passives: ctx.passives.list(player.id as any),
   };
 }
 
@@ -110,6 +117,10 @@ export function diffSnapshots(
         changes.push(`${landIcon} +${label}`);
       }
   }
+  const beforeP = new Set(before.passives);
+  const afterP = new Set(after.passives);
+  for (const id of beforeP)
+    if (!afterP.has(id)) changes.push(`Passive ${id} removed`);
   return changes;
 }
 
@@ -237,5 +248,9 @@ export function diffStepSnapshots(
         changes.push(`${landIcon} +${label}`);
       }
   }
+  const beforeP = new Set(before.passives);
+  const afterP = new Set(after.passives);
+  for (const id of beforeP)
+    if (!afterP.has(id)) changes.push(`Passive ${id} removed`);
   return changes;
 }

--- a/packages/web/tests/land-till-formatter.test.ts
+++ b/packages/web/tests/land-till-formatter.test.ts
@@ -44,9 +44,9 @@ describe('land till formatter', () => {
     expect(items.some((i) => i.includes(slotIcon))).toBe(true);
   });
 
-  it('handles plow action with no summary', () => {
+  it('summarizes plow action', () => {
     const ctx = createCtx();
     const summary = summarizeContent('action', 'plow', ctx);
-    expect(summary).toHaveLength(0);
+    expect(summary.length).toBeGreaterThan(0);
   });
 });

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -34,9 +34,9 @@ describe('log resource sources', () => {
 
     const devPhase = ctx.phases.find((p) => p.id === 'development');
     const step = devPhase?.steps.find((s) => s.id === 'gain-income');
-    const before = snapshotPlayer(ctx.activePlayer);
+    const before = snapshotPlayer(ctx.activePlayer, ctx);
     runEffects(step?.effects || [], ctx);
-    const after = snapshotPlayer(ctx.activePlayer);
+    const after = snapshotPlayer(ctx.activePlayer, ctx);
     const lines = diffStepSnapshots(before, after, step, ctx);
     expect(lines[0]).toBe('🪙 Gold +2 (10→12) (🪙+2 from 🌾)');
   });


### PR DESCRIPTION
## Summary
- add missing Till icon
- expand action and passive summaries so Plow and its workshop reveal nested effects
- show temporary passives on player card and log their lifecycle

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b437c865348325b510f281aa568928