### PR TITLE
feat: derive action cost resource

### DIFF
--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -111,20 +111,20 @@ const LandTile: React.FC<{
 
 const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
   const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
-  const developAction = useMemo(
-    () =>
-      Array.from(
-        (
-          ctx.actions as unknown as {
-            map: Map<
-              string,
-              { category?: string; icon?: string; name: string }
-            >;
-          }
-        ).map.values(),
-      ).find((a) => a.category === 'development'),
-    [ctx],
-  );
+  const developAction = useMemo(() => {
+    const entry = Array.from(
+      (
+        ctx.actions as unknown as {
+          map: Map<string, { category?: string; icon?: string; name: string }>;
+        }
+      ).map.entries(),
+    ).find(([, a]) => a.category === 'development');
+    if (!entry) return undefined;
+    const [, info] = entry;
+    return info.icon
+      ? { icon: info.icon, name: info.name }
+      : { name: info.name };
+  }, [ctx]);
   if (player.lands.length === 0) return null;
   const animateLands = useAnimate<HTMLDivElement>();
   return (

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -140,21 +140,16 @@ export function GameProvider({
   const [tabsEnabled, setTabsEnabled] = useState(false);
   const enqueue = <T,>(task: () => Promise<T> | T) => ctx.enqueue(task);
 
-  const actionCostResource = useMemo(() => {
-    const firstIter = (
-      ctx.actions as unknown as { map: Map<string, Action> }
-    ).map
-      .keys()
-      .next();
-    const firstId = firstIter.done ? '' : firstIter.value;
-    if (!firstId) return '';
-    const sample = getActionCosts(firstId, ctx);
-    const match = Object.entries(sample).find(
-      ([, v]) => v === ctx.services.rules.defaultActionAPCost,
-    );
-    const key = match ? match[0] : Object.keys(sample)[0];
-    return key || '';
-  }, [ctx]) as ResourceKey;
+  const actionCostResource = useMemo<ResourceKey>(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-assertion
+    const reg = ctx.actions as any as { map: Map<string, Action> };
+    const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
+    if (!first) return '' as ResourceKey;
+    const [id] = first;
+    const costs = getActionCosts(id, ctx);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    return (Object.keys(costs)[0] ?? '') as ResourceKey;
+  }, [ctx]);
 
   const actionPhaseId = useMemo(
     () => ctx.phases.find((p) => p.action)?.id,

--- a/packages/web/src/translation/render.tsx
+++ b/packages/web/src/translation/render.tsx
@@ -21,11 +21,11 @@ export function renderSummary(summary: Summary | undefined): React.ReactNode {
 export function renderCosts(
   costs: Record<string, number | undefined> | undefined,
   resources: Record<string, number>,
-  actionResource?: string,
+  actionCostResource?: string,
 ) {
   if (!costs) return null;
   const entries = Object.entries(costs).filter(
-    ([k]) => !actionResource || k !== actionResource,
+    ([k]) => !actionCostResource || k !== actionCostResource,
   );
   if (entries.length === 0)
     return (

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -41,17 +41,14 @@ const ctx = createEngine({
   rules: RULES,
 });
 const actionCostResource = (() => {
-  const firstIter = (
-    ctx.actions as unknown as { map: Map<string, unknown> }
-  ).map
-    .keys()
-    .next();
-  if (firstIter.done) return '';
-  const sample = getActionCosts(firstIter.value as string, ctx);
-  const match = Object.entries(sample).find(
-    ([, v]) => v === ctx.services.rules.defaultActionAPCost,
-  );
-  return (match ? match[0] : Object.keys(sample)[0]) as string;
+  const reg = ACTIONS as unknown as {
+    map: Map<string, { system?: boolean }>;
+  };
+  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
+  if (!first) return '';
+  const [id] = first;
+  const costs = getActionCosts(id, ctx);
+  return (Object.keys(costs)[0] ?? '') as string;
 })();
 const mockGame = {
   ctx,

--- a/packages/web/tests/HoverCard.test.tsx
+++ b/packages/web/tests/HoverCard.test.tsx
@@ -34,17 +34,14 @@ const ctx = createEngine({
   rules: RULES,
 });
 const actionCostResource = (() => {
-  const firstIter = (
-    ctx.actions as unknown as { map: Map<string, unknown> }
-  ).map
-    .keys()
-    .next();
-  if (firstIter.done) return '';
-  const sample = getActionCosts(firstIter.value as string, ctx);
-  const match = Object.entries(sample).find(
-    ([, v]) => v === ctx.services.rules.defaultActionAPCost,
-  );
-  return (match ? match[0] : Object.keys(sample)[0]) as string;
+  const reg = ACTIONS as unknown as {
+    map: Map<string, { system?: boolean }>;
+  };
+  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
+  if (!first) return '';
+  const [id] = first;
+  const costs = getActionCosts(id, ctx);
+  return (Object.keys(costs)[0] ?? '') as string;
 })();
 const mockGame = {
   ctx,

--- a/packages/web/tests/PhasePanel.test.tsx
+++ b/packages/web/tests/PhasePanel.test.tsx
@@ -29,17 +29,14 @@ const ctx = createEngine({
   rules: RULES,
 });
 const actionCostResource = (() => {
-  const firstIter = (
-    ctx.actions as unknown as { map: Map<string, unknown> }
-  ).map
-    .keys()
-    .next();
-  if (firstIter.done) return '';
-  const sample = getActionCosts(firstIter.value as string, ctx);
-  const match = Object.entries(sample).find(
-    ([, v]) => v === ctx.services.rules.defaultActionAPCost,
-  );
-  return (match ? match[0] : Object.keys(sample)[0]) as string;
+  const reg = ACTIONS as unknown as {
+    map: Map<string, { system?: boolean }>;
+  };
+  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
+  if (!first) return '';
+  const [id] = first;
+  const costs = getActionCosts(id, ctx);
+  return (Object.keys(costs)[0] ?? '') as string;
 })();
 const mockGame = {
   ctx,

--- a/packages/web/tests/PlayerPanel.test.tsx
+++ b/packages/web/tests/PlayerPanel.test.tsx
@@ -30,17 +30,14 @@ const ctx = createEngine({
   rules: RULES,
 });
 const actionCostResource = (() => {
-  const firstIter = (
-    ctx.actions as unknown as { map: Map<string, unknown> }
-  ).map
-    .keys()
-    .next();
-  if (firstIter.done) return '';
-  const sample = getActionCosts(firstIter.value as string, ctx);
-  const match = Object.entries(sample).find(
-    ([, v]) => v === ctx.services.rules.defaultActionAPCost,
-  );
-  return (match ? match[0] : Object.keys(sample)[0]) as string;
+  const reg = ACTIONS as unknown as {
+    map: Map<string, { system?: boolean }>;
+  };
+  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
+  if (!first) return '';
+  const [id] = first;
+  const costs = getActionCosts(id, ctx);
+  return (Object.keys(costs)[0] ?? '') as string;
 })();
 const mockGame = {
   ctx,


### PR DESCRIPTION
## Summary
- derive default action cost resource from first non-system action
- filter rendered costs using configured action cost key
- load develop action icon and name dynamically when listing empty land slots

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4c10d718c8325855fce5215f89dcb