### PR TITLE
feat: add plunder system action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ Attach the date of your update as a prefix to your log entry.
 - 2025-09-15: Requirement handlers return `true` or a message; `getActionRequirements` collects these messages for UI prompts.
 - 2025-09-16: Use `evaluator:compare` requirement to compare numeric evaluator outputs without custom handlers.
 - 2025-09-17: Derive requirement icons in the UI by parsing evaluator comparisons; see `getRequirementIcons` utility.
+- 2025-09-18: `result_mod` accepts an `adjust` parameter to tweak evaluation gains like `transfer_pct`.
+- 2025-09-20: Resource transfers use evaluation key `transfer_pct:percent` for modifier targeting.
 
 # Core Agent principles
 

--- a/docs/architecture/plunder_action.md
+++ b/docs/architecture/plunder_action.md
@@ -1,0 +1,27 @@
+# Plunder System Action
+
+The engine includes a `plunder` system action that leverages a generic
+`resource:transfer` effect to move gold from the defender to the attacker.
+
+- **Base percentage** – 25 % of the defender's gold is transferred.
+- **Modifiers** – Passives can adjust the percentage by registering a
+  `result_mod` with `evaluation: { type: 'transfer_pct', id: 'percent' }` and an
+  `adjust` value. Positive values increase the share while negative values reduce
+  it.
+
+Example modifier:
+
+```ts
+{
+  type: 'result_mod',
+  method: 'add',
+  params: {
+    id: 'raiders_guild_bonus',
+    evaluation: { type: 'transfer_pct', id: 'percent' },
+    adjust: 10, // transfer +10%
+  },
+}
+```
+
+This structure allows future content such as a **Raider's Guild** to grant extra
+plunder automatically when the action resolves.

--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -19,7 +19,7 @@ import {
   PassiveMethods,
   CostModMethods,
   BuildingMethods,
-} from '@kingdom-builder/engine/config/builders';
+} from './config/builders';
 
 export type ActionDef = ActionConfig;
 
