### PR TITLE
feat(ui): add icons for land requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
   resolving triggers for non-active players.
 - 2025-08-31: `npm run test:coverage` requires `@vitest/coverage-v8`; install with `npm install --no-save @vitest/coverage-v8` if missing.
 - 2025-08-31: `performAction` returns sub-action traces via `ctx.actionTraces` for nested log attribution.
+- 2025-08-31: Overview screen can pull icons from contents (e.g. ACTION_INFO, LAND_ICON) to keep keywords visually consistent.
 
 # Core Agent principles
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,5 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import Game from './Game';
+import {
+  ACTION_INFO as actionInfo,
+  LAND_ICON as landIcon,
+  SLOT_ICON as slotIcon,
+  RESOURCES,
+} from '@kingdom-builder/contents';
+import { Resource } from '@kingdom-builder/engine';
 
 type Screen = 'menu' | 'overview' | 'game';
 
@@ -24,8 +31,8 @@ export default function App() {
         <h1 className="text-2xl font-bold text-center mb-4">Game Overview</h1>
         <p>
           Kingdom Builder is a turn-based duel where you grow your realm and
-          attempt to outmaneuver your rival. Protect your castle, expand your
-          lands, and manage your resources to prevail.
+          attempt to outmaneuver your rival. Protect your castle, expand your{' '}
+          {landIcon} lands, and manage your resources to prevail.
         </p>
         <h2 className="text-xl font-semibold mt-4 mb-2">Goal</h2>
         <p>
@@ -52,11 +59,16 @@ export default function App() {
         <h2 className="text-xl font-semibold mt-4 mb-2">Core Mechanics</h2>
         <p className="mb-4">
           Actions may require resources or other prerequisites and grant various
-          effects, such as gaining resources, building structures, developing
-          land, or hindering your opponent. Buildings provide passive bonuses,
-          while land around your castle holds developments that yield benefits.
-          Resources like Gold, Action Points, Happiness, and Castle Health are
-          spent and gained throughout the game.
+          effects, such as gaining resources, {actionInfo['build']?.icon}{' '}
+          building structures, {actionInfo['develop']?.icon} developing{' '}
+          {landIcon} land, or hindering your opponent.{' '}
+          {actionInfo['build']?.icon} Buildings provide ♾️ passive bonuses,
+          while {landIcon} land around your castle holds {slotIcon} developments
+          that yield benefits. Resources like
+          {RESOURCES[Resource.gold].icon} Gold, {RESOURCES[Resource.ap].icon}{' '}
+          Action Points, {RESOURCES[Resource.happiness].icon} Happiness, and{' '}
+          {RESOURCES[Resource.castleHP].icon} Castle Health are spent and gained
+          throughout the game.
         </p>
         <button
           className="border px-4 py-2 hoverable cursor-pointer"

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -12,6 +12,7 @@ import {
   DEVELOPMENT_INFO as developmentInfo,
   BUILDING_INFO as buildingInfo,
   SLOT_ICON as slotIcon,
+  LAND_ICON as landIcon,
 } from '@kingdom-builder/contents';
 import {
   describeContent,
@@ -281,7 +282,9 @@ function DevelopOptions({
           });
           const requirements = hasDevelopLand
             ? []
-            : ['Requires land with free development slot'];
+            : [
+                `Requires ${landIcon} land with free ${slotIcon} development slot`,
+              ];
           const canPay =
             hasDevelopLand &&
             Object.entries(costs).every(
@@ -296,7 +299,7 @@ function DevelopOptions({
           const title = !implemented
             ? 'Not implemented yet'
             : !hasDevelopLand
-              ? 'No land with free development slot'
+              ? `No ${landIcon} land with free ${slotIcon} development slot`
               : !canPay
                 ? 'Cannot pay costs'
                 : undefined;

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -20,6 +20,7 @@ import {
   GAME_START,
   POPULATION_ROLES,
   SLOT_ICON,
+  LAND_ICON,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -83,6 +84,11 @@ describe('<ActionsPanel />', () => {
     ctx.activePlayer.lands.forEach((l) => (l.slotsUsed = l.slotsMax));
     render(<ActionsPanel />);
     expect(screen.getAllByText(`Req ${SLOT_ICON}`)[0]).toBeInTheDocument();
+    expect(
+      screen.getAllByTitle(
+        `No ${LAND_ICON} land with free ${SLOT_ICON} development slot`,
+      )[0],
+    ).toBeInTheDocument();
     ctx.activePlayer.lands.forEach((l, i) => (l.slotsUsed = originalSlots[i]));
   });
 });


### PR DESCRIPTION
## Summary
- show land and development slot icons in develop action requirements
- add missing icons to overview and core mechanics descriptions
- test land slot requirement messaging

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b45eef25508325a8dab020dc4e77e5