### PR TITLE
feat: add castle walls building

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Attach the date of your update as a prefix to your log entry.
 - 2025-10-01: Shell starts without standard binaries in PATH; run `export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` to restore.
 - 2025-10-05: `compare` evaluator returns 1 when a comparison holds, allowing conditional effects.
 - 2025-08-31: Node and npm may be missing; install with `apt-get install -y nodejs npm` before running tests.
+- 2025-10-11: Building stat bonuses should use `PassiveMethods.ADD` with a unique id to tie their effects to the building's existence.
 
 # Core Agent principles
 

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -1,5 +1,5 @@
 import { Registry } from '@kingdom-builder/engine/registry';
-import { Resource } from '@kingdom-builder/engine/state';
+import { Resource, Stat } from '@kingdom-builder/engine/state';
 import { buildingSchema } from '@kingdom-builder/engine/config/schema';
 import {
   building,
@@ -9,6 +9,8 @@ import {
   ResultModMethods,
   ResourceMethods,
   ActionMethods,
+  PassiveMethods,
+  StatMethods,
 } from './config/builders';
 import type { BuildingDef } from './defs';
 
@@ -129,7 +131,23 @@ export function createBuildingRegistry() {
       .id('castle_walls')
       .name('Castle Walls')
       .icon('🧱')
-      .cost(Resource.gold, 14)
+      .cost(Resource.gold, 12)
+      .cost(Resource.ap, 1)
+      .onBuild(
+        effect(Types.Passive, PassiveMethods.ADD)
+          .param('id', 'castle_walls_bonus')
+          .effect(
+            effect(Types.Stat, StatMethods.ADD)
+              .params({ key: Stat.fortificationStrength, amount: 5 })
+              .build(),
+          )
+          .effect(
+            effect(Types.Stat, StatMethods.ADD)
+              .params({ key: Stat.absorption, amount: 0.2 })
+              .build(),
+          )
+          .build(),
+      )
       .build(),
   );
   registry.add(

--- a/packages/engine/tests/effects/passive-add.test.ts
+++ b/packages/engine/tests/effects/passive-add.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { runEffects } from '../../src/index.ts';
+import { Resource, Stat } from '../../src/state/index.ts';
+import { createTestEngine } from '../helpers.ts';
+import type { EffectDef } from '../../src/effects/index.ts';
+
+describe('passive:add effect', () => {
+  it('applies nested effects and registers phase triggers', () => {
+    const ctx = createTestEngine();
+    const effect: EffectDef<{ id: string } & Record<string, EffectDef[]>> = {
+      type: 'passive',
+      method: 'add',
+      params: {
+        id: 'temp',
+        onDevelopmentPhase: [
+          {
+            type: 'resource',
+            method: 'add',
+            params: { key: Resource.gold, amount: 1 },
+          },
+        ],
+        onUpkeepPhase: [
+          {
+            type: 'resource',
+            method: 'add',
+            params: { key: Resource.gold, amount: 1 },
+          },
+        ],
+        onBeforeAttacked: [
+          {
+            type: 'resource',
+            method: 'add',
+            params: { key: Resource.gold, amount: 1 },
+          },
+        ],
+        onAttackResolved: [
+          {
+            type: 'resource',
+            method: 'add',
+            params: { key: Resource.gold, amount: 1 },
+          },
+        ],
+      },
+      effects: [
+        {
+          type: 'stat',
+          method: 'add',
+          params: { key: Stat.armyStrength, amount: 1 },
+        },
+      ],
+    };
+
+    const before = ctx.activePlayer.stats[Stat.armyStrength];
+    runEffects([effect], ctx);
+    expect(ctx.activePlayer.stats[Stat.armyStrength]).toBe(before + 1);
+    ctx.passives.removePassive('temp', ctx);
+    expect(ctx.activePlayer.stats[Stat.armyStrength]).toBe(before);
+  });
+});

--- a/tests/integration/castle-walls.test.ts
+++ b/tests/integration/castle-walls.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { performAction, runEffects } from '@kingdom-builder/engine';
+import { Resource, Stat } from '@kingdom-builder/engine/state';
+import { BUILDINGS } from '@kingdom-builder/contents';
+import { createTestContext } from './fixtures';
+import type { EffectDef } from '@kingdom-builder/engine/effects';
+
+function getStatGain(key: Stat): number {
+  const def = BUILDINGS.get('castle_walls');
+  const passive = def.onBuild?.find(
+    (e) => e.type === 'passive' && e.method === 'add',
+  );
+  const effect = passive?.effects?.find(
+    (eff): eff is EffectDef<{ key: Stat; amount: number }> =>
+      eff.type === 'stat' &&
+      typeof eff.params === 'object' &&
+      eff.params !== null &&
+      (eff.params as { key?: unknown }).key === key &&
+      typeof (eff.params as { amount?: unknown }).amount === 'number',
+  );
+  return effect?.params.amount ?? 0;
+}
+
+describe('Castle Walls building', () => {
+  it('applies and removes stat bonuses when built and removed', () => {
+    const def = BUILDINGS.get('castle_walls');
+    const ctx = createTestContext();
+    ctx.activePlayer.gold = def.costs[Resource.gold] ?? 0;
+    ctx.activePlayer.ap =
+      ctx.services.rules.defaultActionAPCost + (def.costs[Resource.ap] ?? 0);
+
+    const fortGain = getStatGain(Stat.fortificationStrength);
+    const absorptionGain = getStatGain(Stat.absorption);
+    const fortBefore = ctx.activePlayer.stats[Stat.fortificationStrength];
+    const absorptionBefore = ctx.activePlayer.stats[Stat.absorption];
+
+    performAction('build', ctx, { id: 'castle_walls' });
+
+    expect(ctx.activePlayer.buildings.has('castle_walls')).toBe(true);
+    expect(ctx.activePlayer.stats[Stat.fortificationStrength]).toBe(
+      fortBefore + fortGain,
+    );
+    expect(ctx.activePlayer.stats[Stat.absorption]).toBeCloseTo(
+      absorptionBefore + absorptionGain,
+    );
+
+    runEffects(
+      [{ type: 'building', method: 'remove', params: { id: 'castle_walls' } }],
+      ctx,
+    );
+
+    expect(ctx.activePlayer.buildings.has('castle_walls')).toBe(false);
+    expect(ctx.activePlayer.stats[Stat.fortificationStrength]).toBe(fortBefore);
+    expect(ctx.activePlayer.stats[Stat.absorption]).toBeCloseTo(
+      absorptionBefore,
+    );
+
+    runEffects(
+      [{ type: 'building', method: 'remove', params: { id: 'castle_walls' } }],
+      ctx,
+    );
+
+    expect(ctx.activePlayer.buildings.has('castle_walls')).toBe(false);
+    expect(ctx.activePlayer.stats[Stat.fortificationStrength]).toBe(fortBefore);
+    expect(ctx.activePlayer.stats[Stat.absorption]).toBeCloseTo(
+      absorptionBefore,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- implement Castle Walls building with fortification and absorption bonuses
- document passive effect pattern for building stat bonuses
- add tests covering Castle Walls bonuses and passive:add branches to satisfy coverage

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b4945c8e948325a6115e72206e5110