### PR TITLE
feat: add builders for remaining content configs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Use the actual calendar date—today is 2025-08-31—and never log entries with 
 - 2025-08-31: Type re-exports from React modules can still break Vite Fast Refresh; move shared types to separate files.
 - 2025-08-31: Engine creation now requires passing a `rules` object; import `RULES` from `@kingdom-builder/contents` when initializing tests or the web context.
 - 2025-08-31: Stat add formatting can be driven by `addFormat` in `STATS` to supply prefixes or percentage displays.
+- 2025-08-31: Trigger info derives from `PHASES`; updating phase icons or labels automatically refreshes trigger metadata.
 
 # Core Agent principles
 

--- a/packages/contents/src/game.ts
+++ b/packages/contents/src/game.ts
@@ -1,35 +1,27 @@
 import { Resource } from './resources';
 import { Stat } from './stats';
 import { PopulationRole } from './populationRoles';
-import type { StartConfig } from '@kingdom-builder/engine/config/schema';
+import { start } from './config/builders';
 
-export const GAME_START: StartConfig = {
-  player: {
-    resources: {
-      [Resource.gold]: 10,
-      [Resource.ap]: 0,
-      [Resource.happiness]: 0,
-      [Resource.castleHP]: 10,
-    },
-    stats: {
-      [Stat.maxPopulation]: 1,
-      [Stat.armyStrength]: 0,
-      [Stat.fortificationStrength]: 0,
-      [Stat.absorption]: 0,
-      [Stat.growth]: 0.25,
-      [Stat.warWeariness]: 0,
-    },
-    population: {
-      [PopulationRole.Council]: 1,
-      [PopulationRole.Commander]: 0,
-      [PopulationRole.Fortifier]: 0,
-      [PopulationRole.Citizen]: 0,
-    },
-    lands: [{ developments: ['farm'] }, {}],
-  },
-  players: {
-    B: {
-      resources: { [Resource.ap]: 1 },
-    },
-  },
-};
+export const GAME_START = start()
+  .player((p) =>
+    p
+      .resource(Resource.gold, 10)
+      .resource(Resource.ap, 0)
+      .resource(Resource.happiness, 0)
+      .resource(Resource.castleHP, 10)
+      .stat(Stat.maxPopulation, 1)
+      .stat(Stat.armyStrength, 0)
+      .stat(Stat.fortificationStrength, 0)
+      .stat(Stat.absorption, 0)
+      .stat(Stat.growth, 0.25)
+      .stat(Stat.warWeariness, 0)
+      .population(PopulationRole.Council, 1)
+      .population(PopulationRole.Commander, 0)
+      .population(PopulationRole.Fortifier, 0)
+      .population(PopulationRole.Citizen, 0)
+      .land(['farm'])
+      .land(),
+  )
+  .bonus('B', (p) => p.resource(Resource.ap, 1))
+  .build();

--- a/packages/contents/src/modifiers.ts
+++ b/packages/contents/src/modifiers.ts
@@ -1,4 +1,10 @@
+import { modifierInfo } from './config/builders';
+
 export const MODIFIER_INFO = {
-  cost: { icon: '💲', label: 'Cost Modifier' },
-  result: { icon: '✨', label: 'Result Modifier' },
+  cost: modifierInfo().id('cost').icon('💲').label('Cost Modifier').build(),
+  result: modifierInfo()
+    .id('result')
+    .icon('✨')
+    .label('Result Modifier')
+    .build(),
 } as const;

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -1,42 +1,35 @@
-import type { TriggerKey } from './defs';
 import { Resource } from './resources';
 import { Stat } from './stats';
 import { PopulationRole } from './populationRoles';
