### PR TITLE
feat: embed icon metadata in content builders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ non-obvious insights that will help future agents work more efficiently. Any upd
   resolving triggers for non-active players.
 - 2025-08-31: `npm run test:coverage` requires `@vitest/coverage-v8`; install with `npm install --no-save @vitest/coverage-v8` if missing.
 - 2025-08-31: `performAction` returns sub-action traces via `ctx.actionTraces` for nested log attribution.
+- 2025-09-01: Use `buildInfo(registry, { id: icon })` to derive icon/label maps from content registries.
+- 2025-09-01: Compose effects with `effect(type, method).param(key, value)` to avoid manual `{ type, method, params }` objects.
+- 2025-09-02: Content builders now chain `.id().name().icon()` and icons live on config entries; standalone info maps are deprecated.
 
 # Core Agent principles
 

--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -4,7 +4,19 @@ import {
   actionSchema,
   type ActionConfig,
 } from '@kingdom-builder/engine/config/schema';
-import { action } from '@kingdom-builder/engine/config/builders';
+import {
+  action,
+  effect,
+  Types,
+  LandMethods,
+  ResourceMethods,
+  DevelopmentMethods,
+  PopulationMethods,
+  ActionMethods,
+  PassiveMethods,
+  CostModMethods,
+  BuildingMethods,
+} from '@kingdom-builder/engine/config/builders';
 
 export type ActionDef = ActionConfig;
 
@@ -13,81 +25,96 @@ export function createActionRegistry() {
 
   registry.add(
     'expand',
-    action('expand', 'Expand')
+    action()
+      .id('expand')
+      .name('Expand')
+      .icon('🌱')
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 2)
-      .effect({ type: 'land', method: 'add', params: { count: 1 } })
-      .effect({
-        type: 'resource',
-        method: 'add',
-        params: { key: Resource.happiness, amount: 1 },
-      })
+      .effect(effect(Types.Land, LandMethods.ADD).param('count', 1).build())
+      .effect(
+        effect(Types.Resource, ResourceMethods.ADD)
+          .params({ key: Resource.happiness, amount: 1 })
+          .build(),
+      )
       .build(),
   );
 
   registry.add(
     'overwork',
-    action('overwork', 'Overwork')
+    action()
+      .id('overwork')
+      .name('Overwork')
+      .icon('🛠️')
       .cost(Resource.ap, 1)
-      .effect({
-        evaluator: { type: 'development', params: { id: 'farm' } },
-        effects: [
-          {
-            type: 'resource',
-            method: 'add',
-            round: 'down',
-            params: { key: Resource.gold, amount: 2 },
-          },
-          {
-            type: 'resource',
-            method: 'add',
-            round: 'up',
-            params: { key: Resource.happiness, amount: -0.5 },
-          },
-        ],
-      })
+      .effect(
+        effect()
+          .evaluator('development', { id: 'farm' })
+          .effect(
+            effect(Types.Resource, ResourceMethods.ADD)
+              .round('down')
+              .params({ key: Resource.gold, amount: 2 })
+              .build(),
+          )
+          .effect(
+            effect(Types.Resource, ResourceMethods.ADD)
+              .round('up')
+              .params({ key: Resource.happiness, amount: -0.5 })
+              .build(),
+          )
+          .build(),
+      )
       .build(),
   );
 
   registry.add(
     'develop',
-    action('develop', 'Develop')
+    action()
+      .id('develop')
+      .name('Develop')
+      .icon('🏗️')
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 3)
-      .effect({
-        type: 'development',
-        method: 'add',
-        params: { id: '$id', landId: '$landId' },
-      })
+      .effect(
+        effect(Types.Development, DevelopmentMethods.ADD)
+          .params({ id: '$id', landId: '$landId' })
+          .build(),
+      )
       .build(),
   );
 
   registry.add(
     'tax',
-    action('tax', 'Tax')
+    action()
+      .id('tax')
+      .name('Tax')
+      .icon('💰')
       .cost(Resource.ap, 1)
-      .effect({
-        evaluator: { type: 'population' },
-        effects: [
-          {
-            type: 'resource',
-            method: 'add',
-            params: { key: Resource.gold, amount: 4 },
-          },
-          {
-            type: 'resource',
-            method: 'add',
-            round: 'up',
-            params: { key: Resource.happiness, amount: -0.5 },
-          },
-        ],
-      })
+      .effect(
+        effect()
+          .evaluator('population')
+          .effect(
+            effect(Types.Resource, ResourceMethods.ADD)
+              .params({ key: Resource.gold, amount: 4 })
+              .build(),
+          )
+          .effect(
+            effect(Types.Resource, ResourceMethods.ADD)
+              .round('up')
+              .params({ key: Resource.happiness, amount: -0.5 })
+              .build(),
+          )
+          .build(),
+      )
       .build(),
   );
 
   registry.add(
     'reallocate',
-    action('reallocate', 'Reallocate')
+    action()
+      .id('reallocate')
+      .name('Reallocate')
+      .icon('🔄')
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 5)
       .build(),