@@ -194,6 +194,23 @@ export function createActionRegistry() {
       .icon('🎉')
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 3)
+      .build(),
+  );
+
+  registry.add(
+    'plunder',
+    action()
+      .id('plunder')
+      .name('Plunder')
+      .icon('🏴\u200d☠️')
+      .system()
+      // Base 25% transfer; modifiers may adjust via result_mod targeting
+      // evaluation { type: 'transfer_pct', id: 'percent' } with an `adjust` value.
+      .effect(
+        effect(Types.Resource, ResourceMethods.TRANSFER)
+          .params({ key: Resource.gold, percent: 25 })
+          .build(),
+      )
       .build(),
   );
 

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -9,7 +9,7 @@ import {
   ResultModMethods,
   ResourceMethods,
   ActionMethods,
-} from '@kingdom-builder/engine/config/builders';
+} from './config/builders';
 import type { BuildingDef } from './defs';
 
 export type { BuildingDef } from './defs';

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -5,9 +5,9 @@ import type {
   PopulationConfig,
   RequirementConfig,
   EffectConfig,
-} from './schema';
-import type { ResourceKey } from '../state';
-import type { EvaluatorDef } from '../evaluators';
+} from '@kingdom-builder/engine/config/schema';
+import type { ResourceKey } from '@kingdom-builder/engine/state';
+import type { EvaluatorDef } from '@kingdom-builder/engine/evaluators';
 
 export const Types = {
   Land: 'land',
@@ -30,6 +30,7 @@ export const LandMethods = {
 export const ResourceMethods = {
   ADD: 'add',
   REMOVE: 'remove',
+  TRANSFER: 'transfer',
 } as const;
 
 export const BuildingMethods = {

--- a/packages/contents/src/developments.ts
+++ b/packages/contents/src/developments.ts
@@ -7,7 +7,7 @@ import {
   Types,
   StatMethods,
   DevelopmentMethods,
-} from '@kingdom-builder/engine/config/builders';
+} from './config/builders';
 import type { DevelopmentDef } from './defs';
 
 export type { DevelopmentDef } from './defs';

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -1,12 +1,7 @@
 import type { TriggerKey } from './defs';
 import { Resource, PopulationRole, Stat } from '@kingdom-builder/engine/state';
 import type { EffectDef } from '@kingdom-builder/engine/effects';
-import {
-  effect,
-  Types,
-  ResourceMethods,
-  StatMethods,
-} from '@kingdom-builder/engine/config/builders';
+import { effect, Types, ResourceMethods, StatMethods } from './config/builders';
 
 export interface StepDef {
   id: string;

--- a/packages/contents/src/populations.ts
+++ b/packages/contents/src/populations.ts
@@ -8,7 +8,7 @@ import {
   ResourceMethods,
   PassiveMethods,
   StatMethods,
-} from '@kingdom-builder/engine/config/builders';
+} from './config/builders';
 import type { PopulationDef } from './defs';
 
 export type { PopulationDef } from './defs';

--- a/packages/engine/src/effects/index.ts
+++ b/packages/engine/src/effects/index.ts
@@ -5,6 +5,7 @@ import type { EvaluatorDef } from '../evaluators';
 import { landAdd } from './land_add';
 import { resourceAdd } from './resource_add';
 import { resourceRemove } from './resource_remove';
+import { resourceTransfer } from './resource_transfer';
 import { buildingAdd } from './building_add';
 import { buildingRemove } from './building_remove';
 import { statAdd } from './stat_add';
@@ -47,6 +48,7 @@ export function registerCoreEffects(registry: EffectRegistry = EFFECTS) {
   registry.add('land:add', landAdd);
   registry.add('resource:add', resourceAdd);
   registry.add('resource:remove', resourceRemove);
+  registry.add('resource:transfer', resourceTransfer);
   registry.add('building:add', buildingAdd);
   registry.add('building:remove', buildingRemove);
   registry.add('stat:add', statAdd);
@@ -96,6 +98,7 @@ export {
   landAdd,
   resourceAdd,
   resourceRemove,
+  resourceTransfer,
   buildingAdd,
   buildingRemove,
   statAdd,

--- a/packages/engine/src/effects/resource_transfer.ts
+++ b/packages/engine/src/effects/resource_transfer.ts
@@ -1,0 +1,27 @@
+import type { EffectHandler } from '.';
+import type { ResourceKey } from '../state';
+import type { ResourceGain } from '../services';
+
+interface TransferParams extends Record<string, unknown> {
+  key: ResourceKey;
+  percent?: number;
+}
+
+export const resourceTransfer: EffectHandler<TransferParams> = (
+  effect,
+  ctx,
+  _mult = 1,
+) => {
+  const { key, percent } = effect.params!;
+  const base = percent ?? 25;
+  const mods: ResourceGain[] = [{ key, amount: base }];
+  ctx.passives.runEvaluationMods('transfer_pct:percent', ctx, mods);
+  const pct = mods[0]!.amount;
+  const defender = ctx.opponent;
+  const attacker = ctx.activePlayer;
+  const available = defender.resources[key] || 0;
+  let amount = Math.floor((available * pct) / 100);
+  if (amount < 0) amount = 0;
+  defender.resources[key] = available - amount;
+  attacker.resources[key] = (attacker.resources[key] || 0) + amount;
+};

--- a/packages/engine/src/effects/result_mod.ts
+++ b/packages/engine/src/effects/result_mod.ts
@@ -6,6 +6,7 @@ interface ResultModParams {
   actionId?: string;
   evaluation?: { type: string; id: string };
   amount?: number;
+  adjust?: number;
   [key: string]: unknown;
 }
 
@@ -33,12 +34,15 @@ export const resultMod: EffectHandler<ResultModParams> = (effect, ctx) => {
       const target = `${evaluation.type}:${evaluation.id}`;
       const rawAmount = effect.params?.['amount'];
       const amount = typeof rawAmount === 'number' ? rawAmount : undefined;
+      const rawAdjust = effect.params?.['adjust'];
+      const adjust = typeof rawAdjust === 'number' ? rawAdjust : undefined;
       ctx.passives.registerEvaluationModifier(
         modId,
         target,
         (innerContext, gains) => {
           if (innerContext.activePlayer.id !== ownerId) return;
           if (effects.length) runEffects(effects, innerContext);
+          if (adjust !== undefined) for (const g of gains) g.amount += adjust;
           if (amount !== undefined)
             for (const g of gains)
               if (g.amount > 0)

--- a/packages/engine/tests/actions/multi_cost.test.ts
+++ b/packages/engine/tests/actions/multi_cost.test.ts
@@ -6,7 +6,7 @@ import {
   advance,
 } from '../../src/index.ts';
 import { createTestEngine } from '../helpers.ts';
-import { action, building } from '../../src/config/builders.ts';
+import { action, building } from '@kingdom-builder/contents/config/builders';
 
 describe('multi-cost content', () => {
   it('supports actions with multiple costs', () => {

--- a/packages/engine/tests/actions/plunder.test.ts
+++ b/packages/engine/tests/actions/plunder.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { performAction, runEffects, Resource } from '../../src/index.ts';
+import { createTestEngine } from '../helpers.ts';
+
+describe('Plunder action', () => {
+  it('transfers base percentage of defender gold', () => {
+    const ctx = createTestEngine();
+    ctx.activePlayer.actions.add('plunder');
+    ctx.activePlayer.resources[Resource.gold] = 0;
+    ctx.opponent.resources[Resource.gold] = 100;
+    performAction('plunder', ctx);
+    expect(ctx.activePlayer.resources[Resource.gold]).toBe(25);
+    expect(ctx.opponent.resources[Resource.gold]).toBe(75);
+  });
+
+  it('transfers nothing if defender lacks gold', () => {
+    const ctx = createTestEngine();
+    ctx.activePlayer.actions.add('plunder');
+    ctx.activePlayer.resources[Resource.gold] = 0;
+    ctx.opponent.resources[Resource.gold] = 0;
+    performAction('plunder', ctx);
+    expect(ctx.activePlayer.resources[Resource.gold]).toBe(0);
+    expect(ctx.opponent.resources[Resource.gold]).toBe(0);
+  });
+
+  it('defaults to 25% when percent is omitted', () => {
+    const ctx = createTestEngine();
+    ctx.activePlayer.resources[Resource.gold] = 0;
+    ctx.opponent.resources[Resource.gold] = 100;
+    runEffects(
+      [
+        {
+          type: 'resource',
+          method: 'transfer',
+          params: { key: Resource.gold },
+        },
+      ],
+      ctx,
+    );
+    expect(ctx.activePlayer.resources[Resource.gold]).toBe(25);
+    expect(ctx.opponent.resources[Resource.gold]).toBe(75);
+  });
+
+  it('honors percentage modifiers', () => {
+    const ctx = createTestEngine();
+    ctx.activePlayer.actions.add('plunder');
+    ctx.activePlayer.resources[Resource.gold] = 0;
+    ctx.opponent.resources[Resource.gold] = 100;
+    runEffects(
+      [
+        {
+          type: 'passive',
+          method: 'add',
+          params: { id: 'plunder_bonus' },
+          effects: [
+            {
+              type: 'result_mod',
+              method: 'add',
+              params: {
+                id: 'plunder_bonus_pct',
+                evaluation: { type: 'transfer_pct', id: 'percent' },
+                adjust: 10,
+              },
+            },
+          ],
+        },
+      ],
+      ctx,
+    );
+    performAction('plunder', ctx);
+    expect(ctx.activePlayer.resources[Resource.gold]).toBe(35);
+    expect(ctx.opponent.resources[Resource.gold]).toBe(65);
+  });
+
+  it('does not transfer negative gold when modifiers drop percentage below zero', () => {
+    const ctx = createTestEngine();
+    ctx.activePlayer.actions.add('plunder');
+    ctx.activePlayer.resources[Resource.gold] = 0;
+    ctx.opponent.resources[Resource.gold] = 100;
+    runEffects(
+      [
+        {
+          type: 'passive',
+          method: 'add',
+          params: { id: 'plunder_penalty' },
+          effects: [
+            {
+              type: 'result_mod',
+              method: 'add',
+              params: {
+                id: 'plunder_penalty_pct',
+                evaluation: { type: 'transfer_pct', id: 'percent' },
+                adjust: -50,
+              },
+            },
+          ],
+        },
+      ],
+      ctx,
+    );
+    performAction('plunder', ctx);
+    expect(ctx.activePlayer.resources[Resource.gold]).toBe(0);
+    expect(ctx.opponent.resources[Resource.gold]).toBe(100);
+  });
+});

--- a/packages/engine/tests/config/requirement_builder.test.ts
+++ b/packages/engine/tests/config/requirement_builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { requirement } from '../../src/config/builders.ts';
+import { requirement } from '@kingdom-builder/contents/config/builders';
 import { Stat, PopulationRole } from '../../src/state/index.ts';
 
 describe('RequirementBuilder', () => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,7 @@
     "baseUrl": ".",
     "paths": {
       "@kingdom-builder/engine/*": ["packages/engine/src/*"],
+      "@kingdom-builder/contents/*": ["packages/contents/src/*"],
       "@kingdom-builder/*": ["packages/*/src"]
     }
   }


### PR DESCRIPTION
## Summary
- rename engine effect to `resource:transfer` with `transfer_pct` modifier hook
- relocate config builders to contents package and update action to use `resource:transfer`
- document plunder action's configurable transfer percentage

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b487496d1883258b7542f4871e7753