### PR TITLE
feat: add raiders guild building

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ Attach the date of your update as a prefix to your log entry.
 - 2025-10-10: `action:perform` handler automatically snapshots for action traces, so nested manual snapshotting is redundant.
 - 2025-10-11: Building stat bonuses should use `PassiveMethods.ADD` with a unique id to tie their effects to the building's existence.
 - 2025-10-19: Population labels are defined in `packages/contents/src/populationRoles.ts` for UI display.
+- 2025-10-23: Summary entries with a `_desc` flag appear under the Description section.
 
 # Core Agent principles
 

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -75,6 +75,16 @@ export function createBuildingRegistry() {
       .name("Raider's Guild")
       .icon('🏴‍☠️')
       .cost(Resource.gold, 8)
+      .cost(Resource.ap, 1)
+      .onBuild(
+        effect(Types.ResultMod, ResultModMethods.ADD)
+          .params({
+            id: 'raiders_guild_plunder_bonus',
+            evaluation: { type: 'transfer_pct', id: 'percent' },
+            adjust: 25,
+          })
+          .build(),
+      )
       .build(),
   );
   registry.add(

--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -4,6 +4,7 @@ import {
 } from '@kingdom-builder/contents';
 import type { ResourceKey } from '@kingdom-builder/engine';
 import { increaseOrDecrease, signed } from '../helpers';
+import { describeContent } from '../../content';
 import {
   registerEffectFormatter,
   summarizeEffects,
@@ -164,8 +165,15 @@ registerEffectFormatter('result_mod', 'add', {
         const actionIcon = action?.icon || 'plunder';
         const actionName = action?.name || 'plunder';
         const amount = Number(eff.params?.['adjust'] ?? 0);
+        const card = describeContent('action', 'plunder', ctx);
         return [
           `${modifierInfo.result.icon} ${modifierInfo.result.label} on ${actionIcon} ${actionName}: ${increaseOrDecrease(amount)} transfer by ${Math.abs(amount)}%`,
+          {
+            title: `${actionIcon} ${actionName}`,
+            items: card,
+            _hoist: true,
+            _desc: true,
+          },
         ];
       }
       return [];

--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -74,33 +74,45 @@ registerEffectFormatter('result_mod', 'add', {
     const evaluation = eff.params?.['evaluation'] as
       | { type: string; id: string }
       | undefined;
-    if (evaluation?.type === 'development') {
-      const dev = ctx.developments.get(evaluation.id);
-      const icon = ctx.developments.get(evaluation.id)?.icon || '';
-      const resource = eff.effects?.find(
-        (e) => e.type === 'resource' && e.method === 'add',
-      );
-      if (resource) {
-        const key = resource.params?.['key'] as string;
-        const resIcon = RESOURCES[key as ResourceKey]?.icon || key;
-        const amount = Number(resource.params?.['amount']);
+    if (evaluation) {
+      if (evaluation.type === 'development') {
+        const dev = ctx.developments.get(evaluation.id);
+        const icon = ctx.developments.get(evaluation.id)?.icon || '';
+        const resource = eff.effects?.find(
+          (e) => e.type === 'resource' && e.method === 'add',
+        );
+        if (resource) {
+          const key = resource.params?.['key'] as string;
+          const resIcon = RESOURCES[key as ResourceKey]?.icon || key;
+          const amount = Number(resource.params?.['amount']);
+          return [
+            `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${dev?.name || evaluation.id}, gain ${resIcon}+${amount} more`,
+          ];
+        }
+        const amount = Number(eff.params?.['amount'] ?? 0);
         return [
-          `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${dev?.name || evaluation.id}, gain ${resIcon}+${amount} more`,
+          `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${dev?.name || evaluation.id}, gain +${amount} more of that resource`,
         ];
       }
-      const amount = Number(eff.params?.['amount'] ?? 0);
-      return [
-        `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${dev?.name || evaluation.id}, gain +${amount} more of that resource`,
-      ];
-    }
-    if (evaluation?.type === 'population') {
-      const action = ctx.actions.get(evaluation.id);
-      const actionIcon = action?.icon || evaluation.id;
-      const actionName = action?.name || evaluation.id;
-      const amount = Number(eff.params?.['amount'] ?? 0);
-      return [
-        `${modifierInfo.result.icon} Every time you gain resources from 👥 Population through ${actionIcon} ${actionName}, gain +${amount} more of that resource`,
-      ];
+      if (evaluation.type === 'population') {
+        const action = ctx.actions.get(evaluation.id);
+        const actionIcon = action?.icon || evaluation.id;
+        const actionName = action?.name || evaluation.id;
+        const amount = Number(eff.params?.['amount'] ?? 0);
+        return [
+          `${modifierInfo.result.icon} Every time you gain resources from 👥 Population through ${actionIcon} ${actionName}, gain +${amount} more of that resource`,
+        ];
+      }
+      if (evaluation.type === 'transfer_pct') {
+        const action = ctx.actions.get('plunder');
+        const actionIcon = action?.icon || 'plunder';
+        const actionName = action?.name || 'plunder';
+        const amount = Number(eff.params?.['adjust'] ?? 0);
+        return [
+          `${modifierInfo.result.icon} ${actionIcon} ${actionName}: ${signed(amount)}${Math.abs(amount)}% transfer`,
+        ];
+      }
+      return [];
     }
     const actionId = eff.params?.['actionId'] as string;
     const actionIcon = ctx.actions.get(actionId)?.icon || actionId;
@@ -118,33 +130,45 @@ registerEffectFormatter('result_mod', 'add', {
     const evaluation = eff.params?.['evaluation'] as
       | { type: string; id: string }
       | undefined;
-    if (evaluation?.type === 'development') {
-      const dev = ctx.developments.get(evaluation.id);
-      const icon = ctx.developments.get(evaluation.id)?.icon || '';
-      const resource = eff.effects?.find(
-        (e) => e.type === 'resource' && e.method === 'add',
-      );
-      if (resource) {
-        const key = resource.params?.['key'] as string;
-        const resIcon = RESOURCES[key as ResourceKey]?.icon || key;
-        const amount = Number(resource.params?.['amount']);
+    if (evaluation) {
+      if (evaluation.type === 'development') {
+        const dev = ctx.developments.get(evaluation.id);
+        const icon = ctx.developments.get(evaluation.id)?.icon || '';
+        const resource = eff.effects?.find(
+          (e) => e.type === 'resource' && e.method === 'add',
+        );
+        if (resource) {
+          const key = resource.params?.['key'] as string;
+          const resIcon = RESOURCES[key as ResourceKey]?.icon || key;
+          const amount = Number(resource.params?.['amount']);
+          return [
+            `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${dev?.name || evaluation.id}, gain ${resIcon}+${amount} more of that resource`,
+          ];
+        }
+        const amount = Number(eff.params?.['amount'] ?? 0);
         return [
-          `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${dev?.name || evaluation.id}, gain ${resIcon}+${amount} more of that resource`,
+          `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${dev?.name || evaluation.id}, gain +${amount} more of that resource`,
         ];
       }
-      const amount = Number(eff.params?.['amount'] ?? 0);
-      return [
-        `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${dev?.name || evaluation.id}, gain +${amount} more of that resource`,
-      ];
-    }
-    if (evaluation?.type === 'population') {
-      const action = ctx.actions.get(evaluation.id);
-      const actionIcon = action?.icon || evaluation.id;
-      const actionName = action?.name || evaluation.id;
-      const amount = Number(eff.params?.['amount'] ?? 0);
-      return [
-        `${modifierInfo.result.icon} Every time you gain resources from 👥 Population through ${actionIcon} ${actionName}, gain +${amount} more of that resource`,
-      ];
+      if (evaluation.type === 'population') {
+        const action = ctx.actions.get(evaluation.id);
+        const actionIcon = action?.icon || evaluation.id;
+        const actionName = action?.name || evaluation.id;
+        const amount = Number(eff.params?.['amount'] ?? 0);
+        return [
+          `${modifierInfo.result.icon} Every time you gain resources from 👥 Population through ${actionIcon} ${actionName}, gain +${amount} more of that resource`,
+        ];
+      }
+      if (evaluation.type === 'transfer_pct') {
+        const action = ctx.actions.get('plunder');
+        const actionIcon = action?.icon || 'plunder';
+        const actionName = action?.name || 'plunder';
+        const amount = Number(eff.params?.['adjust'] ?? 0);
+        return [
+          `${modifierInfo.result.icon} ${modifierInfo.result.label} on ${actionIcon} ${actionName}: ${increaseOrDecrease(amount)} transfer by ${Math.abs(amount)}%`,
+        ];
+      }
+      return [];
     }
     const actionId = eff.params?.['actionId'] as string;
     const actionIcon = ctx.actions.get(actionId)?.icon || actionId;

--- a/packages/web/src/translation/effects/formatters/resource.ts
+++ b/packages/web/src/translation/effects/formatters/resource.ts
@@ -20,3 +20,21 @@ registerEffectFormatter('resource', 'add', {
     return `${icon}${signed(amount)}${amount} ${label}`;
   },
 });
+
+registerEffectFormatter('resource', 'transfer', {
+  summarize: (eff) => {
+    const key = eff.params?.['key'] as string;
+    const res = RESOURCES[key as ResourceKey];
+    const icon = res ? res.icon : key;
+    const percent = Number(eff.params?.['percent']);
+    return `${icon}${percent}%`;
+  },
+  describe: (eff) => {
+    const key = eff.params?.['key'] as string;
+    const res = RESOURCES[key as ResourceKey];
+    const label = res?.label || key;
+    const icon = res?.icon || key;
+    const percent = Number(eff.params?.['percent']);
+    return `Transfer ${percent}% of opponent's ${icon}${label}`;
+  },
+});

--- a/packages/web/src/translation/effects/formatters/resource.ts
+++ b/packages/web/src/translation/effects/formatters/resource.ts
@@ -35,6 +35,6 @@ registerEffectFormatter('resource', 'transfer', {
     const label = res?.label || key;
     const icon = res?.icon || key;
     const percent = Number(eff.params?.['percent']);
-    return `Transfer ${percent}% of opponent's ${icon}${label}`;
+    return `Transfer ${percent}% of opponent's ${icon}${label} to you`;
   },
 });

--- a/packages/web/tests/raiders-guild-translation.test.ts
+++ b/packages/web/tests/raiders-guild-translation.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  describeContent,
+  splitSummary,
+  type Summary,
+} from '../src/translation/content';
+import { createEngine } from '@kingdom-builder/engine';
+import {
+  ACTIONS,
+  BUILDINGS,
+  DEVELOPMENTS,
+  POPULATIONS,
+  PHASES,
+  GAME_START,
+} from '@kingdom-builder/contents';
+
+vi.mock('@kingdom-builder/engine', async () => {
+  return await import('../../engine/src');
+});
+
+function createCtx() {
+  return createEngine({
+    actions: ACTIONS,
+    buildings: BUILDINGS,
+    developments: DEVELOPMENTS,
+    populations: POPULATIONS,
+    phases: PHASES,
+    start: GAME_START,
+  });
+}
+
+describe('raiders guild translation', () => {
+  it('describes plunder action', () => {
+    const ctx = createCtx();
+    const summary = describeContent('building', 'raiders_guild', ctx);
+    const { effects, description } = splitSummary(summary);
+    expect(effects).toHaveLength(1);
+    const build = effects[0] as { title: string; items?: unknown[] };
+    expect(build.items?.[0]).toBe(
+      '✨ Result Modifier on 🏴‍☠️ Plunder: Increase transfer by 25%',
+    );
+    expect(description).toBeDefined();
+    const actionCard = (description as Summary)[0] as { title: string };
+    expect(actionCard.title).toBe('🏴‍☠️ Plunder');
+    expect(JSON.stringify({ effects, description })).not.toMatch(
+      /Immediately|🎯/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Raider's Guild building that boosts plunder by 25%
- translate resource transfer effects and plunder modifier

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b49b2fcb888325b5544edb3e7f5b21