### PR TITLE
feat: externalize rules and popcap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ Use the actual calendar date—today is 2025-08-31—and never log entries with 
 - 2025-08-31: Web effect formatters should import `Resource` and `Stat` from `@kingdom-builder/contents` to avoid undefined index errors when accessing `RESOURCES` and `STATS`.
 - 2025-08-31: Configure runtime phase and population role enums with `setPhaseKeys` and `setPopulationRoleKeys` before creating the engine.
 - 2025-08-31: Type re-exports from React modules can still break Vite Fast Refresh; move shared types to separate files.
+- 2025-08-31: Engine creation now requires passing a `rules` object; import `RULES` from `@kingdom-builder/contents` when initializing tests or the web context.
 
 # Core Agent principles
 

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -249,6 +249,10 @@ export class DevelopmentBuilder extends BaseBuilder<DevelopmentConfig> {
   constructor() {
     super({});
   }
+  populationCap(amount: number) {
+    this.config.populationCap = amount;
+    return this;
+  }
   onBuild(effect: EffectConfig) {
     this.config.onBuild = this.config.onBuild || [];
     this.config.onBuild.push(effect);

--- a/packages/contents/src/developments.ts
+++ b/packages/contents/src/developments.ts
@@ -26,6 +26,7 @@ export function createDevelopmentRegistry() {
       .id('house')
       .name('House')
       .icon('🏠')
+      .populationCap(1)
       .onBuild(
         effect(Types.Stat, StatMethods.ADD)
           .params({ key: Stat.maxPopulation, amount: 1 })

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -14,6 +14,7 @@ export { TRIGGER_INFO } from './triggers';
 export { LAND_ICON, LAND_LABEL, SLOT_ICON, SLOT_LABEL } from './land';
 export { MODIFIER_INFO } from './modifiers';
 export { GAME_START } from './game';
+export { RULES } from './rules';
 export type { ActionDef } from './actions';
 export type { BuildingDef } from './buildings';
 export type { DevelopmentDef } from './developments';

--- a/packages/contents/src/rules.ts
+++ b/packages/contents/src/rules.ts
@@ -1,0 +1,22 @@
+import type { RuleSet } from '@kingdom-builder/engine/services';
+
+export const RULES: RuleSet = {
+  defaultActionAPCost: 1,
+  absorptionCapPct: 1,
+  absorptionRounding: 'down',
+  happinessTiers: [
+    { threshold: 0, effect: { incomeMultiplier: 1 } },
+    { threshold: 3, effect: { incomeMultiplier: 1.25 } },
+    {
+      threshold: 5,
+      effect: { incomeMultiplier: 1.25, buildingDiscountPct: 0.2 },
+    },
+    {
+      threshold: 8,
+      effect: { incomeMultiplier: 1.5, buildingDiscountPct: 0.2 },
+    },
+  ],
+  slotsPerNewLand: 1,
+  maxSlotsPerLand: 2,
+  basePopulationCap: 1,
+};

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -70,6 +70,7 @@ export const developmentSchema = z.object({
   onBeforeAttacked: z.array(effectSchema).optional(),
   onAttackResolved: z.array(effectSchema).optional(),
   system: z.boolean().optional(),
+  populationCap: z.number().optional(),
 });
 
 export type DevelopmentConfig = z.infer<typeof developmentSchema>;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -16,7 +16,7 @@ import type {
   StatKey,
   PopulationRoleId,
 } from './state';
-import { Services, PassiveManager, DefaultRules } from './services';
+import { Services, PassiveManager } from './services';
 import type { CostBag, RuleSet } from './services';
 import { EngineContext } from './context';
 import { runEffects, EFFECTS, registerCoreEffects } from './effects';
@@ -276,7 +276,7 @@ export function createEngine({
   populations: Registry<PopulationDef>;
   phases: PhaseDef[];
   start: StartConfig;
-  rules?: RuleSet;
+  rules: RuleSet;
   config?: GameConfig;
 }) {
   registerCoreEffects();
@@ -316,8 +316,7 @@ export function createEngine({
   setPhaseKeys(phases.map((p) => p.id));
   setPopulationRoleKeys(Object.keys(startCfg.player.population || {}));
 
-  const resolvedRules = rules || DefaultRules;
-  const services = new Services(resolvedRules);
+  const services = new Services(rules, developments);
   const passives = new PassiveManager();
   const game = new GameState('Player A', 'Player B');
 
@@ -342,10 +341,10 @@ export function createEngine({
   const playerA = ctx.game.players[0]!;
   const playerB = ctx.game.players[1]!;
 
-  applyPlayerStart(playerA, startCfg.player, resolvedRules);
-  applyPlayerStart(playerA, compA, resolvedRules);
-  applyPlayerStart(playerB, startCfg.player, resolvedRules);
-  applyPlayerStart(playerB, compB, resolvedRules);
+  applyPlayerStart(playerA, startCfg.player, rules);
+  applyPlayerStart(playerA, compA, rules);
+  applyPlayerStart(playerB, startCfg.player, rules);
+  applyPlayerStart(playerB, compB, rules);
   ctx.game.currentPlayerIndex = 0;
   ctx.game.currentPhase = phases[0]?.id || '';
   ctx.game.currentStep = phases[0]?.steps[0]?.id || '';
@@ -363,7 +362,6 @@ export {
   EngineContext,
   Services,
   PassiveManager,
-  DefaultRules,
 };
 
 export type { RuleSet, ResourceKey, StatKey };

--- a/packages/engine/tests/helpers.ts
+++ b/packages/engine/tests/helpers.ts
@@ -6,6 +6,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 import type {
   ActionConfig as ActionDef,
@@ -34,5 +35,5 @@ const BASE: {
 };
 
 export function createTestEngine(overrides: Partial<typeof BASE> = {}) {
-  return createEngine({ ...BASE, ...overrides });
+  return createEngine({ ...BASE, ...overrides, rules: RULES });
 }

--- a/packages/engine/tests/services/rules.test.ts
+++ b/packages/engine/tests/services/rules.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { Services, DefaultRules } from '../../src/services/index.ts';
+import { Services } from '../../src/services/index.ts';
 import { PlayerState, Land, Resource } from '../../src/state/index.ts';
 import { createTestEngine } from '../helpers.ts';
+import { DEVELOPMENTS, RULES } from '@kingdom-builder/contents';
 
 describe('Services', () => {
   it('evaluates happiness tiers correctly', () => {
-    const services = new Services(DefaultRules);
+    const services = new Services(RULES, DEVELOPMENTS);
     expect(services.happiness.tier(0)?.incomeMultiplier).toBe(1);
     expect(services.happiness.tier(4)?.incomeMultiplier).toBe(1.25);
     expect(services.happiness.tier(5)?.buildingDiscountPct).toBe(0.2);
@@ -13,7 +14,7 @@ describe('Services', () => {
   });
 
   it('calculates population cap from houses on land', () => {
-    const services = new Services(DefaultRules);
+    const services = new Services(RULES, DEVELOPMENTS);
     const player = new PlayerState('A', 'Test');
     const land1 = new Land('l1', 1);
     land1.developments.push('house');

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -22,6 +22,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
   Resource,
 } from '@kingdom-builder/contents';
 import {
@@ -113,6 +114,7 @@ export function GameProvider({
         populations: POPULATIONS,
         phases: PHASES,
         start: GAME_START,
+        rules: RULES,
       }),
     [],
   );

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -18,6 +18,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
   POPULATION_ROLES,
   STATS,
   SLOT_ICON,
@@ -37,6 +38,7 @@ const ctx = createEngine({
   populations: POPULATIONS,
   phases: PHASES,
   start: GAME_START,
+  rules: RULES,
 });
 const mockGame = {
   ctx,

--- a/packages/web/tests/HoverCard.test.tsx
+++ b/packages/web/tests/HoverCard.test.tsx
@@ -18,6 +18,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -31,6 +32,7 @@ const ctx = createEngine({
   populations: POPULATIONS,
   phases: PHASES,
   start: GAME_START,
+  rules: RULES,
 });
 const mockGame = {
   ctx,

--- a/packages/web/tests/PhasePanel.test.tsx
+++ b/packages/web/tests/PhasePanel.test.tsx
@@ -12,6 +12,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -25,6 +26,7 @@ const ctx = createEngine({
   populations: POPULATIONS,
   phases: PHASES,
   start: GAME_START,
+  rules: RULES,
 });
 const mockGame = {
   ctx,

--- a/packages/web/tests/PlayerPanel.test.tsx
+++ b/packages/web/tests/PlayerPanel.test.tsx
@@ -13,6 +13,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -26,6 +27,7 @@ const ctx = createEngine({
   populations: POPULATIONS,
   phases: PHASES,
   start: GAME_START,
+  rules: RULES,
 });
 const mockGame = {
   ctx,

--- a/packages/web/tests/army-attack-translation.test.ts
+++ b/packages/web/tests/army-attack-translation.test.ts
@@ -9,6 +9,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
   RESOURCES,
   STATS,
 } from '@kingdom-builder/contents';
@@ -25,6 +26,7 @@ function createCtx() {
     populations: POPULATIONS,
     phases: PHASES,
     start: GAME_START,
+    rules: RULES,
   });
 }
 

--- a/packages/web/tests/development-summary.test.ts
+++ b/packages/web/tests/development-summary.test.ts
@@ -9,6 +9,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -36,6 +37,7 @@ describe('development translation', () => {
       populations: POPULATIONS,
       phases: PHASES,
       start: GAME_START,
+      rules: RULES,
     });
     const summary = summarizeContent('development', 'farm', ctx);
     const flat = flatten(summary);

--- a/packages/web/tests/land-till-formatter.test.ts
+++ b/packages/web/tests/land-till-formatter.test.ts
@@ -9,6 +9,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
   SLOT_ICON as slotIcon,
 } from '@kingdom-builder/contents';
 
@@ -24,6 +25,7 @@ function createCtx() {
     populations: POPULATIONS,
     phases: PHASES,
     start: GAME_START,
+    rules: RULES,
   });
 }
 

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -12,6 +12,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
 
@@ -28,6 +29,7 @@ describe('log resource sources', () => {
       populations: POPULATIONS,
       phases: PHASES,
       start: GAME_START,
+      rules: RULES,
     });
     // Give opponent (Player B) a mill
     ctx.game.currentPlayerIndex = 1;
@@ -54,6 +56,7 @@ describe('log resource sources', () => {
       populations: POPULATIONS,
       phases: PHASES,
       start: GAME_START,
+      rules: RULES,
     });
     runEffects(
       [{ type: 'building', method: 'add', params: { id: 'market' } }],

--- a/packages/web/tests/plow-action-translation.test.ts
+++ b/packages/web/tests/plow-action-translation.test.ts
@@ -12,6 +12,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -26,6 +27,7 @@ function createCtx() {
     populations: POPULATIONS,
     phases: PHASES,
     start: GAME_START,
+    rules: RULES,
   });
 }
 

--- a/packages/web/tests/plow-workshop-translation.test.ts
+++ b/packages/web/tests/plow-workshop-translation.test.ts
@@ -12,6 +12,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -26,6 +27,7 @@ function createCtx() {
     populations: POPULATIONS,
     phases: PHASES,
     start: GAME_START,
+    rules: RULES,
   });
 }
 

--- a/packages/web/tests/population-summary.test.ts
+++ b/packages/web/tests/population-summary.test.ts
@@ -13,6 +13,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
   POPULATION_ROLES,
 } from '@kingdom-builder/contents';
 
@@ -40,6 +41,7 @@ describe('population effect translation', () => {
     populations: POPULATIONS,
     phases: PHASES,
     start: GAME_START,
+    rules: RULES,
   });
 
   it('summarizes raise_pop action for specific role', () => {

--- a/packages/web/tests/raiders-guild-translation.test.ts
+++ b/packages/web/tests/raiders-guild-translation.test.ts
@@ -12,6 +12,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -26,6 +27,7 @@ function createCtx() {
     populations: POPULATIONS,
     phases: PHASES,
     start: GAME_START,
+    rules: RULES,
   });
 }
 

--- a/packages/web/tests/subaction-log.test.ts
+++ b/packages/web/tests/subaction-log.test.ts
@@ -13,6 +13,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
   RESOURCES,
   SLOT_ICON as slotIcon,
 } from '@kingdom-builder/contents';
@@ -35,6 +36,7 @@ describe('sub-action logging', () => {
       populations: POPULATIONS,
       phases: PHASES,
       start: GAME_START,
+      rules: RULES,
     });
     ctx.activePlayer.actions.add('plow');
     ctx.activePlayer.resources[Resource.gold] = 10;

--- a/packages/web/tests/tax-market-log.test.ts
+++ b/packages/web/tests/tax-market-log.test.ts
@@ -14,6 +14,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
   RESOURCES,
 } from '@kingdom-builder/contents';
 import {
@@ -35,6 +36,7 @@ describe('tax action logging with market', () => {
       populations: POPULATIONS,
       phases: PHASES,
       start: GAME_START,
+      rules: RULES,
     });
     runEffects(
       [{ type: 'building', method: 'add', params: { id: 'market' } }],

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -6,6 +6,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 import type { EngineContext, EffectDef } from '@kingdom-builder/engine';
 import { PlayerState, Land } from '@kingdom-builder/engine/state';
@@ -38,6 +39,7 @@ export function createTestContext(overrides?: { gold?: number; ap?: number }) {
     populations: POPULATIONS,
     phases: PHASES,
     start: GAME_START,
+    rules: RULES,
   });
   if (overrides?.gold !== undefined) ctx.activePlayer.gold = overrides.gold;
   if (overrides?.ap !== undefined) ctx.activePlayer.ap = overrides.ap;

--- a/tests/integration/market-translation.test.ts
+++ b/tests/integration/market-translation.test.ts
@@ -8,6 +8,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 
 describe('Market building translation', () => {
@@ -19,6 +20,7 @@ describe('Market building translation', () => {
       populations: POPULATIONS,
       phases: PHASES,
       start: GAME_START,
+      rules: RULES,
     });
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     const summary = summarizeContent('building', 'market', ctx) as unknown;

--- a/tests/integration/tax-translation.test.ts
+++ b/tests/integration/tax-translation.test.ts
@@ -8,6 +8,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 
 describe('Tax action translation', () => {
@@ -19,6 +20,7 @@ describe('Tax action translation', () => {
       populations: POPULATIONS,
       phases: PHASES,
       start: GAME_START,
+      rules: RULES,
     });
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     const summary = summarizeContent('action', 'tax', ctx) as (

--- a/tests/integration/turn-cycle.test.ts
+++ b/tests/integration/turn-cycle.test.ts
@@ -7,6 +7,7 @@ import {
   POPULATIONS,
   PHASES,
   GAME_START,
+  RULES,
 } from '@kingdom-builder/contents';
 
 describe('Turn cycle integration', () => {
@@ -18,6 +19,7 @@ describe('Turn cycle integration', () => {
       populations: POPULATIONS,
       phases: PHASES,
       start: GAME_START,
+      rules: RULES,
     });
     // player A development & upkeep
     while (ctx.game.currentPhase !== 'main') advance(ctx);


### PR DESCRIPTION
## Summary
- move default rule values to contents and require explicit rules when creating the engine
- derive population capacity from development metadata instead of a house string
- document new rules requirement in AGENTS log

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b4b7d438ac8325935e2a378f94e4a1