### PR TITLE
feat: centralize percent stat display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Use the actual calendar date—today is 2025-08-31—and never log entries with 
 - 2025-08-31: Type re-exports from React modules can still break Vite Fast Refresh; move shared types to separate files.
 - 2025-08-31: Engine creation now requires passing a `rules` object; import `RULES` from `@kingdom-builder/contents` when initializing tests or the web context.
 - 2025-08-31: Stat add formatting can be driven by `addFormat` in `STATS` to supply prefixes or percentage displays.
+- 2025-08-31: Percentage-based stats can be detected from their `addFormat.percent` (or `displayAsPercent`) flag instead of hardcoding keys.
 
 # Core Agent principles
 

--- a/packages/contents/src/stats.ts
+++ b/packages/contents/src/stats.ts
@@ -13,6 +13,7 @@ export interface StatInfo {
   icon: string;
   label: string;
   description: string;
+  displayAsPercent?: boolean;
   addFormat?: {
     prefix?: string;
     percent?: boolean;
@@ -50,6 +51,7 @@ export const STATS: Record<StatKey, StatInfo> = {
     label: 'Absorption',
     description:
       'Absorption reduces incoming damage by a percentage. It represents magical barriers or tactical advantages that soften blows.',
+    displayAsPercent: true,
     addFormat: {
       percent: true,
     },
@@ -60,6 +62,7 @@ export const STATS: Record<StatKey, StatInfo> = {
     label: 'Growth',
     description:
       'Growth increases Army and Fortification Strength during the Raise Strength step.',
+    displayAsPercent: true,
     addFormat: {
       percent: true,
     },

--- a/packages/web/src/components/player/PopulationInfo.tsx
+++ b/packages/web/src/components/player/PopulationInfo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { POPULATION_ROLES, STATS } from '@kingdom-builder/contents';
+import { formatStatValue } from '../../utils/stats';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { useGameEngine } from '../../state/GameContext';
 
@@ -12,11 +13,6 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
   const popEntries = Object.entries(player.population).filter(([, v]) => v > 0);
   const currentPop = popEntries.reduce((sum, [, v]) => sum + v, 0);
   const popDetails = popEntries.map(([role, count]) => ({ role, count }));
-
-  function formatStatValue(key: string, value: number) {
-    if (key === 'absorption' || key === 'growth') return `${value * 100}%`;
-    return String(value);
-  }
 
   const showPopulationCard = () =>
     handleHoverCard({

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -12,6 +12,7 @@ import {
   Stat,
   PopulationRole,
 } from '@kingdom-builder/contents';
+import { statDisplaysAsPercent } from '../utils/stats';
 interface StepDef {
   id: string;
   title?: string;
@@ -85,7 +86,7 @@ export function diffSnapshots(
       const icon = info?.icon ? `${info.icon} ` : '';
       const label = info?.label ?? key;
       const delta = a - b;
-      if (key === 'absorption' || key === 'growth') {
+      if (statDisplaysAsPercent(key)) {
         const bPerc = b * 100;
         const aPerc = a * 100;
         const dPerc = delta * 100;

--- a/packages/web/src/utils/stats.ts
+++ b/packages/web/src/utils/stats.ts
@@ -1,0 +1,10 @@
+import { STATS } from '@kingdom-builder/contents';
+
+export function statDisplaysAsPercent(key: string): boolean {
+  const info = STATS[key as keyof typeof STATS];
+  return Boolean(info?.displayAsPercent ?? info?.addFormat?.percent);
+}
+
+export function formatStatValue(key: string, value: number): string {
+  return statDisplaysAsPercent(key) ? `${value * 100}%` : String(value);
+}


### PR DESCRIPTION
## Summary
- flag percent-based stats in content definitions
- add stat display helper for percentage formatting
- use helper to render stats in logs and player info

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4bc88ee8c8325a5d7a4981ea2d48c