### PR TITLE
Rename Development Phase to Growth Phase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ The game consists of two players, player A and B. Player A always goes first. Pl
 
 # Game phasing
 
-The game is played in turns. Each turn has three phases; Development Phase, Upkeep Phase, Main Phase. Players take turns going through the phases. First Player A goes through Development phase, then Player B goes through Development Phase, then Player A through Upkeep Phase, then player B through Upkeep Phase. If a decision needs to be made by a player in one of these phases, the game halts until the decision has been made. Finally, Player A and B simultaneously go through Main Phase, which is where they can pick their action(s) for their turn. Both players choose their actions, during the Main Phase, simultaneously. They do so in secret. The action(s) are locked in the moment both players have committed their action(s). Then, the Actions play out for Player A first, in the order Player A chose. Then, the actions for Player B play out, in the order player B chose.
+The game is played in turns. Each turn has three phases; Growth Phase, Upkeep Phase, Main Phase. Players take turns going through the phases. First Player A goes through Growth phase, then Player B goes through Growth Phase, then Player A through Upkeep Phase, then player B through Upkeep Phase. If a decision needs to be made by a player in one of these phases, the game halts until the decision has been made. Finally, Player A and B simultaneously go through Main Phase, which is where they can pick their action(s) for their turn. Both players choose their actions, during the Main Phase, simultaneously. They do so in secret. The action(s) are locked in the moment both players have committed their action(s). Then, the Actions play out for Player A first, in the order Player A chose. Then, the actions for Player B play out, in the order player B chose.
 
 # Core mechanic definitions
 
@@ -159,7 +159,7 @@ We have Trigger Effects and Global Effects. The former was explained in section 
 
 # Population
 
-Finally, we have Population, which is made up of four archtypes: Council, Commander, Fortifier and Citizen. Certain Actions can create Population, or change the Archtype of a Population member. Each Population member has one or more Effects, again with specific triggers or global. For example, the Council generates one AP at the end of every Development Phase (trigger effect). The Commander passively provides 1 Army Strength (a stat) (global effect, active at all times). When the Commander is relieved from his position, this global effect is removed. The Commander also permanently grows the current Army Strength by 25% of it's current size, at every Development Phase (trigger effect, permanent stat change). Even if the Commander is removed afterwards, this stat change stays - it was a one-time stat increase, not one tingent on his continued existence.
+Finally, we have Population, which is made up of four archtypes: Council, Commander, Fortifier and Citizen. Certain Actions can create Population, or change the Archtype of a Population member. Each Population member has one or more Effects, again with specific triggers or global. For example, the Council generates one AP at the end of every Growth Phase (trigger effect). The Commander passively provides 1 Army Strength (a stat) (global effect, active at all times). When the Commander is relieved from his position, this global effect is removed. The Commander also permanently grows the current Army Strength by 25% of it's current size, at every Growth Phase (trigger effect, permanent stat change). Even if the Commander is removed afterwards, this stat change stays - it was a one-time stat increase, not one tingent on his continued existence.
 
 # Start of game setup
 
@@ -167,7 +167,7 @@ The game starts with each player having:
 
 - Castle, with 10 Health.
 - Max Population Stat = 1
-- Two Land tiles. One empty (one open Development Slot). One whose Development Slot is filled by Development "Farm". Farm has a single Effect, based on a trigger. On every Development Phase: Gain 2 Gold.
+- Two Land tiles. One empty (one open Development Slot). One whose Development Slot is filled by Development "Farm". Farm has a single Effect, based on a trigger. On every Growth Phase: Gain 2 Gold.
 - One Population with Archtype Council
 - Ten Gold
 - Zero Happiness

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Kingdom Builder is a turn-based 1v1 strategy game. Players grow their realm, man
 
 Each turn flows through three phases:
 
-1. **Development** – collect income, gain action points, and grow your military.
+1. **Growth** – collect income, gain action points, and grow your military.
 2. **Upkeep** – pay upkeep for your people and resolve end-of-phase effects.
 3. **Main** – spend action points to perform strategic actions such as expanding your territory, developing lands, or attacking the enemy.
 
