### PR TITLE
Derive action ordering from content metadata

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -22,14 +22,16 @@ import {
   StatMethods,
 } from './config/builders';
 
-export type ActionDef = ActionConfig;
+export interface ActionDef extends ActionConfig {
+  category?: string;
+  order?: number;
+}
 
 export function createActionRegistry() {
-  const registry = new Registry<ActionDef>(actionSchema);
+  const registry = new Registry<ActionDef>(actionSchema.passthrough());
 
-  registry.add(
-    'expand',
-    action()
+  registry.add('expand', {
+    ...action()
       .id('expand')
       .name('Expand')
       .icon('🌱')
@@ -42,11 +44,12 @@ export function createActionRegistry() {
           .build(),
       )
       .build(),
-  );
+    category: 'basic',
+    order: 1,
+  });
 
-  registry.add(
-    'overwork',
-    action()
+  registry.add('overwork', {
+    ...action()
       .id('overwork')
       .name('Overwork')
       .icon('🛠️')
@@ -69,11 +72,12 @@ export function createActionRegistry() {
           .build(),
       )
       .build(),
-  );
+    category: 'basic',
+    order: 2,
+  });
 
-  registry.add(
-    'develop',
-    action()
+  registry.add('develop', {
+    ...action()
       .id('develop')
       .name('Develop')
       .icon('🏗️')
@@ -85,11 +89,12 @@ export function createActionRegistry() {
           .build(),
       )
       .build(),
-  );
+    category: 'development',
+    order: 1,
+  });
 
-  registry.add(
-    'tax',
-    action()
+  registry.add('tax', {
+    ...action()
       .id('tax')
       .name('Tax')
       .icon('💰')
@@ -111,22 +116,24 @@ export function createActionRegistry() {
           .build(),
       )
       .build(),
-  );
+    category: 'basic',
+    order: 3,
+  });
 
-  registry.add(
-    'reallocate',
-    action()
+  registry.add('reallocate', {
+    ...action()
       .id('reallocate')
       .name('Reallocate')
       .icon('🔄')
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 5)
       .build(),
-  );
+    category: 'basic',
+    order: 4,
+  });
 
-  registry.add(
-    'raise_pop',
-    action()
+  registry.add('raise_pop', {
+    ...action()
       .id('raise_pop')
       .name('Raise Population')
       .icon('👶')
@@ -151,22 +158,24 @@ export function createActionRegistry() {
           .build(),
       )
       .build(),
-  );
+    category: 'population',
+    order: 1,
+  });
 
-  registry.add(
-    'royal_decree',
-    action()
+  registry.add('royal_decree', {
+    ...action()
       .id('royal_decree')
       .name('Royal Decree')
       .icon('📜')
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 12)
       .build(),
-  );
+    category: 'basic',
+    order: 5,
+  });
 
-  registry.add(
-    'army_attack',
-    action()
+  registry.add('army_attack', {
+    ...action()
       .id('army_attack')
       .name('Army Attack')
       .icon('🗡️')
@@ -209,18 +218,21 @@ export function createActionRegistry() {
           .build(),
       )
       .build(),
-  );
+    category: 'basic',
+    order: 6,
+  });
 
-  registry.add(
-    'hold_festival',
-    action()
+  registry.add('hold_festival', {
+    ...action()
       .id('hold_festival')
       .name('Hold Festival')
       .icon('🎉')
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 3)
       .build(),
-  );
+    category: 'basic',
+    order: 7,
+  });
 
   registry.add(
     'plunder',
@@ -291,9 +303,8 @@ export function createActionRegistry() {
       .build(),
   );
 
-  registry.add(
-    'build',
-    action()
+  registry.add('build', {
+    ...action()
       .id('build')
       .name('Build')
       .icon('🏛️')
@@ -301,7 +312,9 @@ export function createActionRegistry() {
         effect(Types.Building, BuildingMethods.ADD).param('id', '$id').build(),
       )
       .build(),
-  );
+    category: 'building',
+    order: 1,
+  });
 
   return registry;
 }

