### PR TITLE
feat(web): translate attack perform effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Use the actual calendar date—today is 2025-08-31—and never log entries with 
 - 2025-10-19: Population labels are defined in `packages/contents/src/populationRoles.ts` for UI display.
 - 2025-08-31: `attack:perform` effect parameters `ignoreAbsorption`, `ignoreFortification` and nested `onCastleDamage` effects require dedicated web formatter for player-facing text.
 - 2025-08-31: Merge attacker and defender on-damage summaries by tagging items "for you" or "for opponent" instead of separate groups.
+- 2025-08-31: Compact on-damage summaries further by prefixing entries with "You" or "Opponent".
 
 # Core Agent principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Use the actual calendar date—today is 2025-08-31—and never log entries with 
 - 2025-10-11: Building stat bonuses should use `PassiveMethods.ADD` with a unique id to tie their effects to the building's existence.
 - 2025-10-19: Population labels are defined in `packages/contents/src/populationRoles.ts` for UI display.
 - 2025-08-31: `attack:perform` effect parameters `ignoreAbsorption`, `ignoreFortification` and nested `onCastleDamage` effects require dedicated web formatter for player-facing text.
+- 2025-08-31: Merge attacker and defender on-damage summaries by tagging items "for you" or "for opponent" instead of separate groups.
 
 # Core Agent principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Use the actual calendar date—today is 2025-08-31—and never log entries with 
 - 2025-08-31: `attack:perform` effect parameters `ignoreAbsorption`, `ignoreFortification` and nested `onCastleDamage` effects require dedicated web formatter for player-facing text.
 - 2025-08-31: Merge attacker and defender on-damage summaries by tagging items "for you" or "for opponent" instead of separate groups.
 - 2025-08-31: Compact on-damage summaries further by prefixing entries with "You" or "Opponent".
+- 2025-08-31: Suffix on-damage summary items with "for you"/"for opponent" to keep icons leading each line.
 
 # Core Agent principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Use the actual calendar date—today is 2025-08-31—and never log entries with 
 - 2025-10-10: `action:perform` handler automatically snapshots for action traces, so nested manual snapshotting is redundant.
 - 2025-10-11: Building stat bonuses should use `PassiveMethods.ADD` with a unique id to tie their effects to the building's existence.
 - 2025-10-19: Population labels are defined in `packages/contents/src/populationRoles.ts` for UI display.
+- 2025-08-31: `attack:perform` effect parameters `ignoreAbsorption`, `ignoreFortification` and nested `onCastleDamage` effects require dedicated web formatter for player-facing text.
 
 # Core Agent principles
 

--- a/packages/web/src/translation/effects/formatters/attack.ts
+++ b/packages/web/src/translation/effects/formatters/attack.ts
@@ -1,5 +1,5 @@
 import { RESOURCES, STATS } from '@kingdom-builder/contents';
