### PR TITLE
Allow resource overrides in test helpers

### DIFF
--- a/tests/integration/building-placement.test.ts
+++ b/tests/integration/building-placement.test.ts
@@ -11,7 +11,7 @@ describe('Building placement integration', () => {
     const ctx = createTestContext();
     const expandBefore = getActionOutcome('expand', ctx);
     const buildCosts = getActionCosts('build', ctx, { id: 'town_charter' });
-    ctx.activePlayer.ap =
+    ctx.activePlayer.resources[Resource.ap] =
       (expandBefore.costs[Resource.ap] ?? 0) + (buildCosts[Resource.ap] ?? 0);
     const resBefore = { ...ctx.activePlayer.resources };
 

--- a/tests/integration/castle-walls.test.ts
+++ b/tests/integration/castle-walls.test.ts
@@ -29,8 +29,8 @@ describe('Castle Walls building', () => {
   it('applies and removes stat bonuses when built and removed', () => {
     const def = BUILDINGS.get('castle_walls');
     const ctx = createTestContext();
-    ctx.activePlayer.gold = def.costs[Resource.gold] ?? 0;
-    ctx.activePlayer.ap = def.costs[Resource.ap] ?? 0;
+    ctx.activePlayer.resources[Resource.gold] = def.costs[Resource.gold] ?? 0;
+    ctx.activePlayer.resources[Resource.ap] = def.costs[Resource.ap] ?? 0;
 
     const fortGain = getStatGain(Stat.fortificationStrength);
     const absorptionGain = getStatGain(Stat.absorption);

--- a/tests/integration/edge-cases.test.ts
+++ b/tests/integration/edge-cases.test.ts
@@ -16,7 +16,7 @@ describe('Action edge cases', () => {
   it('rejects actions when a required resource is exhausted', () => {
     const ctx = createTestContext();
     const costs = getActionCosts('expand', ctx);
-    ctx.activePlayer.ap = costs[Resource.ap] || 0;
+    ctx.activePlayer.resources[Resource.ap] = costs[Resource.ap] || 0;
     const entries = Object.entries(costs).filter(
       ([key]) => key !== Resource.ap,
     ) as [ResourceKey, number][];
@@ -32,8 +32,10 @@ describe('Action edge cases', () => {
   it('rejects actions when action points are exhausted', () => {
     const ctx = createTestContext();
     const cost = getActionCosts('expand', ctx);
-    ctx.activePlayer.ap = (cost[Resource.ap] || 0) - 1;
+    ctx.activePlayer.resources[Resource.ap] = (cost[Resource.ap] || 0) - 1;
     expect(() => performAction('expand', ctx)).toThrow(/Insufficient ap/);
-    expect(ctx.activePlayer.ap).toBe((cost[Resource.ap] || 0) - 1);
+    expect(ctx.activePlayer.resources[Resource.ap]).toBe(
+      (cost[Resource.ap] || 0) - 1,
+    );
   });
 });

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -7,6 +7,7 @@ import {
   PHASES,
   GAME_START,
   RULES,
+  RESOURCES,
 } from '@kingdom-builder/contents';
 import type { EngineContext, EffectDef } from '@kingdom-builder/engine';
 import { PlayerState, Land } from '@kingdom-builder/engine/state';
@@ -31,7 +32,9 @@ function clonePlayer(player: PlayerState) {
   return copy;
 }
 
-export function createTestContext(overrides?: { gold?: number; ap?: number }) {
+export function createTestContext(
+  overrides?: Partial<Record<keyof typeof RESOURCES, number>>,
+) {
   const ctx = createEngine({
     actions: ACTIONS,
     buildings: BUILDINGS,
@@ -41,8 +44,12 @@ export function createTestContext(overrides?: { gold?: number; ap?: number }) {
     start: GAME_START,
     rules: RULES,
   });
-  if (overrides?.gold !== undefined) ctx.activePlayer.gold = overrides.gold;
-  if (overrides?.ap !== undefined) ctx.activePlayer.ap = overrides.ap;
+  if (overrides) {
+    for (const key of Object.keys(RESOURCES) as (keyof typeof RESOURCES)[]) {
+      const value = overrides[key];
+      if (value !== undefined) ctx.activePlayer.resources[key] = value;
+    }
+  }
   return ctx;
 }
 


### PR DESCRIPTION
## Summary
- allow integration test helpers to override any resource key via RESOURCES
- adjust integration tests to use dynamic resource lookups

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4c393e3f483258dd0c5c2efd8a167