### PR TITLE
feat: improve action logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-09-05: Summary entries with a `_hoist` flag are lifted outside installation wrappers.
 - 2025-09-21: Exporting TS interfaces from React modules can trigger Vite Fast Refresh incompatibility; use type-only exports instead.
 - 2025-09-04: Use `rg --hidden` to search hidden directories like `.github`.
-
+- 2025-08-31: `npm run test:coverage` requires `@vitest/coverage-v8`; install with `npm install --no-save @vitest/coverage-v8` if missing.
 
 # Core Agent principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-09-21: Exporting TS interfaces from React modules can trigger Vite Fast Refresh incompatibility; use type-only exports instead.
 - 2025-09-04: Use `rg --hidden` to search hidden directories like `.github`.
 - 2025-08-31: `npm run test:coverage` requires `@vitest/coverage-v8`; install with `npm install --no-save @vitest/coverage-v8` if missing.
+- 2025-10-15: `performAction` returns sub-action traces via `ctx.actionTraces` for nested log attribution.
 
 # Core Agent principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-09-04: Use `rg --hidden` to search hidden directories like `.github`.
 - 2025-08-31: `npm run test:coverage` requires `@vitest/coverage-v8`; install with `npm install --no-save @vitest/coverage-v8` if missing.
 - 2025-10-15: `performAction` returns sub-action traces via `ctx.actionTraces` for nested log attribution.
+- 2025-10-16: Filter top-level log diffs by icon and label to prevent duplicate sub-action entries.
 
 # Core Agent principles
 

--- a/packages/engine/src/context.ts
+++ b/packages/engine/src/context.ts
@@ -8,6 +8,7 @@ import type {
   PopulationConfig as PopulationDef,
 } from './config/schema';
 import type { PhaseDef } from './phases';