-import type { EffectDef } from '@kingdom-builder/engine/effects';
-import { effect, Types, ResourceMethods, StatMethods } from './config/builders';
-
-export interface StepDef {
-  id: string;
-  title?: string;
-  triggers?: TriggerKey[];
-  effects?: EffectDef[];
-  icon?: string;
-}
-
-export interface PhaseDef {
-  id: string;
-  steps: StepDef[];
-  action?: boolean;
-  label: string;
-  icon?: string;
-}
+import {
+  effect,
+  Types,
+  ResourceMethods,
+  StatMethods,
+  phase,
+  step,
+  type PhaseDef,
+} from './config/builders';
+export type { StepDef, PhaseDef } from './config/builders';
 
 export const PHASES: PhaseDef[] = [
-  {
-    id: 'development',
-    label: 'Development',
-    icon: '🏗️',
-    steps: [
-      {
-        id: 'resolve-dynamic-triggers',
-        title: 'Resolve dynamic triggers',
-        triggers: ['onDevelopmentPhase'],
-      },
-      {
-        id: 'gain-income',
-        title: 'Gain Income',
-        icon: '💰',
-        effects: [
+  phase()
+    .id('development')
+    .label('Development')
+    .icon('🏗️')
+    .step(
+      step()
+        .id('resolve-dynamic-triggers')
+        .title('Resolve dynamic triggers')
+        .trigger('onDevelopmentPhase')
+        .build(),
+    )
+    .step(
+      step()
+        .id('gain-income')
+        .title('Gain Income')
+        .icon('💰')
+        .effect(
           effect()
             .evaluator('development', { id: 'farm' })
             .effect(
@@ -45,12 +38,14 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
-        ],
-      },
-      {
-        id: 'gain-ap',
-        title: 'Gain Action Points',
-        effects: [
+        )
+        .build(),
+    )
+    .step(
+      step()
+        .id('gain-ap')
+        .title('Gain Action Points')
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Council })
             .effect(
@@ -59,12 +54,14 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
-        ],
-      },
-      {
-        id: 'raise-strength',
-        title: 'Raise Strength',
-        effects: [
+        )
+        .build(),
+    )
+    .step(
+      step()
+        .id('raise-strength')
+        .title('Raise Strength')
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Commander })
             .effect(
@@ -74,6 +71,8 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
+        )
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Fortifier })
             .effect(
@@ -86,24 +85,26 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
-        ],
-      },
-    ],
-  },
-  {
-    id: 'upkeep',
-    label: 'Upkeep',
-    icon: '🧹',
-    steps: [
-      {
-        id: 'resolve-dynamic-triggers',
-        title: 'Resolve dynamic triggers',
-        triggers: ['onUpkeepPhase'],
-      },
-      {
-        id: 'pay-upkeep',
-        title: 'Pay Upkeep',
-        effects: [
+        )
+        .build(),
+    )
+    .build(),
+  phase()
+    .id('upkeep')
+    .label('Upkeep')
+    .icon('🧹')
+    .step(
+      step()
+        .id('resolve-dynamic-triggers')
+        .title('Resolve dynamic triggers')
+        .trigger('onUpkeepPhase')
+        .build(),
+    )
+    .step(
+      step()
+        .id('pay-upkeep')
+        .title('Pay Upkeep')
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Council })
             .effect(
@@ -112,6 +113,8 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
+        )
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Commander })
             .effect(
@@ -120,6 +123,8 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
+        )
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Fortifier })
             .effect(
@@ -128,12 +133,14 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
-        ],
-      },
-      {
-        id: 'war-recovery',
-        title: 'War recovery',
-        effects: [
+        )
+        .build(),
+    )
+    .step(
+      step()
+        .id('war-recovery')
+        .title('War recovery')
+        .effect(
           effect()
             .evaluator('compare', {
               left: { type: 'stat', params: { key: Stat.warWeariness } },
@@ -146,15 +153,15 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
-        ],
-      },
-    ],
-  },
-  {
-    id: 'main',
-    label: 'Main',
-    icon: '🎯',
-    action: true,
-    steps: [{ id: 'main', title: 'Main Phase' }],
-  },
+        )
+        .build(),
+    )
+    .build(),
+  phase()
+    .id('main')
+    .label('Main')
+    .icon('🎯')
+    .action()
+    .step(step().id('main').title('Main Phase').build())
+    .build(),
 ];

