### PR TITLE
feat: add army attack resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ Attach the date of your update as a prefix to your log entry.
 - 2025-10-01: Shell starts without standard binaries in PATH; run `export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` to restore.
 - 2025-10-05: `compare` evaluator returns 1 when a comparison holds, allowing conditional effects.
 - 2025-08-31: Node and npm may be missing; install with `apt-get install -y nodejs npm` before running tests.
+- 2025-10-07: Set attacker gold after advancing to main phase in tests; upkeep may require initial gold.
+- 2025-10-10: `action:perform` handler automatically snapshots for action traces, so nested manual snapshotting is redundant.
 
 # Core Agent principles
 

--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -19,6 +19,7 @@ import {
   PassiveMethods,
   CostModMethods,
   BuildingMethods,
+  StatMethods,
 } from './config/builders';
 
 export type ActionDef = ActionConfig;
@@ -181,6 +182,30 @@ export function createActionRegistry() {
           .message(
             `${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be lower than ${POPULATION_ROLES[PopulationRole.Commander].icon} ${POPULATION_ROLES[PopulationRole.Commander].label}`,
           )
+          .build(),
+      )
+      .effect(
+        effect('attack', 'perform')
+          .param('onCastleDamage', {
+            attacker: [
+              effect(Types.Resource, ResourceMethods.ADD)
+                .params({ key: Resource.happiness, amount: 1 })
+                .build(),
+              effect(Types.Action, ActionMethods.PERFORM)
+                .param('id', 'plunder')
+                .build(),
+            ],
+            defender: [
+              effect(Types.Resource, ResourceMethods.ADD)
+                .params({ key: Resource.happiness, amount: -1 })
+                .build(),
+            ],
+          })
+          .build(),
+      )
+      .effect(
+        effect(Types.Stat, StatMethods.ADD)
+          .params({ key: Stat.warWeariness, amount: 1 })
           .build(),
       )
       .build(),

--- a/packages/engine/src/effects/attack.ts
+++ b/packages/engine/src/effects/attack.ts
@@ -1,0 +1,89 @@
+import type { EffectDef, EffectHandler } from '.';
+import type { EngineContext } from '../context';
+import { Resource, type PlayerState } from '../state';
+import type { ResourceGain } from '../services';
+import { runEffects } from '.';
+import { collectTriggerEffects } from '../triggers';
+
+export interface AttackCalcOptions {
+  ignoreAbsorption?: boolean;
+  ignoreFortification?: boolean;
+}
+
+export function resolveAttack(
+  defender: PlayerState,
+  damage: number,
+  ctx: EngineContext,
+  opts: AttackCalcOptions = {},
+): number {
+  const original = ctx.game.currentPlayerIndex;
+  const defenderIndex = ctx.game.players.indexOf(defender);
+
+  ctx.game.currentPlayerIndex = defenderIndex;
+  const pre = collectTriggerEffects('onBeforeAttacked', ctx, defender);
+  if (pre.length) runEffects(pre, ctx);
+
+  ctx.game.currentPlayerIndex = original;
+
+  const absorb = opts.ignoreAbsorption
+    ? 0
+    : Math.min(defender.absorption || 0, ctx.services.rules.absorptionCapPct);
+  let reduced = damage * (1 - absorb);
+  const rounding = ctx.services.rules.absorptionRounding;
+  if (rounding === 'down') reduced = Math.floor(reduced);
+  else if (rounding === 'up') reduced = Math.ceil(reduced);
+  else reduced = Math.round(reduced);
+
+  const fortDamage = opts.ignoreFortification
+    ? 0
+    : Math.min(defender.fortificationStrength || 0, reduced);
+  if (fortDamage > 0)
+    defender.fortificationStrength =
+      (defender.fortificationStrength || 0) - fortDamage;
+  const castleDamage = reduced - fortDamage;
+  if (castleDamage > 0)
+    defender.resources[Resource.castleHP] = Math.max(
+      0,
+      (defender.resources[Resource.castleHP] || 0) - castleDamage,
+    );
+
+  ctx.game.currentPlayerIndex = defenderIndex;
+  const post = collectTriggerEffects('onAttackResolved', ctx, defender);
+  if (post.length) runEffects(post, ctx);
+  if ((defender.fortificationStrength || 0) < 0)
+    defender.fortificationStrength = 0;
+  ctx.game.currentPlayerIndex = original;
+  return castleDamage;
+}
+
+export const attackPerform: EffectHandler = (effect, ctx) => {
+  const attacker = ctx.activePlayer;
+  const defender = ctx.opponent;
+  const mods: ResourceGain[] = [
+    { key: Resource.castleHP, amount: attacker.armyStrength },
+  ];
+  ctx.passives.runEvaluationMods('attack:power', ctx, mods);
+  const damage = mods[0]!.amount;
+  const castleDamage = resolveAttack(
+    defender,
+    damage,
+    ctx,
+    effect.params as AttackCalcOptions,
+  );
+  if (castleDamage > 0) {
+    const onDamage = (effect.params?.['onCastleDamage'] || {}) as {
+      attacker?: EffectDef[];
+      defender?: EffectDef[];
+    };
+    if (onDamage.attacker?.length) runEffects(onDamage.attacker, ctx);
+    if (onDamage.defender?.length) {
+      const original = ctx.game.currentPlayerIndex;
+      const defenderIndex = ctx.game.players.indexOf(defender);
+      ctx.game.currentPlayerIndex = defenderIndex;
+      runEffects(onDamage.defender, ctx);
+      ctx.game.currentPlayerIndex = original;
+    }
+  }
+};
+
+export default attackPerform;