+import type { ActionTrace } from './log';
 
 export class EngineContext {
   constructor(
@@ -26,6 +27,7 @@ export class EngineContext {
   // same step (e.g. multiple leaders raising strength).
   statAddPctBases: Record<string, number> = {};
   statAddPctAccums: Record<string, number> = {};
+  actionTraces: ActionTrace[] = [];
   get activePlayer() {
     return this.game.active;
   }

--- a/packages/engine/src/effects/action_perform.ts
+++ b/packages/engine/src/effects/action_perform.ts
@@ -1,6 +1,7 @@
 import type { EffectHandler } from '.';
 import { applyParamsToEffects } from '../utils';
 import { runEffects } from '.';
+import { snapshotPlayer } from '../log';
 
 export const actionPerform: EffectHandler = (effect, ctx, mult = 1) => {
   const id = effect.params?.['id'] as string;
@@ -8,8 +9,11 @@ export const actionPerform: EffectHandler = (effect, ctx, mult = 1) => {
   const params = effect.params as Record<string, unknown>;
   for (let i = 0; i < Math.floor(mult); i++) {
     const def = ctx.actions.get(id);
+    const before = snapshotPlayer(ctx.activePlayer, ctx);
     const resolved = applyParamsToEffects(def.effects, params);
     runEffects(resolved, ctx);
     ctx.passives.runResultMods(def.id, ctx);
+    const after = snapshotPlayer(ctx.activePlayer, ctx);
+    ctx.actionTraces.push({ id: def.id, before, after });
   }
 };

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -36,6 +36,8 @@ import {
   type StartConfig,
 } from './config/schema';
 import type { PhaseDef } from './phases';
+export { snapshotPlayer } from './log';
+export type { PlayerSnapshot, ActionTrace } from './log';
 
 type TriggerKey = string;
 
@@ -201,6 +203,7 @@ export function performAction<T extends string>(
   ctx: EngineContext,
   params?: ActionParams<T>,
 ) {
+  ctx.actionTraces = [];
   const actionDefinition = ctx.actions.get(actionId);
   if (actionDefinition.system && !ctx.activePlayer.actions.has(actionId))
     throw new Error(`Action ${actionId} is locked`);
@@ -226,6 +229,9 @@ export function performAction<T extends string>(
 
   runEffects(resolved, ctx);
   ctx.passives.runResultMods(actionDefinition.id, ctx);
+  const traces = ctx.actionTraces;
+  ctx.actionTraces = [];
+  return traces;
 }
 
 export interface AdvanceResult {

--- a/packages/engine/src/log.ts
+++ b/packages/engine/src/log.ts
@@ -1,0 +1,39 @@
+import type { EngineContext } from './context';
+import type { PlayerState } from './state';
+
+export interface PlayerSnapshot {
+  resources: Record<string, number>;
+  stats: Record<string, number>;
+  buildings: string[];
+  lands: {
+    id: string;
+    slotsMax: number;
+    slotsUsed: number;
+    developments: string[];
+  }[];
+  passives: string[];
+}
+
+export function snapshotPlayer(
+  player: PlayerState,
+  ctx: EngineContext,
+): PlayerSnapshot {
+  return {
+    resources: { ...player.resources },
+    stats: { ...player.stats },
+    buildings: Array.from(player.buildings),
+    lands: player.lands.map((l) => ({
+      id: l.id,
+      slotsMax: l.slotsMax,
+      slotsUsed: l.slotsUsed,
+      developments: [...l.developments],
+    })),
+    passives: ctx.passives.list(player.id),
+  };
+}
+
+export interface ActionTrace {
+  id: string;
+  before: PlayerSnapshot;
+  after: PlayerSnapshot;
+}

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -309,11 +309,15 @@ export function GameProvider({
           messages.splice(idx + 1, 0, ...subChanges.map((c) => `    ${c}`));
       }
 
+      const normalize = (line: string) =>
+        (line.split(' (')[0] ?? '').replace(/\s[+-]?\d+$/, '').trim();
+      const subPrefixes = subLines.map(normalize);
+
       const costLabels = new Set(
         Object.keys(costs) as (keyof typeof RESOURCES)[],
       );
       const filtered = changes.filter((line) => {
-        if (subLines.includes(line)) return false;
+        if (subPrefixes.includes(normalize(line))) return false;
         for (const key of costLabels) {
           const info = RESOURCES[key];
           const prefix = info?.icon ? `${info.icon} ${info.label}` : info.label;

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -273,7 +273,11 @@ export function GameProvider({
       params as ActionParams<string>,
     );
     try {
-      performAction(action.id, ctx, params as ActionParams<string>);
+      const traces = performAction(
+        action.id,
+        ctx,
+        params as ActionParams<string>,
+      );
       const after = snapshotPlayer(ctx.activePlayer, ctx);
       const changes = diffSnapshots(before, after, ctx);
       const messages = logContent('action', action.id, ctx, params);
@@ -291,10 +295,25 @@ export function GameProvider({
       if (costLines.length) {
         messages.splice(1, 0, '  💲 Action cost', ...costLines);
       }
+
+      const subLines: string[] = [];
+      for (const trace of traces) {
+        const subChanges = diffSnapshots(trace.before, trace.after, ctx);
+        if (!subChanges.length) continue;
+        subLines.push(...subChanges);
+        const icon = actionInfo[trace.id]?.icon || '';
+        const name = ctx.actions.get(trace.id).name;
+        const line = `  ${icon} ${name}`;
+        const idx = messages.indexOf(line);
+        if (idx !== -1)
+          messages.splice(idx + 1, 0, ...subChanges.map((c) => `    ${c}`));
+      }
+
       const costLabels = new Set(
         Object.keys(costs) as (keyof typeof RESOURCES)[],
       );
       const filtered = changes.filter((line) => {
+        if (subLines.includes(line)) return false;
         for (const key of costLabels) {
           const info = RESOURCES[key];
           const prefix = info?.icon ? `${info.icon} ${info.label}` : info.label;

--- a/packages/web/src/translation/effects/formatters/passive.ts
+++ b/packages/web/src/translation/effects/formatters/passive.ts
@@ -17,4 +17,11 @@ registerEffectFormatter('passive', 'add', {
       ? [{ title: '♾️ Before your next Upkeep Phase', items: inner }]
       : inner;
   },
+  log: (eff, ctx) => {
+    const inner = describeEffects(eff.effects || [], ctx);
+    const items = [...(inner.length ? inner : [])];
+    if (eff.params?.['onUpkeepPhase'])
+      items.push("♾️ Passive duration: Until player's next Upkeep Phase");
+    return { title: '♾️ Passive added', items };
+  },
 });

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -8,6 +8,7 @@ import {
   STATS,
   POPULATION_ROLES,
   LAND_ICON as landIcon,
+  SLOT_ICON as slotIcon,
   DEVELOPMENT_INFO as developmentInfo,
   ACTION_INFO as actionInfo,
 } from '@kingdom-builder/contents';
@@ -117,6 +118,16 @@ export function diffSnapshots(
         changes.push(`${landIcon} +${label}`);
       }
   }
+  const beforeSlots = before.lands.reduce((sum, l) => sum + l.slotsMax, 0);
+  const afterSlots = after.lands.reduce((sum, l) => sum + l.slotsMax, 0);
+  const newLandSlots = after.lands
+    .filter((l) => !before.lands.some((b) => b.id === l.id))
+    .reduce((sum, l) => sum + l.slotsMax, 0);
+  const slotDelta = afterSlots - newLandSlots - beforeSlots;
+  if (slotDelta !== 0)
+    changes.push(
+      `${slotIcon} Development Slot ${slotDelta >= 0 ? '+' : ''}${slotDelta} (${beforeSlots}→${beforeSlots + slotDelta})`,
+    );
   const beforeP = new Set(before.passives);
   const afterP = new Set(after.passives);
   for (const id of beforeP)
@@ -248,6 +259,16 @@ export function diffStepSnapshots(
         changes.push(`${landIcon} +${label}`);
       }
   }
+  const beforeSlots = before.lands.reduce((sum, l) => sum + l.slotsMax, 0);
+  const afterSlots = after.lands.reduce((sum, l) => sum + l.slotsMax, 0);
+  const newLandSlots = after.lands
+    .filter((l) => !before.lands.some((b) => b.id === l.id))
+    .reduce((sum, l) => sum + l.slotsMax, 0);
+  const slotDelta = afterSlots - newLandSlots - beforeSlots;
+  if (slotDelta !== 0)
+    changes.push(
+      `${slotIcon} Development Slot ${slotDelta >= 0 ? '+' : ''}${slotDelta} (${beforeSlots}→${beforeSlots + slotDelta})`,
+    );
   const beforeP = new Set(before.passives);
   const afterP = new Set(after.passives);
   for (const id of beforeP)

--- a/packages/web/tests/subaction-log.test.ts
+++ b/packages/web/tests/subaction-log.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createEngine,
+  performAction,
+  getActionCosts,
+  Resource,
+  type ActionTrace,
+} from '@kingdom-builder/engine';
+import {
+  ACTIONS,
+  BUILDINGS,
+  DEVELOPMENTS,
+  POPULATIONS,
+  PHASES,
+  GAME_START,
+  ACTION_INFO as actionInfo,
+  RESOURCES,
+} from '@kingdom-builder/contents';
+import { snapshotPlayer, diffSnapshots, logContent } from '../src/translation';
+
+vi.mock('@kingdom-builder/engine', async () => {
+  return await import('../../engine/src');
+});
+
+describe('sub-action logging', () => {
+  it('nests sub-action effects under the triggering action', () => {
+    const ctx = createEngine({
+      actions: ACTIONS,
+      buildings: BUILDINGS,
+      developments: DEVELOPMENTS,
+      populations: POPULATIONS,
+      phases: PHASES,
+      start: GAME_START,
+    });
+    ctx.activePlayer.actions.add('plow');
+    ctx.activePlayer.resources[Resource.gold] = 10;
+    ctx.activePlayer.resources[Resource.ap] = 1;
+    const before = snapshotPlayer(ctx.activePlayer, ctx);
+    const costs = getActionCosts('plow', ctx);
+    const traces = performAction('plow', ctx);
+    const after = snapshotPlayer(ctx.activePlayer, ctx);
+    const changes = diffSnapshots(before, after, ctx);
+    const messages = logContent('action', 'plow', ctx);
+    const costLines: string[] = [];
+    for (const key of Object.keys(costs) as (keyof typeof RESOURCES)[]) {
+      const amt = costs[key] ?? 0;
+      if (!amt) continue;
+      const info = RESOURCES[key];
+      const icon = info?.icon ? `${info.icon} ` : '';
+      const label = info?.label ?? key;
+      const b = before.resources[key] ?? 0;
+      const a = b - amt;
+      costLines.push(`    ${icon}${label} -${amt} (${b}→${a})`);
+    }
+    if (costLines.length)
+      messages.splice(1, 0, '  💲 Action cost', ...costLines);
+
+    const subLines: string[] = [];
+    for (const trace of traces) {
+      const subChanges = diffSnapshots(trace.before, trace.after, ctx);
+      if (!subChanges.length) continue;
+      subLines.push(...subChanges);
+      const icon = actionInfo[trace.id]?.icon || '';
+      const name = ctx.actions.get(trace.id).name;
+      const line = `  ${icon} ${name}`;
+      const idx = messages.indexOf(line);
+      if (idx !== -1)
+        messages.splice(idx + 1, 0, ...subChanges.map((c) => `    ${c}`));
+    }
+
+    const costLabels = new Set(
+      Object.keys(costs) as (keyof typeof RESOURCES)[],
+    );
+    const filtered = changes.filter((line) => {
+      if (subLines.includes(line)) return false;
+      for (const key of costLabels) {
+        const info = RESOURCES[key];
+        const prefix = info?.icon ? `${info.icon} ${info.label}` : info.label;
+        if (line.startsWith(prefix)) return false;
+      }
+      return true;
+    });
+    const logLines = [...messages, ...filtered.map((c) => `  ${c}`)];
+
+    const expandTrace = traces.find((t) => t.id === 'expand') as ActionTrace;
+    const expandDiff = diffSnapshots(
+      expandTrace.before,
+      expandTrace.after,
+      ctx,
+    );
+    expandDiff.forEach((line) => {
+      expect(logLines).toContain(`    ${line}`);
+      expect(logLines).not.toContain(`  ${line}`);
+    });
+    const tillTrace = traces.find((t) => t.id === 'till') as ActionTrace;
+    const tillDiff = diffSnapshots(tillTrace.before, tillTrace.after, ctx);
+    tillDiff.forEach((line) => {
+      expect(logLines).toContain(`    ${line}`);
+      expect(logLines).not.toContain(`  ${line}`);
+    });
+  });
+});

--- a/packages/web/tests/subaction-log.test.ts
+++ b/packages/web/tests/subaction-log.test.ts
@@ -15,6 +15,7 @@ import {
   GAME_START,
   ACTION_INFO as actionInfo,
   RESOURCES,
+  SLOT_ICON as slotIcon,
 } from '@kingdom-builder/contents';
 import { snapshotPlayer, diffSnapshots, logContent } from '../src/translation';
 
@@ -94,6 +95,10 @@ describe('sub-action logging', () => {
     });
     const tillTrace = traces.find((t) => t.id === 'till') as ActionTrace;
     const tillDiff = diffSnapshots(tillTrace.before, tillTrace.after, ctx);
+    expect(tillDiff.length).toBeGreaterThan(0);
+    expect(
+      tillDiff.some((line) => line.startsWith(`${slotIcon} Development Slot`)),
+    ).toBe(true);
     tillDiff.forEach((line) => {
       expect(logLines).toContain(`    ${line}`);
       expect(logLines).not.toContain(`  ${line}`);


### PR DESCRIPTION
## Summary
- log passives with duration and effect details
- show action costs first in log output
- document missing `@vitest/coverage-v8` dependency for tests

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b452cfc07c83258fae6c6b6671bf5e