--- a/packages/contents/src/populationRoles.ts
+++ b/packages/contents/src/populationRoles.ts
@@ -1,3 +1,5 @@
+import { populationRoleInfo } from './config/builders';
+
 export const PopulationRole = {
   Council: 'council',
   Commander: 'commander',
@@ -14,33 +16,45 @@ export interface PopulationRoleInfo {
   description: string;
 }
 
-export const POPULATION_ROLES: Record<PopulationRoleId, PopulationRoleInfo> = {
-  [PopulationRole.Council]: {
-    key: PopulationRole.Council,
-    icon: '⚖️',
-    label: 'Council',
-    description:
-      'The Council advises the crown and generates Action Points during the Development phase. Keeping them employed fuels your economy.',
-  },
-  [PopulationRole.Commander]: {
-    key: PopulationRole.Commander,
-    icon: '🎖️',
-    label: 'Commander',
-    description:
-      'Commanders lead your forces, boosting Army Strength and training troops each Development phase.',
-  },
-  [PopulationRole.Fortifier]: {
-    key: PopulationRole.Fortifier,
-    icon: '🔧',
-    label: 'Fortifier',
-    description:
-      'Fortifiers reinforce your defenses. They raise Fortification Strength and shore up the castle every Development phase.',
-  },
-  [PopulationRole.Citizen]: {
-    key: PopulationRole.Citizen,
-    icon: '👤',
-    label: 'Citizen',
-    description:
-      'Citizens are unassigned populace who await a role. They contribute little on their own but can be trained into specialists.',
-  },
-};
+function createRoleMap() {
+  const list: PopulationRoleInfo[] = [
+    populationRoleInfo()
+      .id(PopulationRole.Council)
+      .icon('⚖️')
+      .label('Council')
+      .description(
+        'The Council advises the crown and generates Action Points during the Development phase. Keeping them employed fuels your economy.',
+      )
+      .build(),
+    populationRoleInfo()
+      .id(PopulationRole.Commander)
+      .icon('🎖️')
+      .label('Commander')
+      .description(
+        'Commanders lead your forces, boosting Army Strength and training troops each Development phase.',
+      )
+      .build(),
+    populationRoleInfo()
+      .id(PopulationRole.Fortifier)
+      .icon('🔧')
+      .label('Fortifier')
+      .description(
+        'Fortifiers reinforce your defenses. They raise Fortification Strength and shore up the castle every Development phase.',
+      )
+      .build(),
+    populationRoleInfo()
+      .id(PopulationRole.Citizen)
+      .icon('👤')
+      .label('Citizen')
+      .description(
+        'Citizens are unassigned populace who await a role. They contribute little on their own but can be trained into specialists.',
+      )
+      .build(),
+  ];
+  return Object.fromEntries(list.map((r) => [r.key, r])) as Record<
+    PopulationRoleId,
+    PopulationRoleInfo
+  >;
+}
+
+export const POPULATION_ROLES = createRoleMap();

--- a/packages/contents/src/resources.ts
+++ b/packages/contents/src/resources.ts
@@ -1,3 +1,5 @@
+import { resourceInfo } from './config/builders';
+
 export const Resource = {
   gold: 'gold',
   ap: 'ap',
@@ -13,33 +15,45 @@ export interface ResourceInfo {
   description: string;
 }
 
-export const RESOURCES: Record<ResourceKey, ResourceInfo> = {
-  [Resource.gold]: {
-    key: Resource.gold,
-    icon: '🪙',
-    label: 'Gold',
-    description:
-      'Gold is the foundational currency of the realm. It is earned through developments and actions and spent to fund buildings, recruit population or pay for powerful plays. A healthy treasury keeps your options open.',
-  },
-  [Resource.ap]: {
-    key: Resource.ap,
-    icon: '⚡',
-    label: 'Action Points',
-    description:
-      'Action Points govern how many actions you can perform during your turn. Plan carefully: once you run out of AP, your main phase ends.',
-  },
-  [Resource.happiness]: {
-    key: Resource.happiness,
-    icon: '😊',
-    label: 'Happiness',
-    description:
-      'Happiness measures the contentment of your subjects. High happiness keeps morale up, while low happiness can lead to unrest or negative effects.',
-  },
-  [Resource.castleHP]: {
-    key: Resource.castleHP,
-    icon: '🏰',
-    label: 'Castle HP',
-    description:
-      'Castle HP represents the durability of your stronghold. If it ever drops to zero, your kingdom falls and the game is lost.',
-  },
-};
+function createResourceMap() {
+  const list: ResourceInfo[] = [
+    resourceInfo()
+      .id(Resource.gold)
+      .icon('🪙')
+      .label('Gold')
+      .description(
+        'Gold is the foundational currency of the realm. It is earned through developments and actions and spent to fund buildings, recruit population or pay for powerful plays. A healthy treasury keeps your options open.',
+      )
+      .build(),
+    resourceInfo()
+      .id(Resource.ap)
+      .icon('⚡')
+      .label('Action Points')
+      .description(
+        'Action Points govern how many actions you can perform during your turn. Plan carefully: once you run out of AP, your main phase ends.',
+      )
+      .build(),
+    resourceInfo()
+      .id(Resource.happiness)
+      .icon('😊')
+      .label('Happiness')
+      .description(
+        'Happiness measures the contentment of your subjects. High happiness keeps morale up, while low happiness can lead to unrest or negative effects.',
+      )
+      .build(),
+    resourceInfo()
+      .id(Resource.castleHP)
+      .icon('🏰')
+      .label('Castle HP')
+      .description(
+        'Castle HP represents the durability of your stronghold. If it ever drops to zero, your kingdom falls and the game is lost.',
+      )
+      .build(),
+  ];
+  return Object.fromEntries(list.map((r) => [r.key, r])) as Record<
+    ResourceKey,
+    ResourceInfo
+  >;
+}
+
+export const RESOURCES = createResourceMap();

--- a/packages/contents/src/rules.ts
+++ b/packages/contents/src/rules.ts
@@ -1,22 +1,14 @@
-import type { RuleSet } from '@kingdom-builder/engine/services';
+import { rules } from './config/builders';
 
-export const RULES: RuleSet = {
-  defaultActionAPCost: 1,
-  absorptionCapPct: 1,
-  absorptionRounding: 'down',
-  happinessTiers: [
-    { threshold: 0, effect: { incomeMultiplier: 1 } },
-    { threshold: 3, effect: { incomeMultiplier: 1.25 } },
-    {
-      threshold: 5,
-      effect: { incomeMultiplier: 1.25, buildingDiscountPct: 0.2 },
-    },
-    {
-      threshold: 8,
-      effect: { incomeMultiplier: 1.5, buildingDiscountPct: 0.2 },
-    },
-  ],
-  slotsPerNewLand: 1,
-  maxSlotsPerLand: 2,
-  basePopulationCap: 1,
-};
+export const RULES = rules()
+  .defaultActionAPCost(1)
+  .absorptionCapPct(1)
+  .absorptionRounding('down')
+  .happinessTier(0, { incomeMultiplier: 1 })
+  .happinessTier(3, { incomeMultiplier: 1.25 })
+  .happinessTier(5, { incomeMultiplier: 1.25, buildingDiscountPct: 0.2 })
+  .happinessTier(8, { incomeMultiplier: 1.5, buildingDiscountPct: 0.2 })
+  .slotsPerNewLand(1)
+  .maxSlotsPerLand(2)
+  .basePopulationCap(1)
+  .build();

--- a/packages/contents/src/stats.ts
+++ b/packages/contents/src/stats.ts
@@ -1,3 +1,5 @@
+import { statInfo } from './config/builders';
+
 export const Stat = {
   maxPopulation: 'maxPopulation',
   armyStrength: 'armyStrength',
@@ -19,56 +21,64 @@ export interface StatInfo {
   };
 }
 
-export const STATS: Record<StatKey, StatInfo> = {
-  [Stat.maxPopulation]: {
-    key: Stat.maxPopulation,
-    icon: '👥',
-    label: 'Max Population',
-    description:
-      'Max Population determines how many subjects your kingdom can sustain. Expand infrastructure or build houses to increase it.',
-    addFormat: {
-      prefix: 'Max ',
-    },
-  },
-  [Stat.armyStrength]: {
-    key: Stat.armyStrength,
-    icon: '⚔️',
-    label: 'Army Strength',
-    description:
-      'Army Strength reflects the overall power of your military forces. A higher value makes your attacks more formidable.',
-  },
-  [Stat.fortificationStrength]: {
-    key: Stat.fortificationStrength,
-    icon: '🛡️',
-    label: 'Fortification Strength',
-    description:
-      'Fortification Strength measures the resilience of your defenses. It reduces damage taken when enemies assault your castle.',
-  },
-  [Stat.absorption]: {
-    key: Stat.absorption,
-    icon: '🌀',
-    label: 'Absorption',
-    description:
-      'Absorption reduces incoming damage by a percentage. It represents magical barriers or tactical advantages that soften blows.',
-    addFormat: {
-      percent: true,
-    },
-  },
-  [Stat.growth]: {
-    key: Stat.growth,
-    icon: '📈',
-    label: 'Growth',
-    description:
-      'Growth increases Army and Fortification Strength during the Raise Strength step.',
-    addFormat: {
-      percent: true,
-    },
-  },
-  [Stat.warWeariness]: {
-    key: Stat.warWeariness,
-    icon: '💤',
-    label: 'War Weariness',
-    description:
-      'War Weariness reflects the fatigue from prolonged conflict. High weariness can sap morale and hinder wartime efforts.',
-  },
-};
+function createStatMap() {
+  const list: StatInfo[] = [
+    statInfo()
+      .id(Stat.maxPopulation)
+      .icon('👥')
+      .label('Max Population')
+      .description(
+        'Max Population determines how many subjects your kingdom can sustain. Expand infrastructure or build houses to increase it.',
+      )
+      .addFormat({ prefix: 'Max ' })
+      .build(),
+    statInfo()
+      .id(Stat.armyStrength)
+      .icon('⚔️')
+      .label('Army Strength')
+      .description(
+        'Army Strength reflects the overall power of your military forces. A higher value makes your attacks more formidable.',
+      )
+      .build(),
+    statInfo()
+      .id(Stat.fortificationStrength)
+      .icon('🛡️')
+      .label('Fortification Strength')
+      .description(
+        'Fortification Strength measures the resilience of your defenses. It reduces damage taken when enemies assault your castle.',
+      )
+      .build(),
+    statInfo()
+      .id(Stat.absorption)
+      .icon('🌀')
+      .label('Absorption')
+      .description(
+        'Absorption reduces incoming damage by a percentage. It represents magical barriers or tactical advantages that soften blows.',
+      )
+      .addFormat({ percent: true })
+      .build(),
+    statInfo()
+      .id(Stat.growth)
+      .icon('📈')
+      .label('Growth')
+      .description(
+        'Growth increases Army and Fortification Strength during the Raise Strength step.',
+      )
+      .addFormat({ percent: true })
+      .build(),
+    statInfo()
+      .id(Stat.warWeariness)
+      .icon('💤')
+      .label('War Weariness')
+      .description(
+        'War Weariness reflects the fatigue from prolonged conflict. High weariness can sap morale and hinder wartime efforts.',
+      )
+      .build(),
+  ];
+  return Object.fromEntries(list.map((s) => [s.key, s])) as Record<
+    StatKey,
+    StatInfo
+  >;
+}
+
+export const STATS = createStatMap();


### PR DESCRIPTION
## Summary
- refactor resource, stat, population role and modifier maps to use builder utilities
- convert phase, rules and game start configs to builder-based APIs
- expose generic info, phase, rules and start builders for flexible content creation

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b4bd0feb8083258cad909b7653ac49