### PR TITLE
fix: remove type export causing fast refresh failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ Use the actual calendar date—today is 2025-08-31—and never log entries with 
 - 2025-08-31: Suffix on-damage summary items with "for you"/"for opponent" to keep icons leading each line.
 - 2025-10-23: Summary entries with a `_desc` flag appear under the Description section.
 - 2025-10-29: Phase icons live in `PHASES`; grab them with `PHASES.find(p => p.id === id)?.icon` for overview displays.
+- 2025-08-31: Type re-exports from React modules can still break Vite Fast Refresh; move shared types to separate files.
 
 # Core Agent principles
 

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -471,5 +471,3 @@ export const useGameEngine = (): GameEngineContextValue => {
   if (!value) throw new Error('useGameEngine must be used within GameProvider');
   return value;
 };
-
-export type { LogEntry, PhaseStep };


### PR DESCRIPTION
## Summary
- remove leftover type re-exports from `GameContext` to allow Vite Fast Refresh
- note fix in `AGENTS.md` discovery log

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4ae6f8a9c83258242038e8d9b4122