### PR TITLE
feat: add market tax bonus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ non-obvious insights that will help future agents work more efficiently. Any upd
 - 2025-08-31: `npm run test:coverage` requires `@vitest/coverage-v8`; install with `npm install --no-save @vitest/coverage-v8` if missing.
 - 2025-08-31: `performAction` returns sub-action traces via `ctx.actionTraces` for nested log attribution.
 - 2025-08-31: Overview screen can pull icons from contents (e.g. ACTION_INFO, LAND_ICON) to keep keywords visually consistent.
+- 2025-08-31: Evaluation modifiers can target action-based gains by giving the action's evaluator an `id`.
 
 # Core Agent principles
 

--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -67,7 +67,7 @@ export function createActionRegistry() {
     action('tax', 'Tax')
       .cost(Resource.ap, 1)
       .effect({
-        evaluator: { type: 'population' },
+        evaluator: { type: 'population', params: { id: 'tax' } },
         effects: [
           {
             type: 'resource',

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -67,7 +67,18 @@ export function createBuildingRegistry() {
   );
   registry.add(
     'market',
-    building('market', 'Market').cost(Resource.gold, 10).build(),
+    building('market', 'Market')
+      .cost(Resource.gold, 10)
+      .onBuild({
+        type: 'result_mod',
+        method: 'add',
+        params: {
+          id: 'market_tax_bonus',
+          evaluation: { type: 'population', id: 'tax' },
+          amount: 1,
+        },
+      })
+      .build(),
   );
   registry.add(
     'barracks',

--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -87,6 +87,14 @@ registerEffectFormatter('result_mod', 'add', {
         `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${dev?.name || evaluation.id}, gain +${amount} more of that resource`,
       ];
     }
+    if (evaluation?.type === 'population') {
+      const action = ctx.actions.get(evaluation.id);
+      const icon = actionInfo[evaluation.id]?.icon || '';
+      const amount = Number(eff.params?.['amount'] ?? 0);
+      return [
+        `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${action?.name || evaluation.id}, gain +${amount} more of that resource`,
+      ];
+    }
     const actionId = eff.params?.['actionId'] as string;
     const actionIcon = actionInfo[actionId]?.icon || actionId;
     return sub.map((s) =>
@@ -120,6 +128,14 @@ registerEffectFormatter('result_mod', 'add', {
       const amount = Number(eff.params?.['amount'] ?? 0);
       return [
         `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${dev?.name || evaluation.id}, gain +${amount} more of that resource`,
+      ];
+    }
+    if (evaluation?.type === 'population') {
+      const action = ctx.actions.get(evaluation.id);
+      const icon = actionInfo[evaluation.id]?.icon || '';
+      const amount = Number(eff.params?.['amount'] ?? 0);
+      return [
+        `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${action?.name || evaluation.id}, gain +${amount} more of that resource`,
       ];
     }
     const actionId = eff.params?.['actionId'] as string;

--- a/tests/integration/market-translation.test.ts
+++ b/tests/integration/market-translation.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { createEngine } from '@kingdom-builder/engine';
+import { summarizeContent } from '@kingdom-builder/web/translation/content';
+import {
+  ACTIONS,
+  BUILDINGS,
+  DEVELOPMENTS,
+  POPULATIONS,
+  PHASES,
+  GAME_START,
+} from '@kingdom-builder/contents';
+
+describe('Market building translation', () => {
+  it('mentions tax bonus', () => {
+    const ctx = createEngine({
+      actions: ACTIONS,
+      buildings: BUILDINGS,
+      developments: DEVELOPMENTS,
+      populations: POPULATIONS,
+      phases: PHASES,
+      start: GAME_START,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+    const summary = summarizeContent('building', 'market', ctx) as unknown;
+    expect(JSON.stringify(summary)).toContain('Tax');
+  });
+});


### PR DESCRIPTION
## Summary
- give Tax action a population evaluator id for targeted modifiers
- add Market building result modifier that grants +1 resource per population when taxing
- translate population-based result modifiers and test Market strings

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b464f2c2148325b0960dd9dde16759