### PR TITLE
refactor: add builders for content configuration

### DIFF
--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -2,7 +2,8 @@ export { ACTIONS, createActionRegistry } from './actions';
 export { BUILDINGS, createBuildingRegistry } from './buildings';
 export { DEVELOPMENTS, createDevelopmentRegistry } from './developments';
 export { POPULATIONS, createPopulationRegistry } from './populations';
-export { PHASES, type PhaseDef, type StepDef } from './phases';
+export { PHASES } from './phases';
+export type { PhaseDef, StepDef } from './config/builders';
 export {
   POPULATION_ROLES,
   PopulationRole,

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -1,42 +1,30 @@
-import type { TriggerKey } from './defs';
 import { Resource } from './resources';
 import { Stat } from './stats';
 import { PopulationRole } from './populationRoles';
-import type { EffectDef } from '@kingdom-builder/engine/effects';
-import { effect, Types, ResourceMethods, StatMethods } from './config/builders';
-
-export interface StepDef {
-  id: string;
-  title?: string;
-  triggers?: TriggerKey[];
-  effects?: EffectDef[];
-  icon?: string;
-}
-
-export interface PhaseDef {
-  id: string;
-  steps: StepDef[];
-  action?: boolean;
-  label: string;
-  icon?: string;
-}
+import {
+  effect,
+  Types,
+  ResourceMethods,
+  StatMethods,
+  phase,
+  step,
+  type PhaseDef,
+} from './config/builders';
 
 export const PHASES: PhaseDef[] = [
-  {
-    id: 'development',
-    label: 'Development',
-    icon: '🏗️',
-    steps: [
-      {
-        id: 'resolve-dynamic-triggers',
-        title: 'Resolve dynamic triggers',
-        triggers: ['onDevelopmentPhase'],
-      },
-      {
-        id: 'gain-income',
-        title: 'Gain Income',
-        icon: '💰',
-        effects: [
+  phase('development')
+    .label('Development')
+    .icon('🏗️')
+    .step(
+      step('resolve-dynamic-triggers')
+        .title('Resolve dynamic triggers')
+        .triggers('onDevelopmentPhase'),
+    )
+    .step(
+      step('gain-income')
+        .title('Gain Income')
+        .icon('💰')
+        .effect(
           effect()
             .evaluator('development', { id: 'farm' })
             .effect(
@@ -45,12 +33,12 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
-        ],
-      },
-      {
-        id: 'gain-ap',
-        title: 'Gain Action Points',
-        effects: [
+        ),
+    )
+    .step(
+      step('gain-ap')
+        .title('Gain Action Points')
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Council })
             .effect(
@@ -59,12 +47,12 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
-        ],
-      },
-      {
-        id: 'raise-strength',
-        title: 'Raise Strength',
-        effects: [
+        ),
+    )
+    .step(
+      step('raise-strength')
+        .title('Raise Strength')
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Commander })
             .effect(
@@ -74,6 +62,8 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
+        )
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Fortifier })
             .effect(
@@ -86,24 +76,21 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
-        ],
-      },
-    ],
-  },
-  {
-    id: 'upkeep',
-    label: 'Upkeep',
-    icon: '🧹',
-    steps: [
-      {
-        id: 'resolve-dynamic-triggers',
-        title: 'Resolve dynamic triggers',
-        triggers: ['onUpkeepPhase'],
-      },
-      {
-        id: 'pay-upkeep',
-        title: 'Pay Upkeep',
-        effects: [
+        ),
+    )
+    .build(),
+  phase('upkeep')
+    .label('Upkeep')
+    .icon('🧹')
+    .step(
+      step('resolve-dynamic-triggers')
+        .title('Resolve dynamic triggers')
+        .triggers('onUpkeepPhase'),
+    )
+    .step(
+      step('pay-upkeep')
+        .title('Pay Upkeep')
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Council })
             .effect(
@@ -112,6 +99,8 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
+        )
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Commander })
             .effect(
@@ -120,6 +109,8 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
+        )
+        .effect(
           effect()
             .evaluator('population', { role: PopulationRole.Fortifier })
             .effect(
@@ -128,12 +119,12 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
-        ],
-      },
-      {
-        id: 'war-recovery',
-        title: 'War recovery',
-        effects: [
+        ),
+    )
+    .step(
+      step('war-recovery')
+        .title('War recovery')
+        .effect(
           effect()
             .evaluator('compare', {
               left: { type: 'stat', params: { key: Stat.warWeariness } },
@@ -146,15 +137,13 @@ export const PHASES: PhaseDef[] = [
                 .build(),
             )
             .build(),
-        ],
-      },
-    ],
-  },
-  {
-    id: 'main',
-    label: 'Main',
-    icon: '🎯',
-    action: true,
-    steps: [{ id: 'main', title: 'Main Phase' }],
-  },
+        ),
+    )
+    .build(),
+  phase('main')
+    .label('Main')
+    .icon('🎯')
+    .action()
+    .step(step('main').title('Main Phase'))
+    .build(),
 ];

