### PR TITLE
feat(web): add dev mode toggle for faster testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-08-31: `npm run dev` prebuilds `@kingdom-builder/contents` via a `predev` script to avoid missing dist files.
 - 2025-09-01: Player snapshots now require the engine context to include active passive IDs; use `snapshotPlayer(player, ctx)`.
 - 2025-08-31: `handleEndTurn` will not advance phases if a player has remaining AP; automated tests must spend or clear AP first.
+- 2025-09-01: To auto-pass turns when AP hits zero, include `ctx.activePlayer.ap` in `useEffect` dependencies.
 
 # Core Agent principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
 - 2025-08-31: `npm run dev` prebuilds `@kingdom-builder/contents` via a `predev` script to avoid missing dist files.
 - 2025-09-01: Player snapshots now require the engine context to include active passive IDs; use `snapshotPlayer(player, ctx)`.
+- 2025-08-31: `handleEndTurn` will not advance phases if a player has remaining AP; automated tests must spend or clear AP first.
 
 # Core Agent principles
 

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -7,7 +7,8 @@ import PhasePanel from './components/phases/PhasePanel';
 import LogPanel from './components/LogPanel';
 
 function GameLayout() {
-  const { ctx, onExit, darkMode, onToggleDark } = useGameEngine();
+  const { ctx, onExit, darkMode, onToggleDark, devMode, onToggleDev } =
+    useGameEngine();
   return (
     <div className="p-4 w-full bg-slate-100 text-gray-900 dark:bg-slate-900 dark:text-gray-100 min-h-screen">
       <div className="flex items-center justify-between mb-6">
@@ -16,6 +17,14 @@ function GameLayout() {
         </h1>
         {onExit && (
           <div className="flex items-center gap-2 ml-4">
+            <button
+              className={`px-3 py-1 rounded text-white hover:opacity-90 ${
+                devMode ? 'bg-green-600' : 'bg-gray-600'
+              }`}
+              onClick={onToggleDev}
+            >
+              {`Dev Mode${devMode ? ': On' : ': Off'}`}
+            </button>
             <button
               className="px-3 py-1 bg-gray-600 text-white rounded hover:bg-gray-700"
               onClick={onToggleDark}

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -299,8 +299,10 @@ export function GameProvider({
   useEffect(() => {
     if (!devMode) return;
     const phaseDef = ctx.phases[ctx.game.phaseIndex];
+    if (!phaseDef?.action) return;
+    const playerA = ctx.game.players[0]!;
     const playerB = ctx.game.players[1]!;
-    if (phaseDef?.action && ctx.activePlayer.id === playerB.id) {
+    if (ctx.activePlayer.id === playerB.id) {
       while (ctx.activePlayer.ap > 0) {
         handlePerform({
           id: 'tax',
@@ -309,8 +311,13 @@ export function GameProvider({
         });
       }
       void handleEndTurn();
+    } else if (
+      ctx.activePlayer.id === playerA.id &&
+      ctx.activePlayer.ap === 0
+    ) {
+      void handleEndTurn();
     }
-  }, [devMode, ctx.game.phaseIndex, ctx.activePlayer.id]);
+  }, [devMode, ctx.game.phaseIndex, ctx.activePlayer.id, ctx.activePlayer.ap]);
 
   const value: GameEngineContextValue = {
     ctx,


### PR DESCRIPTION
## Summary
- add Dev Mode toggle in UI
- speed up timers and auto-play Tax for player B when dev mode is on

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b43df1901c83259b647cc3bd4eb0d1