### PR TITLE
feat(engine): configure phases and population roles dynamically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Use the actual calendar date—today is 2025-08-31—and never log entries with 
 - 2025-10-23: Summary entries with a `_desc` flag appear under the Description section.
 - 2025-10-29: Phase icons live in `PHASES`; grab them with `PHASES.find(p => p.id === id)?.icon` for overview displays.
 - 2025-08-31: Web effect formatters should import `Resource` and `Stat` from `@kingdom-builder/contents` to avoid undefined index errors when accessing `RESOURCES` and `STATS`.
+- 2025-08-31: Configure runtime phase and population role enums with `setPhaseKeys` and `setPopulationRoleKeys` before creating the engine.
 - 2025-08-31: Type re-exports from React modules can still break Vite Fast Refresh; move shared types to separate files.
 
 # Core Agent principles

--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -1,8 +1,7 @@
 import { Registry } from '@kingdom-builder/engine/registry';
 import { Resource } from './resources';
 import { Stat, STATS } from './stats';
-import { PopulationRole } from '@kingdom-builder/engine/state';
-import { POPULATION_ROLES } from './populationRoles';
+import { PopulationRole, POPULATION_ROLES } from './populationRoles';
 import {
   actionSchema,
   type ActionConfig,

--- a/packages/contents/src/game.ts
+++ b/packages/contents/src/game.ts
@@ -1,6 +1,6 @@
 import { Resource } from './resources';
 import { Stat } from './stats';
-import { PopulationRole } from '@kingdom-builder/engine/state';
+import { PopulationRole } from './populationRoles';
 import type { StartConfig } from '@kingdom-builder/engine/config/schema';
 
 export const GAME_START: StartConfig = {

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -3,7 +3,11 @@ export { BUILDINGS, createBuildingRegistry } from './buildings';
 export { DEVELOPMENTS, createDevelopmentRegistry } from './developments';
 export { POPULATIONS, createPopulationRegistry } from './populations';
 export { PHASES, type PhaseDef, type StepDef } from './phases';
-export { POPULATION_ROLES } from './populationRoles';
+export {
+  POPULATION_ROLES,
+  PopulationRole,
+  type PopulationRoleId,
+} from './populationRoles';
 export { Resource, type ResourceKey, RESOURCES } from './resources';
 export { Stat, type StatKey, STATS } from './stats';
 export { TRIGGER_INFO } from './triggers';

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -1,7 +1,7 @@
 import type { TriggerKey } from './defs';
 import { Resource } from './resources';
 import { Stat } from './stats';
-import { PopulationRole } from '@kingdom-builder/engine/state';
+import { PopulationRole } from './populationRoles';
 import type { EffectDef } from '@kingdom-builder/engine/effects';
 import { effect, Types, ResourceMethods, StatMethods } from './config/builders';
 

--- a/packages/contents/src/populationRoles.ts
+++ b/packages/contents/src/populationRoles.ts
@@ -1,5 +1,11 @@
-import type { PopulationRoleId } from '@kingdom-builder/engine/state';
-import { PopulationRole } from '@kingdom-builder/engine/state';
+export const PopulationRole = {
+  Council: 'council',
+  Commander: 'commander',
+  Fortifier: 'fortifier',
+  Citizen: 'citizen',
+} as const;
+export type PopulationRoleId =
+  (typeof PopulationRole)[keyof typeof PopulationRole];
 
 export interface PopulationRoleInfo {
   key: PopulationRoleId;

--- a/packages/contents/src/populations.ts
+++ b/packages/contents/src/populations.ts
@@ -1,5 +1,5 @@
 import { Registry } from '@kingdom-builder/engine/registry';
-import { PopulationRole } from '@kingdom-builder/engine/state';
+import { PopulationRole } from './populationRoles';
 import { Resource } from './resources';
 import { Stat } from './stats';
 import { populationSchema } from '@kingdom-builder/engine/config/schema';

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { PopulationRole } from '../state';
 import type { EffectDef } from '../effects';
 
 const requirementSchema = z.object({
@@ -99,7 +98,7 @@ const landStartSchema = z.object({
 const playerStartSchema = z.object({
   resources: z.record(z.string(), z.number()).optional(),
   stats: z.record(z.string(), z.number()).optional(),
-  population: z.record(z.nativeEnum(PopulationRole), z.number()).optional(),
+  population: z.record(z.string(), z.number()).optional(),
   lands: z.array(landStartSchema).optional(),
 });
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -7,6 +7,8 @@ import {
   Land,
   setResourceKeys,
   setStatKeys,
+  setPhaseKeys,
+  setPopulationRoleKeys,
 } from './state';
 import type {
   ResourceKey,
@@ -219,7 +221,7 @@ function applyPlayerStart(
     if (val !== 0) player.statsHistory[key] = true;
   }
   for (const [key, value] of Object.entries(config.population || {}))
-    player.population[key as PopulationRoleId] = value ?? 0;
+    player.population[key] = value ?? 0;
   if (config.lands)
     config.lands.forEach((landCfg, idx) => {
       const land = new Land(
@@ -311,6 +313,8 @@ export function createEngine({
 
   setResourceKeys(Object.keys(startCfg.player.resources || {}));
   setStatKeys(Object.keys(startCfg.player.stats || {}));
+  setPhaseKeys(phases.map((p) => p.id));
+  setPopulationRoleKeys(Object.keys(startCfg.player.population || {}));
 
   const resolvedRules = rules || DefaultRules;
   const services = new Services(resolvedRules);

--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -12,21 +12,20 @@ export function setStatKeys(keys: string[]) {
   for (const key of keys) Stat[key] = key;
 }
 
-export const Phase = {
-  Development: 'development',
-  Upkeep: 'upkeep',
-  Main: 'main',
-} as const;
-export type PhaseId = (typeof Phase)[keyof typeof Phase];
+export const Phase: Record<string, string> = {};
+export type PhaseId = string;
+export function setPhaseKeys(keys: string[]) {
+  for (const key of Object.keys(Phase)) delete Phase[key];
+  for (const id of keys) Phase[id.charAt(0).toUpperCase() + id.slice(1)] = id;
+}
 
-export const PopulationRole = {
-  Council: 'council',
-  Commander: 'commander',
-  Fortifier: 'fortifier',
-  Citizen: 'citizen',
-} as const;
-export type PopulationRoleId =
-  (typeof PopulationRole)[keyof typeof PopulationRole];
+export const PopulationRole: Record<string, string> = {};
+export type PopulationRoleId = string;
+export function setPopulationRoleKeys(keys: string[]) {
+  for (const key of Object.keys(PopulationRole)) delete PopulationRole[key];
+  for (const id of keys)
+    PopulationRole[id.charAt(0).toUpperCase() + id.slice(1)] = id;
+}
 
 export type PlayerId = 'A' | 'B';
 
@@ -57,12 +56,7 @@ export class PlayerState {
    * returned to zero after previously having a value.
    */
   statsHistory: Record<StatKey, boolean>;
-  population: Record<PopulationRoleId, number> = {
-    [PopulationRole.Council]: 0,
-    [PopulationRole.Commander]: 0,
-    [PopulationRole.Fortifier]: 0,
-    [PopulationRole.Citizen]: 0,
-  };
+  population: Record<PopulationRoleId, number>;
   lands: Land[] = [];
   buildings: Set<string> = new Set();
   actions: Set<string> = new Set();
@@ -97,6 +91,10 @@ export class PlayerState {
         enumerable: false,
         configurable: true,
       });
+    }
+    this.population = {};
+    for (const key of Object.values(PopulationRole)) {
+      this.population[key] = 0;
     }
   }
 }

--- a/packages/engine/tests/config/requirement_builder.test.ts
+++ b/packages/engine/tests/config/requirement_builder.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { requirement } from '@kingdom-builder/contents/config/builders';
-import { Stat, PopulationRole } from '../../src/state/index.ts';
+import { Stat, PopulationRole } from '@kingdom-builder/contents';
 
 describe('RequirementBuilder', () => {
   it('builds requirement configs with params', () => {

--- a/packages/engine/tests/phases/development.test.ts
+++ b/packages/engine/tests/phases/development.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { advance, PopulationRole, Stat } from '../../src';
+import { advance, Stat } from '../../src';
 import {
   PHASES,
   GAME_START,
   Resource as CResource,
   Stat as CStat,
+  PopulationRole,
 } from '@kingdom-builder/contents';
 import { createTestEngine } from '../helpers.ts';
 

--- a/packages/engine/tests/phases/upkeep.test.ts
+++ b/packages/engine/tests/phases/upkeep.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { advance, PopulationRole } from '../../src';
-import { PHASES, Resource as CResource } from '@kingdom-builder/contents';
+import { advance } from '../../src';
+import {
+  PHASES,
+  Resource as CResource,
+  PopulationRole,
+} from '@kingdom-builder/contents';
 import { createTestEngine } from '../helpers.ts';
 
 const upkeepPhase = PHASES.find((p) => p.id === 'upkeep')!;

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -8,9 +8,8 @@ import {
   Resource,
   PHASES,
   POPULATION_ROLES,
+  PopulationRole,
 } from '@kingdom-builder/contents';
-
-import { PopulationRole } from '@kingdom-builder/engine';
 
 type Screen = 'menu' | 'overview' | 'game';
 

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -1,13 +1,10 @@
 import React, { useMemo } from 'react';
-import {
-  getActionCosts,
-  getActionRequirements,
-  PopulationRole,
-} from '@kingdom-builder/engine';
+import { getActionCosts, getActionRequirements } from '@kingdom-builder/engine';
 import {
   Resource,
   RESOURCES,
   POPULATION_ROLES,
+  PopulationRole,
   SLOT_ICON as slotIcon,
   SLOT_LABEL as slotLabel,
   LAND_ICON as landIcon,

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -10,8 +10,8 @@ import {
   LAND_ICON as landIcon,
   SLOT_ICON as slotIcon,
   Stat,
+  PopulationRole,
 } from '@kingdom-builder/contents';
-import { PopulationRole } from '@kingdom-builder/engine/state';
 interface StepDef {
   id: string;
   title?: string;

--- a/packages/web/src/utils/getRequirementIcons.ts
+++ b/packages/web/src/utils/getRequirementIcons.ts
@@ -1,7 +1,10 @@
 import type { EngineContext } from '@kingdom-builder/engine';
-import { STATS, POPULATION_ROLES } from '@kingdom-builder/contents';
-import type { StatKey } from '@kingdom-builder/contents';
-import type { PopulationRoleId } from '@kingdom-builder/engine/state';
+import {
+  STATS,
+  POPULATION_ROLES,
+  type StatKey,
+  type PopulationRoleId,
+} from '@kingdom-builder/contents';
 
 interface EvalConfig {
   type: string;


### PR DESCRIPTION
## Summary
- derive phase and population role enums at runtime via `setPhaseKeys`/`setPopulationRoleKeys`
- initialize player population entries dynamically
- expose population role definitions from contents and update web to source them

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b4b4477cf08325aad19c7f4ebe57d0