-import type { EffectDef } from '@kingdom-builder/engine';
+import type { EffectDef, EngineContext } from '@kingdom-builder/engine';
 import { Resource, Stat } from '@kingdom-builder/engine';
 import type { SummaryEntry } from '../../content';
 import {
@@ -9,80 +9,118 @@ import {
   logEffects,
 } from '../factory';
 
-function baseAttackText(eff: EffectDef<Record<string, unknown>>) {
+type Mode = 'summarize' | 'describe' | 'log';
+
+function baseEntry(eff: EffectDef<Record<string, unknown>>, mode: Mode) {
   const army = STATS[Stat.armyStrength];
   const castle = RESOURCES[Resource.castleHP];
   const absorption = STATS[Stat.absorption];
   const fort = STATS[Stat.fortificationStrength];
-  let text = `Attack opponent's ${castle.icon} ${castle.label} with your ${army.icon} ${army.label}`;
-  if (eff.params?.['ignoreAbsorption'])
-    text += `, ignoring ${absorption.icon} ${absorption.label}`;
-  if (eff.params?.['ignoreFortification'])
-    text += `, ignoring ${fort.icon} ${fort.label}`;
-  return { text, castle };
+  const title = `Attack opponent with your ${army.icon} ${army.label}`;
+  const items: SummaryEntry[] = [];
+
+  if (mode === 'describe') {
+    if (eff.params?.['ignoreAbsorption'])
+      items.push(
+        `Ignoring ${absorption.icon} ${absorption.label} damage reduction`,
+      );
+    else
+      items.push(
+        `${absorption.icon} ${absorption.label} damage reduction applied`,
+      );
+
+    if (eff.params?.['ignoreFortification'])
+      items.push(
+        `Damage applied directly to opponent's ${castle.icon} ${castle.label}`,
+      );
+    else {
+      items.push(`Damage applied to opponent's ${fort.icon} ${fort.label}`);
+      items.push(
+        `If opponent ${fort.icon} ${fort.label} reduced to 0, overflow remaining damage on opponent ${castle.icon} ${castle.label}`,
+      );
+    }
+  } else {
+    if (eff.params?.['ignoreAbsorption'])
+      items.push(`Ignore ${absorption.icon} ${absorption.label}`);
+    else items.push(`${absorption.icon} reduces damage`);
+
+    if (eff.params?.['ignoreFortification'])
+      items.push(`Hits ${castle.icon} ${castle.label} directly`);
+    else items.push(`Hits opponent's ${fort.icon} then ${castle.icon}`);
+  }
+
+  return { entry: { title, items }, castle };
+}
+
+function onCastleDamageEntry(
+  eff: EffectDef<Record<string, unknown>>,
+  ctx: EngineContext,
+  mode: Mode,
+) {
+  const castle = RESOURCES[Resource.castleHP];
+  const onDamage = eff.params?.['onCastleDamage'] as
+    | { attacker?: EffectDef[]; defender?: EffectDef[] }
+    | undefined;
+  if (!onDamage) return null;
+
+  const format =
+    mode === 'summarize'
+      ? summarizeEffects
+      : mode === 'describe'
+        ? describeEffects
+        : logEffects;
+
+  const attackerDefs = onDamage.attacker ?? [];
+  const defenderDefs = onDamage.defender ?? [];
+  const attackerItems = format(attackerDefs, ctx);
+  const defenderItems = format(defenderDefs, ctx);
+  const items: SummaryEntry[] = [];
+  const actionItems: SummaryEntry[] = [];
+
+  attackerItems.forEach((item, i) => {
+    const def = attackerDefs[i]!;
+    if (def.type === 'action' && def.method === 'perform')
+      actionItems.push(item);
+    else if (typeof item === 'string') items.push(`${item} for you`);
+    else items.push({ ...item, title: `${item.title} for you` });
+  });
+
+  defenderItems.forEach((item, i) => {
+    const def = defenderDefs[i]!;
+    if (def.type === 'action' && def.method === 'perform')
+      actionItems.push(item);
+    else if (typeof item === 'string') items.push(`${item} for opponent`);
+    else items.push({ ...item, title: `${item.title} for opponent` });
+  });
+
+  const all = items.concat(actionItems);
+  if (!all.length) return null;
+  return {
+    title: `On opponent ${castle.icon} ${castle.label} damage`,
+    items: all,
+  };
 }
 
 registerEffectFormatter('attack', 'perform', {
   summarize: (eff, ctx) => {
-    const { text, castle } = baseAttackText(eff);
-    const parts: SummaryEntry[] = [text];
-    const onDamage = eff.params?.['onCastleDamage'] as
-      | { attacker?: EffectDef[]; defender?: EffectDef[] }
-      | undefined;
-    if (onDamage?.attacker?.length) {
-      parts.push({
-        title: `On ${castle.icon} ${castle.label} damage (you)`,
-        items: summarizeEffects(onDamage.attacker, ctx),
-      });
-    }
-    if (onDamage?.defender?.length) {
-      parts.push({
-        title: `On ${castle.icon} ${castle.label} damage (opponent)`,
-        items: summarizeEffects(onDamage.defender, ctx),
-      });
-    }
+    const { entry } = baseEntry(eff, 'summarize');
+    const parts: SummaryEntry[] = [entry];
+    const onDamage = onCastleDamageEntry(eff, ctx, 'summarize');
+    if (onDamage) parts.push(onDamage);
     return parts;
   },
   describe: (eff, ctx) => {
-    const { text, castle } = baseAttackText(eff);
-    const parts: SummaryEntry[] = [text];
-    const onDamage = eff.params?.['onCastleDamage'] as
-      | { attacker?: EffectDef[]; defender?: EffectDef[] }
-      | undefined;
-    if (onDamage?.attacker?.length) {
-      parts.push({
-        title: `On ${castle.icon} ${castle.label} damage (you)`,
-        items: describeEffects(onDamage.attacker, ctx),
-      });
-    }
-    if (onDamage?.defender?.length) {
-      parts.push({
-        title: `On ${castle.icon} ${castle.label} damage (opponent)`,
-        items: describeEffects(onDamage.defender, ctx),
-      });
-    }
+    const { entry } = baseEntry(eff, 'describe');
+    const parts: SummaryEntry[] = [entry];
+    const onDamage = onCastleDamageEntry(eff, ctx, 'describe');
+    if (onDamage) parts.push(onDamage);
     return parts;
   },
   log: (eff, ctx) => {
-    const { text, castle } = baseAttackText(eff);
-    const parts: SummaryEntry[] = [text];
-    const onDamage = eff.params?.['onCastleDamage'] as
-      | { attacker?: EffectDef[]; defender?: EffectDef[] }
-      | undefined;
-    if (onDamage?.attacker?.length || onDamage?.defender?.length) {
-      const items: SummaryEntry[] = [];
-      if (onDamage.attacker?.length)
-        items.push({
-          title: 'Attacker',
-          items: logEffects(onDamage.attacker, ctx),
-        });
-      if (onDamage.defender?.length)
-        items.push({
-          title: 'Defender',
-          items: logEffects(onDamage.defender, ctx),
-        });
-      parts.push({ title: `On ${castle.icon} ${castle.label} damage`, items });
-    }
+    const { entry } = baseEntry(eff, 'describe');
+    const parts: SummaryEntry[] = [entry];
+    const onDamage = onCastleDamageEntry(eff, ctx, 'log');
+    if (onDamage) parts.push(onDamage);
     return parts;
   },
 });

--- a/packages/web/src/translation/effects/formatters/attack.ts
+++ b/packages/web/src/translation/effects/formatters/attack.ts
@@ -1,0 +1,88 @@
+import { RESOURCES, STATS } from '@kingdom-builder/contents';
+import type { EffectDef } from '@kingdom-builder/engine';
+import { Resource, Stat } from '@kingdom-builder/engine';
+import type { SummaryEntry } from '../../content';
+import {
+  registerEffectFormatter,
+  summarizeEffects,
+  describeEffects,
+  logEffects,
+} from '../factory';
+
+function baseAttackText(eff: EffectDef<Record<string, unknown>>) {
+  const army = STATS[Stat.armyStrength];
+  const castle = RESOURCES[Resource.castleHP];
+  const absorption = STATS[Stat.absorption];
+  const fort = STATS[Stat.fortificationStrength];
+  let text = `Attack opponent's ${castle.icon} ${castle.label} with your ${army.icon} ${army.label}`;
+  if (eff.params?.['ignoreAbsorption'])
+    text += `, ignoring ${absorption.icon} ${absorption.label}`;
+  if (eff.params?.['ignoreFortification'])
+    text += `, ignoring ${fort.icon} ${fort.label}`;
+  return { text, castle };
+}
+
+registerEffectFormatter('attack', 'perform', {
+  summarize: (eff, ctx) => {
+    const { text, castle } = baseAttackText(eff);
+    const parts: SummaryEntry[] = [text];
+    const onDamage = eff.params?.['onCastleDamage'] as
+      | { attacker?: EffectDef[]; defender?: EffectDef[] }
+      | undefined;
+    if (onDamage?.attacker?.length) {
+      parts.push({
+        title: `On ${castle.icon} ${castle.label} damage (you)`,
+        items: summarizeEffects(onDamage.attacker, ctx),
+      });
+    }
+    if (onDamage?.defender?.length) {
+      parts.push({
+        title: `On ${castle.icon} ${castle.label} damage (opponent)`,
+        items: summarizeEffects(onDamage.defender, ctx),
+      });
+    }
+    return parts;
+  },
+  describe: (eff, ctx) => {
+    const { text, castle } = baseAttackText(eff);
+    const parts: SummaryEntry[] = [text];
+    const onDamage = eff.params?.['onCastleDamage'] as
+      | { attacker?: EffectDef[]; defender?: EffectDef[] }
+      | undefined;
+    if (onDamage?.attacker?.length) {
+      parts.push({
+        title: `On ${castle.icon} ${castle.label} damage (you)`,
+        items: describeEffects(onDamage.attacker, ctx),
+      });
+    }
+    if (onDamage?.defender?.length) {
+      parts.push({
+        title: `On ${castle.icon} ${castle.label} damage (opponent)`,
+        items: describeEffects(onDamage.defender, ctx),
+      });
+    }
+    return parts;
+  },
+  log: (eff, ctx) => {
+    const { text, castle } = baseAttackText(eff);
+    const parts: SummaryEntry[] = [text];
+    const onDamage = eff.params?.['onCastleDamage'] as
+      | { attacker?: EffectDef[]; defender?: EffectDef[] }
+      | undefined;
+    if (onDamage?.attacker?.length || onDamage?.defender?.length) {
+      const items: SummaryEntry[] = [];
+      if (onDamage.attacker?.length)
+        items.push({
+          title: 'Attacker',
+          items: logEffects(onDamage.attacker, ctx),
+        });
+      if (onDamage.defender?.length)
+        items.push({
+          title: 'Defender',
+          items: logEffects(onDamage.defender, ctx),
+        });
+      parts.push({ title: `On ${castle.icon} ${castle.label} damage`, items });
+    }
+    return parts;
+  },
+});

--- a/packages/web/src/translation/effects/formatters/attack.ts
+++ b/packages/web/src/translation/effects/formatters/attack.ts
@@ -18,7 +18,7 @@ function baseEntry(eff: EffectDef<Record<string, unknown>>, mode: Mode) {
   const fort = STATS[Stat.fortificationStrength];
 
   if (mode === 'summarize') {
-    const title = `${army.icon} Attack opponent's ${fort.icon}${castle.icon}`;
+    const title = `${army.icon} opponent's ${fort.icon}${castle.icon}`;
     return { entry: title, castle };
   }
 
@@ -83,17 +83,11 @@ function onCastleDamageEntry(
             : (item as { title: string }).title
           : item,
       );
-    else if (typeof item === 'string')
-      items.push(
-        mode === 'summarize' ? `Opponent ${item}` : `${item} for opponent`,
-      );
+    else if (typeof item === 'string') items.push(`${item} for opponent`);
     else
       items.push({
         ...item,
-        title:
-          mode === 'summarize'
-            ? `Opponent ${item.title}`
-            : `${item.title} for opponent`,
+        title: `${item.title} for opponent`,
       });
   });
 
@@ -107,13 +101,11 @@ function onCastleDamageEntry(
             : (item as { title: string }).title
           : item,
       );
-    else if (typeof item === 'string')
-      items.push(mode === 'summarize' ? `You ${item}` : `${item} for you`);
+    else if (typeof item === 'string') items.push(`${item} for you`);
     else
       items.push({
         ...item,
-        title:
-          mode === 'summarize' ? `You ${item.title}` : `${item.title} for you`,
+        title: `${item.title} for you`,
       });
   });
 
