### PR TITLE
refactor: derive test data from registries

### DIFF
--- a/packages/web/tests/App.test.tsx
+++ b/packages/web/tests/App.test.tsx
@@ -4,6 +4,16 @@ import React from 'react';
 import App from '../src/App';
 
 vi.mock('@kingdom-builder/engine', () => {
+  const phaseA = 'phaseA';
+  const phaseB = 'phaseB';
+  const phaseC = 'phaseC';
+  const resources = {
+    r1: 'r1',
+    r2: 'r2',
+    r3: 'r3',
+    r4: 'r4',
+  } as const;
+
   const player = {
     id: 'A',
     name: 'A',
@@ -21,7 +31,7 @@ vi.mock('@kingdom-builder/engine', () => {
       buildings: { map: new Map(), get: () => undefined },
       passives: { list: () => [] },
       game: {
-        currentPhase: 'growth',
+        currentPhase: phaseA,
         players: [player],
         currentPlayerIndex: 0,
       },
@@ -30,18 +40,13 @@ vi.mock('@kingdom-builder/engine', () => {
     runEffects: () => {},
     collectTriggerEffects: () => [],
     getActionCosts: () => ({}),
-    Phase: { Growth: 'growth', Upkeep: 'upkeep', Main: 'main' },
+    Phase: { Growth: phaseA, Upkeep: phaseB, Main: phaseC },
     PHASES: [
-      { id: 'growth', label: 'Growth', icon: '🏗️', steps: [] },
-      { id: 'upkeep', label: 'Upkeep', icon: '🧹', steps: [] },
-      { id: 'main', label: 'Main', icon: '🎯', steps: [], action: true },
+      { id: phaseA, label: 'Phase A', icon: '🏗️', steps: [] },
+      { id: phaseB, label: 'Phase B', icon: '🧹', steps: [] },
+      { id: phaseC, label: 'Phase C', icon: '🎯', steps: [], action: true },
     ],
-    Resource: {
-      gold: 'gold',
-      ap: 'ap',
-      happiness: 'happiness',
-      castleHP: 'castleHP',
-    },
+    Resource: resources,
   };
 });
 

--- a/packages/web/tests/HoverCard.test.tsx
+++ b/packages/web/tests/HoverCard.test.tsx
@@ -43,6 +43,22 @@ const actionCostResource = (() => {
   const costs = getActionCosts(id, ctx);
   return (Object.keys(costs)[0] ?? '') as string;
 })();
+
+const findActionWithReq = () => {
+  for (const [id] of (ACTIONS as unknown as { map: Map<string, unknown> })
+    .map) {
+    const requirements = getActionRequirements(id, ctx);
+    const costs = getActionCosts(id, ctx);
+    if (
+      requirements.length &&
+      Object.keys(costs).some((k) => k !== actionCostResource)
+    ) {
+      return { id, requirements, costs } as const;
+    }
+  }
+  return { id: '', requirements: [], costs: {} } as const;
+};
+const actionData = findActionWithReq();
 const mockGame = {
   ctx,
   log: [],
@@ -79,11 +95,9 @@ vi.mock('../src/state/GameContext', () => ({
 
 describe('<HoverCard />', () => {
   it('renders hover card details from context', () => {
-    const actionId = 'raise_pop';
-    const actionName = ctx.actions.get(actionId)?.name || '';
-    const title = `${ctx.actions.get(actionId).icon} ${actionName}`;
-    const costs = getActionCosts(actionId, ctx);
-    const requirements = getActionRequirements(actionId, ctx);
+    const { id, requirements, costs } = actionData;
+    const def = ctx.actions.get(id);
+    const title = `${def.icon} ${def.name}`;
     mockGame.hoverCard = {
       title,
       effects: [],

--- a/packages/web/tests/development-summary.test.ts
+++ b/packages/web/tests/development-summary.test.ts
@@ -32,7 +32,7 @@ function flatten(summary: Summary): string[] {
 }
 
 describe('development translation', () => {
-  it('includes phase effects for farm', () => {
+  it('includes phase effects for a development', () => {
     const ctx = createEngine({
       actions: ACTIONS,
       buildings: BUILDINGS,
@@ -42,17 +42,22 @@ describe('development translation', () => {
       start: GAME_START,
       rules: RULES,
     });
-    const summary = summarizeContent('development', 'farm', ctx);
+    const phase = ctx.phases.find((p) =>
+      p.steps.some((s: StepDef) =>
+        s.effects?.some((e) => e.evaluator?.type === 'development'),
+      ),
+    );
+    const step = phase?.steps.find((s: StepDef) =>
+      s.effects?.some((e) => e.evaluator?.type === 'development'),
+    ) as StepDef | undefined;
+    const devEffect = step?.effects?.find((e) => e.evaluator);
+    const devId = devEffect?.evaluator?.params?.['id'];
+    const summary = summarizeContent('development', devId, ctx);
     const flat = flatten(summary);
     const goldIcon = RESOURCES[Resource.gold].icon;
-    const farmIcon = DEVELOPMENTS.get('farm')?.icon || '';
-    const growthPhase = ctx.phases.find((p) => p.id === 'growth');
-    const gainIncome = growthPhase?.steps.find(
-      (s) => s.id === 'gain-income',
-    ) as StepDef | undefined;
-    const farmEffect = gainIncome?.effects?.find((e) => e.evaluator);
-    const inner = farmEffect?.effects?.find((e) => e.type === 'resource');
+    const devIcon = DEVELOPMENTS.get(devId)?.icon || '';
+    const inner = devEffect?.effects?.find((e) => e.type === 'resource');
     const amt = (inner?.params as { amount?: number })?.amount ?? 0;
-    expect(flat).toContain(`${goldIcon}+${amt} per ${farmIcon}`);
+    expect(flat).toContain(`${goldIcon}+${amt} per ${devIcon}`);
   });
 });

--- a/packages/web/tests/land-till-formatter.test.ts
+++ b/packages/web/tests/land-till-formatter.test.ts
@@ -38,7 +38,19 @@ describe('land till formatter', () => {
 
   it('summarizes till action', () => {
     const ctx = createCtx();
-    const summary = summarizeContent('action', 'till', ctx);
+    const tillId = Array.from(
+      (
+        ACTIONS as unknown as {
+          map: Map<string, { effects: { type: string; method?: string }[] }>;
+        }
+      ).map.entries(),
+    ).find(([, a]) =>
+      a.effects.some(
+        (e: { type: string; method?: string }) =>
+          e.type === 'land' && e.method === 'till',
+      ),
+    )?.[0] as string;
+    const summary = summarizeContent('action', tillId, ctx);
     const hasIcon = summary.some(
       (i) => typeof i === 'string' && i.includes(slotIcon),
     );

--- a/packages/web/tests/phase-history.test.ts
+++ b/packages/web/tests/phase-history.test.ts
@@ -6,14 +6,17 @@ vi.mock('@kingdom-builder/engine', async () => {
 });
 
 // Ensure actions remain enabled when viewing previous phase history.
-// Specifically, current phase is main, but tabs display a prior phase.
+// Specifically, the check should depend solely on the provided phase ids.
 
 describe('isActionPhaseActive', () => {
+  const phaseA = 'phaseA';
+  const phaseB = 'phaseB';
+
   it('returns true when game is in action phase regardless of display phase', () => {
-    expect(isActionPhaseActive('main', 'main', true)).toBe(true);
+    expect(isActionPhaseActive(phaseA, phaseA, true)).toBe(true);
   });
 
   it('returns false when not in action phase', () => {
-    expect(isActionPhaseActive('growth', 'main', true)).toBe(false);
+    expect(isActionPhaseActive(phaseB, phaseA, true)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- parameterize utility and component tests to fetch identifiers and icons from registries
- avoid hard-coded phase and action values in web test suite

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5d653455083258c6c0a616ffe8974