### PR TITLE
docs: forbid hardcoded content in guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,8 @@
+## 🚫 Hardcoded content prohibited
+
+- **Engine and Web may not hardcode game data.** Never reference specific resource or stat keys, starting values or effect behavior in these domains. All content lives in `packages/contents` and can change without code updates.
+- **Tests may not rely on literals.** Fetch expected names and numeric values from the Content domain or mock registries so that content changes (e.g. different starting gold or altered action effects) do not break tests unless the engine itself lacks support.
+
 # Knowledge sharing
 
 ## Maintain a discovery log

--- a/CONTRIBUTING/AGENTS.md
+++ b/CONTRIBUTING/AGENTS.md
@@ -1,5 +1,10 @@
 # Contributing
 
+## 🚫 Hardcoded content prohibited
+
+- **Engine and Web may not hardcode game data.** All resource/stat keys, starting values and effect behaviour must originate from the `contents` package so designs can change without modifying core code.
+- **Tests may not rely on literals.** When writing tests, obtain ids and values from the Content domain or mocks; content changes should not require test updates unless they expose unsupported scenarios.
+
 Thanks for your interest in improving Kingdom Builder! This guide describes the
 workflow for contributors so that changes remain consistent and easy to review.
 

--- a/SAMPLE_CONFIG/AGENTS.md
+++ b/SAMPLE_CONFIG/AGENTS.md
@@ -1,3 +1,8 @@
+# 🚫 Hardcoded content prohibited
+
+- **Engine and Web may not hardcode game data.** All resource/stat names and starting values defined in this sample config are part of the Content domain and may change without requiring code updates.
+- **Tests may not rely on literals.** When verifying behaviour against this config, fetch ids and values from the content registries or mocks so that adjustments here do not break tests unless they reveal unsupported scenarios.
+
 ## 0) Icon Legend & Conventions
 
 - 🪙Gold — money; cannot go negative

--- a/docs/architecture/AGENTS.md
+++ b/docs/architecture/AGENTS.md
@@ -1,5 +1,10 @@
 # Architecture Overview
 
+## 🚫 Hardcoded content prohibited
+
+- **Engine and Web may not hardcode game data.** All resource/stat keys, starting values and effect behaviour must come from the Content domain so that rules can evolve freely.
+- **Tests may not rely on literals.** Fetch ids and values from the content registries or mocks; content tweaks should not cause test failures unless they expose unsupported engine features.
+
 The kingdom builder engine is designed for flexibility and extensibility.
 This document outlines the core systems that make it easy to bolt on new
 content without touching existing logic.

--- a/docs/code_standards/AGENTS.md
+++ b/docs/code_standards/AGENTS.md
@@ -1,5 +1,10 @@
 # Code Standards
 
+## 🚫 Hardcoded content prohibited
+
+- **Engine and Web may not hardcode game data.** All resource/stat keys, starting values and effect behaviour belong in the Content domain and can change at any time.
+- **Tests may not rely on literals.** Always pull ids and values from the content registries or mocks; content tweaks should not require test updates unless they reveal unsupported scenarios.
+
 This project follows a few simple conventions to keep the codebase readable and
 maintainable.
 

--- a/docs/frontend_translation/AGENTS.md
+++ b/docs/frontend_translation/AGENTS.md
@@ -1,5 +1,10 @@
 # Frontend Translation Architecture
 
+## 🚫 Hardcoded content prohibited
+
+- **Engine and Web may not hardcode game data.** The translation layer must obtain all resource/stat names and values from the Content domain so that wording adjusts automatically when content changes.
+- **Tests may not rely on literals.** Translation tests should pull ids and expected values from content registries or mocks; content tweaks should not require test updates unless they reveal unsupported scenarios.
+
 The web client converts raw engine definitions into player-facing text through a
 layered translation system. The goal is to keep UI strings decoupled from engine
 data so that new content can be introduced without touching the `Game` component

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,5 +1,10 @@
 # Package Overview
 
+## 🚫 Hardcoded content prohibited
+
+- **Engine and Web may not hardcode game data.** Resource or stat keys, starting amounts and effect behaviour must come from the `contents` package so designs can change freely.
+- **Tests may not rely on literals.** Always read values from the Content domain or mock registries; changes in content should not break tests unless they reveal missing engine support.
+
 This directory houses the monorepo packages:
 
 - **engine** – core game logic, effect handlers and registries. No game content

--- a/packages/contents/src/AGENTS.md
+++ b/packages/contents/src/AGENTS.md
@@ -1,5 +1,10 @@
 # Game Content Configurations
 
+## 🚫 Hardcoded content prohibited
+
+- **Engine and Web may not hardcode game data.** Any resource/stat keys or default values shown in these configuration files are subject to change and must not be referenced directly in other domains.
+- **Tests may not rely on literals.** Always read required ids and values from the content registry or mocks so that changing these configs does not break tests unless it uncovers missing engine support.
+
 This directory holds the flexible configuration files that define the default game content:
 Actions, Buildings, Developments and Populations. These files are meant to be tweaked
 frequently during playtesting or balancing. Only the _structure_ of the objects must obey

--- a/packages/engine/src/effects/AGENTS.md
+++ b/packages/engine/src/effects/AGENTS.md
@@ -1,5 +1,10 @@
 # Effect Registry
 
+## 🚫 Hardcoded content prohibited
+
+- **Engine and Web may not hardcode game data.** Effect handlers must not reference specific resource or stat keys or depend on default values from the content package.
+- **Tests may not rely on literals.** When asserting effect behaviour, pull required ids and amounts from the Content domain or mock registries so content updates do not break tests unless the engine lacks support.
+
 The engine resolves action effects through handler functions stored in the `EFFECTS` registry.
 Each handler implements the `EffectHandler` interface and is keyed by a `type:method` pair
 such as `resource:add` or `land:till`.

--- a/packages/engine/src/evaluators/AGENTS.md
+++ b/packages/engine/src/evaluators/AGENTS.md
@@ -1,5 +1,10 @@
 # Evaluator Registry
 
+## 🚫 Hardcoded content prohibited
+
+- **Engine and Web may not hardcode game data.** Evaluators must not assume specific resource or stat keys or depend on fixed values from the content package.
+- **Tests may not rely on literals.** When testing evaluators, fetch ids and amounts from the Content domain or mocks so content changes do not break tests unless they expose unsupported scenarios.
+
 Evaluators compute numbers used by effects and result modifiers to determine how
 many times nested effects execute. They receive the evaluator definition and the
 current `EngineContext`, and return a numeric multiplier.


### PR DESCRIPTION
## Summary
- emphasize that Engine and Web must not hardcode resource or stat names or values
- require tests to read dynamic data from the Content domain instead of literals
- mirror this warning across all AGENTS files including sample config and docs

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b490bb2b8c832597a337d905ca1771