### PR TITLE
fix land addition ordering

### DIFF
--- a/packages/engine/tests/effects/land_add.test.ts
+++ b/packages/engine/tests/effects/land_add.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { runEffects } from '../../src/effects/index.ts';
+import { createTestEngine } from '../helpers.ts';
+
+describe('land:add effect', () => {
+  it('appends new lands to the end', () => {
+    const ctx = createTestEngine();
+    const beforeIds = ctx.activePlayer.lands.map((l) => l.id);
+    const beforeCount = beforeIds.length;
+
+    runEffects(
+      [
+        {
+          type: 'land',
+          method: 'add',
+          params: { count: 2 },
+        },
+      ],
+      ctx,
+    );
+
+    const lands = ctx.activePlayer.lands;
+    expect(lands.length).toBe(beforeCount + 2);
+    expect(lands.slice(0, beforeCount).map((l) => l.id)).toEqual(beforeIds);
+    expect(lands[beforeCount]?.id).toBe(
+      `${ctx.activePlayer.id}-L${beforeCount + 1}`,
+    );
+    expect(lands[beforeCount + 1]?.id).toBe(
+      `${ctx.activePlayer.id}-L${beforeCount + 2}`,
+    );
+  });
+});

--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -14,12 +14,11 @@ interface LandDisplayProps {
 
 const LandTile: React.FC<{
   land: EngineContext['activePlayer']['lands'][number];
-  idx: number;
   ctx: ReturnType<typeof useGameEngine>['ctx'];
   handleHoverCard: ReturnType<typeof useGameEngine>['handleHoverCard'];
   clearHoverCard: ReturnType<typeof useGameEngine>['clearHoverCard'];
   developAction?: { icon?: string; name: string } | undefined;
-}> = ({ land, idx, ctx, handleHoverCard, clearHoverCard, developAction }) => {
+}> = ({ land, ctx, handleHoverCard, clearHoverCard, developAction }) => {
   const showLandCard = () => {
     const full = describeContent('land', land, ctx);
     const { effects, description } = splitSummary(full);
@@ -35,7 +34,6 @@ const LandTile: React.FC<{
   const animateSlots = useAnimate<HTMLDivElement>();
   return (
     <div
-      key={idx}
       className="relative panel-card p-2 text-center hoverable cursor-help"
       onMouseEnter={showLandCard}
       onMouseLeave={clearHoverCard}
@@ -129,11 +127,10 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
   const animateLands = useAnimate<HTMLDivElement>();
   return (
     <div ref={animateLands} className="flex flex-wrap gap-2 mt-2 w-fit">
-      {player.lands.map((land, idx) => (
+      {player.lands.map((land) => (
         <LandTile
-          key={idx}
+          key={land.id}
           land={land}
-          idx={idx}
           ctx={ctx}
           handleHoverCard={handleHoverCard}
           clearHoverCard={clearHoverCard}


### PR DESCRIPTION
## Summary
- keep land ids when rendering to preserve append order
- test land:add effect appends lands at the end

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4c207c1848325bb42bf1d51d1270a