### PR TITLE
test: derive expectations from content

### DIFF
--- a/packages/web/tests/army-attack-translation.test.ts
+++ b/packages/web/tests/army-attack-translation.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { SummaryEntry } from '../src/translation/content';
 import { summarizeContent, describeContent } from '../src/translation/content';
-import { createEngine, Resource, Stat } from '@kingdom-builder/engine';
+import {
+  createEngine,
+  Resource,
+  Stat,
+  type EffectDef,
+} from '@kingdom-builder/engine';
 import {
   ACTIONS,
   BUILDINGS,
@@ -39,18 +44,46 @@ describe('army attack translation', () => {
     const happiness = RESOURCES[Resource.happiness];
     const plunder = ctx.actions.get('plunder');
     const warWeariness = STATS[Stat.warWeariness];
+    const armyAttack = ctx.actions.get('army_attack');
+    const attackEffect = armyAttack.effects.find(
+      (e: EffectDef) => e.type === 'attack',
+    );
+    const onDamage = attackEffect?.params?.['onCastleDamage'] as {
+      attacker: EffectDef[];
+      defender: EffectDef[];
+    };
+    const attackerRes = onDamage?.attacker.find(
+      (e: EffectDef) =>
+        e.type === 'resource' &&
+        (e.params as { key?: string }).key === Resource.happiness,
+    );
+    const defenderRes = onDamage?.defender.find(
+      (e: EffectDef) =>
+        e.type === 'resource' &&
+        (e.params as { key?: string }).key === Resource.happiness,
+    );
+    const attackerAmt =
+      (attackerRes?.params as { amount?: number })?.amount ?? 0;
+    const defenderAmt =
+      (defenderRes?.params as { amount?: number })?.amount ?? 0;
+    const warRes = armyAttack.effects.find(
+      (e: EffectDef) =>
+        e.type === 'stat' &&
+        (e.params as { key?: string }).key === Stat.warWeariness,
+    );
+    const warAmt = (warRes?.params as { amount?: number })?.amount ?? 0;
     const summary = summarizeContent('action', 'army_attack', ctx);
     expect(summary).toEqual([
       `${army.icon} opponent's ${fort.icon}${castle.icon}`,
       {
         title: `On opponent ${castle.icon} damage`,
         items: [
-          `${happiness.icon}-1 for opponent`,
-          `${happiness.icon}+1 for you`,
+          `${happiness.icon}${defenderAmt} for opponent`,
+          `${happiness.icon}${attackerAmt >= 0 ? '+' : ''}${attackerAmt} for you`,
           `${plunder.icon} ${plunder.name}`,
         ],
       },
-      `${warWeariness.icon}+1`,
+      `${warWeariness.icon}${warAmt >= 0 ? '+' : ''}${warAmt}`,
     ]);
   });
 

--- a/packages/web/tests/development-summary.test.ts
+++ b/packages/web/tests/development-summary.test.ts
@@ -10,6 +10,9 @@ import {
   PHASES,
   GAME_START,
   RULES,
+  RESOURCES,
+  Resource,
+  type StepDef,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -41,6 +44,15 @@ describe('development translation', () => {
     });
     const summary = summarizeContent('development', 'farm', ctx);
     const flat = flatten(summary);
-    expect(flat).toContain('🪙+2 per 🌾');
+    const goldIcon = RESOURCES[Resource.gold].icon;
+    const farmIcon = DEVELOPMENTS.get('farm')?.icon || '';
+    const devPhase = ctx.phases.find((p) => p.id === 'development');
+    const gainIncome = devPhase?.steps.find((s) => s.id === 'gain-income') as
+      | StepDef
+      | undefined;
+    const farmEffect = gainIncome?.effects?.find((e) => e.evaluator);
+    const inner = farmEffect?.effects?.find((e) => e.type === 'resource');
+    const amt = (inner?.params as { amount?: number })?.amount ?? 0;
+    expect(flat).toContain(`${goldIcon}+${amt} per ${farmIcon}`);
   });
 });

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -13,6 +13,8 @@ import {
   PHASES,
   GAME_START,
   RULES,
+  RESOURCES,
+  Resource,
 } from '@kingdom-builder/contents';
 import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
 