@@ -122,7 +114,7 @@ function onCastleDamageEntry(
   return {
     title:
       mode === 'summarize'
-        ? `On ${castle.icon} damage`
+        ? `On opponent ${castle.icon} damage`
         : `On opponent ${castle.icon} ${castle.label} damage`,
     items: all,
   };

--- a/packages/web/src/translation/effects/formatters/resource.ts
+++ b/packages/web/src/translation/effects/formatters/resource.ts
@@ -20,3 +20,21 @@ registerEffectFormatter('resource', 'add', {
     return `${icon}${signed(amount)}${amount} ${label}`;
   },
 });
+
+registerEffectFormatter('resource', 'transfer', {
+  summarize: (eff) => {
+    const key = eff.params?.['key'] as string;
+    const res = RESOURCES[key as ResourceKey];
+    const icon = res?.icon || key;
+    const percent = Number(eff.params?.['percent']);
+    return `Transfer ${percent}% ${icon}`;
+  },
+  describe: (eff) => {
+    const key = eff.params?.['key'] as string;
+    const res = RESOURCES[key as ResourceKey];
+    const label = res?.label || key;
+    const icon = res?.icon || key;
+    const percent = Number(eff.params?.['percent']);
+    return `Transfer ${percent}% ${icon} ${label}`;
+  },
+});

