### PR TITLE
Implement war weariness recovery during upkeep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Attach the date of your update as a prefix to your log entry.
 - 2025-09-16: Use `evaluator:compare` requirement to compare numeric evaluator outputs without custom handlers.
 - 2025-09-17: Derive requirement icons in the UI by parsing evaluator comparisons; see `getRequirementIcons` utility.
 - 2025-10-01: Shell starts without standard binaries in PATH; run `export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` to restore.
+- 2025-10-05: `compare` evaluator returns 1 when a comparison holds, allowing conditional effects.
 
 # Core Agent principles
 

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -133,6 +133,24 @@ export const PHASES: PhaseDef[] = [
             .build(),
         ],
       },
+      {
+        id: 'war-recovery',
+        title: 'War recovery',
+        effects: [
+          effect()
+            .evaluator('compare', {
+              left: { type: 'stat', params: { key: Stat.warWeariness } },
+              operator: 'gt',
+              right: 0,
+            })
+            .effect(
+              effect(Types.Stat, StatMethods.REMOVE)
+                .params({ key: Stat.warWeariness, amount: 1 })
+                .build(),
+            )
+            .build(),
+        ],
+      },
     ],
   },
   {

--- a/packages/engine/src/evaluators/compare.ts
+++ b/packages/engine/src/evaluators/compare.ts
@@ -1,0 +1,42 @@
+import { EVALUATORS, type EvaluatorDef, type EvaluatorHandler } from './index';
+
+interface CompareParams extends Record<string, unknown> {
+  left: EvaluatorDef | number;
+  right: EvaluatorDef | number;
+  operator: 'lt' | 'lte' | 'gt' | 'gte' | 'eq' | 'ne';
+}
+
+function compare(a: number, b: number, op: CompareParams['operator']) {
+  switch (op) {
+    case 'lt':
+      return a < b;
+    case 'lte':
+      return a <= b;
+    case 'gt':
+      return a > b;
+    case 'gte':
+      return a >= b;
+    case 'eq':
+      return a === b;
+    case 'ne':
+      return a !== b;
+    default:
+      return false;
+  }
+}
+
+export const compareEvaluator: EvaluatorHandler<number, CompareParams> = (
+  definition,
+  ctx,
+) => {
+  const params = definition.params as CompareParams;
+  const leftVal =
+    typeof params.left === 'number'
+      ? params.left
+      : Number(EVALUATORS.get(params.left.type)(params.left, ctx));
+  const rightVal =
+    typeof params.right === 'number'
+      ? params.right
+      : Number(EVALUATORS.get(params.right.type)(params.right, ctx));
+  return compare(leftVal, rightVal, params.operator) ? 1 : 0;
+};

--- a/packages/engine/src/evaluators/index.ts
+++ b/packages/engine/src/evaluators/index.ts
@@ -4,6 +4,7 @@ import type { EngineContext } from '../context';
 import { developmentEvaluator } from './development';
 import { populationEvaluator } from './population';
 import { statEvaluator } from './stat';
+import { compareEvaluator } from './compare';
 export interface EvaluatorDef<
   P extends Record<string, unknown> = Record<string, unknown>,
 > {
@@ -28,8 +29,10 @@ export function registerCoreEvaluators(
   registry.add('development', developmentEvaluator);
   registry.add('population', populationEvaluator);
   registry.add('stat', statEvaluator);
+  registry.add('compare', compareEvaluator);
 }
 
 export { developmentEvaluator } from './development';
 export { populationEvaluator } from './population';
 export { statEvaluator } from './stat';
+export { compareEvaluator } from './compare';

--- a/packages/engine/tests/actions/army_attack.test.ts
+++ b/packages/engine/tests/actions/army_attack.test.ts
@@ -7,7 +7,7 @@ describe('Army Attack action', () => {
   it('blocks when war weariness is not lower than commanders', () => {
     const ctx = createTestEngine();
     ctx.activePlayer.population[PopulationRole.Commander] = 1;
-    ctx.activePlayer.warWeariness = 1;
+    ctx.activePlayer.warWeariness = 2;
     while (ctx.game.currentPhase !== 'main') advance(ctx);
     const failures = getActionRequirements('army_attack', ctx);
     expect(failures).toHaveLength(1);

--- a/packages/engine/tests/phases/upkeep.test.ts
+++ b/packages/engine/tests/phases/upkeep.test.ts
@@ -5,6 +5,7 @@ import { createTestEngine } from '../helpers.ts';
 
 const upkeepPhase = PHASES.find((p) => p.id === 'upkeep')!;
 const payStep = upkeepPhase.steps.find((s) => s.id === 'pay-upkeep')!;
+const warStep = upkeepPhase.steps.find((s) => s.id === 'war-recovery')!;
 
 function getUpkeep(role: PopulationRole) {
   return Number(
@@ -61,5 +62,35 @@ describe('Upkeep phase', () => {
     const totalCost = councilUpkeep * councils + commanderUpkeep;
     ctx.activePlayer.gold = totalCost - 1;
     expect(() => advance(ctx)).toThrow();
+  });
+
+  it('reduces war weariness by 1 when above 0', () => {
+    const ctx = createTestEngine();
+    const idx = PHASES.findIndex((p) => p.id === 'upkeep');
+    ctx.game.phaseIndex = idx;
+    ctx.game.currentPhase = PHASES[idx]!.id;
+    ctx.game.stepIndex = PHASES[idx]!.steps.findIndex(
+      (s) => s.id === warStep.id,
+    );
+    ctx.game.currentStep = warStep.id;
+    ctx.activePlayer.warWeariness = 2;
+    advance(ctx);
+    ctx.game.currentPlayerIndex = 0;
+    expect(ctx.activePlayer.warWeariness).toBe(1);
+  });
+
+  it('does not drop war weariness below zero', () => {
+    const ctx = createTestEngine();
+    const idx = PHASES.findIndex((p) => p.id === 'upkeep');
+    ctx.game.phaseIndex = idx;
+    ctx.game.currentPhase = PHASES[idx]!.id;
+    ctx.game.stepIndex = PHASES[idx]!.steps.findIndex(
+      (s) => s.id === warStep.id,
+    );
+    ctx.game.currentStep = warStep.id;
+    ctx.activePlayer.warWeariness = 0;
+    advance(ctx);
+    ctx.game.currentPlayerIndex = 0;
+    expect(ctx.activePlayer.warWeariness).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- decrement war weariness at the end of upkeep via new "War recovery" step
- add compare evaluator to conditionally run effects based on numeric comparisons
- adjust tests for upkeep and army attack scenarios

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 120 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b48dc72ea48325877dfc35bd772740