### PR TITLE
Hide untouched zero stats on player card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-08-31: `npm run test:coverage` requires `@vitest/coverage-v8`; install with `npm install --no-save @vitest/coverage-v8` if missing.
 - 2025-08-31: `performAction` returns sub-action traces via `ctx.actionTraces` for nested log attribution.
 - 2025-08-31: Overview screen can pull icons from contents (e.g. ACTION_INFO, LAND_ICON) to keep keywords visually consistent.
+- 2025-08-31: PlayerState maintains `statsHistory` so stats returning to zero remain visible; initialize new non-zero stats accordingly.
 
 # Core Agent principles
 

--- a/packages/engine/src/effects/stat_add.ts
+++ b/packages/engine/src/effects/stat_add.ts
@@ -4,6 +4,7 @@ import type { StatKey } from '../state';
 export const statAdd: EffectHandler = (effect, ctx, mult = 1) => {
   const key = effect.params!['key'] as StatKey;
   const amount = effect.params!['amount'] as number;
-  ctx.activePlayer.stats[key] =
-    (ctx.activePlayer.stats[key] || 0) + amount * mult;
+  const newVal = (ctx.activePlayer.stats[key] || 0) + amount * mult;
+  ctx.activePlayer.stats[key] = newVal;
+  if (newVal !== 0) ctx.activePlayer.statsHistory[key] = true;
 };

--- a/packages/engine/src/effects/stat_add_pct.ts
+++ b/packages/engine/src/effects/stat_add_pct.ts
@@ -16,5 +16,7 @@ export const statAddPct: EffectHandler = (effect, ctx, mult = 1) => {
 
   const base = ctx.statAddPctBases[cacheKey]!;
   ctx.statAddPctAccums[cacheKey]! += base * (pct / 100) * mult;
-  ctx.activePlayer.stats[key] = base + ctx.statAddPctAccums[cacheKey]!;
+  const newVal = base + ctx.statAddPctAccums[cacheKey]!;
+  ctx.activePlayer.stats[key] = newVal;
+  if (newVal !== 0) ctx.activePlayer.statsHistory[key] = true;
 };

