### PR TITLE
refactor: shift building AP costs to config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ Attach the date of your update as a prefix to your log entry.
 - 2025-10-10: `action:perform` handler automatically snapshots for action traces, so nested manual snapshotting is redundant.
 - 2025-10-11: Building stat bonuses should use `PassiveMethods.ADD` with a unique id to tie their effects to the building's existence.
 - 2025-10-19: Population labels are defined in `packages/contents/src/populationRoles.ts` for UI display.
+- 2025-10-28: BuildingBuilder now defaults to 1 AP; tests adding buildings must allocate AP equal to building costs.
 
 # Core Agent principles
 

--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -297,7 +297,6 @@ export function createActionRegistry() {
       .id('build')
       .name('Build')
       .icon('🏛️')
-      .cost(Resource.ap, 1)
       .effect(
         effect(Types.Building, BuildingMethods.ADD).param('id', '$id').build(),
       )

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -132,7 +132,7 @@ export function createBuildingRegistry() {
       .name('Castle Walls')
       .icon('🧱')
       .cost(Resource.gold, 12)
-      .cost(Resource.ap, 1)
+      .cost(Resource.ap, 2)
       .onBuild(
         effect(Types.Passive, PassiveMethods.ADD)
           .param('id', 'castle_walls_bonus')

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -7,6 +7,7 @@ import type {
   EffectConfig,
 } from '@kingdom-builder/engine/config/schema';
 import type { ResourceKey } from '@kingdom-builder/engine/state';
+import { Resource } from '@kingdom-builder/engine/state';
 import type { EvaluatorDef } from '@kingdom-builder/engine/evaluators';
 
 export const Types = {
@@ -211,7 +212,7 @@ export class ActionBuilder extends BaseBuilder<ActionConfig> {
 
 export class BuildingBuilder extends BaseBuilder<BuildingConfig> {
   constructor() {
-    super({ costs: {}, onBuild: [] });
+    super({ costs: { [Resource.ap]: 1 }, onBuild: [] });
   }
   cost(key: ResourceKey, amount: number) {
     this.config.costs[key] = amount;

--- a/packages/engine/tests/effects/add_building.test.ts
+++ b/packages/engine/tests/effects/add_building.test.ts
@@ -23,6 +23,8 @@ function getExpandGoldCost(ctx: EngineContext) {
 describe('building:add effect', () => {
   it('adds building and applies its passives', () => {
     const ctx = createTestEngine({ actions });
+    ctx.activePlayer.ap =
+      ctx.buildings.get('town_charter').costs[Resource.ap] ?? 0;
     const before = getExpandGoldCost(ctx);
     performAction('free_charter', ctx);
     expect(ctx.activePlayer.buildings.has('town_charter')).toBe(true);

--- a/tests/integration/building-placement.test.ts
+++ b/tests/integration/building-placement.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { performAction, getActionCosts } from '@kingdom-builder/engine';
+import {
+  performAction,
+  getActionCosts,
+  Resource,
+} from '@kingdom-builder/engine';
 import { createTestContext, getActionOutcome } from './fixtures';
 
 describe('Building placement integration', () => {
   it('applies building effects to subsequent actions', () => {
     const ctx = createTestContext();
-    ctx.activePlayer.ap = ctx.services.rules.defaultActionAPCost * 2;
     const expandBefore = getActionOutcome('expand', ctx);
     const buildCosts = getActionCosts('build', ctx, { id: 'town_charter' });
+    ctx.activePlayer.ap =
+      (expandBefore.costs[Resource.ap] ?? 0) + (buildCosts[Resource.ap] ?? 0);
     const resBefore = { ...ctx.activePlayer.resources };
 
     performAction('build', ctx, { id: 'town_charter' });

--- a/tests/integration/castle-walls.test.ts
+++ b/tests/integration/castle-walls.test.ts
@@ -26,8 +26,7 @@ describe('Castle Walls building', () => {
     const def = BUILDINGS.get('castle_walls');
     const ctx = createTestContext();
     ctx.activePlayer.gold = def.costs[Resource.gold] ?? 0;
-    ctx.activePlayer.ap =
-      ctx.services.rules.defaultActionAPCost + (def.costs[Resource.ap] ?? 0);
+    ctx.activePlayer.ap = def.costs[Resource.ap] ?? 0;
 
     const fortGain = getStatGain(Stat.fortificationStrength);
     const absorptionGain = getStatGain(Stat.absorption);


### PR DESCRIPTION
## Summary
- set BuildingBuilder default AP cost to 1 and drop build action surcharge
- bump Castle Walls AP cost and adjust tests accordingly
- fix building add test to pay building AP cost

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b49b536b0c832590222777c5c82cf6