--- a/packages/web/src/translation/effects/index.ts
+++ b/packages/web/src/translation/effects/index.ts
@@ -15,5 +15,6 @@ import './formatters/modifier';
 import './formatters/action';
 import './formatters/passive';
 import './formatters/population';
+import './formatters/attack';
 import './evaluators/development';
 import './evaluators/population';

--- a/packages/web/tests/army-attack-translation.test.ts
+++ b/packages/web/tests/army-attack-translation.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { summarizeContent } from '../src/translation/content';
+import { createEngine, Resource, Stat } from '@kingdom-builder/engine';
+import {
+  ACTIONS,
+  BUILDINGS,
+  DEVELOPMENTS,
+  POPULATIONS,
+  PHASES,
+  GAME_START,
+  RESOURCES,
+  STATS,
+} from '@kingdom-builder/contents';
+
+vi.mock('@kingdom-builder/engine', async () => {
+  return await import('../../engine/src');
+});
+
+function createCtx() {
+  return createEngine({
+    actions: ACTIONS,
+    buildings: BUILDINGS,
+    developments: DEVELOPMENTS,
+    populations: POPULATIONS,
+    phases: PHASES,
+    start: GAME_START,
+  });
+}
+
+describe('army attack translation', () => {
+  it('summarizes attack action with on-damage effects', () => {
+    const ctx = createCtx();
+    const castle = RESOURCES[Resource.castleHP];
+    const army = STATS[Stat.armyStrength];
+    const happiness = RESOURCES[Resource.happiness];
+    const plunder = ctx.actions.get('plunder');
+    const warWeariness = STATS[Stat.warWeariness];
+    const summary = summarizeContent('action', 'army_attack', ctx);
+    expect(summary).toEqual([
+      `Attack opponent's ${castle.icon} ${castle.label} with your ${army.icon} ${army.label}`,
+      {
+        title: `On ${castle.icon} ${castle.label} damage (you)`,
+        items: [`${happiness.icon}+1`, `${plunder.icon} ${plunder.name}`],
+      },
+      {
+        title: `On ${castle.icon} ${castle.label} damage (opponent)`,
+        items: [`${happiness.icon}-1`],
+      },
+      `${warWeariness.icon}+1`,
+    ]);
+  });
+});

