### PR TITLE
Add onBeforeAttacked trigger for defenders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ Attach the date of your update as a prefix to your log entry.
 - 2025-09-15: Requirement handlers return `true` or a message; `getActionRequirements` collects these messages for UI prompts.
 - 2025-09-16: Use `evaluator:compare` requirement to compare numeric evaluator outputs without custom handlers.
 - 2025-09-17: Derive requirement icons in the UI by parsing evaluator comparisons; see `getRequirementIcons` utility.
+- 2025-10-01: Shell starts without standard binaries in PATH; run `export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` to restore.
 
 # Core Agent principles
 

--- a/packages/contents/src/defs.ts
+++ b/packages/contents/src/defs.ts
@@ -8,6 +8,7 @@ import type { EffectDef } from '@kingdom-builder/engine/effects';
 export interface Triggered {
   onDevelopmentPhase?: EffectDef[] | undefined;
   onUpkeepPhase?: EffectDef[] | undefined;
+  onBeforeAttacked?: EffectDef[] | undefined;
   onAttackResolved?: EffectDef[] | undefined;
 }
 

--- a/packages/contents/src/triggers.ts
+++ b/packages/contents/src/triggers.ts
@@ -17,6 +17,11 @@ export const TRIGGER_INFO = {
     future: 'Until removed',
     past: 'Build',
   },