@@ -29,4 +29,4 @@ Each turn flows through three phases:
 - Castle HP 10 and one 🏠 House
 - Population: 1 ⚖️ Council member
 - Army Strength 0, Fortification Strength 0, Happiness 0
-- Player order: A then B; B gains +1 ⚡️ Action Point on their first Development phase
+- Player order: A then B; B gains +1 ⚡️ Action Point on their first Growth phase

--- a/SAMPLE_CONFIG/AGENTS.md
+++ b/SAMPLE_CONFIG/AGENTS.md
@@ -11,13 +11,13 @@
 - 🏚️Development — a built feature occupying a 🧩Development Slot
 - 👥Population — citizens (roles below)
   - ⚖️Council — each grants 1 ⚡Action Point at the start of your turn
-  - 🎖️Commander — **+1 ⚔️Army Strength (flat)** & contributes +25% 📈⚔️Growth each 📈Development Phase
-  - 🔧Fortifier — **+1 🛡️Fortification Strength (flat)** & contributes +25% 📈🛡️Growth each 📈Development Phase
+  - 🎖️Commander — **+1 ⚔️Army Strength (flat)** & contributes +25% 📈⚔️Growth each 📈Growth Phase
+  - 🔧Fortifier — **+1 🛡️Fortification Strength (flat)** & contributes +25% 📈🛡️Growth each 📈Growth Phase
   - 👤Citizen — unassigned; no benefits until assigned (upkeep 0🪙)
 - ⚡Action Point (AP) — each Action costs 1⚡
 - ⚔️Army Strength — total offensive strength
 - 🛡️Fortification Strength — total defensive strength
-- 📈⚔️/📈🛡️ Growth — % increase applied during 📈Development
+- 📈⚔️/📈🛡️ Growth — % increase applied during 📈Growth
 - 😊Happiness — morale (–10 … +10)
 - 🏰Castle HP — starts at 10
 - 🧑‍🌾Till — add +1 🧩Development Slot to an 🗺️Land (max 2 🧩)
@@ -39,10 +39,10 @@
 
 ## 2) Turn Structure
 
-### 2.1 📈Development Phase
+### 2.1 📈Growth Phase
 
 - **Gain 💹Income**: resolve sources that trigger now (e.g., 🌾, 🌿, Temple).
-- **Generate ⚡**: +1⚡ per ⚖️Council; Player B gets +1⚡ in their first 📈Development only.
+- **Generate ⚡**: +1⚡ per ⚖️Council; Player B gets +1⚡ in their first 📈Growth only.
 - **Grow Strengths**:
   - ⚔️ increases by +25% per 🎖️ (rounded up), applied to current ⚔️ which already includes +1 per 🎖️.
   - 🛡️ increases by +25% per 🔧 (rounded up), applied to current 🛡️ which already includes +1 per 🔧.

--- a/docs/architecture/AGENTS.md
+++ b/docs/architecture/AGENTS.md
@@ -13,7 +13,7 @@ content without touching existing logic.
 
 Rules and content are encoded as declarative **effects** that respond to
 specific **triggers**. A trigger represents a moment in the game such as the
-start of the Development phase or the resolution of an action. When a trigger
+start of the Growth phase or the resolution of an action. When a trigger
 fires the engine looks up all matching effects and resolves them through the
 central registry. All trigger lookups funnel through a single helper,
 `collectTriggerEffects`, which gathers the relevant effects for a player before
