### PR TITLE
feat: add war weariness stat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Attach the date of your update as a prefix to your log entry.
 - 2025-08-31: Overview screen can pull icons from contents (e.g. ACTION_INFO, LAND_ICON) to keep keywords visually consistent.
 - 2025-08-31: PlayerState maintains `statsHistory` so stats returning to zero remain visible; initialize new non-zero stats accordingly.
 - 2025-09-01: `stat:add_pct` effects honor a `round` setting like resources; use `round: 'up'` to keep strength stats integer and non-negative.
+- 2025-09-14: PlayerState auto-initializes stats by iterating over `Stat` keys; adding a new stat requires only updating the `Stat` map and providing getters/setters.
 
 # Core Agent principles
 

--- a/packages/contents/src/game.ts
+++ b/packages/contents/src/game.ts
@@ -14,6 +14,7 @@ export const GAME_START: StartConfig = {
       [Stat.armyStrength]: 0,
       [Stat.fortificationStrength]: 0,
       [Stat.absorption]: 0,
+      [Stat.warWeariness]: 0,
     },
     population: {
       [PopulationRole.Council]: 1,

--- a/packages/contents/src/stats.ts
+++ b/packages/contents/src/stats.ts
@@ -37,4 +37,11 @@ export const STATS: Record<StatKey, StatInfo> = {
     description:
       'Absorption reduces incoming damage by a percentage. It represents magical barriers or tactical advantages that soften blows.',
   },
+  [Stat.warWeariness]: {
+    key: Stat.warWeariness,
+    icon: '💤',
+    label: 'War Weariness',
+    description:
+      'War Weariness reflects the fatigue from prolonged conflict. High weariness can sap morale and hinder wartime efforts.',
+  },
 };

--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -11,6 +11,7 @@ export const Stat = {
   armyStrength: 'armyStrength',
   fortificationStrength: 'fortificationStrength',
   absorption: 'absorption',
+  warWeariness: 'warWeariness',
 } as const;
 export type StatKey = (typeof Stat)[keyof typeof Stat];
 
@@ -130,6 +131,14 @@ export class PlayerState {
   set absorption(v: number) {
     this.stats[Stat.absorption] = v;
     if (v !== 0) this.statsHistory[Stat.absorption] = true;
+  }
+
+  get warWeariness() {
+    return this.stats[Stat.warWeariness];
+  }
+  set warWeariness(v: number) {
+    this.stats[Stat.warWeariness] = v;
+    if (v !== 0) this.statsHistory[Stat.warWeariness] = true;
   }
 }
 

--- a/packages/engine/tests/state/state.test.ts
+++ b/packages/engine/tests/state/state.test.ts
@@ -13,8 +13,15 @@ describe('State classes', () => {
     const player = new PlayerState('A', 'Alice');
     player.gold = 5;
     player.maxPopulation = 3;
+    player.warWeariness = 2;
     expect(player.gold).toBe(5);
     expect(player.maxPopulation).toBe(3);
+    expect(player.warWeariness).toBe(2);
+  });
+
+  it('defaults war weariness to 0', () => {
+    const player = new PlayerState('A', 'Alice');
+    expect(player.warWeariness).toBe(0);
   });
 
   it('tracks stat history when values become non-zero', () => {

--- a/packages/web/tests/App.test.tsx
+++ b/packages/web/tests/App.test.tsx
@@ -8,7 +8,7 @@ vi.mock('@kingdom-builder/engine', () => {
     id: 'A',
     name: 'A',
     resources: {} as Record<string, number>,
-    stats: { maxPopulation: 0 } as Record<string, number>,
+    stats: { maxPopulation: 0, warWeariness: 0 } as Record<string, number>,
     population: {} as Record<string, number>,
     buildings: new Set<string>(),
     lands: [] as unknown[],


### PR DESCRIPTION
## Summary
- add `warWeariness` to player stats and snapshot support
- seed new games with `warWeariness: 0`
- expose icon/label metadata for war weariness

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b475bc3ab08325a3be8d7fd84eb737