### PR TITLE
fix: use contents constants for attack formatter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ Use the actual calendar date—today is 2025-08-31—and never log entries with 
 - 2025-08-31: Suffix on-damage summary items with "for you"/"for opponent" to keep icons leading each line.
 - 2025-10-23: Summary entries with a `_desc` flag appear under the Description section.
 - 2025-10-29: Phase icons live in `PHASES`; grab them with `PHASES.find(p => p.id === id)?.icon` for overview displays.
+- 2025-08-31: Web effect formatters should import `Resource` and `Stat` from `@kingdom-builder/contents` to avoid undefined index errors when accessing `RESOURCES` and `STATS`.
 - 2025-08-31: Type re-exports from React modules can still break Vite Fast Refresh; move shared types to separate files.
 
 # Core Agent principles

--- a/packages/web/src/translation/effects/formatters/attack.ts
+++ b/packages/web/src/translation/effects/formatters/attack.ts
@@ -1,6 +1,5 @@
-import { RESOURCES, STATS } from '@kingdom-builder/contents';
+import { RESOURCES, STATS, Resource, Stat } from '@kingdom-builder/contents';
 import type { EffectDef, EngineContext } from '@kingdom-builder/engine';
-import { Resource, Stat } from '@kingdom-builder/engine';
 import type { SummaryEntry } from '../../content';
 import {
   registerEffectFormatter,


### PR DESCRIPTION
## Summary
- use Resource and Stat from @kingdom-builder/contents in web attack formatter
- document Resource/Stat usage in discovery log

## Testing
- `npm run check`
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4b19121bc8325ba6bf31ef938b491