--- a/packages/engine/src/effects/stat_remove.ts
+++ b/packages/engine/src/effects/stat_remove.ts
@@ -4,6 +4,7 @@ import type { StatKey } from '../state';
 export const statRemove: EffectHandler = (effect, ctx, mult = 1) => {
   const key = effect.params!['key'] as StatKey;
   const amount = effect.params!['amount'] as number;
-  ctx.activePlayer.stats[key] =
-    (ctx.activePlayer.stats[key] || 0) - amount * mult;
+  const newVal = (ctx.activePlayer.stats[key] || 0) - amount * mult;
+  ctx.activePlayer.stats[key] = newVal;
+  if (newVal !== 0) ctx.activePlayer.statsHistory[key] = true;
 };

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -277,8 +277,12 @@ function applyPlayerStart(
 ) {
   for (const [key, value] of Object.entries(config.resources || {}))
     player.resources[key as ResourceKey] = value ?? 0;
-  for (const [key, value] of Object.entries(config.stats || {}))
-    player.stats[key as StatKey] = value ?? 0;
+  for (const [key, value] of Object.entries(config.stats || {})) {
+    const val = value ?? 0;
+    const statKey = key as StatKey;
+    player.stats[statKey] = val;
+    if (val !== 0) player.statsHistory[statKey] = true;
+  }
   for (const [key, value] of Object.entries(config.population || {}))
     player.population[key as PopulationRoleId] = value ?? 0;
   if (config.lands)

--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -51,18 +51,14 @@ export class Land {
 export class PlayerState {
   id: PlayerId;
   name: string;
-  resources: Record<ResourceKey, number> = {
-    [Resource.gold]: 0,
-    [Resource.ap]: 0,
-    [Resource.happiness]: 0,
-    [Resource.castleHP]: 10,
-  };
-  stats: Record<StatKey, number> = {
-    [Stat.maxPopulation]: 1,
-    [Stat.armyStrength]: 0,
-    [Stat.fortificationStrength]: 0,
-    [Stat.absorption]: 0,
-  };
+  resources: Record<ResourceKey, number>;
+  stats: Record<StatKey, number>;
+  /**
+   * Tracks whether a stat has ever been non-zero. This allows the UI to hide
+   * stats that are zero and have never changed while still showing stats that
+   * returned to zero after previously having a value.
+   */
+  statsHistory: Record<StatKey, boolean>;
   population: Record<PopulationRoleId, number> = {
     [PopulationRole.Council]: 0,
     [PopulationRole.Commander]: 0,
@@ -75,6 +71,19 @@ export class PlayerState {
   constructor(id: PlayerId, name: string) {
     this.id = id;
     this.name = name;
+    this.resources = {
+      [Resource.gold]: 0,
+      [Resource.ap]: 0,
+      [Resource.happiness]: 0,
+      [Resource.castleHP]: 10,
+    };
+    this.stats = {} as Record<StatKey, number>;
+    this.statsHistory = {} as Record<StatKey, boolean>;
+    for (const key of Object.values(Stat) as StatKey[]) {
+      const value = key === Stat.maxPopulation ? 1 : 0;
+      this.stats[key] = value;
+      this.statsHistory[key] = value !== 0;
+    }
   }
   get gold() {
     return this.resources[Resource.gold];
@@ -99,24 +108,28 @@ export class PlayerState {
   }
   set maxPopulation(v: number) {
     this.stats[Stat.maxPopulation] = v;
+    if (v !== 0) this.statsHistory[Stat.maxPopulation] = true;
   }
   get armyStrength() {
     return this.stats[Stat.armyStrength];
   }
   set armyStrength(v: number) {
     this.stats[Stat.armyStrength] = v;
+    if (v !== 0) this.statsHistory[Stat.armyStrength] = true;
   }
   get fortificationStrength() {
     return this.stats[Stat.fortificationStrength];
   }
   set fortificationStrength(v: number) {
     this.stats[Stat.fortificationStrength] = v;
+    if (v !== 0) this.statsHistory[Stat.fortificationStrength] = true;
   }
   get absorption() {
     return this.stats[Stat.absorption];
   }
   set absorption(v: number) {
     this.stats[Stat.absorption] = v;
+    if (v !== 0) this.statsHistory[Stat.absorption] = true;
   }
 }
 

--- a/packages/engine/tests/state/state.test.ts
+++ b/packages/engine/tests/state/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { Land, PlayerState, GameState } from '../../src/state/index.ts';
+import { Land, PlayerState, GameState, Stat } from '../../src/state/index.ts';
 
 describe('State classes', () => {
   it('calculates free slots on land', () => {
@@ -15,6 +15,15 @@ describe('State classes', () => {
     player.maxPopulation = 3;
     expect(player.gold).toBe(5);
     expect(player.maxPopulation).toBe(3);
+  });
+
+  it('tracks stat history when values become non-zero', () => {
+    const player = new PlayerState('A', 'Alice');
+    expect(player.statsHistory[Stat.armyStrength]).toBe(false);
+    player.armyStrength = 1;
+    expect(player.statsHistory[Stat.armyStrength]).toBe(true);
+    player.armyStrength = 0;
+    expect(player.statsHistory[Stat.armyStrength]).toBe(true);
   });
 
   it('provides active and opponent players', () => {

--- a/packages/web/src/components/player/PopulationInfo.tsx
+++ b/packages/web/src/components/player/PopulationInfo.tsx
@@ -77,7 +77,12 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
         )}
       </span>
       {Object.entries(player.stats)
-        .filter(([k]) => k !== 'maxPopulation')
+        .filter(
+          ([k, v]) =>
+            k !== 'maxPopulation' &&
+            (v !== 0 ||
+              player.statsHistory?.[k as keyof typeof player.statsHistory]),
+        )
         .map(([k, v]) => {
           const info = STATS[k as keyof typeof STATS];
           return (


### PR DESCRIPTION
## Summary
- track per-stat history in PlayerState so stats that were once non-zero stay visible
- mark stat history in effect handlers and starting config
- hide stats that remain zero and untouched on the player card
- test stat history tracking

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b463acd6bc8325b5deb1ce189efca1