@@ -95,7 +122,10 @@ export function createActionRegistry() {
 
   registry.add(
     'raise_pop',
-    action('raise_pop', 'Raise Population')
+    action()
+      .id('raise_pop')
+      .name('Raise Population')
+      .icon('👶')
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 5)
       .requirement({
@@ -103,22 +133,25 @@ export function createActionRegistry() {
         method: 'cap',
         message: 'Free space for 👥',
       })
-      .effect({
-        type: 'population',
-        method: 'add',
-        params: { role: '$role' },
-      })
-      .effect({
-        type: 'resource',
-        method: 'add',
-        params: { key: Resource.happiness, amount: 1 },
-      })
+      .effect(
+        effect(Types.Population, PopulationMethods.ADD)
+          .param('role', '$role')
+          .build(),
+      )
+      .effect(
+        effect(Types.Resource, ResourceMethods.ADD)
+          .params({ key: Resource.happiness, amount: 1 })
+          .build(),
+      )
       .build(),
   );
 
   registry.add(
     'royal_decree',
-    action('royal_decree', 'Royal Decree')
+    action()
+      .id('royal_decree')
+      .name('Royal Decree')
+      .icon('📜')
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 12)
       .build(),
@@ -126,12 +159,20 @@ export function createActionRegistry() {
 
   registry.add(
     'army_attack',
-    action('army_attack', 'Army Attack').cost(Resource.ap, 1).build(),
+    action()
+      .id('army_attack')
+      .name('Army Attack')
+      .icon('🗡️')
+      .cost(Resource.ap, 1)
+      .build(),
   );
 
   registry.add(
     'hold_festival',
-    action('hold_festival', 'Hold Festival')
+    action()
+      .id('hold_festival')
+      .name('Hold Festival')
+      .icon('🎉')
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 3)
       .build(),
@@ -139,53 +180,66 @@ export function createActionRegistry() {
 
   registry.add(
     'plow',
-    action('plow', 'Plow')
+    action()
+      .id('plow')
+      .name('Plow')
+      .icon('🚜')
       .system()
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 6)
-      .effect({ type: 'action', method: 'perform', params: { id: 'expand' } })
-      .effect({ type: 'action', method: 'perform', params: { id: 'till' } })
-      .effect({
-        type: 'passive',
-        method: 'add',
-        params: {
-          id: 'plow_cost_mod',
-          onUpkeepPhase: [
-            {
-              type: 'passive',
-              method: 'remove',
-              params: { id: 'plow_cost_mod' },
-            },
-          ],
-        },
-        effects: [
-          {
-            type: 'cost_mod',
-            method: 'add',
-            params: {
-              id: 'plow_cost_all',
-              key: Resource.gold,
-              amount: 2,
-            },
-          },
-        ],
-      })
+      .effect(
+        effect(Types.Action, ActionMethods.PERFORM)
+          .param('id', 'expand')
+          .build(),
+      )
+      .effect(
+        effect(Types.Action, ActionMethods.PERFORM).param('id', 'till').build(),
+      )
+      .effect(
+        effect(Types.Passive, PassiveMethods.ADD)
+          .params({
+            id: 'plow_cost_mod',
+            onUpkeepPhase: [
+              effect(Types.Passive, PassiveMethods.REMOVE)
+                .param('id', 'plow_cost_mod')
+                .build(),
+            ],
+          })
+          .effect(
+            effect(Types.CostMod, CostModMethods.ADD)
+              .params({
+                id: 'plow_cost_all',
+                key: Resource.gold,
+                amount: 2,
+              })
+              .build(),
+          )
+          .build(),
+      )
       .build(),
   );
 
   registry.add(
     'till',
-    action('till', 'Till')
+    action()
+      .id('till')
+      .name('Till')
+      .icon('🧑‍🌾')
       .system()
-      .effect({ type: 'land', method: 'till' })
+      .effect(effect(Types.Land, LandMethods.TILL).build())
       .build(),
   );
 
   registry.add(
     'build',
-    action('build', 'Build')
+    action()
+      .id('build')
+      .name('Build')
+      .icon('🏛️')
       .cost(Resource.ap, 1)
-      .effect({ type: 'building', method: 'add', params: { id: '$id' } })
+      .effect(
+        effect(Types.Building, BuildingMethods.ADD).param('id', '$id').build(),
+      )
       .build(),
   );
 
@@ -193,18 +247,3 @@ export function createActionRegistry() {
 }
 
 export const ACTIONS = createActionRegistry();
-
-export const ACTION_INFO: Record<string, { icon: string; label: string }> = {
-  expand: { icon: '🌱', label: ACTIONS.get('expand').name },
-  overwork: { icon: '🛠️', label: ACTIONS.get('overwork').name },
-  develop: { icon: '🏗️', label: ACTIONS.get('develop').name },
-  tax: { icon: '💰', label: ACTIONS.get('tax').name },
-  reallocate: { icon: '🔄', label: ACTIONS.get('reallocate').name },
-  raise_pop: { icon: '👶', label: ACTIONS.get('raise_pop').name },
-  royal_decree: { icon: '📜', label: ACTIONS.get('royal_decree').name },
-  army_attack: { icon: '🗡️', label: ACTIONS.get('army_attack').name },
-  hold_festival: { icon: '🎉', label: ACTIONS.get('hold_festival').name },
-  plow: { icon: '🚜', label: ACTIONS.get('plow').name },
-  till: { icon: '🧑‍🌾', label: ACTIONS.get('till').name },
-  build: { icon: '🏛️', label: ACTIONS.get('build').name },
-} as const;

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -1,7 +1,15 @@
 import { Registry } from '@kingdom-builder/engine/registry';
 import { Resource } from '@kingdom-builder/engine/state';
 import { buildingSchema } from '@kingdom-builder/engine/config/schema';
-import { building } from '@kingdom-builder/engine/config/builders';
+import {
+  building,
+  effect,
+  Types,
+  CostModMethods,
+  ResultModMethods,
+  ResourceMethods,
+  ActionMethods,
+} from '@kingdom-builder/engine/config/builders';
 import type { BuildingDef } from './defs';
 
 export type { BuildingDef } from './defs';
@@ -11,111 +19,148 @@ export function createBuildingRegistry() {
 
   registry.add(
     'town_charter',
-    building('town_charter', 'Town Charter')
+    building()
+      .id('town_charter')
+      .name('Town Charter')
+      .icon('🏘️')
       .cost(Resource.gold, 5)
-      .onBuild({
-        type: 'cost_mod',
-        method: 'add',
-        params: {
-          id: 'tc_expand_cost',
-          actionId: 'expand',
-          key: Resource.gold,
-          amount: 2,
-        },
-      })
-      .onBuild({
-        type: 'result_mod',
-        method: 'add',
-        params: { id: 'tc_expand_result', actionId: 'expand' },
-        effects: [
-          {
-            type: 'resource',
-            method: 'add',
-            params: { key: Resource.happiness, amount: 1 },
-          },
-        ],
-      })
+      .onBuild(
+        effect(Types.CostMod, CostModMethods.ADD)
+          .params({
+            id: 'tc_expand_cost',
+            actionId: 'expand',
+            key: Resource.gold,
+            amount: 2,
+          })
+          .build(),
+      )
+      .onBuild(
+        effect(Types.ResultMod, ResultModMethods.ADD)
+          .params({ id: 'tc_expand_result', actionId: 'expand' })
+          .effect(
+            effect(Types.Resource, ResourceMethods.ADD)
+              .params({ key: Resource.happiness, amount: 1 })
+              .build(),
+          )
+          .build(),
+      )
       .build(),
   );
 
   // TODO: remaining buildings from original manual config
   registry.add(
     'mill',
-    building('mill', 'Mill')
+    building()
+      .id('mill')
+      .name('Mill')
+      .icon('⚙️')
       .cost(Resource.gold, 7)
-      .onBuild({
-        type: 'result_mod',
-        method: 'add',
-        params: {
-          id: 'mill_farm_bonus',
-          evaluation: { type: 'development', id: 'farm' },
-          amount: 1,
-        },
-      })
+      .onBuild(
+        effect(Types.ResultMod, ResultModMethods.ADD)
+          .params({
+            id: 'mill_farm_bonus',
+            evaluation: { type: 'development', id: 'farm' },
+            amount: 1,
+          })
+          .build(),
+      )
       .build(),
   );
   registry.add(
     'raiders_guild',
-    building('raiders_guild', "Raider's Guild").cost(Resource.gold, 8).build(),
+    building()
+      .id('raiders_guild')
+      .name("Raider's Guild")
+      .icon('🏴‍☠️')
+      .cost(Resource.gold, 8)
+      .build(),
   );
   registry.add(
     'plow_workshop',
-    building('plow_workshop', 'Plow Workshop')
+    building()
+      .id('plow_workshop')
+      .name('Plow Workshop')
+      .icon('🏭')
       .cost(Resource.gold, 10)
-      .onBuild({ type: 'action', method: 'add', params: { id: 'plow' } })
+      .onBuild(
+        effect(Types.Action, ActionMethods.ADD).param('id', 'plow').build(),
+      )
       .build(),
   );
   registry.add(
     'market',
-    building('market', 'Market').cost(Resource.gold, 10).build(),
+    building()
+      .id('market')
+      .name('Market')
+      .icon('🏪')
+      .cost(Resource.gold, 10)
+      .build(),
   );
   registry.add(
     'barracks',
-    building('barracks', 'Barracks').cost(Resource.gold, 12).build(),
+    building()
+      .id('barracks')
+      .name('Barracks')
+      .icon('🪖')
+      .cost(Resource.gold, 12)
+      .build(),
   );
   registry.add(
     'citadel',
-    building('citadel', 'Citadel').cost(Resource.gold, 12).build(),
+    building()
+      .id('citadel')
+      .name('Citadel')
+      .icon('🏯')
+      .cost(Resource.gold, 12)
+      .build(),
   );
   registry.add(
     'castle_walls',
-    building('castle_walls', 'Castle Walls').cost(Resource.gold, 14).build(),
+    building()
+      .id('castle_walls')
+      .name('Castle Walls')
+      .icon('🧱')
+      .cost(Resource.gold, 14)
+      .build(),
   );
   registry.add(
     'castle_gardens',
-    building('castle_gardens', 'Castle Gardens')
+    building()
+      .id('castle_gardens')
+      .name('Castle Gardens')
+      .icon('🌷')
       .cost(Resource.gold, 15)
       .build(),
   );
   registry.add(
     'temple',
-    building('temple', 'Temple').cost(Resource.gold, 16).build(),
+    building()
+      .id('temple')
+      .name('Temple')
+      .icon('⛪')
+      .cost(Resource.gold, 16)
+      .build(),
   );
   registry.add(
     'palace',
-    building('palace', 'Palace').cost(Resource.gold, 20).build(),
+    building()
+      .id('palace')
+      .name('Palace')
+      .icon('👑')
+      .cost(Resource.gold, 20)
+      .build(),
   );
   registry.add(
     'great_hall',
-    building('great_hall', 'Great Hall').cost(Resource.gold, 22).build(),
+    building()
+      .id('great_hall')
+      .name('Great Hall')
+      .icon('🏟️')
+      .cost(Resource.gold, 22)
+      .build(),
   );
 
   return registry;
 }
 
 export const BUILDINGS = createBuildingRegistry();
-
-export const BUILDING_INFO: Record<string, { icon: string; label: string }> = {
-  town_charter: { icon: '🏘️', label: BUILDINGS.get('town_charter').name },
-  mill: { icon: '⚙️', label: BUILDINGS.get('mill').name },
-  raiders_guild: { icon: '🏴‍☠️', label: BUILDINGS.get('raiders_guild').name },
-  plow_workshop: { icon: '🏭', label: BUILDINGS.get('plow_workshop').name },
-  market: { icon: '🏪', label: BUILDINGS.get('market').name },
-  barracks: { icon: '🪖', label: BUILDINGS.get('barracks').name },
-  citadel: { icon: '🏯', label: BUILDINGS.get('citadel').name },
-  castle_walls: { icon: '🧱', label: BUILDINGS.get('castle_walls').name },
-  castle_gardens: { icon: '🌷', label: BUILDINGS.get('castle_gardens').name },
-  temple: { icon: '⛪', label: BUILDINGS.get('temple').name },
-  palace: { icon: '👑', label: BUILDINGS.get('palace').name },
-  great_hall: { icon: '🏟️', label: BUILDINGS.get('great_hall').name },
-};

--- a/packages/contents/src/developments.ts
+++ b/packages/contents/src/developments.ts
@@ -1,7 +1,13 @@
 import { Registry } from '@kingdom-builder/engine/registry';
 import { Stat } from '@kingdom-builder/engine/state';
 import { developmentSchema } from '@kingdom-builder/engine/config/schema';
-import { development } from '@kingdom-builder/engine/config/builders';
+import {
+  development,
+  effect,
+  Types,
+  StatMethods,
+  DevelopmentMethods,
+} from '@kingdom-builder/engine/config/builders';
 import type { DevelopmentDef } from './defs';
 
 export type { DevelopmentDef } from './defs';
@@ -9,68 +15,74 @@ export type { DevelopmentDef } from './defs';
 export function createDevelopmentRegistry() {
   const registry = new Registry<DevelopmentDef>(developmentSchema);
 
-  registry.add('farm', development('farm', 'Farm').build());
+  registry.add(
+    'farm',
+    development().id('farm').name('Farm').icon('🌾').build(),
+  );
 
   registry.add(
     'house',
-    development('house', 'House')
-      .onBuild({
-        type: 'stat',
-        method: 'add',
-        params: { key: Stat.maxPopulation, amount: 1 },
-      })
+    development()
+      .id('house')
+      .name('House')
+      .icon('🏠')
+      .onBuild(
+        effect(Types.Stat, StatMethods.ADD)
+          .params({ key: Stat.maxPopulation, amount: 1 })
+          .build(),
+      )
       .build(),
   );
 
   registry.add(
     'outpost',
-    development('outpost', 'Outpost')
-      .onBuild({
-        type: 'stat',
-        method: 'add',
-        params: { key: Stat.armyStrength, amount: 1 },
-      })
-      .onBuild({
-        type: 'stat',
-        method: 'add',
-        params: { key: Stat.fortificationStrength, amount: 1 },
-      })
+    development()
+      .id('outpost')
+      .name('Outpost')
+      .icon('🏹')
+      .onBuild(
+        effect(Types.Stat, StatMethods.ADD)
+          .params({ key: Stat.armyStrength, amount: 1 })
+          .build(),
+      )
+      .onBuild(
+        effect(Types.Stat, StatMethods.ADD)
+          .params({ key: Stat.fortificationStrength, amount: 1 })
+          .build(),
+      )
       .build(),
   );
 
   registry.add(
     'watchtower',
-    development('watchtower', 'Watchtower')
-      .onBuild({
-        type: 'stat',
-        method: 'add',
-        params: { key: Stat.fortificationStrength, amount: 2 },
-      })
-      .onBuild({
-        type: 'stat',
-        method: 'add',
-        params: { key: Stat.absorption, amount: 0.5 },
-      })
-      .onAttackResolved({
-        type: 'development',
-        method: 'remove',
-        params: { id: 'watchtower', landId: '$landId' },
-      })
+    development()
+      .id('watchtower')
+      .name('Watchtower')
+      .icon('🗼')
+      .onBuild(
+        effect(Types.Stat, StatMethods.ADD)
+          .params({ key: Stat.fortificationStrength, amount: 2 })
+          .build(),
+      )
+      .onBuild(
+        effect(Types.Stat, StatMethods.ADD)
+          .params({ key: Stat.absorption, amount: 0.5 })
+          .build(),
+      )
+      .onAttackResolved(
+        effect(Types.Development, DevelopmentMethods.REMOVE)
+          .params({ id: 'watchtower', landId: '$landId' })
+          .build(),
+      )
       .build(),
   );
 
-  registry.add('garden', development('garden', 'Garden').system().build());
+  registry.add(
+    'garden',
+    development().id('garden').name('Garden').icon('🌿').system().build(),
+  );
 
   return registry;
 }
 
 export const DEVELOPMENTS = createDevelopmentRegistry();
-
-export const DEVELOPMENT_INFO: Record<string, { icon: string; label: string }> =
-  {
-    house: { icon: '🏠', label: DEVELOPMENTS.get('house').name },
-    farm: { icon: '🌾', label: DEVELOPMENTS.get('farm').name },
-    outpost: { icon: '🏹', label: DEVELOPMENTS.get('outpost').name },
-    watchtower: { icon: '🗼', label: DEVELOPMENTS.get('watchtower').name },
-    garden: { icon: '🌿', label: DEVELOPMENTS.get('garden').name },
-  };

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -1,12 +1,8 @@
-export { ACTIONS, ACTION_INFO, createActionRegistry } from './actions';
-export { BUILDINGS, BUILDING_INFO, createBuildingRegistry } from './buildings';
-export {
-  DEVELOPMENTS,
-  DEVELOPMENT_INFO,
-  createDevelopmentRegistry,
-} from './developments';
+export { ACTIONS, createActionRegistry } from './actions';
+export { BUILDINGS, createBuildingRegistry } from './buildings';
+export { DEVELOPMENTS, createDevelopmentRegistry } from './developments';
 export { POPULATIONS, createPopulationRegistry } from './populations';
-export { PHASES, PHASE_INFO, type PhaseDef, type StepDef } from './phases';
+export { PHASES, type PhaseDef, type StepDef } from './phases';
 export { POPULATION_ROLES } from './populationRoles';
 export { RESOURCES } from './resources';
 export { STATS } from './stats';

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -1,6 +1,12 @@
 import type { TriggerKey } from './defs';
 import { Resource, PopulationRole, Stat } from '@kingdom-builder/engine/state';
 import type { EffectDef } from '@kingdom-builder/engine/effects';
+import {
+  effect,
+  Types,
+  ResourceMethods,
+  StatMethods,
+} from '@kingdom-builder/engine/config/builders';
 
 export interface StepDef {
   id: string;
@@ -15,7 +21,7 @@ export interface PhaseDef {
   steps: StepDef[];
   action?: boolean;
   label: string;
-  icon: string;
+  icon?: string;
 }
 
 export const PHASES: PhaseDef[] = [
@@ -34,67 +40,53 @@ export const PHASES: PhaseDef[] = [
         title: 'Gain Income',
         icon: '💰',
         effects: [
-          {
-            evaluator: { type: 'development', params: { id: 'farm' } },
-            effects: [
-              {
-                type: 'resource',
-                method: 'add',
-                params: { key: Resource.gold, amount: 2 },
-              },
-            ],
-          },
+          effect()
+            .evaluator('development', { id: 'farm' })
+            .effect(
+              effect(Types.Resource, ResourceMethods.ADD)
+                .params({ key: Resource.gold, amount: 2 })
+                .build(),
+            )
+            .build(),
         ],
       },
       {
         id: 'gain-ap',
         title: 'Gain Action Points',
         effects: [
-          {
-            evaluator: {
-              type: 'population',
-              params: { role: PopulationRole.Council },
-            },
-            effects: [
-              {
-                type: 'resource',
-                method: 'add',
-                params: { key: Resource.ap, amount: 1 },
-              },
-            ],
-          },
+          effect()
+            .evaluator('population', { role: PopulationRole.Council })
+            .effect(
+              effect(Types.Resource, ResourceMethods.ADD)
+                .params({ key: Resource.ap, amount: 1 })
+                .build(),
+            )
+            .build(),
         ],
       },
       {
         id: 'raise-strength',
         title: 'Raise Strength',
         effects: [
-          {
-            evaluator: {
-              type: 'population',
-              params: { role: PopulationRole.Commander },
-            },
-            effects: [
-              {
-                type: 'stat',
-                method: 'add_pct',
-                params: { key: Stat.armyStrength, percent: 25 },
-              },
-            ],
-          },
-          {
-            evaluator: {
-              type: 'population',
-              params: { role: PopulationRole.Fortifier },
-            },
-            effects: [
-              {
-                type: 'stat',
-                method: 'add_pct',
-                params: { key: Stat.fortificationStrength, percent: 25 },
-              },
-            ],
-          },
+          effect()
+            .evaluator('population', { role: PopulationRole.Commander })
+            .effect(
+              effect(Types.Stat, StatMethods.ADD_PCT)
+                .params({ key: Stat.armyStrength, percent: 25 })
+                .build(),
+            )
+            .build(),
+          effect()
+            .evaluator('population', { role: PopulationRole.Fortifier })
+            .effect(
+              effect(Types.Stat, StatMethods.ADD_PCT)
+                .params({
+                  key: Stat.fortificationStrength,
+                  percent: 25,
+                })
+                .build(),
+            )
+            .build(),
         ],
       },
     ],
@@ -113,45 +105,30 @@ export const PHASES: PhaseDef[] = [
         id: 'pay-upkeep',
         title: 'Pay Upkeep',
         effects: [
-          {
-            evaluator: {
-              type: 'population',
-              params: { role: PopulationRole.Council },
-            },
-            effects: [
-              {
-                type: 'resource',
-                method: 'remove',
-                params: { key: Resource.gold, amount: 2 },
-              },
-            ],
-          },
-          {
-            evaluator: {
-              type: 'population',
-              params: { role: PopulationRole.Commander },
-            },
-            effects: [
-              {
-                type: 'resource',
-                method: 'remove',
-                params: { key: Resource.gold, amount: 1 },
-              },
-            ],
-          },
-          {
-            evaluator: {
-              type: 'population',
-              params: { role: PopulationRole.Fortifier },
-            },
-            effects: [
-              {
-                type: 'resource',
-                method: 'remove',
-                params: { key: Resource.gold, amount: 1 },
-              },
-            ],
-          },
+          effect()
+            .evaluator('population', { role: PopulationRole.Council })
+            .effect(
+              effect(Types.Resource, ResourceMethods.REMOVE)
+                .params({ key: Resource.gold, amount: 2 })
+                .build(),
+            )
+            .build(),
+          effect()
+            .evaluator('population', { role: PopulationRole.Commander })
+            .effect(
+              effect(Types.Resource, ResourceMethods.REMOVE)
+                .params({ key: Resource.gold, amount: 1 })
+                .build(),
+            )
+            .build(),
+          effect()
+            .evaluator('population', { role: PopulationRole.Fortifier })
+            .effect(
+              effect(Types.Resource, ResourceMethods.REMOVE)
+                .params({ key: Resource.gold, amount: 1 })
+                .build(),
+            )
+            .build(),
         ],
       },
     ],
@@ -164,8 +141,3 @@ export const PHASES: PhaseDef[] = [
     steps: [{ id: 'main', title: 'Main Phase' }],
   },
 ];
-
-export const PHASE_INFO: Record<string, { icon: string; label: string }> =
-  Object.fromEntries(
-    PHASES.map((p) => [p.id, { icon: p.icon, label: p.label }]),
-  );

--- a/packages/contents/src/populations.ts
+++ b/packages/contents/src/populations.ts
@@ -1,7 +1,14 @@
 import { Registry } from '@kingdom-builder/engine/registry';
 import { PopulationRole, Resource, Stat } from '@kingdom-builder/engine/state';
 import { populationSchema } from '@kingdom-builder/engine/config/schema';
-import { population } from '@kingdom-builder/engine/config/builders';
+import {
+  population,
+  effect,
+  Types,
+  ResourceMethods,
+  PassiveMethods,
+  StatMethods,
+} from '@kingdom-builder/engine/config/builders';
 import type { PopulationDef } from './defs';
 
 export type { PopulationDef } from './defs';
@@ -11,69 +18,74 @@ export function createPopulationRegistry() {
 
   registry.add(
     PopulationRole.Council,
-    population(PopulationRole.Council, 'Council')
-      .onAssigned({
-        type: 'resource',
-        method: 'add',
-        params: { key: Resource.ap, amount: 1 },
-      })
-      .onUnassigned({
-        type: 'resource',
-        method: 'remove',
-        params: { key: Resource.ap, amount: 1 },
-      })
+    population()
+      .id(PopulationRole.Council)
+      .name('Council')
+      .icon('⚖️')
+      .onAssigned(
+        effect(Types.Resource, ResourceMethods.ADD)
+          .params({ key: Resource.ap, amount: 1 })
+          .build(),
+      )
+      .onUnassigned(
+        effect(Types.Resource, ResourceMethods.REMOVE)
+          .params({ key: Resource.ap, amount: 1 })
+          .build(),
+      )
       .build(),
   );
 
   registry.add(
     PopulationRole.Commander,
-    population(PopulationRole.Commander, 'Army Commander')
-      .onAssigned({
-        type: 'passive',
-        method: 'add',
-        params: { id: 'commander_$player_$index' },
-        effects: [
-          {
-            type: 'stat',
-            method: 'add',
-            params: { key: Stat.armyStrength, amount: 1 },
-          },
-        ],
-      })
-      .onUnassigned({
-        type: 'passive',
-        method: 'remove',
-        params: { id: 'commander_$player_$index' },
-      })
+    population()
+      .id(PopulationRole.Commander)
+      .name('Army Commander')
+      .icon('🎖️')
+      .onAssigned(
+        effect(Types.Passive, PassiveMethods.ADD)
+          .param('id', 'commander_$player_$index')
+          .effect(
+            effect(Types.Stat, StatMethods.ADD)
+              .params({ key: Stat.armyStrength, amount: 1 })
+              .build(),
+          )
+          .build(),
+      )
+      .onUnassigned(
+        effect(Types.Passive, PassiveMethods.REMOVE)
+          .param('id', 'commander_$player_$index')
+          .build(),
+      )
       .build(),
   );
 
   registry.add(
     PopulationRole.Fortifier,
-    population(PopulationRole.Fortifier, 'Fortifier')
-      .onAssigned({
-        type: 'passive',
-        method: 'add',
-        params: { id: 'fortifier_$player_$index' },
-        effects: [
-          {
-            type: 'stat',
-            method: 'add',
-            params: { key: Stat.fortificationStrength, amount: 1 },
-          },
-        ],
-      })
-      .onUnassigned({
-        type: 'passive',
-        method: 'remove',
-        params: { id: 'fortifier_$player_$index' },
-      })
+    population()
+      .id(PopulationRole.Fortifier)
+      .name('Fortifier')
+      .icon('🔧')
+      .onAssigned(
+        effect(Types.Passive, PassiveMethods.ADD)
+          .param('id', 'fortifier_$player_$index')
+          .effect(
+            effect(Types.Stat, StatMethods.ADD)
+              .params({ key: Stat.fortificationStrength, amount: 1 })
+              .build(),
+          )
+          .build(),
+      )
+      .onUnassigned(
+        effect(Types.Passive, PassiveMethods.REMOVE)
+          .param('id', 'fortifier_$player_$index')
+          .build(),
+      )
       .build(),
   );
 
   registry.add(
     PopulationRole.Citizen,
-    population(PopulationRole.Citizen, 'Citizen').build(),
+    population().id(PopulationRole.Citizen).name('Citizen').icon('👤').build(),
   );
 
   return registry;

--- a/packages/contents/src/triggers.ts
+++ b/packages/contents/src/triggers.ts
@@ -1,4 +1,4 @@
-import { PHASES, PHASE_INFO } from './phases';
+import { PHASES } from './phases';
 
 const phaseTriggers = Object.fromEntries(
   PHASES.map((p) => [
@@ -23,9 +23,9 @@ export const TRIGGER_INFO = {
     past: 'After attack',
   },
   mainPhase: {
-    icon: PHASE_INFO['main']?.icon || '🎯',
+    icon: PHASES.find((p) => p.id === 'main')?.icon || '🎯',
     future: '',
-    past: `${PHASE_INFO['main']?.label || 'Main'} phase`,
+    past: `${PHASES.find((p) => p.id === 'main')?.label || 'Main'} phase`,
   },
   ...phaseTriggers,
 } as const;

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -37,6 +37,7 @@ export type EffectConfig = EffectDef;
 export const actionSchema = z.object({
   id: z.string(),
   name: z.string(),
+  icon: z.string().optional(),
   baseCosts: costBagSchema.optional(),
   requirements: z.array(requirementSchema).optional(),
   effects: z.array(effectSchema),
@@ -49,6 +50,7 @@ export type ActionConfig = z.infer<typeof actionSchema>;
 export const buildingSchema = z.object({
   id: z.string(),
   name: z.string(),
+  icon: z.string().optional(),
   costs: costBagSchema,
   onBuild: z.array(effectSchema).optional(),
   onDevelopmentPhase: z.array(effectSchema).optional(),
@@ -62,6 +64,7 @@ export type BuildingConfig = z.infer<typeof buildingSchema>;
 export const developmentSchema = z.object({
   id: z.string(),
   name: z.string(),
+  icon: z.string().optional(),
   onBuild: z.array(effectSchema).optional(),
   onDevelopmentPhase: z.array(effectSchema).optional(),
   onAttackResolved: z.array(effectSchema).optional(),
@@ -74,6 +77,7 @@ export type DevelopmentConfig = z.infer<typeof developmentSchema>;
 export const populationSchema = z.object({
   id: z.string(),
   name: z.string(),
+  icon: z.string().optional(),
   onAssigned: z.array(effectSchema).optional(),
   onUnassigned: z.array(effectSchema).optional(),
   onDevelopmentPhase: z.array(effectSchema).optional(),

--- a/packages/engine/tests/actions/multi_cost.test.ts
+++ b/packages/engine/tests/actions/multi_cost.test.ts
@@ -10,7 +10,9 @@ import { action, building } from '../../src/config/builders.ts';
 
 describe('multi-cost content', () => {
   it('supports actions with multiple costs', () => {
-    const multiCostAction = action('multi_cost_action', 'Multi Cost Action')
+    const multiCostAction = action()
+      .id('multi_cost_action')
+      .name('Multi Cost Action')
       .cost(Resource.gold, 3)
       .cost(Resource.happiness, 2)
       .effect({
@@ -36,18 +38,16 @@ describe('multi-cost content', () => {
   });
 
   it('supports building actions with multiple costs', () => {
-    const multiCostBuildingDefinition = building(
-      'multi_cost_building',
-      'Multi Cost Building',
-    )
+    const multiCostBuildingDefinition = building()
+      .id('multi_cost_building')
+      .name('Multi Cost Building')
       .cost(Resource.gold, 4)
       .cost(Resource.happiness, 1)
       .build();
 
-    const buildAction = action(
-      'build_multi_cost_building',
-      'Build Multi Cost Building',
-    )
+    const buildAction = action()
+      .id('build_multi_cost_building')
+      .name('Build Multi Cost Building')
       .cost(Resource.gold, 4)
       .cost(Resource.happiness, 1)
       .effect({

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Game from './Game';
 import {
-  ACTION_INFO as actionInfo,
+  ACTIONS as actionInfo,
   LAND_ICON as landIcon,
   SLOT_ICON as slotIcon,
   RESOURCES,
@@ -59,10 +59,10 @@ export default function App() {
         <h2 className="text-xl font-semibold mt-4 mb-2">Core Mechanics</h2>
         <p className="mb-4">
           Actions may require resources or other prerequisites and grant various
-          effects, such as gaining resources, {actionInfo['build']?.icon}{' '}
-          building structures, {actionInfo['develop']?.icon} developing{' '}
+          effects, such as gaining resources, {actionInfo.get('build')?.icon}{' '}
+          building structures, {actionInfo.get('develop')?.icon} developing{' '}
           {landIcon} land, or hindering your opponent.{' '}
-          {actionInfo['build']?.icon} Buildings provide ♾️ passive bonuses,
+          {actionInfo.get('build')?.icon} Buildings provide ♾️ passive bonuses,
           while {landIcon} land around your castle holds {slotIcon} developments
           that yield benefits. Resources like
           {RESOURCES[Resource.gold].icon} Gold, {RESOURCES[Resource.ap].icon}{' '}

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -8,9 +8,6 @@ import {
 import {
   RESOURCES,
   POPULATION_ROLES,
-  ACTION_INFO as actionInfo,
-  DEVELOPMENT_INFO as developmentInfo,
-  BUILDING_INFO as buildingInfo,
   SLOT_ICON as slotIcon,
 } from '@kingdom-builder/contents';
 import {
@@ -91,7 +88,7 @@ function GenericActions({
             onClick={() => enabled && handlePerform(action)}
             onMouseEnter={() =>
               handleHoverCard({
-                title: `${actionInfo[action.id]?.icon || ''} ${action.name}`,
+                title: `${ctx.actions.get(action.id)?.icon || ''} ${action.name}`,
                 effects: describeContent('action', action.id, ctx),
                 requirements,
                 costs,
@@ -105,7 +102,7 @@ function GenericActions({
             onMouseLeave={clearHoverCard}
           >
             <span className="text-base font-medium">
-              {actionInfo[action.id]?.icon || ''} {action.name}
+              {ctx.actions.get(action.id)?.icon || ''} {action.name}
             </span>
             <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
               {renderCosts(costs, ctx.activePlayer.resources)}
@@ -179,7 +176,7 @@ function RaisePopOptions({
             onClick={() => enabled && handlePerform(action, { role })}
             onMouseEnter={() =>
               handleHoverCard({
-                title: `${actionInfo['raise_pop']?.icon ?? ''}${
+                title: `${ctx.actions.get('raise_pop').icon || ''}${
                   POPULATION_ROLES[role]?.icon
                 } - Hire ${POPULATION_ROLES[role]?.label || ''}`,
                 effects: summary,
@@ -191,7 +188,7 @@ function RaisePopOptions({
             onMouseLeave={clearHoverCard}
           >
             <span className="text-base font-medium">
-              {actionInfo['raise_pop']?.icon ?? ''}
+              {ctx.actions.get('raise_pop').icon || ''}
               {POPULATION_ROLES[role]?.icon} - Hire{' '}
               {POPULATION_ROLES[role]?.label}
             </span>
@@ -267,7 +264,8 @@ function DevelopOptions({
   return (
     <div>
       <h3 className="font-medium">
-        {actionInfo['develop']?.icon ?? ''} {actionInfo['develop']?.label ?? ''}{' '}
+        {ctx.actions.get('develop').icon || ''}{' '}
+        {ctx.actions.get('develop').name}{' '}
         <span className="italic text-sm font-normal">
           (Effects take place on build and last until development is removed)
         </span>
@@ -318,9 +316,9 @@ function DevelopOptions({
               }}
               onMouseEnter={() =>
                 handleHoverCard({
-                  title: `${actionInfo['develop']?.icon ?? ''} ${
-                    actionInfo['develop']?.label ?? ''
-                  } - ${developmentInfo[d.id]?.icon} ${d.name}`,
+                  title: `${ctx.actions.get('develop').icon || ''} ${
+                    ctx.actions.get('develop').name
+                  } - ${ctx.developments.get(d.id)?.icon} ${d.name}`,
                   effects: describeContent('development', d.id, ctx),
                   requirements,
                   costs,
@@ -334,7 +332,7 @@ function DevelopOptions({
               onMouseLeave={clearHoverCard}
             >
               <span className="text-base font-medium">
-                {developmentInfo[d.id]?.icon} {d.name}
+                {ctx.developments.get(d.id)?.icon} {d.name}
               </span>
               <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
                 {renderCosts(costs, ctx.activePlayer.resources)}
@@ -377,7 +375,7 @@ function BuildOptions({
   return (
     <div>
       <h3 className="font-medium">
-        {actionInfo['build']?.icon ?? ''} {actionInfo['build']?.label ?? ''}{' '}
+        {ctx.actions.get('build').icon || ''} {ctx.actions.get('build').name}{' '}
         <span className="italic text-sm font-normal">
           (Effects take place on build and last until building is removed)
         </span>
@@ -412,9 +410,9 @@ function BuildOptions({
               onClick={() => enabled && handlePerform(action, { id: b.id })}
               onMouseEnter={() =>
                 handleHoverCard({
-                  title: `${actionInfo['build']?.icon ?? ''} ${
-                    actionInfo['build']?.label ?? ''
-                  } - ${buildingInfo[b.id]?.icon || ''} ${b.name}`,
+                  title: `${ctx.actions.get('build').icon || ''} ${
+                    ctx.actions.get('build').name
+                  } - ${ctx.buildings.get(b.id)?.icon || ''} ${b.name}`,
                   effects: descriptions.get(b.id) ?? [],
                   requirements,
                   costs,
@@ -428,7 +426,9 @@ function BuildOptions({
               onMouseLeave={clearHoverCard}
             >
               <span className="text-base font-medium">
-                {buildingInfo[b.id]?.icon || actionInfo['build']?.icon || ''}{' '}
+                {ctx.buildings.get(b.id)?.icon ||
+                  ctx.actions.get('build').icon ||
+                  ''}{' '}
                 {b.name}
               </span>
               <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">

--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -70,7 +70,7 @@ const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
                   : ''
               }`}
             >
-              {p?.icon} {p?.label}
+              {p.icon} {p.label}
             </button>
           );
         })}

--- a/packages/web/src/components/player/BuildingDisplay.tsx
+++ b/packages/web/src/components/player/BuildingDisplay.tsx
@@ -1,8 +1,4 @@
 import React from 'react';
-import {
-  ACTION_INFO as actionInfo,
-  BUILDING_INFO as buildingInfo,
-} from '@kingdom-builder/contents';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { describeContent } from '../../translation';
 import { useGameEngine } from '../../state/GameContext';
@@ -18,7 +14,8 @@ const BuildingDisplay: React.FC<BuildingDisplayProps> = ({ player }) => {
     <div className="flex flex-wrap gap-2 mt-2 w-fit">
       {Array.from(player.buildings).map((b) => {
         const name = ctx.buildings.get(b)?.name || b;
-        const icon = buildingInfo[b]?.icon || actionInfo['build']?.icon || '';
+        const icon =
+          ctx.buildings.get(b)?.icon || ctx.actions.get('build').icon || '';
         const title = `${icon} ${name}`;
         return (
           <div

--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import {
-  ACTION_INFO as actionInfo,
-  DEVELOPMENT_INFO as developmentInfo,
   LAND_ICON as landIcon,
   SLOT_ICON as slotIcon,
 } from '@kingdom-builder/contents';
@@ -40,7 +38,7 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
                 const devId = land.developments[i];
                 if (devId) {
                   const name = ctx.developments.get(devId)?.name || devId;
-                  const title = `${developmentInfo[devId]?.icon || ''} ${name}`;
+                  const title = `${ctx.developments.get(devId)?.icon || ''} ${name}`;
                   const handleLeave = () => showLandCard();
                   return (
                     <span
@@ -62,7 +60,7 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
                         handleLeave();
                       }}
                     >
-                      {developmentInfo[devId]?.icon} {name}
+                      {ctx.developments.get(devId)?.icon} {name}
                     </span>
                   );
                 }
@@ -76,8 +74,8 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
                       handleHoverCard({
                         title: `${slotIcon} Development Slot (empty)`,
                         effects: [],
-                        description: `Use ${actionInfo['develop']?.icon ?? ''} ${
-                          actionInfo['develop']?.label ?? ''
+                        description: `Use ${ctx.actions.get('develop').icon || ''} ${
+                          ctx.actions.get('develop').name
                         } to build here`,
                         requirements: [],
                         bgClass: 'bg-gray-100 dark:bg-gray-700',

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -17,7 +17,6 @@ import {
 } from '@kingdom-builder/engine';
 import {
   RESOURCES,
-  ACTION_INFO as actionInfo,
   ACTIONS,
   BUILDINGS,
   DEVELOPMENTS,
@@ -301,7 +300,7 @@ export function GameProvider({
         const subChanges = diffSnapshots(trace.before, trace.after, ctx);
         if (!subChanges.length) continue;
         subLines.push(...subChanges);
-        const icon = actionInfo[trace.id]?.icon || '';
+        const icon = ctx.actions.get(trace.id)?.icon || '';
         const name = ctx.actions.get(trace.id).name;
         const line = `  ${icon} ${name}`;
         const idx = messages.indexOf(line);
@@ -327,7 +326,7 @@ export function GameProvider({
       });
       addLog([...messages, ...filtered.map((c) => `  ${c}`)]);
     } catch (e) {
-      const icon = actionInfo[action.id]?.icon || '';
+      const icon = ctx.actions.get(action.id)?.icon || '';
       addLog(`Failed to play ${icon} ${action.name}: ${(e as Error).message}`);
       return;
     }
@@ -366,7 +365,7 @@ export function GameProvider({
       while (ctx.activePlayer.ap > 0) {
         handlePerform({
           id: 'tax',
-          name: actionInfo['tax']!.label,
+          name: ctx.actions.get('tax').name,
           system: true,
         });
       }

--- a/packages/web/src/translation/content/action.ts
+++ b/packages/web/src/translation/content/action.ts
@@ -1,5 +1,4 @@
 import type { EngineContext } from '@kingdom-builder/engine';
-import { ACTION_INFO as actionInfo } from '@kingdom-builder/contents';
 import { summarizeEffects, describeEffects, logEffects } from '../effects';
 import { applyParamsToEffects } from '@kingdom-builder/engine';
 import { registerContentTranslator, logContent } from './factory';
@@ -61,9 +60,8 @@ class ActionTranslator
     params?: Record<string, unknown>,
   ): string[] {
     const def = ctx.actions.get(id);
-    const info = actionInfo[id];
-    const icon = info?.icon || '';
-    const label = info?.label || def.name;
+    const icon = def.icon || '';
+    const label = def.name;
     let message = `Played ${icon} ${label}`;
     const extra = this.logHandlers[id]?.(ctx, params);
     if (extra) message += extra;

--- a/packages/web/src/translation/content/building.ts
+++ b/packages/web/src/translation/content/building.ts
@@ -4,10 +4,6 @@ import type { ContentTranslator, Summary } from './types';
 import { PhasedTranslator } from './phased';
 import type { PhasedDef } from './phased';
 import { withInstallation } from './decorators';
-import {
-  BUILDING_INFO as buildingInfo,
-  ACTION_INFO as actionInfo,
-} from '@kingdom-builder/contents';
 
 class BuildingCore implements ContentTranslator<string> {
   private phased = new PhasedTranslator();
@@ -21,7 +17,7 @@ class BuildingCore implements ContentTranslator<string> {
   }
   log(id: string, ctx: EngineContext): string[] {
     const def = ctx.buildings.get(id);
-    const icon = buildingInfo[id]?.icon || actionInfo['build']?.icon || '';
+    const icon = def.icon || ctx.actions.get('build').icon || '';
     return [`${icon}${def.name}`];
   }
 }

--- a/packages/web/src/translation/content/development.ts
+++ b/packages/web/src/translation/content/development.ts
@@ -4,7 +4,6 @@ import type { ContentTranslator, Summary } from './types';
 import { PhasedTranslator } from './phased';
 import type { PhasedDef } from './phased';
 import { withInstallation } from './decorators';
-import { DEVELOPMENT_INFO as developmentInfo } from '@kingdom-builder/contents';
 
 interface PhaseEffects {
   onAttackResolved?: EffectDef[];
@@ -71,7 +70,7 @@ class DevelopmentCore implements ContentTranslator<string> {
   }
   log(id: string, ctx: EngineContext): string[] {
     const def = ctx.developments.get(id);
-    const icon = developmentInfo[id]?.icon || '';
+    const icon = def.icon || '';
     return [`${icon}${def.name}`];
   }
 }

--- a/packages/web/src/translation/content/land.ts
+++ b/packages/web/src/translation/content/land.ts
@@ -1,8 +1,5 @@
 import type { EngineContext } from '@kingdom-builder/engine';
-import {
-  DEVELOPMENT_INFO as developmentInfo,
-  SLOT_ICON as slotIcon,
-} from '@kingdom-builder/contents';
+import { SLOT_ICON as slotIcon } from '@kingdom-builder/contents';
 import {
   describeContent,
   summarizeContent,
@@ -25,7 +22,7 @@ function translate(
     const devId = land.developments[i];
     if (devId) {
       items.push({
-        title: `${developmentInfo[devId]?.icon || ''} ${
+        title: `${ctx.developments.get(devId)?.icon || ''} ${
           ctx.developments.get(devId)?.name || devId
         }`,
         items: fn('development', devId, ctx, { installed: true }),

--- a/packages/web/src/translation/content/phased.ts
+++ b/packages/web/src/translation/content/phased.ts
@@ -18,11 +18,12 @@ export class PhasedTranslator {
       const key =
         `on${phase.id.charAt(0).toUpperCase() + phase.id.slice(1)}Phase` as keyof PhasedDef;
       const eff = summarizeEffects(def[key], ctx);
-      if (eff.length)
+      if (eff.length) {
         root.push({
           title: `${phase.icon} On each ${phase.label} Phase`,
           items: eff,
         });
+      }
     }
     const atk = summarizeEffects(def.onAttackResolved, ctx);
     if (atk.length)
@@ -41,11 +42,12 @@ export class PhasedTranslator {
       const key =
         `on${phase.id.charAt(0).toUpperCase() + phase.id.slice(1)}Phase` as keyof PhasedDef;
       const eff = describeEffects(def[key], ctx);
-      if (eff.length)
+      if (eff.length) {
         root.push({
           title: `${phase.icon} On each ${phase.label} Phase`,
           items: eff,
         });
+      }
     }
     const atk = describeEffects(def.onAttackResolved, ctx);
     if (atk.length)

--- a/packages/web/src/translation/effects/evaluators/development.ts
+++ b/packages/web/src/translation/effects/evaluators/development.ts
@@ -1,25 +1,34 @@
-import { DEVELOPMENT_INFO as developmentInfo } from '@kingdom-builder/contents';
 import { registerEvaluatorFormatter } from '../factory';
 
 registerEvaluatorFormatter('development', {
-  summarize: (ev, sub) => {
+  summarize: (ev, sub, ctx) => {
     const devId = (ev.params as Record<string, string>)['id']!;
-    const icon = developmentInfo[devId]?.icon || devId;
+    let icon = devId;
+    try {
+      icon = ctx.developments.get(devId).icon || devId;
+    } catch {
+      /* ignore */
+    }
     return sub.map((s) =>
       typeof s === 'string'
         ? `${s} per ${icon}`
         : { ...s, title: `${s.title} per ${icon}` },
     );
   },
-  describe: (ev, sub) => {
+  describe: (ev, sub, ctx) => {
     const devId = (ev.params as Record<string, string>)['id']!;
-    const info = developmentInfo[devId];
+    let def: { name: string; icon?: string | undefined } | undefined;
+    try {
+      def = ctx.developments.get(devId);
+    } catch {
+      /* ignore */
+    }
     return sub.map((s) =>
       typeof s === 'string'
-        ? `${s} for each ${info?.icon || ''}${info?.label || devId}`
+        ? `${s} for each ${def?.icon || ''}${def?.name || devId}`
         : {
             ...s,
-            title: `${s.title} for each ${info?.icon || ''}${info?.label || devId}`,
+            title: `${s.title} for each ${def?.icon || ''}${def?.name || devId}`,
           },
     );
   },

--- a/packages/web/src/translation/effects/formatters/action.ts
+++ b/packages/web/src/translation/effects/formatters/action.ts
@@ -1,16 +1,17 @@
 import type { EngineContext } from '@kingdom-builder/engine';
-import { ACTION_INFO as actionInfo } from '@kingdom-builder/contents';
 import { describeContent } from '../../content';
 import { registerEffectFormatter, logEffects } from '../factory';
 
 function getActionLabel(id: string, ctx: EngineContext) {
   let name = id;
+  let icon = '';
   try {
-    name = ctx.actions.get(id).name;
+    const def = ctx.actions.get(id);
+    name = def.name;
+    icon = def.icon || '';
   } catch {
     // ignore missing action
   }
-  const icon = actionInfo[id]?.icon || '';
   return { icon, name };
 }
 

--- a/packages/web/src/translation/effects/formatters/building.ts
+++ b/packages/web/src/translation/effects/formatters/building.ts
@@ -1,30 +1,32 @@
-import {
-  BUILDING_INFO as buildingInfo,
-  ACTION_INFO as actionInfo,
-} from '@kingdom-builder/contents';
 import { registerEffectFormatter } from '../factory';
 
 registerEffectFormatter('building', 'add', {
   summarize: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     let name = id;
+    let icon = '';
     try {
-      name = ctx.buildings.get(id).name;
+      const def = ctx.buildings.get(id);
+      name = def.name;
+      icon = def.icon || '';
     } catch {
       // ignore
     }
-    const icon = buildingInfo[id]?.icon || actionInfo['build']?.icon || '';
+    if (!icon) icon = ctx.actions.get('build').icon || '';
     return `${icon}${name}`;
   },
   describe: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     let name = id;
+    let icon = '';
     try {
-      name = ctx.buildings.get(id).name;
+      const def = ctx.buildings.get(id);
+      name = def.name;
+      icon = def.icon || '';
     } catch {
       // ignore
     }
-    const icon = buildingInfo[id]?.icon || actionInfo['build']?.icon || '';
+    if (!icon) icon = ctx.actions.get('build').icon || '';
     return `Construct ${icon}${name}`;
   },
 });

--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -1,32 +1,51 @@
-import { DEVELOPMENT_INFO as developmentInfo } from '@kingdom-builder/contents';
 import { registerEffectFormatter } from '../factory';
 
 registerEffectFormatter('development', 'add', {
-  summarize: (eff) => {
+  summarize: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
-    const icon = developmentInfo[id]?.icon || id;
+    let icon = id;
+    try {
+      icon = ctx.developments.get(id).icon || id;
+    } catch {
+      /* ignore */
+    }
     return `${icon}`;
   },
-  describe: (eff) => {
+  describe: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
-    const info = developmentInfo[id];
-    const label = info?.label || id;
-    const icon = info?.icon || '';
+    let def: { name: string; icon?: string | undefined } | undefined;
+    try {
+      def = ctx.developments.get(id);
+    } catch {
+      /* ignore */
+    }
+    const label = def?.name || id;
+    const icon = def?.icon || '';
     return `Add ${icon}${label}`;
   },
 });
 
 registerEffectFormatter('development', 'remove', {
-  summarize: (eff) => {
+  summarize: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
-    const icon = developmentInfo[id]?.icon || id;
+    let icon = id;
+    try {
+      icon = ctx.developments.get(id).icon || id;
+    } catch {
+      /* ignore */
+    }
     return `Remove ${icon}`;
   },
-  describe: (eff) => {
+  describe: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
-    const info = developmentInfo[id];
-    const label = info?.label || id;
-    const icon = info?.icon || '';
+    let def: { name: string; icon?: string | undefined } | undefined;
+    try {
+      def = ctx.developments.get(id);
+    } catch {
+      /* ignore */
+    }
+    const label = def?.name || id;
+    const icon = def?.icon || '';
     return `Remove ${icon}${label}`;
   },
 });

--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -1,7 +1,5 @@
 import {
-  ACTION_INFO as actionInfo,
   MODIFIER_INFO as modifierInfo,
-  DEVELOPMENT_INFO as developmentInfo,
   RESOURCES,
 } from '@kingdom-builder/contents';
 import type { ResourceKey } from '@kingdom-builder/engine';
@@ -13,12 +11,14 @@ import {
 } from '../factory';
 
 registerEffectFormatter('cost_mod', 'add', {
-  summarize: (eff, _ctx) => {
+  summarize: (eff, ctx) => {
     const key = eff.params?.['key'] as string;
     const icon = RESOURCES[key as ResourceKey]?.icon || key;
     const amount = Number(eff.params?.['amount']);
     const actionId = eff.params?.['actionId'] as string | undefined;
-    const actionIcon = actionId ? actionInfo[actionId]?.icon || actionId : '';
+    const actionIcon = actionId
+      ? ctx.actions.get(actionId)?.icon || actionId
+      : '';
     const prefix = actionId ? `${actionIcon}: ` : ': ';
     return `${modifierInfo.cost.icon}${prefix}${icon}${signed(amount)}${Math.abs(amount)}`;
   },
@@ -27,7 +27,9 @@ registerEffectFormatter('cost_mod', 'add', {
     const icon = RESOURCES[key as ResourceKey]?.icon || key;
     const amount = Number(eff.params?.['amount']);
     const actionId = eff.params?.['actionId'] as string | undefined;
-    const actionIcon = actionId ? actionInfo[actionId]?.icon || actionId : '';
+    const actionIcon = actionId
+      ? ctx.actions.get(actionId)?.icon || actionId
+      : '';
     const actionName = actionId
       ? ctx.actions.get(actionId)?.name || actionId
       : 'all actions';
@@ -37,12 +39,14 @@ registerEffectFormatter('cost_mod', 'add', {
 });
 
 registerEffectFormatter('cost_mod', 'remove', {
-  summarize: (eff, _ctx) => {
+  summarize: (eff, ctx) => {
     const key = eff.params?.['key'] as string;
     const icon = RESOURCES[key as ResourceKey]?.icon || key;
     const amount = Number(eff.params?.['amount']);
     const actionId = eff.params?.['actionId'] as string | undefined;
-    const actionIcon = actionId ? actionInfo[actionId]?.icon || actionId : '';
+    const actionIcon = actionId
+      ? ctx.actions.get(actionId)?.icon || actionId
+      : '';
     const prefix = actionId ? `${actionIcon}: ` : ': ';
     const delta = -amount;
     const sign = delta >= 0 ? '+' : '-';
@@ -53,7 +57,9 @@ registerEffectFormatter('cost_mod', 'remove', {
     const icon = RESOURCES[key as ResourceKey]?.icon || key;
     const amount = Number(eff.params?.['amount']);
     const actionId = eff.params?.['actionId'] as string | undefined;
-    const actionIcon = actionId ? actionInfo[actionId]?.icon || actionId : '';
+    const actionIcon = actionId
+      ? ctx.actions.get(actionId)?.icon || actionId
+      : '';
     const actionName = actionId
       ? ctx.actions.get(actionId)?.name || actionId
       : 'all actions';
@@ -70,7 +76,7 @@ registerEffectFormatter('result_mod', 'add', {
       | undefined;
     if (evaluation?.type === 'development') {
       const dev = ctx.developments.get(evaluation.id);
-      const icon = developmentInfo[evaluation.id]?.icon || '';
+      const icon = ctx.developments.get(evaluation.id)?.icon || '';
       const resource = eff.effects?.find(
         (e) => e.type === 'resource' && e.method === 'add',
       );
@@ -88,7 +94,7 @@ registerEffectFormatter('result_mod', 'add', {
       ];
     }
     const actionId = eff.params?.['actionId'] as string;
-    const actionIcon = actionInfo[actionId]?.icon || actionId;
+    const actionIcon = ctx.actions.get(actionId)?.icon || actionId;
     return sub.map((s) =>
       typeof s === 'string'
         ? `${modifierInfo.result.icon} ${actionIcon}: ${s}`
@@ -105,7 +111,7 @@ registerEffectFormatter('result_mod', 'add', {
       | undefined;
     if (evaluation?.type === 'development') {
       const dev = ctx.developments.get(evaluation.id);
-      const icon = developmentInfo[evaluation.id]?.icon || '';
+      const icon = ctx.developments.get(evaluation.id)?.icon || '';
       const resource = eff.effects?.find(
         (e) => e.type === 'resource' && e.method === 'add',
       );
@@ -123,7 +129,7 @@ registerEffectFormatter('result_mod', 'add', {
       ];
     }
     const actionId = eff.params?.['actionId'] as string;
-    const actionIcon = actionInfo[actionId]?.icon || actionId;
+    const actionIcon = ctx.actions.get(actionId)?.icon || actionId;
     let actionName = actionId;
     try {
       actionName = ctx.actions.get(actionId).name;

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -9,8 +9,6 @@ import {
   POPULATION_ROLES,
   LAND_ICON as landIcon,
   SLOT_ICON as slotIcon,
-  DEVELOPMENT_INFO as developmentInfo,
-  ACTION_INFO as actionInfo,
 } from '@kingdom-builder/contents';
 interface StepDef {
   id: string;
@@ -156,7 +154,7 @@ function collectResourceSources(
         const count = Number(handler(ev, ctx));
         if (ev.type === 'development') {
           const id = (ev.params as Record<string, string> | undefined)?.['id'];
-          const icon = id ? developmentInfo[id]?.icon || '' : '';
+          const icon = id ? ctx.developments.get(id)?.icon || '' : '';
           entry.icons += icon.repeat(count);
         } else if (ev.type === 'population') {
           const role = (ev.params as Record<string, string> | undefined)?.[
@@ -189,7 +187,8 @@ function collectResourceSources(
   const result: Record<string, string> = {};
   for (const [key, { icons, mods }] of Object.entries(map)) {
     let part = icons;
-    if (mods > 0) part += `+${(actionInfo['build']?.icon || '').repeat(mods)}`;
+    if (mods > 0)
+      part += `+${(ctx.actions.get('build').icon || '').repeat(mods)}`;
     result[key] = part;
   }
   return result;

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -11,7 +11,6 @@ import {
 } from '@kingdom-builder/engine';
 import {
   RESOURCES,
-  ACTION_INFO,
   ACTIONS,
   BUILDINGS,
   DEVELOPMENTS,
@@ -67,8 +66,8 @@ describe('<ActionsPanel />', () => {
     render(<ActionsPanel />);
     const apIcon = RESOURCES[Resource.ap].icon;
     expect(screen.getByText(`Actions (1 ${apIcon} each)`)).toBeInTheDocument();
-    const developName = ctx.actions.get('develop')?.name || '';
-    const developLabel = `${ACTION_INFO['develop'].icon} ${developName}`;
+    const developDef = ctx.actions.get('develop');
+    const developLabel = `${developDef.icon} ${developDef.name}`;
     expect(screen.getByText(developLabel)).toBeInTheDocument();
   });
 

--- a/packages/web/tests/HoverCard.test.tsx
+++ b/packages/web/tests/HoverCard.test.tsx
@@ -12,7 +12,6 @@ import {
 } from '@kingdom-builder/engine';
 import {
   RESOURCES,
-  ACTION_INFO,
   ACTIONS,
   BUILDINGS,
   DEVELOPMENTS,
@@ -70,7 +69,7 @@ describe('<HoverCard />', () => {
   it('renders hover card details from context', () => {
     const actionId = 'raise_pop';
     const actionName = ctx.actions.get(actionId)?.name || '';
-    const title = `${ACTION_INFO[actionId].icon} ${actionName}`;
+    const title = `${ctx.actions.get(actionId).icon} ${actionName}`;
     const costs = getActionCosts(actionId, ctx);
     const requirements = getActionRequirements(actionId, ctx);
     mockGame.hoverCard = {

--- a/packages/web/tests/subaction-log.test.ts
+++ b/packages/web/tests/subaction-log.test.ts
@@ -13,7 +13,6 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
-  ACTION_INFO as actionInfo,
   RESOURCES,
   SLOT_ICON as slotIcon,
 } from '@kingdom-builder/contents';
@@ -61,7 +60,7 @@ describe('sub-action logging', () => {
       const subChanges = diffSnapshots(trace.before, trace.after, ctx);
       if (!subChanges.length) continue;
       subLines.push(...subChanges);
-      const icon = actionInfo[trace.id]?.icon || '';
+      const icon = ctx.actions.get(trace.id)?.icon || '';
       const name = ctx.actions.get(trace.id).name;
       const line = `  ${icon} ${name}`;
       const idx = messages.indexOf(line);


### PR DESCRIPTION
## Summary
- add chainable `id`, `name`, and `icon` methods to content builders so configs hold their own icons
- drop standalone info maps and update default actions, buildings, developments, populations, and phases to declare icons inline
- adjust web translators, components, tests, and triggers to read icons from registries

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b46058ccb883258d9229fe02e4bd8a