### PR TITLE
Isolate passive upkeep triggers per player

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Attach the date of your update as a prefix to your log entry.
 - 2025-08-31: Overview screen can pull icons from contents (e.g. ACTION_INFO, LAND_ICON) to keep keywords visually consistent.
 - 2025-08-31: PlayerState maintains `statsHistory` so stats returning to zero remain visible; initialize new non-zero stats accordingly.
 - 2025-09-14: PlayerState auto-initializes stats by iterating over `Stat` keys; adding a new stat requires only updating the `Stat` map and providing getters/setters.
+- 2025-08-31: Clone trigger arrays when adding passives to avoid shared references across players.
 
 # Core Agent principles
 

--- a/packages/engine/src/effects/passive_add.ts
+++ b/packages/engine/src/effects/passive_add.ts
@@ -23,9 +23,12 @@ export const passiveAdd: EffectHandler<PassiveParams> = (
     onUpkeepPhase?: EffectDef[];
     onAttackResolved?: EffectDef[];
   } = { id, effects: effect.effects || [] };
-  if (onDevelopmentPhase) passive.onDevelopmentPhase = onDevelopmentPhase;
-  if (onUpkeepPhase) passive.onUpkeepPhase = onUpkeepPhase;
-  if (onAttackResolved) passive.onAttackResolved = onAttackResolved;
+  if (onDevelopmentPhase)
+    passive.onDevelopmentPhase = onDevelopmentPhase.map((e) => ({ ...e }));
+  if (onUpkeepPhase)
+    passive.onUpkeepPhase = onUpkeepPhase.map((e) => ({ ...e }));
+  if (onAttackResolved)
+    passive.onAttackResolved = onAttackResolved.map((e) => ({ ...e }));
   for (let index = 0; index < Math.floor(mult); index++) {
     ctx.passives.addPassive(passive, ctx);
   }

--- a/packages/engine/tests/passive_upkeep_isolation.test.ts
+++ b/packages/engine/tests/passive_upkeep_isolation.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { createTestEngine } from './helpers.ts';
+import {
+  runEffects,
+  collectTriggerEffects,
+  advance,
+  Resource,
+} from '../src/index.ts';
+
+describe('passive upkeep isolation', () => {
+  it('only triggers for owning player', () => {
+    const ctx = createTestEngine();
+    runEffects(
+      [
+        {
+          type: 'passive',
+          method: 'add',
+          params: {
+            id: 'temp_upkeep',
+            onUpkeepPhase: [
+              {
+                type: 'resource',
+                method: 'remove',
+                params: { key: Resource.gold, amount: 2 },
+              },
+            ],
+          },
+        },
+      ],
+      ctx,
+    );
+    while (
+      !(
+        ctx.game.currentPlayerIndex === 1 &&
+        ctx.game.currentPhase === 'upkeep' &&
+        ctx.game.currentStep === 'resolve-dynamic-triggers'
+      )
+    ) {
+      advance(ctx);
+    }
+    expect(collectTriggerEffects('onUpkeepPhase', ctx)).toHaveLength(0);
+    while (
+      !(
+        ctx.game.turn === 2 &&
+        ctx.game.currentPlayerIndex === 0 &&
+        ctx.game.currentPhase === 'upkeep' &&
+        ctx.game.currentStep === 'resolve-dynamic-triggers'
+      )
+    ) {
+      advance(ctx);
+    }
+    const effects = collectTriggerEffects('onUpkeepPhase', ctx);
+    expect(effects).toHaveLength(1);
+    expect(effects[0]?.params).toMatchObject({ key: Resource.gold, amount: 2 });
+  });
+});


### PR DESCRIPTION
## Summary
- clone passive trigger arrays when adding passives so each player owns independent copies
- add regression test confirming upkeep triggers only fire for the owning player
- document cloning requirement in discovery log

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4770bd6d483259077c54238a57eb2