### PR TITLE
refactor tests to use local registries

### DIFF
--- a/packages/engine/tests/actions/build.test.ts
+++ b/packages/engine/tests/actions/build.test.ts
@@ -1,46 +1,79 @@
 import { describe, it, expect } from 'vitest';
+import { performAction, getActionCosts, runEffects, advance } from '../../src';
+import { createTestEngine } from '../helpers';
 import {
-  performAction,
-  getActionCosts,
-  runEffects,
-  advance,
-} from '../../src/index.ts';
-import { createTestEngine } from '../helpers.ts';
-import { BUILDINGS, Resource as CResource } from '@kingdom-builder/contents';
+  createActionRegistry,
+  createBuildingRegistry,
+  ACTIONS,
+  BUILDINGS,
+} from '@kingdom-builder/contents';
+import { Resource as ctxResource } from '../../src/state';
+
+function clone<T>(v: T): T {
+  return structuredClone(v);
+}
+
+const buildId = 'test_build';
+const expandId = 'test_expand';
+const charterId = 'test_charter';
+
+function setup() {
+  const actions = createActionRegistry();
+  const buildings = createBuildingRegistry();
+
+  const buildDef = clone(ACTIONS.get('build'));
+  buildDef.id = buildId;
+  actions.add(buildId, buildDef);
+
+  const expandDef = clone(ACTIONS.get('expand'));
+  expandDef.id = expandId;
+  actions.add(expandId, expandDef);
+
+  const charterSrc = Array.from(BUILDINGS.map.values()).find((b) =>
+    (b.onBuild || []).some(
+      (e) => ((e.params ?? {}) as { actionId?: string }).actionId === 'expand',
+    ),
+  );
+  if (!charterSrc) throw new Error('charter not found');
+  const charterDef = clone(charterSrc);
+  charterDef.id = charterId;
+  charterDef.onBuild = (charterDef.onBuild || []).map((e) => {
+    const params = { ...(e.params ?? {}) } as { actionId?: string };
+    if (params.actionId === 'expand') params.actionId = expandId;
+    return { ...e, params };
+  });
+  buildings.add(charterId, charterDef);
+
+  const ctx = createTestEngine({ actions, buildings });
+  while (ctx.game.currentPhase !== 'main') advance(ctx);
+  return ctx;
+}
 
 describe('Build action', () => {
-  it('rejects when gold is insufficient', () => {
-    const ctx = createTestEngine();
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    const [townCharterId] = Array.from(
-      (BUILDINGS as unknown as { map: Map<string, unknown> }).map.keys(),
-    );
-    const cost = getActionCosts('build', ctx, { id: townCharterId });
-    ctx.activePlayer.gold = (cost[CResource.gold] || 0) - 1;
-    expect(() => performAction('build', ctx, { id: townCharterId })).toThrow(
-      /Insufficient gold/,
+  it('rejects when resources are insufficient', () => {
+    const ctx = setup();
+    const cost = getActionCosts(buildId, ctx, { id: charterId });
+    const payKey = Object.keys(cost).find((k) => k !== ctxResource.ap)!;
+    ctx.activePlayer.resources[payKey] = (cost[payKey] || 0) - 1;
+    const expected = `Insufficient ${payKey}: need ${cost[payKey]}, have ${ctx.activePlayer.resources[payKey]}`;
+    expect(() => performAction(buildId, ctx, { id: charterId })).toThrow(
+      expected,
     );
   });
 
-  it('adds Town Charter modifying Expand until removed', () => {
-    const ctx = createTestEngine();
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-
-    const baseCost = getActionCosts('expand', ctx);
-    const [townCharterId] = Array.from(
-      (BUILDINGS as unknown as { map: Map<string, unknown> }).map.keys(),
-    );
-    performAction('build', ctx, { id: townCharterId });
-    expect(ctx.activePlayer.buildings.has(townCharterId)).toBe(true);
-    const modifiedCost = getActionCosts('expand', ctx);
-    expect(modifiedCost).not.toEqual(baseCost);
-
+  it('adds charter modifying expand until removed', () => {
+    const ctx = setup();
+    const baseCost = getActionCosts(expandId, ctx);
+    performAction(buildId, ctx, { id: charterId });
+    expect(ctx.activePlayer.buildings.has(charterId)).toBe(true);
+    const modified = getActionCosts(expandId, ctx);
+    expect(modified).not.toEqual(baseCost);
     runEffects(
-      [{ type: 'building', method: 'remove', params: { id: townCharterId } }],
+      [{ type: 'building', method: 'remove', params: { id: charterId } }],
       ctx,
     );
-    expect(ctx.activePlayer.buildings.has(townCharterId)).toBe(false);
-    const revertedCost = getActionCosts('expand', ctx);
-    expect(revertedCost).toEqual(baseCost);
+    expect(ctx.activePlayer.buildings.has(charterId)).toBe(false);
+    const reverted = getActionCosts(expandId, ctx);
+    expect(reverted).toEqual(baseCost);
   });
 });

--- a/packages/engine/tests/actions/plow.test.ts
+++ b/packages/engine/tests/actions/plow.test.ts
@@ -6,35 +6,120 @@ import {
   runEffects,
   advance,
   type EngineContext,
-} from '../../src/index.ts';
-import { createTestEngine } from '../helpers.ts';
-import { BUILDINGS, Resource as CResource } from '@kingdom-builder/contents';
+} from '../../src';
+import { createTestEngine } from '../helpers';
+import {
+  createActionRegistry,
+  createBuildingRegistry,
+  ACTIONS,
+  BUILDINGS,
+} from '@kingdom-builder/contents';
 
-const [, , , plowWorkshopId] = Array.from(
-  (BUILDINGS as unknown as { map: Map<string, unknown> }).map.keys(),
-);
+function clone<T>(v: T): T {
+  return structuredClone(v);
+}
+
+const expandId = 'test_expand';
+const tillId = 'test_till';
+const plowId = 'test_plow';
+const buildId = 'test_build';
+const workshopId = 'test_workshop';
+
+function setup() {
+  const actions = createActionRegistry();
+  const buildings = createBuildingRegistry();
+
+  const expandDef = clone(ACTIONS.get('expand'));
+  expandDef.id = expandId;
+  actions.add(expandId, expandDef);
+
+  const tillDef = clone(ACTIONS.get('till'));
+  tillDef.id = tillId;
+  actions.add(tillId, tillDef);
+
+  const plowDef = clone(ACTIONS.get('plow'));
+  plowDef.id = plowId;
+  plowDef.effects = plowDef.effects.map((e) => {
+    const params = { ...(e.params ?? {}) } as { id?: string };
+    if (e.type === 'action' && e.method === 'perform') {
+      if (params.id === 'expand') params.id = expandId;
+      if (params.id === 'till') params.id = tillId;
+    }
+    return { ...e, params };
+  });
+  actions.add(plowId, plowDef);
+
+  const buildDef = clone(ACTIONS.get('build'));
+  buildDef.id = buildId;
+  actions.add(buildId, buildDef);
+
+  const workshopSrc = Array.from(BUILDINGS.map.values()).find((b) =>
+    (b.onBuild || []).some(
+      (e) => ((e.params ?? {}) as { id?: string }).id === 'plow',
+    ),
+  );
+  if (!workshopSrc) throw new Error('workshop not found');
+  const workshopDef = clone(workshopSrc);
+  workshopDef.id = workshopId;
+  workshopDef.onBuild = (workshopDef.onBuild || []).map((e) => {
+    const params = { ...(e.params ?? {}) } as { id?: string };
+    if (e.type === 'action' && e.method === 'add' && params.id === 'plow')
+      params.id = plowId;
+    return { ...e, params };
+  });
+  buildings.add(workshopId, workshopDef);
+
+  const ctx = createTestEngine({ actions, buildings });
+  while (ctx.game.currentPhase !== 'main') advance(ctx);
+  return ctx;
+}
 
 function countTilled(ctx: EngineContext): number {
   return ctx.activePlayer.lands.filter((l) => l.tilled).length;
 }
 
+function getCostMod(ctx: EngineContext) {
+  const plowDef = ctx.actions.get(plowId);
+  const passive = plowDef.effects.find((e) => e.type === 'passive');
+  const costMod = (passive?.effects || []).find(
+    (e) => e.type === 'cost_mod' && e.method === 'add',
+  );
+  const key = ((costMod?.params ?? {}) as { key: string }).key;
+  const amount = Number(
+    ((costMod?.params ?? {}) as { amount?: number }).amount ?? 0,
+  );
+  return { key, amount };
+}
+
 describe('Plow action', () => {
   it('expands, tills and adds temporary cost modifier', () => {
-    const ctx = createTestEngine();
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    const baseCost = getActionCosts('expand', ctx);
-    ctx.activePlayer.gold += 20;
-    performAction('build', ctx, { id: plowWorkshopId });
-    ctx.activePlayer.ap += 1;
+    const ctx = setup();
+    const baseCost = getActionCosts(expandId, ctx);
+    const { key, amount } = getCostMod(ctx);
+    const buildCost = getActionCosts(buildId, ctx, { id: workshopId });
+    for (const k of Object.keys(buildCost)) {
+      ctx.activePlayer.resources[k] = Math.max(
+        ctx.activePlayer.resources[k] || 0,
+        buildCost[k] || 0,
+      );
+    }
+    performAction(buildId, ctx, { id: workshopId });
+    const plowCost = getActionCosts(plowId, ctx);
+    for (const k of Object.keys(plowCost)) {
+      ctx.activePlayer.resources[k] = Math.max(
+        ctx.activePlayer.resources[k] || 0,
+        plowCost[k] || 0,
+      );
+    }
     const landsBefore = ctx.activePlayer.lands.length;
     const tilledBefore = countTilled(ctx);
-    performAction('plow', ctx);
+    performAction(plowId, ctx);
     expect(ctx.activePlayer.lands.length).toBe(landsBefore + 1);
     expect(countTilled(ctx)).toBe(tilledBefore + 1);
-    const modified = getActionCosts('expand', ctx);
-    expect(modified[CResource.gold]).toBe((baseCost[CResource.gold] || 0) + 2);
+    const modified = getActionCosts(expandId, ctx);
+    expect(modified[key]).toBe((baseCost[key] || 0) + amount);
     runEffects(collectTriggerEffects('onUpkeepPhase', ctx), ctx);
-    const reverted = getActionCosts('expand', ctx);
-    expect(reverted[CResource.gold]).toBe(baseCost[CResource.gold] || 0);
+    const reverted = getActionCosts(expandId, ctx);
+    expect(reverted[key]).toBe(baseCost[key] || 0);
   });
 });

--- a/packages/engine/tests/actions/plow_lock.test.ts
+++ b/packages/engine/tests/actions/plow_lock.test.ts
@@ -1,16 +1,94 @@
 import { describe, it, expect } from 'vitest';
-import { performAction, advance } from '../../src/index.ts';
-import { createTestEngine } from '../helpers.ts';
+import { performAction, advance, getActionCosts } from '../../src';
+import { createTestEngine } from '../helpers';
+import {
+  createActionRegistry,
+  createBuildingRegistry,
+  ACTIONS,
+  BUILDINGS,
+} from '@kingdom-builder/contents';
+
+function clone<T>(v: T): T {
+  return structuredClone(v);
+}
+
+const expandId = 'test_expand';
+const tillId = 'test_till';
+const plowId = 'test_plow';
+const buildId = 'test_build';
+const workshopId = 'test_workshop';
+
+function setup() {
+  const actions = createActionRegistry();
+  const buildings = createBuildingRegistry();
+
+  const expandDef = clone(ACTIONS.get('expand'));
+  expandDef.id = expandId;
+  actions.add(expandId, expandDef);
+
+  const tillDef = clone(ACTIONS.get('till'));
+  tillDef.id = tillId;
+  actions.add(tillId, tillDef);
+
+  const plowDef = clone(ACTIONS.get('plow'));
+  plowDef.id = plowId;
+  plowDef.effects = plowDef.effects.map((e) => {
+    const params = { ...(e.params ?? {}) } as { id?: string };
+    if (e.type === 'action' && e.method === 'perform') {
+      if (params.id === 'expand') params.id = expandId;
+      if (params.id === 'till') params.id = tillId;
+    }
+    return { ...e, params };
+  });
+  actions.add(plowId, plowDef);
+
+  const buildDef = clone(ACTIONS.get('build'));
+  buildDef.id = buildId;
+  actions.add(buildId, buildDef);
+
+  const workshopSrc = Array.from(BUILDINGS.map.values()).find((b) =>
+    (b.onBuild || []).some(
+      (e) => ((e.params ?? {}) as { id?: string }).id === 'plow',
+    ),
+  );
+  if (!workshopSrc) throw new Error('workshop not found');
+  const workshopDef = clone(workshopSrc);
+  workshopDef.id = workshopId;
+  workshopDef.onBuild = (workshopDef.onBuild || []).map((e) => {
+    const params = { ...(e.params ?? {}) } as { id?: string };
+    if (e.type === 'action' && e.method === 'add' && params.id === 'plow')
+      params.id = plowId;
+    return { ...e, params };
+  });
+  buildings.add(workshopId, workshopDef);
+
+  const ctx = createTestEngine({ actions, buildings });
+  while (ctx.game.currentPhase !== 'main') advance(ctx);
+  return ctx;
+}
 
 describe('Plow action lock', () => {
-  it('is locked until Plow Workshop is built', () => {
-    const ctx = createTestEngine();
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    expect(() => performAction('plow', ctx)).toThrow(/locked/);
-    performAction('build', ctx, { id: 'plow_workshop' });
-    ctx.activePlayer.ap += 1;
-    ctx.activePlayer.gold += 6;
-    expect(ctx.activePlayer.actions.has('plow')).toBe(true);
-    expect(() => performAction('plow', ctx)).not.toThrow();
+  it('is locked until workshop is built', () => {
+    const ctx = setup();
+    expect(() => performAction(plowId, ctx)).toThrow(
+      `Action ${plowId} is locked`,
+    );
+    const buildCost = getActionCosts(buildId, ctx, { id: workshopId });
+    for (const key of Object.keys(buildCost)) {
+      ctx.activePlayer.resources[key] = Math.max(
+        ctx.activePlayer.resources[key] || 0,
+        buildCost[key] || 0,
+      );
+    }
+    performAction(buildId, ctx, { id: workshopId });
+    const plowCost = getActionCosts(plowId, ctx);
+    for (const key of Object.keys(plowCost)) {
+      ctx.activePlayer.resources[key] = Math.max(
+        ctx.activePlayer.resources[key] || 0,
+        plowCost[key] || 0,
+      );
+    }
+    expect(ctx.activePlayer.actions.has(plowId)).toBe(true);
+    expect(() => performAction(plowId, ctx)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- isolate expand action tests with bespoke registries and dynamic expectations
- clone building actions into local registries and compute error messages
- lock/unlock plow via workshop-defined registry entries
- verify plow adds temporary expand cost modifier using custom registries

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5d6574c5883258889ec6239f84c25