### PR TITLE
Align percentage handling for absorption and growth stats

### DIFF
--- a/packages/engine/src/effects/stat_add_pct.ts
+++ b/packages/engine/src/effects/stat_add_pct.ts
@@ -7,7 +7,7 @@ export const statAddPct: EffectHandler = (effect, ctx, mult = 1) => {
   if (pct === undefined) {
     const statKey = effect.params!['percentStat'] as StatKey;
     const statVal = ctx.activePlayer.stats[statKey] || 0;
-    pct = statVal * 100;
+    pct = statVal;
   }
 
   // Use a cache keyed by turn/phase/step so multiple evaluations in the
@@ -20,7 +20,7 @@ export const statAddPct: EffectHandler = (effect, ctx, mult = 1) => {
   }
 
   const base = ctx.statAddPctBases[cacheKey]!;
-  ctx.statAddPctAccums[cacheKey]! += base * (pct / 100) * mult;
+  ctx.statAddPctAccums[cacheKey]! += base * pct * mult;
   let newVal = base + ctx.statAddPctAccums[cacheKey]!;
   if (effect.round === 'up')
     newVal = newVal >= 0 ? Math.ceil(newVal) : Math.floor(newVal);

--- a/packages/web/src/components/player/PopulationInfo.tsx
+++ b/packages/web/src/components/player/PopulationInfo.tsx
@@ -14,7 +14,7 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
   const popDetails = popEntries.map(([role, count]) => ({ role, count }));
 
   function formatStatValue(key: string, value: number) {
-    if (key === 'absorption') return `${value * 100}%`;
+    if (key === 'absorption' || key === 'growth') return `${value * 100}%`;
     return String(value);
   }
 

--- a/packages/web/src/translation/effects/formatters/stat/growth.ts
+++ b/packages/web/src/translation/effects/formatters/stat/growth.ts
@@ -1,0 +1,19 @@
+import { STATS } from '@kingdom-builder/contents';
+import { increaseOrDecrease, signed } from '../../helpers';
+import { registerStatAddFormatter } from './registry';
+
+registerStatAddFormatter('growth', {
+  summarize: (eff) => {
+    const amount = Number(eff.params?.['amount']);
+    const stat = STATS['growth'];
+    const icon = stat ? stat.icon : 'growth';
+    return `${icon}${signed(amount * 100)}${amount * 100}%`;
+  },
+  describe: (eff) => {
+    const amount = Number(eff.params?.['amount']);
+    const stat = STATS['growth'];
+    const label = stat?.label || 'growth';
+    const icon = stat?.icon || '';
+    return `${increaseOrDecrease(amount)} ${icon}${label} by ${amount * 100}%`;
+  },
+});

--- a/packages/web/src/translation/effects/formatters/stat/index.ts
+++ b/packages/web/src/translation/effects/formatters/stat/index.ts
@@ -13,21 +13,41 @@ registerEffectFormatter('stat', 'add_pct', {
     const key = eff.params?.['key'] as string;
     const stat = STATS[key as keyof typeof STATS];
     const icon = stat ? stat.icon : key;
-    const percent = Number(eff.params?.['percent']);
-    return `${icon}${signed(percent)}${percent}%`;
+    const percent = eff.params?.['percent'];
+    if (percent !== undefined) {
+      const pct = Number(percent) * 100;
+      return `${icon}${signed(pct)}${pct}%`;
+    }
+    const pctStat = eff.params?.['percentStat'] as string | undefined;
+    if (pctStat) {
+      const pctIcon = STATS[pctStat as keyof typeof STATS]?.icon || pctStat;
+      return `${icon}${pctIcon}`;
+    }
+    return icon;
   },
   describe: (eff) => {
     const key = eff.params?.['key'] as string;
     const stat = STATS[key as keyof typeof STATS];
     const label = stat?.label || key;
     const icon = stat?.icon || '';
-    const percent = Number(eff.params?.['percent']);
-    return `${increaseOrDecrease(percent)} ${icon}${label} by ${Math.abs(
-      percent,
-    )}%`;
+    const percent = eff.params?.['percent'];
+    if (percent !== undefined) {
+      const raw = Number(percent);
+      const pct = raw * 100;
+      return `${increaseOrDecrease(raw)} ${icon}${label} by ${Math.abs(pct)}%`;
+    }
+    const pctStat = eff.params?.['percentStat'] as string | undefined;
+    if (pctStat) {
+      const pctInfo = STATS[pctStat as keyof typeof STATS];
+      const pctIcon = pctInfo?.icon || '';
+      const pctLabel = pctInfo?.label || pctStat;
+      return `Increase ${icon}${label} by ${pctIcon}${pctLabel}`;
+    }
+    return `${increaseOrDecrease(0)} ${icon}${label}`;
   },
 });
 
 import './default';
 import './maxPopulation';
 import './absorption';
+import './growth';

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -84,7 +84,7 @@ export function diffSnapshots(
       const icon = info?.icon ? `${info.icon} ` : '';
       const label = info?.label ?? key;
       const delta = a - b;
-      if (key === 'absorption') {
+      if (key === 'absorption' || key === 'growth') {
         const bPerc = b * 100;
         const aPerc = a * 100;
         const dPerc = delta * 100;
@@ -239,7 +239,7 @@ export function diffStepSnapshots(
       const icon = iconOnly ? `${iconOnly} ` : '';
       const label = info?.label ?? key;
       const delta = a - b;
-      if (key === 'absorption') {
+      if (key === 'absorption' || key === 'growth') {
         const bPerc = b * 100;
         const aPerc = a * 100;
         const dPerc = delta * 100;
@@ -261,7 +261,7 @@ export function diffStepSnapshots(
           const popIcon = POPULATION_ROLES[role]?.icon || '';
           const growth = ctx.activePlayer.stats[Stat.growth] ?? 0;
           const growthIcon = STATS[Stat.growth]?.icon || '';
-          line += ` (${iconOnly}${b} + (${popIcon}${count} * ${growthIcon}${growth}) = ${iconOnly}${a})`;
+          line += ` (${iconOnly}${b} + (${popIcon}${count} * ${growthIcon}${growth * 100}%) = ${iconOnly}${a})`;
         }
         changes.push(line);
       }


### PR DESCRIPTION
## Summary
- Treat percentage stats uniformly as decimals in stat add percent effect
- Display growth stat as a percentage in player UI and logs
- Add web translator support for growth percentage formatting

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b48cda499883258832607788376c83