### PR TITLE
feat: add hold festival action

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -18,6 +18,7 @@ import {
   ActionMethods,
   PassiveMethods,
   CostModMethods,
+  ResultModMethods,
   BuildingMethods,
   StatMethods,
 } from './config/builders';
@@ -229,6 +230,51 @@ export function createActionRegistry() {
       .icon('🎉')
       .cost(Resource.ap, 1)
       .cost(Resource.gold, 3)
+      .requirement(
+        requirement('evaluator', 'compare')
+          .param('left', { type: 'stat', params: { key: Stat.warWeariness } })
+          .param('operator', 'eq')
+          .param('right', 0)
+          .message(
+            `${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be 0`,
+          )
+          .build(),
+      )
+      .effect(
+        effect(Types.Resource, ResourceMethods.ADD)
+          .params({ key: Resource.happiness, amount: 3 })
+          .build(),
+      )
+      .effect(
+        effect(Types.Stat, StatMethods.ADD)
+          .params({ key: Stat.fortificationStrength, amount: -3 })
+          .build(),
+      )
+      .effect(
+        effect(Types.Passive, PassiveMethods.ADD)
+          .params({
+            id: 'hold_festival_attack_mod',
+            onUpkeepPhase: [
+              effect(Types.Passive, PassiveMethods.REMOVE)
+                .param('id', 'hold_festival_attack_mod')
+                .build(),
+            ],
+          })
+          .effect(
+            effect(Types.ResultMod, ResultModMethods.ADD)
+              .params({
+                id: 'hold_festival_attack_penalty',
+                actionId: 'army_attack',
+              })
+              .effect(
+                effect(Types.Resource, ResourceMethods.ADD)
+                  .params({ key: Resource.happiness, amount: -3 })
+                  .build(),
+              )
+              .build(),
+          )
+          .build(),
+      )
       .build(),
     category: 'basic',
     order: 7,

--- a/packages/engine/tests/actions/hold_festival.test.ts
+++ b/packages/engine/tests/actions/hold_festival.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  performAction,
+  getActionRequirements,
+  advance,
+  runEffects,
+  type EffectDef,
+} from '../../src';
+import { PopulationRole, Resource, Stat } from '../../src/state';
+import { createTestEngine } from '../helpers';
+
+describe('Hold Festival action', () => {
+  it('requires zero war weariness', () => {
+    const ctx = createTestEngine();
+    while (ctx.game.currentPhase !== 'main') advance(ctx);
+    ctx.activePlayer.warWeariness = 1;
+    const failures = getActionRequirements('hold_festival', ctx);
+    expect(failures).toHaveLength(1);
+    expect(() => performAction('hold_festival', ctx)).toThrow();
+  });
+
+  it('boosts happiness, lowers fortification and penalizes next army attack', () => {
+    const ctx = createTestEngine();
+    while (ctx.game.currentPhase !== 'main') advance(ctx);
+    const def = ctx.actions.get('hold_festival');
+    const hapEff = def.effects.find(
+      (e: EffectDef) =>
+        e.type === 'resource' &&
+        (e.params as { key?: string }).key === Resource.happiness,
+    );
+    const hapAmt = (hapEff?.params as { amount?: number })?.amount ?? 0;
+    const fortEff = def.effects.find(
+      (e: EffectDef) =>
+        e.type === 'stat' &&
+        (e.params as { key?: string }).key === Stat.fortificationStrength,
+    );
+    const fortAmt = (fortEff?.params as { amount?: number })?.amount ?? 0;
+    const passive = def.effects.find((e: EffectDef) => e.type === 'passive');
+    const resMod = passive?.effects?.find(
+      (e: EffectDef) => e.type === 'result_mod',
+    );
+    const penaltyRes = resMod?.effects?.find(
+      (e: EffectDef) => e.type === 'resource',
+    );
+    const penaltyAmt = (penaltyRes?.params as { amount?: number })?.amount ?? 0;
+
+    ctx.activePlayer.population[PopulationRole.Commander] = 1;
+    ctx.activePlayer.resources[Resource.ap] = 1;
+    ctx.activePlayer.resources[Resource.gold] = 3;
+
+    performAction('hold_festival', ctx);
+    expect(ctx.activePlayer.resources[Resource.happiness]).toBe(hapAmt);
+    expect(ctx.activePlayer.stats[Stat.fortificationStrength]).toBe(fortAmt);
+
+    ctx.activePlayer.resources[Resource.ap] = 1;
+    const before = ctx.activePlayer.resources[Resource.happiness];
+    performAction('army_attack', ctx);
+    expect(ctx.activePlayer.resources[Resource.happiness]).toBe(
+      before + penaltyAmt,
+    );
+
+    const passiveInst = ctx.passives
+      .values(ctx.activePlayer.id)
+      .find((p) => p.id === 'hold_festival_attack_mod');
+    if (passiveInst?.onUpkeepPhase) runEffects(passiveInst.onUpkeepPhase, ctx);
+    ctx.activePlayer.warWeariness = 0;
+    ctx.activePlayer.resources[Resource.ap] = 1;
+    const before2 = ctx.activePlayer.resources[Resource.happiness];
+    performAction('army_attack', ctx);
+    expect(ctx.activePlayer.resources[Resource.happiness]).toBe(before2);
+  });
+});

