### PR TITLE
refactor: unify trigger resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,9 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-09-21: Exporting TS interfaces from React modules can trigger Vite Fast Refresh incompatibility; use type-only exports instead.
 - 2025-09-04: Use `rg --hidden` to search hidden directories like `.github`.
 
+- 2025-08-31: Trigger handling now uses `collectTriggerEffects`; direct
+  `runTrigger` helper has been removed. Switch the active player index when
+  resolving triggers for non-active players.
 
 # Core Agent principles
 

--- a/docs/architecture/AGENTS.md
+++ b/docs/architecture/AGENTS.md
@@ -10,7 +10,10 @@ Rules and content are encoded as declarative **effects** that respond to
 specific **triggers**. A trigger represents a moment in the game such as the
 start of the Development phase or the resolution of an action. When a trigger
 fires the engine looks up all matching effects and resolves them through the
-central registry.
+central registry. All trigger lookups funnel through a single helper,
+`collectTriggerEffects`, which gathers the relevant effects for a player before
+execution. This unified path avoids divergent trigger systems and ensures new
+content hooks into triggers consistently.
 
 Each effect definition contains:
 


### PR DESCRIPTION
## Summary
- remove legacy `runTrigger` helper and centralize trigger processing through `collectTriggerEffects`
- update architecture docs to describe unified trigger path
- add discovery log note about `collectTriggerEffects`

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b4534fc4d88325aceb32e7399a366d