+  onBeforeAttacked: {
+    icon: '🛡️',
+    future: 'Before being attacked',
+    past: 'Before attack',
+  },
   onAttackResolved: {
     icon: '⚔️',
     future: 'After having been attacked',

--- a/packages/engine/src/config/builders.ts
+++ b/packages/engine/src/config/builders.ts
@@ -231,6 +231,11 @@ export class BuildingBuilder extends BaseBuilder<BuildingConfig> {
     this.config.onUpkeepPhase.push(effect);
     return this;
   }
+  onBeforeAttacked(effect: EffectConfig) {
+    this.config.onBeforeAttacked = this.config.onBeforeAttacked || [];
+    this.config.onBeforeAttacked.push(effect);
+    return this;
+  }
   onAttackResolved(effect: EffectConfig) {
     this.config.onAttackResolved = this.config.onAttackResolved || [];
     this.config.onAttackResolved.push(effect);
@@ -250,6 +255,11 @@ export class DevelopmentBuilder extends BaseBuilder<DevelopmentConfig> {
   onDevelopmentPhase(effect: EffectConfig) {
     this.config.onDevelopmentPhase = this.config.onDevelopmentPhase || [];
     this.config.onDevelopmentPhase.push(effect);
+    return this;
+  }
+  onBeforeAttacked(effect: EffectConfig) {
+    this.config.onBeforeAttacked = this.config.onBeforeAttacked || [];
+    this.config.onBeforeAttacked.push(effect);
     return this;
   }
   onAttackResolved(effect: EffectConfig) {

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -55,6 +55,7 @@ export const buildingSchema = z.object({
   onBuild: z.array(effectSchema).optional(),
   onDevelopmentPhase: z.array(effectSchema).optional(),
   onUpkeepPhase: z.array(effectSchema).optional(),
+  onBeforeAttacked: z.array(effectSchema).optional(),
   onAttackResolved: z.array(effectSchema).optional(),
 });
 
@@ -67,6 +68,7 @@ export const developmentSchema = z.object({
   icon: z.string().optional(),
   onBuild: z.array(effectSchema).optional(),
   onDevelopmentPhase: z.array(effectSchema).optional(),
+  onBeforeAttacked: z.array(effectSchema).optional(),
   onAttackResolved: z.array(effectSchema).optional(),
   system: z.boolean().optional(),
 });

--- a/packages/engine/src/effects/passive_add.ts
+++ b/packages/engine/src/effects/passive_add.ts
@@ -4,6 +4,7 @@ interface PassiveParams {
   id: string;
   onDevelopmentPhase?: EffectDef[];
   onUpkeepPhase?: EffectDef[];
+  onBeforeAttacked?: EffectDef[];
   onAttackResolved?: EffectDef[];
   [key: string]: unknown;
 }
@@ -14,17 +15,25 @@ export const passiveAdd: EffectHandler<PassiveParams> = (
   mult = 1,
 ) => {
   const params = effect.params || ({} as PassiveParams);
-  const { id, onDevelopmentPhase, onUpkeepPhase, onAttackResolved } = params;
+  const {
+    id,
+    onDevelopmentPhase,
+    onUpkeepPhase,
+    onBeforeAttacked,
+    onAttackResolved,
+  } = params;
   if (!id) throw new Error('passive:add requires id');
   const passive: {
     id: string;
     effects: EffectDef[];
     onDevelopmentPhase?: EffectDef[];
     onUpkeepPhase?: EffectDef[];
+    onBeforeAttacked?: EffectDef[];
     onAttackResolved?: EffectDef[];
   } = { id, effects: effect.effects || [] };
   if (onDevelopmentPhase) passive.onDevelopmentPhase = onDevelopmentPhase;
   if (onUpkeepPhase) passive.onUpkeepPhase = onUpkeepPhase;
+  if (onBeforeAttacked) passive.onBeforeAttacked = onBeforeAttacked;
   if (onAttackResolved) passive.onAttackResolved = onAttackResolved;
   for (let index = 0; index < Math.floor(mult); index++) {
     ctx.passives.addPassive(passive, ctx);

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -252,6 +252,11 @@ export function resolveAttack(
   damage: number,
   ctx: EngineContext,
 ) {
+  const original = ctx.game.currentPlayerIndex;
+  const index = ctx.game.players.indexOf(defender);
+  ctx.game.currentPlayerIndex = index;
+  const pre = collectTriggerEffects('onBeforeAttacked', ctx, defender);
+  if (pre.length) runEffects(pre, ctx);
   const absorb = Math.min(
     defender.absorption || 0,
     ctx.services.rules.absorptionCapPct,
@@ -261,9 +266,6 @@ export function resolveAttack(
   if (rounding === 'down') final = Math.floor(final);
   else if (rounding === 'up') final = Math.ceil(final);
   else final = Math.round(final);
-  const original = ctx.game.currentPlayerIndex;
-  const index = ctx.game.players.indexOf(defender);
-  ctx.game.currentPlayerIndex = index;
   const effects = collectTriggerEffects('onAttackResolved', ctx, defender);
   if (effects.length) runEffects(effects, ctx);
   ctx.game.currentPlayerIndex = original;

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -91,6 +91,7 @@ export class PassiveManager {
       effects: EffectDef[];
       onDevelopmentPhase?: EffectDef[];
       onUpkeepPhase?: EffectDef[];
+      onBeforeAttacked?: EffectDef[];
       onAttackResolved?: EffectDef[];
       owner: PlayerId;
     }
@@ -151,6 +152,7 @@ export class PassiveManager {
       effects: EffectDef[];
       onDevelopmentPhase?: EffectDef[];
       onUpkeepPhase?: EffectDef[];
+      onBeforeAttacked?: EffectDef[];
       onAttackResolved?: EffectDef[];
     },
     ctx: EngineContext,

--- a/packages/engine/tests/resolveAttack.test.ts
+++ b/packages/engine/tests/resolveAttack.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAttack } from '../src/index.ts';
+import { createTestEngine } from './helpers.ts';
+import { Stat } from '../src/state/index.ts';
+import type { EffectDef } from '../src/effects';
+
+function makeAbsorptionEffect(amount: number): EffectDef {
+  return {
+    type: 'stat',
+    method: 'add',
+    params: { key: Stat.absorption, amount },
+  };
+}
+
+describe('resolveAttack', () => {
+  it('runs onBeforeAttacked triggers before damage calc', () => {
+    const ctx = createTestEngine();
+    const defender = ctx.activePlayer;
+    ctx.passives.addPassive(
+      {
+        id: 'shield',
+        effects: [],
+        onBeforeAttacked: [makeAbsorptionEffect(0.5)],
+      },
+      ctx,
+    );
+    const dmg = resolveAttack(defender, 10, ctx);
+    expect(dmg).toBe(5);
+  });
+});

--- a/packages/web/src/translation/content/development.ts
+++ b/packages/web/src/translation/content/development.ts
@@ -6,6 +6,7 @@ import type { PhasedDef } from './phased';
 import { withInstallation } from './decorators';
 
 interface PhaseEffects {
+  onBeforeAttacked?: EffectDef[];
   onAttackResolved?: EffectDef[];
   [key: string]: EffectDef[] | undefined;
 }

--- a/packages/web/src/translation/content/phased.ts
+++ b/packages/web/src/translation/content/phased.ts
@@ -5,6 +5,7 @@ import type { Summary, SummaryEntry } from './types';
 
 export interface PhasedDef {
   onBuild?: EffectDef<Record<string, unknown>>[] | undefined;
+  onBeforeAttacked?: EffectDef<Record<string, unknown>>[] | undefined;
   onAttackResolved?: EffectDef<Record<string, unknown>>[] | undefined;
   [key: string]: EffectDef<Record<string, unknown>>[] | undefined;
 }
@@ -25,6 +26,12 @@ export class PhasedTranslator {
         });
       }
     }
+    const pre = summarizeEffects(def.onBeforeAttacked, ctx);
+    if (pre.length)
+      root.push({
+        title: `${triggerInfo.onBeforeAttacked.icon} ${triggerInfo.onBeforeAttacked.future}`,
+        items: pre,
+      });
     const atk = summarizeEffects(def.onAttackResolved, ctx);
     if (atk.length)
       root.push({
@@ -49,6 +56,12 @@ export class PhasedTranslator {
         });
       }
     }
+    const pre = describeEffects(def.onBeforeAttacked, ctx);
+    if (pre.length)
+      root.push({
+        title: `${triggerInfo.onBeforeAttacked.icon} ${triggerInfo.onBeforeAttacked.future}`,
+        items: pre,
+      });
     const atk = describeEffects(def.onAttackResolved, ctx);
     if (atk.length)
       root.push({


### PR DESCRIPTION
## Summary
- allow passives, buildings, and developments to define `onBeforeAttacked` effects
- resolve defender `onBeforeAttacked` triggers before damage calculation
- document PATH quirk in agent discovery log and add unit test covering new hook

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b488ae92dc832584a1f2d57fdac7c4