--- a/packages/engine/src/effects/index.ts
+++ b/packages/engine/src/effects/index.ts
@@ -23,6 +23,7 @@ import { populationRemove } from './population_remove';
 import { actionAdd } from './action_add';
 import { actionRemove } from './action_remove';
 import { actionPerform } from './action_perform';
+import { attackPerform } from './attack';
 
 export interface EffectDef<
   P extends Record<string, unknown> = Record<string, unknown>,
@@ -68,6 +69,7 @@ export function registerCoreEffects(registry: EffectRegistry = EFFECTS) {
   registry.add('action:add', actionAdd);
   registry.add('action:remove', actionRemove);
   registry.add('action:perform', actionPerform);
+  registry.add('attack:perform', attackPerform);
 }
 
 export function runEffects(effects: EffectDef[], ctx: EngineContext, mult = 1) {

--- a/packages/engine/src/triggers.ts
+++ b/packages/engine/src/triggers.ts
@@ -1,0 +1,46 @@
+import type { EngineContext } from './context';
+import type { PlayerState } from './state';
+import type { EffectDef } from './effects';
+import { applyParamsToEffects } from './utils';
+
+function getEffects(def: unknown, trigger: string): EffectDef[] | undefined {
+  const val = (def as Record<string, unknown>)[trigger];
+  return Array.isArray(val) ? (val as EffectDef[]) : undefined;
+}
+
+export function collectTriggerEffects(
+  trigger: string,
+  ctx: EngineContext,
+  player: PlayerState = ctx.activePlayer,
+): EffectDef[] {
+  const effects: EffectDef[] = [];
+  for (const [role, count] of Object.entries(player.population)) {
+    const populationDefinition = ctx.populations.get(role);
+    const list = getEffects(populationDefinition, trigger);
+    if (!list) continue;
+    for (let i = 0; i < Number(count); i++)
+      effects.push(...list.map((e) => ({ ...e })));
+  }
+  for (const land of player.lands) {
+    for (const id of land.developments) {
+      const developmentDefinition = ctx.developments.get(id);
+      const list = getEffects(developmentDefinition, trigger);
+      if (!list) continue;
+      effects.push(
+        ...applyParamsToEffects(list, { landId: land.id, id }).map((e) => ({
+          ...e,
+        })),
+      );
+    }
+  }
+  for (const id of player.buildings) {
+    const buildingDefinition = ctx.buildings.get(id);
+    const list = getEffects(buildingDefinition, trigger);
+    if (list) effects.push(...list.map((e) => ({ ...e })));
+  }
+  for (const passive of ctx.passives.values(player.id)) {
+    const list = getEffects(passive, trigger);
+    if (list) effects.push(...list.map((e) => ({ ...e })));
+  }
+  return effects;
+}

--- a/packages/engine/tests/actions/army_attack.test.ts
+++ b/packages/engine/tests/actions/army_attack.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { performAction, getActionRequirements, advance } from '../../src';
-import { PopulationRole } from '../../src/state';
+import {
+  performAction,
+  getActionRequirements,
+  advance,
+  runEffects,
+  type EffectDef,
+} from '../../src';
+import { PopulationRole, Resource, Stat } from '../../src/state';
 import { createTestEngine } from '../helpers.ts';
 
 describe('Army Attack action', () => {
@@ -22,5 +28,62 @@ describe('Army Attack action', () => {
     const failures = getActionRequirements('army_attack', ctx);
     expect(failures).toHaveLength(0);
     expect(() => performAction('army_attack', ctx)).not.toThrow();
+  });
+
+  it('calculates attack power with modifiers, damages castle, plunders and adds war weariness', () => {
+    const ctx = createTestEngine();
+    const attacker = ctx.activePlayer;
+    const defender = ctx.game.opponent;
+    attacker.population[PopulationRole.Commander] = 1;
+    attacker.armyStrength = 3;
+    defender.gold = 100;
+    const startHP = defender.resources[Resource.castleHP];
+    const startGold = defender.gold;
+    runEffects(
+      [
+        {
+          type: 'result_mod',
+          method: 'add',
+          params: {
+            id: 'boost',
+            evaluation: { type: 'attack', id: 'power' },
+            adjust: 2,
+          },
+        },
+      ],
+      ctx,
+    );
+    ctx.game.currentPlayerIndex = 1;
+    ctx.passives.addPassive(
+      {
+        id: 'shield',
+        effects: [],
+        onBeforeAttacked: [
+          {
+            type: 'stat',
+            method: 'add',
+            params: { key: Stat.absorption, amount: 0.4 },
+          },
+        ],
+      },
+      ctx,
+    );
+    ctx.game.currentPlayerIndex = 0;
+    while (ctx.game.currentPhase !== 'main') advance(ctx);
+    attacker.gold = 0;
+    performAction('army_attack', ctx);
+    const plunderDef = ctx.actions.get('plunder');
+    const plunderEffect = plunderDef.effects[0] as EffectDef<{
+      percent?: number;
+    }>;
+    const percent = plunderEffect.params?.percent ?? 0;
+    const expectedPlunder = Math.floor((startGold * percent) / 100);
+    const expectedDamage = Math.floor((attacker.armyStrength + 2) * (1 - 0.4));
+    expect(defender.resources[Resource.castleHP]).toBe(
+      startHP - expectedDamage,
+    );
+    expect(attacker.warWeariness).toBe(1);
+    expect(attacker.gold).toBe(expectedPlunder);
+    expect(defender.gold).toBe(startGold - expectedPlunder);
   });
 });

--- a/packages/engine/tests/resolveAttack.test.ts
+++ b/packages/engine/tests/resolveAttack.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { resolveAttack, runEffects } from '../src/index.ts';
+import { resolveAttack, runEffects, type EffectDef } from '../src/index.ts';
 import { createTestEngine } from './helpers.ts';
 import { Resource, Stat } from '../src/state/index.ts';
-import type { EffectDef } from '../src/effects';
 
 function makeAbsorptionEffect(amount: number): EffectDef {
   return {
@@ -28,20 +27,59 @@ describe('resolveAttack', () => {
     expect(dmg).toBe(5);
   });
 
-  it('applies fortification, castle damage, happiness and plunder before post triggers', () => {
+  it('applies fortification and castle damage before post triggers', () => {
     const ctx = createTestEngine();
     const attacker = ctx.activePlayer;
     const defender = ctx.game.opponent;
     defender.stats[Stat.fortificationStrength] = 1;
     defender.gold = 100;
     attacker.gold = 0;
+    const startHP = defender.resources[Resource.castleHP];
+    const startGold = defender.gold;
     const dmg = resolveAttack(defender, 5, ctx);
     expect(dmg).toBe(4);
-    expect(defender.resources[Resource.castleHP]).toBe(6);
-    expect(defender.happiness).toBe(-1);
-    expect(attacker.happiness).toBe(1);
-    expect(defender.gold).toBe(75);
-    expect(attacker.gold).toBe(25);
+    expect(defender.resources[Resource.castleHP]).toBe(startHP - dmg);
+    expect(defender.fortificationStrength).toBe(0);
+    // ensure no content-driven effects run inside resolveAttack
+    expect(defender.gold).toBe(startGold);
+    expect(attacker.gold).toBe(0);
+    expect(defender.happiness).toBe(0);
+    expect(attacker.happiness).toBe(0);
+    expect(attacker.warWeariness).toBe(0);
+  });
+
+  it('rounds absorbed damage up when rules specify', () => {
+    const ctx = createTestEngine();
+    const defender = ctx.game.opponent;
+    ctx.services.rules.absorptionRounding = 'up';
+    defender.absorption = 0.5;
+    const start = defender.resources[Resource.castleHP];
+    const dmg = resolveAttack(defender, 1, ctx);
+    expect(dmg).toBe(1);
+    expect(defender.resources[Resource.castleHP]).toBe(start - 1);
+  });
+
+  it('rounds absorbed damage to nearest when rules specify', () => {
+    const ctx = createTestEngine();
+    const defender = ctx.game.opponent;
+    ctx.services.rules.absorptionRounding = 'nearest';
+    defender.absorption = 0.6;
+    const dmg = resolveAttack(defender, 1, ctx);
+    expect(dmg).toBe(0);
+  });
+
+  it('can ignore absorption and fortification when options specify', () => {
+    const ctx = createTestEngine();
+    const defender = ctx.game.opponent;
+    defender.absorption = 0.5;
+    defender.stats[Stat.fortificationStrength] = 5;
+    const dmg = resolveAttack(defender, 10, ctx, {
+      ignoreAbsorption: true,
+      ignoreFortification: true,
+    });
+    expect(dmg).toBe(10);
+    expect(defender.fortificationStrength).toBe(5);
+    expect(defender.resources[Resource.castleHP]).toBe(0);
   });
 
   it('resolves post-damage triggers like watchtower removal', () => {


### PR DESCRIPTION
## Summary
- refactor attack effect to be content-driven with configurable on-damage hooks and optional absorption/fortification bypass
- shift happiness, plunder, and war weariness handling to Army Attack content
- extend tests for resolveAttack and options

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b4937be3a48325b475878119cb0d60