@@ -38,9 +38,9 @@ definitions can be reused with different data.
 The engine processes effects with `runEffects`:
 
 ```ts
-// Farm development: on every Development phase gain 2 Gold
+// Farm development: on every Growth phase gain 2 Gold
 {
-  onDevelopmentPhase: [
+  onGrowthPhase: [
     { type: "resource", method: "add", params: { key: "gold", amount: 2 } }
   ]
 }

--- a/docs/frontend_translation/AGENTS.md
+++ b/docs/frontend_translation/AGENTS.md
@@ -66,8 +66,8 @@ State changes are derived through `snapshotPlayer` and `diffSnapshots` in
 `translation/log.ts`. These utilities capture player state before and after an
 effect resolves and emit human readable change strings such as
 `Gold +2 (10→12)`. Phase headings draw from `triggerInfo`, which provides both a
-`future` label for summaries (e.g. "On each Development Phase") and a `past`
-label for log entries ("Development Phase").
+`future` label for summaries (e.g. "On each Growth Phase") and a `past`
+label for log entries ("Growth Phase").
 
 This structure keeps translation logic isolated and makes the UI resilient to
 engine and content changes.

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -227,9 +227,9 @@ export class BuildingBuilder extends BaseBuilder<BuildingConfig> {
     this.config.onBuild.push(effect);
     return this;
   }
-  onDevelopmentPhase(effect: EffectConfig) {
-    this.config.onDevelopmentPhase = this.config.onDevelopmentPhase || [];
-    this.config.onDevelopmentPhase.push(effect);
+  onGrowthPhase(effect: EffectConfig) {
+    this.config.onGrowthPhase = this.config.onGrowthPhase || [];
+    this.config.onGrowthPhase.push(effect);
     return this;
   }
   onUpkeepPhase(effect: EffectConfig) {
@@ -262,9 +262,9 @@ export class DevelopmentBuilder extends BaseBuilder<DevelopmentConfig> {
     this.config.onBuild.push(effect);
     return this;
   }
-  onDevelopmentPhase(effect: EffectConfig) {
-    this.config.onDevelopmentPhase = this.config.onDevelopmentPhase || [];
-    this.config.onDevelopmentPhase.push(effect);
+  onGrowthPhase(effect: EffectConfig) {
+    this.config.onGrowthPhase = this.config.onGrowthPhase || [];
+    this.config.onGrowthPhase.push(effect);
     return this;
   }
   onBeforeAttacked(effect: EffectConfig) {
@@ -297,9 +297,9 @@ export class PopulationBuilder extends BaseBuilder<PopulationConfig> {
     this.config.onUnassigned.push(effect);
     return this;
   }
-  onDevelopmentPhase(effect: EffectConfig) {
-    this.config.onDevelopmentPhase = this.config.onDevelopmentPhase || [];
-    this.config.onDevelopmentPhase.push(effect);
+  onGrowthPhase(effect: EffectConfig) {
+    this.config.onGrowthPhase = this.config.onGrowthPhase || [];
+    this.config.onGrowthPhase.push(effect);
     return this;
   }
   onUpkeepPhase(effect: EffectConfig) {

--- a/packages/contents/src/defs.ts
+++ b/packages/contents/src/defs.ts
@@ -6,7 +6,7 @@ import type {
 import type { EffectDef } from '@kingdom-builder/engine/effects';
 
 export interface Triggered {
-  onDevelopmentPhase?: EffectDef[] | undefined;
+  onGrowthPhase?: EffectDef[] | undefined;
   onUpkeepPhase?: EffectDef[] | undefined;
   onBeforeAttacked?: EffectDef[] | undefined;
   onAttackResolved?: EffectDef[] | undefined;

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -12,13 +12,13 @@ import {
 } from './config/builders';
 
 export const PHASES: PhaseDef[] = [
-  phase('development')
-    .label('Development')
+  phase('growth')
+    .label('Growth')
     .icon('🏗️')
     .step(
       step('resolve-dynamic-triggers')
         .title('Resolve dynamic triggers')
-        .triggers('onDevelopmentPhase'),
+        .triggers('onGrowthPhase'),
     )
     .step(
       step('gain-income')

--- a/packages/contents/src/populationRoles.ts
+++ b/packages/contents/src/populationRoles.ts
@@ -18,21 +18,21 @@ const defs: PopulationRoleInfo[] = [
     .icon('⚖️')
     .label('Council')
     .description(
-      'The Council advises the crown and generates Action Points during the Development phase. Keeping them employed fuels your economy.',
+      'The Council advises the crown and generates Action Points during the Growth phase. Keeping them employed fuels your economy.',
     )
     .build(),
   populationRole(PopulationRole.Commander)
     .icon('🎖️')
     .label('Commander')
     .description(
-      'Commanders lead your forces, boosting Army Strength and training troops each Development phase.',
+      'Commanders lead your forces, boosting Army Strength and training troops each Growth phase.',
     )
     .build(),
   populationRole(PopulationRole.Fortifier)
     .icon('🔧')
     .label('Fortifier')
     .description(
-      'Fortifiers reinforce your defenses. They raise Fortification Strength and shore up the castle every Development phase.',
+      'Fortifiers reinforce your defenses. They raise Fortification Strength and shore up the castle every Growth phase.',
     )
     .build(),
   populationRole(PopulationRole.Citizen)

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -52,7 +52,7 @@ export const buildingSchema = z.object({
   icon: z.string().optional(),
   costs: costBagSchema,
   onBuild: z.array(effectSchema).optional(),
-  onDevelopmentPhase: z.array(effectSchema).optional(),
+  onGrowthPhase: z.array(effectSchema).optional(),
   onUpkeepPhase: z.array(effectSchema).optional(),
   onBeforeAttacked: z.array(effectSchema).optional(),
   onAttackResolved: z.array(effectSchema).optional(),
@@ -66,7 +66,7 @@ export const developmentSchema = z.object({
   name: z.string(),
   icon: z.string().optional(),
   onBuild: z.array(effectSchema).optional(),
-  onDevelopmentPhase: z.array(effectSchema).optional(),
+  onGrowthPhase: z.array(effectSchema).optional(),
   onBeforeAttacked: z.array(effectSchema).optional(),
   onAttackResolved: z.array(effectSchema).optional(),
   system: z.boolean().optional(),
@@ -82,7 +82,7 @@ export const populationSchema = z.object({
   icon: z.string().optional(),
   onAssigned: z.array(effectSchema).optional(),
   onUnassigned: z.array(effectSchema).optional(),
-  onDevelopmentPhase: z.array(effectSchema).optional(),
+  onGrowthPhase: z.array(effectSchema).optional(),
   onUpkeepPhase: z.array(effectSchema).optional(),
 });
 

--- a/packages/engine/src/effects/passive_add.ts
+++ b/packages/engine/src/effects/passive_add.ts
@@ -2,7 +2,7 @@ import type { EffectHandler, EffectDef } from '.';
 
 interface PassiveParams {
   id: string;
-  onDevelopmentPhase?: EffectDef[];
+  onGrowthPhase?: EffectDef[];
   onUpkeepPhase?: EffectDef[];
   onBeforeAttacked?: EffectDef[];
   onAttackResolved?: EffectDef[];
@@ -17,7 +17,7 @@ export const passiveAdd: EffectHandler<PassiveParams> = (
   const params = effect.params || ({} as PassiveParams);
   const {
     id,
-    onDevelopmentPhase,
+    onGrowthPhase,
     onUpkeepPhase,
     onBeforeAttacked,
     onAttackResolved,
@@ -26,12 +26,12 @@ export const passiveAdd: EffectHandler<PassiveParams> = (
   const passive: {
     id: string;
     effects: EffectDef[];
-    onDevelopmentPhase?: EffectDef[];
+    onGrowthPhase?: EffectDef[];
     onUpkeepPhase?: EffectDef[];
     onBeforeAttacked?: EffectDef[];
     onAttackResolved?: EffectDef[];
   } = { id, effects: effect.effects || [] };
-  if (onDevelopmentPhase) passive.onDevelopmentPhase = onDevelopmentPhase;
+  if (onGrowthPhase) passive.onGrowthPhase = onGrowthPhase;
   if (onUpkeepPhase) passive.onUpkeepPhase = onUpkeepPhase;
   if (onBeforeAttacked) passive.onBeforeAttacked = onBeforeAttacked;
   if (onAttackResolved) passive.onAttackResolved = onAttackResolved;

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -75,7 +75,7 @@ export class PassiveManager {
     string,
     {
       effects: EffectDef[];
-      onDevelopmentPhase?: EffectDef[];
+      onGrowthPhase?: EffectDef[];
       onUpkeepPhase?: EffectDef[];
       onBeforeAttacked?: EffectDef[];
       onAttackResolved?: EffectDef[];
@@ -136,7 +136,7 @@ export class PassiveManager {
     passive: {
       id: string;
       effects: EffectDef[];
-      onDevelopmentPhase?: EffectDef[];
+      onGrowthPhase?: EffectDef[];
       onUpkeepPhase?: EffectDef[];
       onBeforeAttacked?: EffectDef[];
       onAttackResolved?: EffectDef[];

--- a/packages/engine/tests/effects/passive-add.test.ts
+++ b/packages/engine/tests/effects/passive-add.test.ts
@@ -12,7 +12,7 @@ describe('passive:add effect', () => {
       method: 'add',
       params: {
         id: 'temp',
-        onDevelopmentPhase: [
+        onGrowthPhase: [
           {
             type: 'resource',
             method: 'add',

--- a/packages/engine/tests/phases/growth.test.ts
+++ b/packages/engine/tests/phases/growth.test.ts
@@ -9,8 +9,8 @@ import {
 } from '@kingdom-builder/contents';
 import { createTestEngine } from '../helpers.ts';
 
-const devPhase = PHASES.find((p) => p.id === 'development')!;
-const incomeStep = devPhase.steps.find((s) => s.id === 'gain-income');
+const growthPhase = PHASES.find((p) => p.id === 'growth')!;
+const incomeStep = growthPhase.steps.find((s) => s.id === 'gain-income');
 const farmGoldGain = Number(
   incomeStep?.effects?.[0]?.effects?.find(
     (e) =>
@@ -20,7 +20,7 @@ const farmGoldGain = Number(
   )?.params.amount ?? 0,
 );
 
-const apStep = devPhase.steps.find((s) => s.id === 'gain-ap');
+const apStep = growthPhase.steps.find((s) => s.id === 'gain-ap');
 const councilApGain = Number(
   apStep?.effects?.[0]?.effects?.find(
     (e) =>
@@ -30,19 +30,19 @@ const councilApGain = Number(
   )?.params.amount ?? 0,
 );
 
-describe('Development phase', () => {
+describe('Growth phase', () => {
   it('triggers population and development effects', () => {
     const ctx = createTestEngine();
     const player = ctx.activePlayer;
     const apBefore = player.ap;
     const goldBefore = player.gold;
-    while (ctx.game.currentPhase === 'development') advance(ctx);
+    while (ctx.game.currentPhase === 'growth') advance(ctx);
     const councils = player.population[PopulationRole.Council];
     expect(player.ap).toBe(apBefore + councilApGain * councils);
     expect(player.gold).toBe(goldBefore + farmGoldGain);
   });
 
-  it('applies player B compensation at start and not during development', () => {
+  it('applies player B compensation at start and not during growth', () => {
     const ctx = createTestEngine();
     const baseAp = GAME_START.player.resources?.[CResource.ap] || 0;
     const comp =
@@ -50,21 +50,21 @@ describe('Development phase', () => {
     expect(ctx.game.players[0].ap).toBe(baseAp);
     expect(ctx.game.players[1].ap).toBe(baseAp + comp);
 
-    const gainApIdx = devPhase.steps.findIndex((s) => s.id === 'gain-ap');
+    const gainApIdx = growthPhase.steps.findIndex((s) => s.id === 'gain-ap');
 
-    // Player A development
+    // Player A growth
     let player = ctx.activePlayer;
     player.ap = 0;
-    ctx.game.currentPhase = 'development';
+    ctx.game.currentPhase = 'growth';
     ctx.game.currentStep = 'gain-ap';
     ctx.game.stepIndex = gainApIdx;
     advance(ctx);
     const councilsA = player.population[PopulationRole.Council];
     expect(player.ap).toBe(councilApGain * councilsA);
 
-    // Player B development (compensation already applied)
+    // Player B growth (compensation already applied)
     ctx.game.currentPlayerIndex = 1;
-    ctx.game.currentPhase = 'development';
+    ctx.game.currentPhase = 'growth';
     ctx.game.currentStep = 'gain-ap';
     ctx.game.stepIndex = gainApIdx;
     player = ctx.activePlayer;
@@ -73,10 +73,10 @@ describe('Development phase', () => {
     const councilsB = player.population[PopulationRole.Council];
     expect(player.ap).toBe(councilApGain * councilsB);
 
-    // Subsequent Player B developments
+    // Subsequent Player B growth phases
     for (let i = 0; i < 3; i++) {
       ctx.game.currentPlayerIndex = 1;
-      ctx.game.currentPhase = 'development';
+      ctx.game.currentPhase = 'growth';
       ctx.game.currentStep = 'gain-ap';
       ctx.game.stepIndex = gainApIdx;
       player.ap = 0;
@@ -93,7 +93,7 @@ describe('Development phase', () => {
     ctx.activePlayer.stats[Stat.fortificationStrength] = 4;
     const player = ctx.activePlayer;
     const growth = player.stats[Stat.growth];
-    while (ctx.game.currentPhase === 'development') advance(ctx);
+    while (ctx.game.currentPhase === 'growth') advance(ctx);
     const expectedArmy = Math.ceil(8 + 8 * growth);
     const expectedFort = Math.ceil(4 + 4 * growth);
     expect(player.stats[Stat.armyStrength]).toBe(expectedArmy);
@@ -113,7 +113,7 @@ describe('Development phase', () => {
     ctx.activePlayer.stats[Stat.armyStrength] = 10;
     ctx.activePlayer.stats[Stat.fortificationStrength] = 10;
     const growth = ctx.activePlayer.stats[Stat.growth];
-    while (ctx.game.currentPhase === 'development') advance(ctx);
+    while (ctx.game.currentPhase === 'growth') advance(ctx);
     const expectedArmy = Math.ceil(10 + 10 * growth * 2);
     const expectedFort = Math.ceil(10 + 10 * growth * 2);
     expect(ctx.activePlayer.stats[Stat.armyStrength]).toBe(expectedArmy);
@@ -172,7 +172,7 @@ describe('Development phase', () => {
       player.population[PopulationRole.Fortifier] = fortifiers;
       player.stats[Stat.armyStrength] = baseArmy;
       player.stats[Stat.fortificationStrength] = baseFort;
-      while (ctx.game.currentPhase === 'development') advance(ctx);
+      while (ctx.game.currentPhase === 'growth') advance(ctx);
       expect(player.stats[Stat.armyStrength]).toBe(expArmy);
       expect(player.stats[Stat.fortificationStrength]).toBe(expFort);
       expect(Number.isInteger(player.stats[Stat.armyStrength])).toBe(true);
@@ -192,7 +192,7 @@ describe('Development phase', () => {
       player.population[PopulationRole.Fortifier] = 1;
       player.stats[Stat.armyStrength] = -5;
       player.stats[Stat.fortificationStrength] = -5;
-      while (ctx.game.currentPhase === 'development') advance(ctx);
+      while (ctx.game.currentPhase === 'growth') advance(ctx);
       expect(player.stats[Stat.armyStrength]).toBe(0);
       expect(player.stats[Stat.fortificationStrength]).toBe(0);
       expect(Number.isInteger(player.stats[Stat.armyStrength])).toBe(true);

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -29,7 +29,7 @@ export default function App() {
   }, []);
 
   if (screen === 'overview') {
-    const devIcon = PHASES.find((p) => p.id === 'development')?.icon;
+    const devIcon = PHASES.find((p) => p.id === 'growth')?.icon;
     const upkeepIcon = PHASES.find((p) => p.id === 'upkeep')?.icon;
     const mainIcon = PHASES.find((p) => p.id === 'main')?.icon;
     return (
@@ -58,8 +58,8 @@ export default function App() {
           <p>Each round flows through three phases:</p>
           <ul className="list-disc list-inside">
             <li>
-              <strong>{devIcon} Development</strong> – your realm produces
-              income and triggered effects fire.
+              <strong>{devIcon} Growth</strong> – your realm produces income and
+              triggered effects fire.
             </li>
             <li>
               <strong>{upkeepIcon} Upkeep</strong> – pay wages and resolve

--- a/packages/web/tests/App.test.tsx
+++ b/packages/web/tests/App.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@kingdom-builder/engine', () => {
       buildings: { map: new Map(), get: () => undefined },
       passives: { list: () => [] },
       game: {
-        currentPhase: 'development',
+        currentPhase: 'growth',
         players: [player],
         currentPlayerIndex: 0,
       },
@@ -30,9 +30,9 @@ vi.mock('@kingdom-builder/engine', () => {
     runEffects: () => {},
     collectTriggerEffects: () => [],
     getActionCosts: () => ({}),
-    Phase: { Development: 'development', Upkeep: 'upkeep', Main: 'main' },
+    Phase: { Growth: 'growth', Upkeep: 'upkeep', Main: 'main' },
     PHASES: [
-      { id: 'development', label: 'Development', icon: '🏗️', steps: [] },
+      { id: 'growth', label: 'Growth', icon: '🏗️', steps: [] },
       { id: 'upkeep', label: 'Upkeep', icon: '🧹', steps: [] },
       { id: 'main', label: 'Main', icon: '🎯', steps: [], action: true },
     ],

--- a/packages/web/tests/development-summary.test.ts
+++ b/packages/web/tests/development-summary.test.ts
@@ -46,10 +46,10 @@ describe('development translation', () => {
     const flat = flatten(summary);
     const goldIcon = RESOURCES[Resource.gold].icon;
     const farmIcon = DEVELOPMENTS.get('farm')?.icon || '';
-    const devPhase = ctx.phases.find((p) => p.id === 'development');
-    const gainIncome = devPhase?.steps.find((s) => s.id === 'gain-income') as
-      | StepDef
-      | undefined;
+    const growthPhase = ctx.phases.find((p) => p.id === 'growth');
+    const gainIncome = growthPhase?.steps.find(
+      (s) => s.id === 'gain-income',
+    ) as StepDef | undefined;
     const farmEffect = gainIncome?.effects?.find((e) => e.evaluator);
     const inner = farmEffect?.effects?.find((e) => e.type === 'resource');
     const amt = (inner?.params as { amount?: number })?.amount ?? 0;

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -41,8 +41,8 @@ describe('log resource sources', () => {
     );
     ctx.game.currentPlayerIndex = 0;
 
-    const devPhase = ctx.phases.find((p) => p.id === 'development');
-    const step = devPhase?.steps.find((s) => s.id === 'gain-income');
+    const growthPhase = ctx.phases.find((p) => p.id === 'growth');
+    const step = growthPhase?.steps.find((s) => s.id === 'gain-income');
     const before = snapshotPlayer(ctx.activePlayer, ctx);
     runEffects(step?.effects || [], ctx);
     const after = snapshotPlayer(ctx.activePlayer, ctx);

--- a/packages/web/tests/phase-history.test.ts
+++ b/packages/web/tests/phase-history.test.ts
@@ -14,6 +14,6 @@ describe('isActionPhaseActive', () => {
   });
 
   it('returns false when not in action phase', () => {
-    expect(isActionPhaseActive('development', 'main', true)).toBe(false);
+    expect(isActionPhaseActive('growth', 'main', true)).toBe(false);
   });
 });

--- a/tests/integration/turn-cycle.test.ts
+++ b/tests/integration/turn-cycle.test.ts
@@ -35,6 +35,6 @@ describe('Turn cycle integration', () => {
     advance(ctx);
     expect(ctx.game.turn).toBe(2);
     expect(ctx.game.currentPlayerIndex).toBe(0);
-    expect(ctx.game.currentPhase).toBe('development');
+    expect(ctx.game.currentPhase).toBe('growth');
   });
 });


### PR DESCRIPTION
## Summary
- Rename the Development phase to Growth phase across content, engine, docs and tests
- Update trigger and passive hook names from `onDevelopmentPhase` to `onGrowthPhase`
- Refresh player-facing copy and population role descriptions to reference Growth

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b4ca5da1988325abdf59f1065a19f7