--- a/packages/contents/src/defs.ts
+++ b/packages/contents/src/defs.ts
@@ -13,7 +13,9 @@ export interface Triggered {
 }
 
 export interface PopulationDef extends PopulationConfig, Triggered {}
-export interface DevelopmentDef extends DevelopmentConfig, Triggered {}
+export interface DevelopmentDef extends DevelopmentConfig, Triggered {
+  order?: number;
+}
 export interface BuildingDef extends BuildingConfig, Triggered {}
 
 export type TriggerKey = keyof Triggered;

--- a/packages/contents/src/developments.ts
+++ b/packages/contents/src/developments.ts
@@ -13,16 +13,17 @@ import type { DevelopmentDef } from './defs';
 export type { DevelopmentDef } from './defs';
 
 export function createDevelopmentRegistry() {
-  const registry = new Registry<DevelopmentDef>(developmentSchema);
-
-  registry.add(
-    'farm',
-    development().id('farm').name('Farm').icon('🌾').build(),
+  const registry = new Registry<DevelopmentDef>(
+    developmentSchema.passthrough(),
   );
 
-  registry.add(
-    'house',
-    development()
+  registry.add('farm', {
+    ...development().id('farm').name('Farm').icon('🌾').build(),
+    order: 2,
+  });
+
+  registry.add('house', {
+    ...development()
       .id('house')
       .name('House')
       .icon('🏠')
@@ -32,11 +33,11 @@ export function createDevelopmentRegistry() {
           .build(),
       )
       .build(),
-  );
+    order: 1,
+  });
 
-  registry.add(
-    'outpost',
-    development()
+  registry.add('outpost', {
+    ...development()
       .id('outpost')
       .name('Outpost')
       .icon('🏹')
@@ -51,11 +52,11 @@ export function createDevelopmentRegistry() {
           .build(),
       )
       .build(),
-  );
+    order: 3,
+  });
 
-  registry.add(
-    'watchtower',
-    development()
+  registry.add('watchtower', {
+    ...development()
       .id('watchtower')
       .name('Watchtower')
       .icon('🗼')
@@ -75,7 +76,8 @@ export function createDevelopmentRegistry() {
           .build(),
       )
       .build(),
-  );
+    order: 4,
+  });
 
   registry.add(
     'garden',

--- a/packages/web/src/translation/content/actionLogHooks.ts
+++ b/packages/web/src/translation/content/actionLogHooks.ts
@@ -1,0 +1,37 @@
+import type { EngineContext } from '@kingdom-builder/engine';
+import { logContent } from './factory';
+
+export type ActionLogHook = (
+  ctx: EngineContext,
+  params?: Record<string, unknown>,
+) => string;
+
+const hooks = new Map<string, ActionLogHook>();
+
+export function registerActionLogHook(id: string, hook: ActionLogHook) {
+  hooks.set(id, hook);
+}
+
+export function getActionLogHook(id: string) {
+  return hooks.get(id);
+}
+
+registerActionLogHook('develop', (ctx, params) => {
+  const id =
+    typeof (params as { id?: string })?.id === 'string'
+      ? (params as { id: string }).id
+      : undefined;
+  if (!id) return '';
+  const target = logContent('development', id, ctx)[0];
+  return target ? ` - ${target}` : '';
+});
+
+registerActionLogHook('build', (ctx, params) => {
+  const id =
+    typeof (params as { id?: string })?.id === 'string'
+      ? (params as { id: string }).id
+      : undefined;
+  if (!id) return '';
+  const target = logContent('building', id, ctx)[0];
+  return target ? ` - ${target}` : '';
+});


### PR DESCRIPTION
## Summary
- annotate actions and developments with UI category and order metadata
- sort and group ActionsPanel via content metadata instead of hardcoded IDs
- add registry for action-specific log hooks

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4b7e64e788325b2c2f50c670d0746