--- a/packages/web/tests/army-attack-translation.test.ts
+++ b/packages/web/tests/army-attack-translation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { summarizeContent } from '../src/translation/content';
+import type { SummaryEntry } from '../src/translation/content';
+import { summarizeContent, describeContent } from '../src/translation/content';
 import { createEngine, Resource, Stat } from '@kingdom-builder/engine';
 import {
   ACTIONS,
@@ -32,29 +33,45 @@ describe('army attack translation', () => {
     const ctx = createCtx();
     const castle = RESOURCES[Resource.castleHP];
     const army = STATS[Stat.armyStrength];
-    const absorption = STATS[Stat.absorption];
     const fort = STATS[Stat.fortificationStrength];
     const happiness = RESOURCES[Resource.happiness];
     const plunder = ctx.actions.get('plunder');
     const warWeariness = STATS[Stat.warWeariness];
     const summary = summarizeContent('action', 'army_attack', ctx);
     expect(summary).toEqual([
+      `${army.icon} Attack opponent's ${fort.icon}${castle.icon}`,
       {
-        title: `Attack opponent with your ${army.icon} ${army.label}`,
+        title: `On ${castle.icon} damage`,
         items: [
-          `${absorption.icon} reduces damage`,
-          `Hits opponent's ${fort.icon} then ${castle.icon}`,
-        ],
-      },
-      {
-        title: `On opponent ${castle.icon} ${castle.label} damage`,
-        items: [
-          `${happiness.icon}+1 for you`,
-          `${happiness.icon}-1 for opponent`,
+          `Opponent ${happiness.icon}-1`,
+          `You ${happiness.icon}+1`,
           `${plunder.icon} ${plunder.name}`,
         ],
       },
       `${warWeariness.icon}+1`,
     ]);
+  });
+
+  it('describes plunder effects under on-damage entry', () => {
+    const ctx = createCtx();
+    const plunder = ctx.actions.get('plunder');
+    const desc = describeContent('action', 'army_attack', ctx);
+    const onDamage = desc.find(
+      (e) =>
+        typeof e === 'object' &&
+        'title' in e &&
+        e.title.startsWith('On opponent'),
+    ) as { items: SummaryEntry[] };
+    const plunderEntry = onDamage.items.find(
+      (i) =>
+        typeof i === 'object' &&
+        (i as { title: string }).title === `${plunder.icon} ${plunder.name}`,
+    ) as { items: unknown[] } | undefined;
+    expect(plunderEntry).toBeDefined();
+    expect(
+      plunderEntry &&
+        Array.isArray(plunderEntry.items) &&
+        plunderEntry.items.length > 0,
+    ).toBeTruthy();
   });
 });

