### PR TITLE
feat(web): color-code log entries by player

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-08-31: `npm run dev` prebuilds `@kingdom-builder/contents` via a `predev` script to avoid missing dist files.
 - 2025-09-01: Player snapshots now require the engine context to include active passive IDs; use `snapshotPlayer(player, ctx)`.
 - 2025-09-02: Log entries include `playerId` so the web UI can style messages per player.
+- 2025-09-03: Player log text can reuse inactive player panel hues; dark mode should invert to lighter shades for readability.
 
 # Core Agent principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
 - 2025-08-31: `npm run dev` prebuilds `@kingdom-builder/contents` via a `predev` script to avoid missing dist files.
 - 2025-09-01: Player snapshots now require the engine context to include active passive IDs; use `snapshotPlayer(player, ctx)`.
+- 2025-09-02: Log entries include `playerId` so the web UI can style messages per player.
 
 # Core Agent principles
 

--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { useGameEngine } from '../state/GameContext';
 
 export default function LogPanel() {
-  const { log: entries } = useGameEngine();
+  const { log: entries, ctx } = useGameEngine();
   const logRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -19,11 +19,24 @@ export default function LogPanel() {
     >
       <h2 className="text-xl font-semibold mb-2">Log</h2>
       <ul className="mt-2 space-y-1">
-        {entries.map((entry, idx) => (
-          <li key={idx} className="text-xs font-mono whitespace-pre-wrap">
-            [{entry.time}] {entry.text}
-          </li>
-        ))}
+        {entries.map((entry, idx) => {
+          const aId = ctx.game.players[0]?.id;
+          const bId = ctx.game.players[1]?.id;
+          const colorClass =
+            entry.playerId === aId
+              ? 'log-entry-a'
+              : entry.playerId === bId
+                ? 'log-entry-b'
+                : '';
+          return (
+            <li
+              key={idx}
+              className={`text-xs font-mono whitespace-pre-wrap rounded px-1 ${colorClass}`}
+            >
+              [{entry.time}] {entry.text}
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -31,7 +31,7 @@ export default function LogPanel() {
           return (
             <li
               key={idx}
-              className={`text-xs font-mono whitespace-pre-wrap rounded px-1 ${colorClass}`}
+              className={`text-xs font-mono whitespace-pre-wrap ${colorClass}`}
             >
               [{entry.time}] {entry.text}
             </li>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -73,15 +73,15 @@
     --player-color: rgba(220, 38, 38, 0.4);
   }
   .log-entry-a {
-    background-color: rgba(219, 234, 254, 0.5);
+    color: rgb(30, 58, 138);
   }
   .log-entry-b {
-    background-color: rgba(254, 226, 226, 0.5);
+    color: rgb(127, 29, 29);
   }
   .dark .log-entry-a {
-    background-color: rgba(30, 58, 138, 0.3);
+    color: rgb(219, 234, 254);
   }
   .dark .log-entry-b {
-    background-color: rgba(127, 29, 29, 0.3);
+    color: rgb(254, 226, 226);
   }
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -72,4 +72,16 @@
   .dark .player-bg-red-active {
     --player-color: rgba(220, 38, 38, 0.4);
   }
+  .log-entry-a {
+    background-color: rgba(219, 234, 254, 0.5);
+  }
+  .log-entry-b {
+    background-color: rgba(254, 226, 226, 0.5);
+  }
+  .dark .log-entry-a {
+    background-color: rgba(30, 58, 138, 0.3);
+  }
+  .dark .log-entry-b {
+    background-color: rgba(127, 29, 29, 0.3);
+  }
 }

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -41,6 +41,7 @@ interface Action {
 export interface LogEntry {
   time: string;
   text: string;
+  playerId: string;
 }
 
 interface HoverCard {
@@ -138,11 +139,16 @@ export function GameProvider({
     setPhasePaused(v);
   }
 
-  const addLog = (entry: string | string[], playerName?: string) =>
+  const addLog = (
+    entry: string | string[],
+    player?: EngineContext['activePlayer'],
+  ) =>
     setLog((prev) => {
+      const p = player ?? ctx.activePlayer;
       const items = (Array.isArray(entry) ? entry : [entry]).map((text) => ({
         time: new Date().toLocaleTimeString(),
-        text: `[${playerName ?? ctx.activePlayer.name}] ${text}`,
+        text: `[${p.name}] ${text}`,
+        playerId: p.id,
       }));
       return [...prev, ...items];
     });
@@ -218,7 +224,7 @@ export function GameProvider({
         await runDelay(1500);
         setPhaseSteps([]);
         setDisplayPhase(phase);
-        addLog(`${phaseDef.icon} ${phaseDef.label} Phase`, player.name);
+        addLog(`${phaseDef.icon} ${phaseDef.label} Phase`, player);
         lastPhase = phase;
       }
       const after = snapshotPlayer(player, ctx);
@@ -226,7 +232,7 @@ export function GameProvider({
       if (changes.length) {
         addLog(
           changes.map((c) => `  ${c}`),
-          player.name,
+          player,
         );
       }
       const entry = {


### PR DESCRIPTION
## Summary
- color log entries using player-specific subtle hues
- track playerId in logs for styling

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b43e8bd33083258bafa815b48e4b4f