### PR TITLE
fix: show development slot requirement icon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-09-21: Exporting TS interfaces from React modules can trigger Vite Fast Refresh incompatibility; use type-only exports instead.
 - 2025-09-04: Use `rg --hidden` to search hidden directories like `.github`.
 
+- 2025-09-24: Use `SLOT_ICON` from `@kingdom-builder/contents` for development slot requirement indicators.
+
 - 2025-08-31: Trigger handling now uses `collectTriggerEffects`; direct
   `runTrigger` helper has been removed. Switch the active player index when
   resolving triggers for non-active players.

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -11,6 +11,7 @@ import {
   ACTION_INFO as actionInfo,
   DEVELOPMENT_INFO as developmentInfo,
   BUILDING_INFO as buildingInfo,
+  SLOT_ICON as slotIcon,
 } from '@kingdom-builder/contents';
 import {
   describeContent,
@@ -340,7 +341,7 @@ function DevelopOptions({
               </span>
               {requirements.length > 0 && (
                 <span className="absolute top-7 right-2 text-xs text-red-600">
-                  Req {POPULATION_ROLES[PopulationRole.Citizen]?.icon}
+                  Req {slotIcon}
                 </span>
               )}
               <ul className="text-sm list-disc pl-4 text-left">

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -19,6 +19,7 @@ import {
   PHASES,
   GAME_START,
   POPULATION_ROLES,
+  SLOT_ICON,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -75,5 +76,13 @@ describe('<ActionsPanel />', () => {
     render(<ActionsPanel />);
     const popIcon = POPULATION_ROLES[PopulationRole.Citizen].icon;
     expect(screen.getAllByText(`Req ${popIcon}`)[0]).toBeInTheDocument();
+  });
+
+  it('shows development slot requirement indicator when no slots are free', () => {
+    const originalSlots = ctx.activePlayer.lands.map((l) => l.slotsUsed);
+    ctx.activePlayer.lands.forEach((l) => (l.slotsUsed = l.slotsMax));
+    render(<ActionsPanel />);
+    expect(screen.getAllByText(`Req ${SLOT_ICON}`)[0]).toBeInTheDocument();
+    ctx.activePlayer.lands.forEach((l, i) => (l.slotsUsed = originalSlots[i]));
   });
 });


### PR DESCRIPTION
## Summary
- display development slot icon when no build slots remain
- test development slot requirement handling
- log discovery about SLOT_ICON usage

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b45c14ca24832595e814f99c250005