--- a/packages/web/tests/army-attack-translation.test.ts
+++ b/packages/web/tests/army-attack-translation.test.ts
@@ -39,12 +39,12 @@ describe('army attack translation', () => {
     const warWeariness = STATS[Stat.warWeariness];
     const summary = summarizeContent('action', 'army_attack', ctx);
     expect(summary).toEqual([
-      `${army.icon} Attack opponent's ${fort.icon}${castle.icon}`,
+      `${army.icon} opponent's ${fort.icon}${castle.icon}`,
       {
-        title: `On ${castle.icon} damage`,
+        title: `On opponent ${castle.icon} damage`,
         items: [
-          `Opponent ${happiness.icon}-1`,
-          `You ${happiness.icon}+1`,
+          `${happiness.icon}-1 for opponent`,
+          `${happiness.icon}+1 for you`,
           `${plunder.icon} ${plunder.name}`,
         ],
       },

--- a/packages/web/tests/army-attack-translation.test.ts
+++ b/packages/web/tests/army-attack-translation.test.ts
@@ -32,19 +32,27 @@ describe('army attack translation', () => {
     const ctx = createCtx();
     const castle = RESOURCES[Resource.castleHP];
     const army = STATS[Stat.armyStrength];
+    const absorption = STATS[Stat.absorption];
+    const fort = STATS[Stat.fortificationStrength];
     const happiness = RESOURCES[Resource.happiness];
     const plunder = ctx.actions.get('plunder');
     const warWeariness = STATS[Stat.warWeariness];
     const summary = summarizeContent('action', 'army_attack', ctx);
     expect(summary).toEqual([
-      `Attack opponent's ${castle.icon} ${castle.label} with your ${army.icon} ${army.label}`,
       {
-        title: `On ${castle.icon} ${castle.label} damage (you)`,
-        items: [`${happiness.icon}+1`, `${plunder.icon} ${plunder.name}`],
+        title: `Attack opponent with your ${army.icon} ${army.label}`,
+        items: [
+          `${absorption.icon} reduces damage`,
+          `Hits opponent's ${fort.icon} then ${castle.icon}`,
+        ],
       },
       {
-        title: `On ${castle.icon} ${castle.label} damage (opponent)`,
-        items: [`${happiness.icon}-1`],
+        title: `On opponent ${castle.icon} ${castle.label} damage`,
+        items: [
+          `${happiness.icon}+1 for you`,
+          `${happiness.icon}-1 for opponent`,
+          `${plunder.icon} ${plunder.name}`,
+        ],
       },
       `${warWeariness.icon}+1`,
     ]);


### PR DESCRIPTION
## Summary
- add formatter for attack perform effect to surface on-damage attacker and defender outcomes in UI and logs
- wire attack formatter into effect translation registry
- cover army attack summary formatting with unit test

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b49cf28494832597c631265d8bd653