### PR TITLE
refactor: derive test data from content

### DIFF
--- a/packages/engine/tests/actions/build.test.ts
+++ b/packages/engine/tests/actions/build.test.ts
@@ -1,20 +1,23 @@
 import { describe, it, expect } from 'vitest';
 import {
   performAction,
-  Resource,
   getActionCosts,
   runEffects,
   advance,
 } from '../../src/index.ts';
 import { createTestEngine } from '../helpers.ts';
+import { BUILDINGS, Resource as CResource } from '@kingdom-builder/contents';
 
 describe('Build action', () => {
   it('rejects when gold is insufficient', () => {
     const ctx = createTestEngine();
     while (ctx.game.currentPhase !== 'main') advance(ctx);
-    const cost = getActionCosts('build', ctx, { id: 'town_charter' });
-    ctx.activePlayer.gold = (cost[Resource.gold] || 0) - 1;
-    expect(() => performAction('build', ctx, { id: 'town_charter' })).toThrow(
+    const [townCharterId] = Array.from(
+      (BUILDINGS as unknown as { map: Map<string, unknown> }).map.keys(),
+    );
+    const cost = getActionCosts('build', ctx, { id: townCharterId });
+    ctx.activePlayer.gold = (cost[CResource.gold] || 0) - 1;
+    expect(() => performAction('build', ctx, { id: townCharterId })).toThrow(
       /Insufficient gold/,
     );
   });
@@ -24,16 +27,19 @@ describe('Build action', () => {
     while (ctx.game.currentPhase !== 'main') advance(ctx);
 
     const baseCost = getActionCosts('expand', ctx);
-    performAction('build', ctx, { id: 'town_charter' });
-    expect(ctx.activePlayer.buildings.has('town_charter')).toBe(true);
+    const [townCharterId] = Array.from(
+      (BUILDINGS as unknown as { map: Map<string, unknown> }).map.keys(),
+    );
+    performAction('build', ctx, { id: townCharterId });
+    expect(ctx.activePlayer.buildings.has(townCharterId)).toBe(true);
     const modifiedCost = getActionCosts('expand', ctx);
     expect(modifiedCost).not.toEqual(baseCost);
 
     runEffects(
-      [{ type: 'building', method: 'remove', params: { id: 'town_charter' } }],
+      [{ type: 'building', method: 'remove', params: { id: townCharterId } }],
       ctx,
     );
-    expect(ctx.activePlayer.buildings.has('town_charter')).toBe(false);
+    expect(ctx.activePlayer.buildings.has(townCharterId)).toBe(false);
     const revertedCost = getActionCosts('expand', ctx);
     expect(revertedCost).toEqual(baseCost);
   });

--- a/packages/engine/tests/actions/develop.test.ts
+++ b/packages/engine/tests/actions/develop.test.ts
@@ -12,6 +12,11 @@ import {
 import { PlayerState, Land, GameState } from '../../src/state/index.ts';
 import { createTestEngine } from '../helpers.ts';
 import { applyParamsToEffects } from '../../src/utils.ts';
+import { DEVELOPMENTS } from '@kingdom-builder/contents';
+
+const [farmId, houseId, outpostId, watchtowerId] = Array.from(
+  (DEVELOPMENTS as unknown as { map: Map<string, unknown> }).map.keys(),
+);
 
 function clonePlayer(player: PlayerState): PlayerState {
   const copy = new PlayerState(player.id, player.name);
@@ -76,9 +81,9 @@ describe('Develop action', () => {
     while (ctx.game.currentPhase !== 'main') advance(ctx);
     const land = ctx.activePlayer.lands[1];
     const slotsBefore = land.slotsUsed;
-    const expected = simulateBuild(ctx, 'farm', land.id);
-    performAction('develop', ctx, { id: 'farm', landId: land.id });
-    expect(land.developments).toContain('farm');
+    const expected = simulateBuild(ctx, farmId, land.id);
+    performAction('develop', ctx, { id: farmId, landId: land.id });
+    expect(land.developments).toContain(farmId);
     expect(land.slotsUsed).toBe(slotsBefore + 1);
     expectState(ctx.activePlayer, expected.activePlayer);
   });
@@ -88,9 +93,9 @@ describe('Develop action', () => {
     while (ctx.game.currentPhase !== 'main') advance(ctx);
     const land = ctx.activePlayer.lands[1];
     const slotsBefore = land.slotsUsed;
-    const expected = simulateBuild(ctx, 'house', land.id);
-    performAction('develop', ctx, { id: 'house', landId: land.id });
-    expect(land.developments).toContain('house');
+    const expected = simulateBuild(ctx, houseId, land.id);
+    performAction('develop', ctx, { id: houseId, landId: land.id });
+    expect(land.developments).toContain(houseId);
     expect(land.slotsUsed).toBe(slotsBefore + 1);
     expectState(ctx.activePlayer, expected.activePlayer);
   });
@@ -100,9 +105,9 @@ describe('Develop action', () => {
     while (ctx.game.currentPhase !== 'main') advance(ctx);
     const land = ctx.activePlayer.lands[1];
     const slotsBefore = land.slotsUsed;
-    const expected = simulateBuild(ctx, 'outpost', land.id);
-    performAction('develop', ctx, { id: 'outpost', landId: land.id });
-    expect(land.developments).toContain('outpost');
+    const expected = simulateBuild(ctx, outpostId, land.id);
+    performAction('develop', ctx, { id: outpostId, landId: land.id });
+    expect(land.developments).toContain(outpostId);
     expect(land.slotsUsed).toBe(slotsBefore + 1);
     expectState(ctx.activePlayer, expected.activePlayer);
   });
@@ -112,16 +117,16 @@ describe('Develop action', () => {
     while (ctx.game.currentPhase !== 'main') advance(ctx);
     const land = ctx.activePlayer.lands[1];
 
-    const expectedBuild = simulateBuild(ctx, 'watchtower', land.id);
-    const expectedAfterAttack = simulateBuild(ctx, 'watchtower', land.id);
+    const expectedBuild = simulateBuild(ctx, watchtowerId, land.id);
+    const expectedAfterAttack = simulateBuild(ctx, watchtowerId, land.id);
     resolveAttack(expectedAfterAttack.activePlayer, 0, expectedAfterAttack);
 
-    performAction('develop', ctx, { id: 'watchtower', landId: land.id });
-    expect(land.developments).toContain('watchtower');
+    performAction('develop', ctx, { id: watchtowerId, landId: land.id });
+    expect(land.developments).toContain(watchtowerId);
     expectState(ctx.activePlayer, expectedBuild.activePlayer);
 
     resolveAttack(ctx.activePlayer, 0, ctx);
-    expect(land.developments).not.toContain('watchtower');
+    expect(land.developments).not.toContain(watchtowerId);
     expectState(ctx.activePlayer, expectedAfterAttack.activePlayer);
   });
 
@@ -130,14 +135,14 @@ describe('Develop action', () => {
     while (ctx.game.currentPhase !== 'main') advance(ctx);
     const land = ctx.activePlayer.lands[1];
 
-    const def = ctx.developments.get('house');
+    const def = ctx.developments.get(houseId);
     const statEffect = def.onBuild.find((e) => e.type === 'stat') as {
       params: { amount: number };
     };
     const amount = statEffect.params.amount;
 
     const before = ctx.activePlayer.stats.maxPopulation;
-    performAction('develop', ctx, { id: 'house', landId: land.id });
+    performAction('develop', ctx, { id: houseId, landId: land.id });
     expect(ctx.activePlayer.stats.maxPopulation).toBe(before + amount);
 
     runEffects(
@@ -145,12 +150,12 @@ describe('Develop action', () => {
         {
           type: 'development',
           method: 'remove',
-          params: { id: 'house', landId: land.id },
+          params: { id: houseId, landId: land.id },
         },
       ],
       ctx,
     );
     expect(ctx.activePlayer.stats.maxPopulation).toBe(before);
-    expect(land.developments).not.toContain('house');
+    expect(land.developments).not.toContain(houseId);
   });
 });

--- a/packages/engine/tests/actions/plow.test.ts
+++ b/packages/engine/tests/actions/plow.test.ts
@@ -2,13 +2,17 @@ import { describe, it, expect } from 'vitest';
 import {
   performAction,
   getActionCosts,
-  Resource,
   collectTriggerEffects,
   runEffects,
   advance,
   type EngineContext,
 } from '../../src/index.ts';
 import { createTestEngine } from '../helpers.ts';
+import { BUILDINGS, Resource as CResource } from '@kingdom-builder/contents';
+
+const [, , , plowWorkshopId] = Array.from(
+  (BUILDINGS as unknown as { map: Map<string, unknown> }).map.keys(),
+);
 
 function countTilled(ctx: EngineContext): number {
   return ctx.activePlayer.lands.filter((l) => l.tilled).length;
@@ -18,9 +22,9 @@ describe('Plow action', () => {
   it('expands, tills and adds temporary cost modifier', () => {
     const ctx = createTestEngine();
     while (ctx.game.currentPhase !== 'main') advance(ctx);
-    ctx.activePlayer.gold += 20;
     const baseCost = getActionCosts('expand', ctx);
-    performAction('build', ctx, { id: 'plow_workshop' });
+    ctx.activePlayer.gold += 20;
+    performAction('build', ctx, { id: plowWorkshopId });
     ctx.activePlayer.ap += 1;
     const landsBefore = ctx.activePlayer.lands.length;
     const tilledBefore = countTilled(ctx);
@@ -28,9 +32,9 @@ describe('Plow action', () => {
     expect(ctx.activePlayer.lands.length).toBe(landsBefore + 1);
     expect(countTilled(ctx)).toBe(tilledBefore + 1);
     const modified = getActionCosts('expand', ctx);
-    expect(modified[Resource.gold]).toBe((baseCost[Resource.gold] || 0) + 2);
+    expect(modified[CResource.gold]).toBe((baseCost[CResource.gold] || 0) + 2);
     runEffects(collectTriggerEffects('onUpkeepPhase', ctx), ctx);
     const reverted = getActionCosts('expand', ctx);
-    expect(reverted[Resource.gold]).toBe(baseCost[Resource.gold] || 0);
+    expect(reverted[CResource.gold]).toBe(baseCost[CResource.gold] || 0);
   });
 });

--- a/packages/engine/tests/effects/add_building.test.ts
+++ b/packages/engine/tests/effects/add_building.test.ts
@@ -1,36 +1,38 @@
 import { describe, it, expect } from 'vitest';
-import { performAction, Resource, getActionCosts } from '../../src/index.ts';
+import { performAction, getActionCosts } from '../../src/index.ts';
 import {
   createActionRegistry,
   Resource as CResource,
+  BUILDINGS,
 } from '@kingdom-builder/contents';
 import { createTestEngine } from '../helpers.ts';
 import type { EngineContext } from '../../src/index.ts';
 
 // Custom action that grants Town Charter for free to test the effect handler
 const actions = createActionRegistry();
+const [townCharterId] = Array.from(
+  (BUILDINGS as unknown as { map: Map<string, unknown> }).map.keys(),
+);
 actions.add('free_charter', {
   id: 'free_charter',
   name: 'Free Charter',
   baseCosts: { [CResource.ap]: 0 },
-  effects: [
-    { type: 'building', method: 'add', params: { id: 'town_charter' } },
-  ],
+  effects: [{ type: 'building', method: 'add', params: { id: townCharterId } }],
 });
 
 function getExpandGoldCost(ctx: EngineContext) {
   const costs = getActionCosts('expand', ctx);
-  return costs[Resource.gold] || 0;
+  return costs[CResource.gold] || 0;
 }
 
 describe('building:add effect', () => {
   it('adds building and applies its passives', () => {
     const ctx = createTestEngine({ actions });
     ctx.activePlayer.ap =
-      ctx.buildings.get('town_charter').costs[Resource.ap] ?? 0;
+      ctx.buildings.get(townCharterId).costs[CResource.ap] ?? 0;
     const before = getExpandGoldCost(ctx);
     performAction('free_charter', ctx);
-    expect(ctx.activePlayer.buildings.has('town_charter')).toBe(true);
+    expect(ctx.activePlayer.buildings.has(townCharterId)).toBe(true);
     const after = getExpandGoldCost(ctx);
     expect(after).toBeGreaterThan(before);
   });

--- a/packages/engine/tests/services/rules.test.ts
+++ b/packages/engine/tests/services/rules.test.ts
@@ -1,45 +1,68 @@
 import { describe, it, expect } from 'vitest';
 import { Services } from '../../src/services/index.ts';
-import { PlayerState, Land, Resource } from '../../src/state/index.ts';
+import { PlayerState, Land } from '../../src/state/index.ts';
 import { createTestEngine } from '../helpers.ts';
-import { DEVELOPMENTS, RULES } from '@kingdom-builder/contents';
+import {
+  DEVELOPMENTS,
+  RULES,
+  Resource as CResource,
+} from '@kingdom-builder/contents';
+import { getActionCosts } from '../../src/index.ts';
 
 describe('Services', () => {
   it('evaluates happiness tiers correctly', () => {
     const services = new Services(RULES, DEVELOPMENTS);
-    expect(services.happiness.tier(0)?.incomeMultiplier).toBe(1);
-    expect(services.happiness.tier(4)?.incomeMultiplier).toBe(1.25);
-    expect(services.happiness.tier(5)?.buildingDiscountPct).toBe(0.2);
-    expect(services.happiness.tier(8)?.incomeMultiplier).toBe(1.5);
+    const getTierEffect = (value: number) =>
+      RULES.happinessTiers.filter((t) => t.threshold <= value).at(-1)?.effect ||
+      {};
+    expect(services.happiness.tier(0)?.incomeMultiplier).toBe(
+      getTierEffect(0).incomeMultiplier,
+    );
+    expect(services.happiness.tier(4)?.incomeMultiplier).toBe(
+      getTierEffect(4).incomeMultiplier,
+    );
+    expect(services.happiness.tier(5)?.buildingDiscountPct).toBe(
+      getTierEffect(5).buildingDiscountPct,
+    );
+    expect(services.happiness.tier(8)?.incomeMultiplier).toBe(
+      getTierEffect(8).incomeMultiplier,
+    );
   });
 
   it('calculates population cap from houses on land', () => {
     const services = new Services(RULES, DEVELOPMENTS);
     const player = new PlayerState('A', 'Test');
+    const [farmId, houseId] = Array.from(
+      (DEVELOPMENTS as unknown as { map: Map<string, unknown> }).map.keys(),
+    );
     const land1 = new Land('l1', 1);
-    land1.developments.push('house');
+    land1.developments.push(houseId);
     const land2 = new Land('l2', 2);
-    land2.developments.push('farm', 'house');
+    land2.developments.push(farmId, houseId);
     player.lands = [land1, land2];
     const cap = services.popcap.getCap(player);
-    // base castle houses (1) + 2 houses on land
-    expect(cap).toBe(3);
+    const houseCap =
+      DEVELOPMENTS.get(houseId).onBuild.find((e) => e.type === 'stat')
+        ?.params?.['amount'] ?? 0;
+    const baseCap = RULES.basePopulationCap;
+    expect(cap).toBe(baseCap + houseCap * 2);
   });
 });
 
 describe('PassiveManager', () => {
   it('applies and unregisters cost modifiers', () => {
     const ctx = createTestEngine();
-    const base = { [Resource.gold]: 2 };
-    ctx.passives.registerCostModifier('tax', (action, cost) => ({
+    const baseCost = getActionCosts('expand', ctx);
+    const base = { [CResource.gold]: baseCost[CResource.gold] || 0 };
+    ctx.passives.registerCostModifier('tax', (_action, cost) => ({
       ...cost,
-      [Resource.gold]: (cost[Resource.gold] || 0) + 1,
+      [CResource.gold]: (cost[CResource.gold] || 0) + 1,
     }));
     const modified = ctx.passives.applyCostMods('expand', base, ctx);
-    expect(modified[Resource.gold]).toBe(3);
+    expect(modified[CResource.gold]).toBe((base[CResource.gold] || 0) + 1);
     ctx.passives.unregisterCostModifier('tax');
     const reverted = ctx.passives.applyCostMods('expand', base, ctx);
-    expect(reverted[Resource.gold]).toBe(2);
+    expect(reverted[CResource.gold]).toBe(base[CResource.gold]);
   });
 
   it('runs result modifiers and handles passives', () => {
@@ -57,7 +80,7 @@ describe('PassiveManager', () => {
         {
           type: 'resource',
           method: 'add',
-          params: { key: Resource.gold, amount: 2 },
+          params: { key: CResource.gold, amount: 2 },
         },
       ],
     };


### PR DESCRIPTION
## Summary
- source action and building ids from registry internals in engine tests
- compute expectations from content-defined costs, effects, and percentages
- replace hardcoded resource keys with contents' Resource enum

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b4c119d8688325919e67f6b2c9fbae