--- a/packages/web/tests/hold-festival-translation.test.ts
+++ b/packages/web/tests/hold-festival-translation.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { summarizeContent, describeContent } from '../src/translation/content';
+import { createEngine, type EffectDef } from '@kingdom-builder/engine';
+import {
+  ACTIONS,
+  BUILDINGS,
+  DEVELOPMENTS,
+  POPULATIONS,
+  PHASES,
+  GAME_START,
+  RULES,
+  RESOURCES,
+  STATS,
+  Resource,
+  Stat,
+  MODIFIER_INFO,
+} from '@kingdom-builder/contents';
+
+vi.mock('@kingdom-builder/engine', async () => {
+  return await import('../../engine/src');
+});
+
+function createCtx() {
+  return createEngine({
+    actions: ACTIONS,
+    buildings: BUILDINGS,
+    developments: DEVELOPMENTS,
+    populations: POPULATIONS,
+    phases: PHASES,
+    start: GAME_START,
+    rules: RULES,
+  });
+}
+
+describe('hold festival translation', () => {
+  it('summarizes and describes hold festival', () => {
+    const ctx = createCtx();
+    const summary = summarizeContent('action', 'hold_festival', ctx);
+    const desc = describeContent('action', 'hold_festival', ctx);
+    const def = ctx.actions.get('hold_festival');
+    const hapEff = def.effects.find(
+      (e: EffectDef) =>
+        e.type === 'resource' &&
+        (e.params as { key?: string }).key === Resource.happiness,
+    );
+    const hapAmt = (hapEff?.params as { amount?: number })?.amount ?? 0;
+    const fortEff = def.effects.find(
+      (e: EffectDef) =>
+        e.type === 'stat' &&
+        (e.params as { key?: string }).key === Stat.fortificationStrength,
+    );
+    const fortAmt = (fortEff?.params as { amount?: number })?.amount ?? 0;
+    const passive = def.effects.find((e: EffectDef) => e.type === 'passive');
+    const resMod = passive?.effects?.find(
+      (e: EffectDef) => e.type === 'result_mod',
+    );
+    const penaltyRes = resMod?.effects?.find(
+      (e: EffectDef) => e.type === 'resource',
+    );
+    const penaltyAmt = (penaltyRes?.params as { amount?: number })?.amount ?? 0;
+
+    const hapInfo = RESOURCES[Resource.happiness];
+    const fortInfo = STATS[Stat.fortificationStrength];
+    const army = ctx.actions.get('army_attack');
+    const modInfo = MODIFIER_INFO.result;
+
+    expect(summary).toEqual([
+      `${hapInfo.icon}+${hapAmt}`,
+      `${fortInfo.icon}${fortAmt}`,
+      {
+        title: '♾️ Until next Upkeep',
+        items: [`${modInfo.icon} ${army.icon}: ${hapInfo.icon}${penaltyAmt}`],
+      },
+    ]);
+
+    expect(desc).toEqual([
+      `${hapInfo.icon}+${hapAmt} ${hapInfo.label}`,
+      `Lose ${Math.abs(fortAmt)} ${fortInfo.icon} ${fortInfo.label}`,
+      {
+        title: '♾️ Until your next Upkeep Phase',
+        items: [
+          `${modInfo.icon} ${modInfo.label} on ${army.icon} ${army.name}: ${hapInfo.icon}${penaltyAmt} ${hapInfo.label}`,
+        ],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement Hold Festival action with happiness boost and fortification loss
- add temporary passive that penalizes next Army Attack with -3 happiness
- test Hold Festival behavior and translation

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4ca59105083258a8e92bf5f5a4e29