--- a/packages/contents/src/populationRoles.ts
+++ b/packages/contents/src/populationRoles.ts
@@ -1,3 +1,9 @@
+import {
+  populationRole,
+  type PopulationRoleInfo,
+  toRecord,
+} from './config/builders';
+
 export const PopulationRole = {
   Council: 'council',
   Commander: 'commander',
@@ -7,40 +13,36 @@ export const PopulationRole = {
 export type PopulationRoleId =
   (typeof PopulationRole)[keyof typeof PopulationRole];
 
-export interface PopulationRoleInfo {
-  key: PopulationRoleId;
-  icon: string;
-  label: string;
-  description: string;
-}
-
-export const POPULATION_ROLES: Record<PopulationRoleId, PopulationRoleInfo> = {
-  [PopulationRole.Council]: {
-    key: PopulationRole.Council,
-    icon: '⚖️',
-    label: 'Council',
-    description:
+const defs: PopulationRoleInfo[] = [
+  populationRole(PopulationRole.Council)
+    .icon('⚖️')
+    .label('Council')
+    .description(
       'The Council advises the crown and generates Action Points during the Development phase. Keeping them employed fuels your economy.',
-  },
-  [PopulationRole.Commander]: {
-    key: PopulationRole.Commander,
-    icon: '🎖️',
-    label: 'Commander',
-    description:
+    )
+    .build(),
+  populationRole(PopulationRole.Commander)
+    .icon('🎖️')
+    .label('Commander')
+    .description(
       'Commanders lead your forces, boosting Army Strength and training troops each Development phase.',
-  },
-  [PopulationRole.Fortifier]: {
-    key: PopulationRole.Fortifier,
-    icon: '🔧',
-    label: 'Fortifier',
-    description:
+    )
+    .build(),
+  populationRole(PopulationRole.Fortifier)
+    .icon('🔧')
+    .label('Fortifier')
+    .description(
       'Fortifiers reinforce your defenses. They raise Fortification Strength and shore up the castle every Development phase.',
-  },
-  [PopulationRole.Citizen]: {
-    key: PopulationRole.Citizen,
-    icon: '👤',
-    label: 'Citizen',
-    description:
+    )
+    .build(),
+  populationRole(PopulationRole.Citizen)
+    .icon('👤')
+    .label('Citizen')
+    .description(
       'Citizens are unassigned populace who await a role. They contribute little on their own but can be trained into specialists.',
-  },
-};
+    )
+    .build(),
+];
+
+export const POPULATION_ROLES: Record<PopulationRoleId, PopulationRoleInfo> =
+  toRecord(defs) as Record<PopulationRoleId, PopulationRoleInfo>;

--- a/packages/contents/src/resources.ts
+++ b/packages/contents/src/resources.ts
@@ -1,3 +1,5 @@
+import { resource, type ResourceInfo, toRecord } from './config/builders';
+
 export const Resource = {
   gold: 'gold',
   ap: 'ap',
@@ -6,40 +8,37 @@ export const Resource = {
 } as const;
 export type ResourceKey = (typeof Resource)[keyof typeof Resource];
 
-export interface ResourceInfo {
-  key: ResourceKey;
-  icon: string;
-  label: string;
-  description: string;
-}
-
-export const RESOURCES: Record<ResourceKey, ResourceInfo> = {
-  [Resource.gold]: {
-    key: Resource.gold,
-    icon: '🪙',
-    label: 'Gold',
-    description:
+const defs: ResourceInfo[] = [
+  resource(Resource.gold)
+    .icon('🪙')
+    .label('Gold')
+    .description(
       'Gold is the foundational currency of the realm. It is earned through developments and actions and spent to fund buildings, recruit population or pay for powerful plays. A healthy treasury keeps your options open.',
-  },
-  [Resource.ap]: {
-    key: Resource.ap,
-    icon: '⚡',
-    label: 'Action Points',
-    description:
+    )
+    .build(),
+  resource(Resource.ap)
+    .icon('⚡')
+    .label('Action Points')
+    .description(
       'Action Points govern how many actions you can perform during your turn. Plan carefully: once you run out of AP, your main phase ends.',
-  },
-  [Resource.happiness]: {
-    key: Resource.happiness,
-    icon: '😊',
-    label: 'Happiness',
-    description:
+    )
+    .build(),
+  resource(Resource.happiness)
+    .icon('😊')
+    .label('Happiness')
+    .description(
       'Happiness measures the contentment of your subjects. High happiness keeps morale up, while low happiness can lead to unrest or negative effects.',
-  },
-  [Resource.castleHP]: {
-    key: Resource.castleHP,
-    icon: '🏰',
-    label: 'Castle HP',
-    description:
+    )
+    .build(),
+  resource(Resource.castleHP)
+    .icon('🏰')
+    .label('Castle HP')
+    .description(
       'Castle HP represents the durability of your stronghold. If it ever drops to zero, your kingdom falls and the game is lost.',
-  },
-};
+    )
+    .build(),
+];
+
+export const RESOURCES: Record<ResourceKey, ResourceInfo> = toRecord(
+  defs,
+) as Record<ResourceKey, ResourceInfo>;

--- a/packages/contents/src/stats.ts
+++ b/packages/contents/src/stats.ts
@@ -1,3 +1,5 @@
+import { stat, type StatInfo, toRecord } from './config/builders';
+
 export const Stat = {
   maxPopulation: 'maxPopulation',
   armyStrength: 'armyStrength',
@@ -8,70 +10,57 @@ export const Stat = {
 } as const;
 export type StatKey = (typeof Stat)[keyof typeof Stat];
 
-export interface StatInfo {
-  key: StatKey;
-  icon: string;
-  label: string;
-  description: string;
-  displayAsPercent?: boolean;
-  addFormat?: {
-    prefix?: string;
-    percent?: boolean;
-  };
-}
-
-export const STATS: Record<StatKey, StatInfo> = {
-  [Stat.maxPopulation]: {
-    key: Stat.maxPopulation,
-    icon: '👥',
-    label: 'Max Population',
-    description:
+const defs: StatInfo[] = [
+  stat(Stat.maxPopulation)
+    .icon('👥')
+    .label('Max Population')
+    .description(
       'Max Population determines how many subjects your kingdom can sustain. Expand infrastructure or build houses to increase it.',
-    addFormat: {
-      prefix: 'Max ',
-    },
-  },
-  [Stat.armyStrength]: {
-    key: Stat.armyStrength,
-    icon: '⚔️',
-    label: 'Army Strength',
-    description:
+    )
+    .addFormat({ prefix: 'Max ' })
+    .build(),
+  stat(Stat.armyStrength)
+    .icon('⚔️')
+    .label('Army Strength')
+    .description(
       'Army Strength reflects the overall power of your military forces. A higher value makes your attacks more formidable.',
-  },
-  [Stat.fortificationStrength]: {
-    key: Stat.fortificationStrength,
-    icon: '🛡️',
-    label: 'Fortification Strength',
-    description:
+    )
+    .build(),
+  stat(Stat.fortificationStrength)
+    .icon('🛡️')
+    .label('Fortification Strength')
+    .description(
       'Fortification Strength measures the resilience of your defenses. It reduces damage taken when enemies assault your castle.',
-  },
-  [Stat.absorption]: {
-    key: Stat.absorption,
-    icon: '🌀',
-    label: 'Absorption',
-    description:
+    )
+    .build(),
+  stat(Stat.absorption)
+    .icon('🌀')
+    .label('Absorption')
+    .description(
       'Absorption reduces incoming damage by a percentage. It represents magical barriers or tactical advantages that soften blows.',
-    displayAsPercent: true,
-    addFormat: {
-      percent: true,
-    },
-  },
-  [Stat.growth]: {
-    key: Stat.growth,
-    icon: '📈',
-    label: 'Growth',
-    description:
+    )
+    .displayAsPercent()
+    .addFormat({ percent: true })
+    .build(),
+  stat(Stat.growth)
+    .icon('📈')
+    .label('Growth')
+    .description(
       'Growth increases Army and Fortification Strength during the Raise Strength step.',
-    displayAsPercent: true,
-    addFormat: {
-      percent: true,
-    },
-  },
-  [Stat.warWeariness]: {
-    key: Stat.warWeariness,
-    icon: '💤',
-    label: 'War Weariness',
-    description:
+    )
+    .displayAsPercent()
+    .addFormat({ percent: true })
+    .build(),
+  stat(Stat.warWeariness)
+    .icon('💤')
+    .label('War Weariness')
+    .description(
       'War Weariness reflects the fatigue from prolonged conflict. High weariness can sap morale and hinder wartime efforts.',
-  },
-};
+    )
+    .build(),
+];
+
+export const STATS: Record<StatKey, StatInfo> = toRecord(defs) as Record<
+  StatKey,
+  StatInfo
+>;


### PR DESCRIPTION
## Summary
- add generic builders for resources, stats, population roles and phase steps
- rewrite resource, stat, population role, and phase definitions to use builders
- expose new phase types via contents index

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4c01e08fc8325ba071e4740c9540e