@@ -45,7 +47,14 @@ describe('log resource sources', () => {
     runEffects(step?.effects || [], ctx);
     const after = snapshotPlayer(ctx.activePlayer, ctx);
     const lines = diffStepSnapshots(before, after, step, ctx);
-    expect(lines[0]).toBe('🪙 Gold +2 (10→12) (🪙+2 from 🌾)');
+    const goldInfo = RESOURCES[Resource.gold];
+    const farmIcon = DEVELOPMENTS.get('farm')?.icon || '';
+    const b = before.resources[Resource.gold] ?? 0;
+    const a = after.resources[Resource.gold] ?? 0;
+    const delta = a - b;
+    expect(lines[0]).toBe(
+      `${goldInfo.icon} ${goldInfo.label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a}) (${goldInfo.icon}${delta >= 0 ? '+' : ''}${delta} from ${farmIcon})`,
+    );
   });
 
   it('logs market bonus when taxing population', () => {
@@ -68,7 +77,14 @@ describe('log resource sources', () => {
     performAction('tax', ctx);
     const after = snapshotPlayer(ctx.activePlayer, ctx);
     const lines = diffStepSnapshots(before, after, step, ctx);
-    const goldLine = lines.find((l) => l.startsWith('🪙 Gold'));
-    expect(goldLine).toMatch(/from 👥\+🏪\)$/);
+    const goldInfo = RESOURCES[Resource.gold];
+    const populationIcon = '👥';
+    const marketIcon = BUILDINGS.get('market')?.icon || '';
+    const goldLine = lines.find((l) =>
+      l.startsWith(`${goldInfo.icon} ${goldInfo.label}`),
+    );
+    expect(goldLine).toMatch(
+      new RegExp(`from ${populationIcon}\\+${marketIcon}\\)$`),
+    );
   });
 });

--- a/packages/web/tests/tax-market-log.test.ts
+++ b/packages/web/tests/tax-market-log.test.ts
@@ -16,6 +16,7 @@ import {
   GAME_START,
   RULES,
   RESOURCES,
+  Resource,
 } from '@kingdom-builder/contents';
 import {
   snapshotPlayer,
@@ -42,7 +43,7 @@ describe('tax action logging with market', () => {
       [{ type: 'building', method: 'add', params: { id: 'market' } }],
       ctx,
     );
-    ctx.activePlayer.resources['gold'] = 0;
+    ctx.activePlayer.resources[Resource.gold] = 0;
     while (ctx.game.currentPhase !== 'main') advance(ctx);
     const action = ctx.actions.get('tax');
     const before = snapshotPlayer(ctx.activePlayer, ctx);
@@ -98,7 +99,17 @@ describe('tax action logging with market', () => {
       return true;
     });
     const logLines = [...messages, ...filtered.map((c) => `  ${c}`)];
-    const goldLine = logLines.find((l) => l.trimStart().startsWith('🪙 Gold'));
-    expect(goldLine).toBe('  🪙 Gold +5 (0→5) (🪙+5 from 👥+🏪)');
+    const goldInfo = RESOURCES[Resource.gold];
+    const populationIcon = '👥';
+    const marketIcon = BUILDINGS.get('market')?.icon || '';
+    const b = before.resources[Resource.gold] ?? 0;
+    const a = after.resources[Resource.gold] ?? 0;
+    const delta = a - b;
+    const goldLine = logLines.find((l) =>
+      l.trimStart().startsWith(`${goldInfo.icon} ${goldInfo.label}`),
+    );
+    expect(goldLine).toBe(
+      `  ${goldInfo.icon} ${goldInfo.label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a}) (${goldInfo.icon}${delta >= 0 ? '+' : ''}${delta} from ${populationIcon}+${marketIcon})`,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- compute resource log lines and deltas from RESOURCES and registries
- derive action and phase icons/labels for web translation tests
- pull effect amounts from content instead of hardcoded literals

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4c38fd7f4832586cfee1de0e76e31