### PR TITLE
feat: add growth stat and show raise strength formula

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Attach the date of your update as a prefix to your log entry.
 - 2025-08-31: Overview screen can pull icons from contents (e.g. ACTION_INFO, LAND_ICON) to keep keywords visually consistent.
 - 2025-08-31: PlayerState maintains `statsHistory` so stats returning to zero remain visible; initialize new non-zero stats accordingly.
 - 2025-09-01: `stat:add_pct` effects honor a `round` setting like resources; use `round: 'up'` to keep strength stats integer and non-negative.
+- 2025-09-07: `stat:add_pct` can read a `percentStat` to apply a player's stat as the percentage.
 
 # Core Agent principles
 

--- a/packages/contents/src/game.ts
+++ b/packages/contents/src/game.ts
@@ -14,6 +14,7 @@ export const GAME_START: StartConfig = {
       [Stat.armyStrength]: 0,
       [Stat.fortificationStrength]: 0,
       [Stat.absorption]: 0,
+      [Stat.growth]: 0.25,
     },
     population: {
       [PopulationRole.Council]: 1,

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -72,7 +72,7 @@ export const PHASES: PhaseDef[] = [
             .evaluator('population', { role: PopulationRole.Commander })
             .effect(
               effect(Types.Stat, StatMethods.ADD_PCT)
-                .params({ key: Stat.armyStrength, percent: 25 })
+                .params({ key: Stat.armyStrength, percentStat: Stat.growth })
                 .round('up')
                 .build(),
             )
@@ -81,7 +81,10 @@ export const PHASES: PhaseDef[] = [
             .evaluator('population', { role: PopulationRole.Fortifier })
             .effect(
               effect(Types.Stat, StatMethods.ADD_PCT)
-                .params({ key: Stat.fortificationStrength, percent: 25 })
+                .params({
+                  key: Stat.fortificationStrength,
+                  percentStat: Stat.growth,
+                })
                 .round('up')
                 .build(),
             )

--- a/packages/contents/src/stats.ts
+++ b/packages/contents/src/stats.ts
@@ -37,4 +37,11 @@ export const STATS: Record<StatKey, StatInfo> = {
     description:
       'Absorption reduces incoming damage by a percentage. It represents magical barriers or tactical advantages that soften blows.',
   },
+  [Stat.growth]: {
+    key: Stat.growth,
+    icon: '📈',
+    label: 'Growth',
+    description:
+      'Growth increases Army and Fortification Strength during the Raise Strength step.',
+  },
 };

--- a/packages/engine/src/effects/stat_add_pct.ts
+++ b/packages/engine/src/effects/stat_add_pct.ts
@@ -3,7 +3,12 @@ import type { StatKey } from '../state';
 
 export const statAddPct: EffectHandler = (effect, ctx, mult = 1) => {
   const key = effect.params!['key'] as StatKey;
-  const pct = effect.params!['percent'] as number;
+  let pct = effect.params!['percent'] as number | undefined;
+  if (pct === undefined) {
+    const statKey = effect.params!['percentStat'] as StatKey;
+    const statVal = ctx.activePlayer.stats[statKey] || 0;
+    pct = statVal * 100;
+  }
 
   // Use a cache keyed by turn/phase/step so multiple evaluations in the
   // same step (e.g. multiple commanders) scale additively from the

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -5,8 +5,7 @@ import { runEffects, type EffectDef } from '../effects';
 export type HappinessTierEffect = {
   incomeMultiplier: number;
   buildingDiscountPct?: number; // 0.2 = 20%
-  growthBonusPctArmy?: number;
-  growthBonusPctFort?: number;
+  growthBonusPct?: number;
   upkeepCouncilReduction?: number; // if present, e.g., 1 instead of 2
   halveCouncilAPInUpkeep?: boolean;
   disableGrowth?: boolean;

--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -11,6 +11,7 @@ export const Stat = {
   armyStrength: 'armyStrength',
   fortificationStrength: 'fortificationStrength',
   absorption: 'absorption',
+  growth: 'growth',
 } as const;
 export type StatKey = (typeof Stat)[keyof typeof Stat];
 
@@ -80,7 +81,9 @@ export class PlayerState {
     this.stats = {} as Record<StatKey, number>;
     this.statsHistory = {} as Record<StatKey, boolean>;
     for (const key of Object.values(Stat) as StatKey[]) {
-      const value = key === Stat.maxPopulation ? 1 : 0;
+      let value = 0;
+      if (key === Stat.maxPopulation) value = 1;
+      else if (key === Stat.growth) value = 0.25;
       this.stats[key] = value;
       this.statsHistory[key] = value !== 0;
     }
@@ -130,6 +133,13 @@ export class PlayerState {
   set absorption(v: number) {
     this.stats[Stat.absorption] = v;
     if (v !== 0) this.statsHistory[Stat.absorption] = true;
+  }
+  get growth() {
+    return this.stats[Stat.growth];
+  }
+  set growth(v: number) {
+    this.stats[Stat.growth] = v;
+    if (v !== 0) this.statsHistory[Stat.growth] = true;
   }
 }
 

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -10,6 +10,7 @@ import {
   LAND_ICON as landIcon,
   SLOT_ICON as slotIcon,
 } from '@kingdom-builder/contents';
+import { PopulationRole, Stat } from '@kingdom-builder/engine/state';
 interface StepDef {
   id: string;
   title?: string;
@@ -222,7 +223,8 @@ export function diffStepSnapshots(
     const a = after.stats[key] ?? 0;
     if (a !== b) {
       const info = STATS[key as keyof typeof STATS];
-      const icon = info?.icon ? `${info.icon} ` : '';
+      const iconOnly = info?.icon || '';
+      const icon = iconOnly ? `${iconOnly} ` : '';
       const label = info?.label ?? key;
       const delta = a - b;
       if (key === 'absorption') {
@@ -233,9 +235,23 @@ export function diffStepSnapshots(
           `${icon}${label} ${dPerc >= 0 ? '+' : ''}${dPerc}% (${bPerc}→${aPerc}%)`,
         );
       } else {
-        changes.push(
-          `${icon}${label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a})`,
-        );
+        let line = `${icon}${label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a})`;
+        if (
+          step?.id === 'raise-strength' &&
+          (key === Stat.armyStrength || key === Stat.fortificationStrength) &&
+          delta > 0
+        ) {
+          const role =
+            key === Stat.armyStrength
+              ? PopulationRole.Commander
+              : PopulationRole.Fortifier;
+          const count = ctx.activePlayer.population[role] ?? 0;
+          const popIcon = POPULATION_ROLES[role]?.icon || '';
+          const growth = ctx.activePlayer.stats[Stat.growth] ?? 0;
+          const growthIcon = STATS[Stat.growth]?.icon || '';
+          line += ` (${iconOnly}${b} + (${popIcon}${count} * ${growthIcon}${growth}) = ${iconOnly}${a})`;
+        }
+        changes.push(line);
       }
     }
   }


### PR DESCRIPTION
## Summary
- add growth stat with default 25% and expose it in UI
- apply growth stat during Raise Strength using `percentStat`
- display growth formula when strength increases in Raise Strength step

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4753649888325b2300e8fa7e61609