### PR TITLE
feat(engine): expose dynamic action cost resource

### DIFF
--- a/packages/engine/src/context.ts
+++ b/packages/engine/src/context.ts
@@ -25,6 +25,7 @@ export class EngineContext {
       A: {},
       B: {},
     },
+    public actionCostResource: ResourceKey,
   ) {}
   recentResourceGains: { key: ResourceKey; amount: number }[] = [];
   // Cache base values for stat:add_pct per turn/phase/step to ensure

--- a/packages/engine/tests/actions/action-config.test.ts
+++ b/packages/engine/tests/actions/action-config.test.ts
@@ -51,7 +51,8 @@ describe('Action configuration overrides', () => {
     const landsBefore = ctx.activePlayer.lands.length;
     const hapBefore = ctx.activePlayer.happiness;
     const expected = getExpandExpectations(ctx);
-    ctx.activePlayer.ap = expected.costs[Resource.ap] || 0;
+    ctx.activePlayer[ctx.actionCostResource] =
+      expected.costs[ctx.actionCostResource] || 0;
     performAction('expand', ctx);
     expect(ctx.activePlayer.gold).toBe(
       goldBefore - (expected.costs[Resource.gold] || 0),

--- a/packages/engine/tests/actions/develop.test.ts
+++ b/packages/engine/tests/actions/develop.test.ts
@@ -48,6 +48,9 @@ function simulateBuild(ctx: EngineContext, id: string, landId: string) {
     ctx.developments,
     ctx.populations,
     new PassiveManager(),
+    ctx.phases,
+    ctx.compensations,
+    ctx.actionCostResource,
   );
   for (const [resourceKey, cost] of Object.entries(costs)) {
     sim.activePlayer.resources[resourceKey as ResourceKey] -= cost;

--- a/packages/engine/tests/effects/add_development.test.ts
+++ b/packages/engine/tests/effects/add_development.test.ts
@@ -87,6 +87,9 @@ function simulateBuild(ctx: EngineContext, id: string, landId: string) {
     ctx.developments,
     ctx.populations,
     new PassiveManager(),
+    ctx.phases,
+    ctx.compensations,
+    ctx.actionCostResource,
   );
   for (const [resourceKey, cost] of Object.entries(costs)) {
     sim.activePlayer.resources[resourceKey as ResourceKey] -= cost;

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -140,16 +140,7 @@ export function GameProvider({
   const [tabsEnabled, setTabsEnabled] = useState(false);
   const enqueue = <T,>(task: () => Promise<T> | T) => ctx.enqueue(task);
 
-  const actionCostResource = useMemo<ResourceKey>(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-assertion
-    const reg = ctx.actions as any as { map: Map<string, Action> };
-    const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
-    if (!first) return '' as ResourceKey;
-    const [id] = first;
-    const costs = getActionCosts(id, ctx);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return (Object.keys(costs)[0] ?? '') as ResourceKey;
-  }, [ctx]);
+  const actionCostResource = ctx.actionCostResource;
 
   const actionPhaseId = useMemo(
     () => ctx.phases.find((p) => p.action)?.id,
@@ -223,12 +214,13 @@ export function GameProvider({
     const total = apStartOverride ?? mainApStart;
     const remaining = ctx.activePlayer.resources[actionCostResource] ?? 0;
     const spent = total - remaining;
+    const info = RESOURCES[actionCostResource as keyof typeof RESOURCES];
     const steps = [
       {
-        title: `Step 1 - Spend all ${RESOURCES[actionCostResource].label}`,
+        title: `Step 1 - Spend all ${info.label}`,
         items: [
           {
-            text: `${RESOURCES[actionCostResource].icon} ${spent}/${total} spent`,
+            text: `${info.icon} ${spent}/${total} spent`,
             done: remaining === 0,
           },
         ],
@@ -473,7 +465,7 @@ export function GameProvider({
     setDisplayPhase,
     phaseHistories,
     tabsEnabled,
-    actionCostResource,
+    actionCostResource: actionCostResource as ResourceKey,
     handlePerform,
     runUntilActionPhase,
     handleEndTurn,

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -4,12 +4,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import ActionsPanel from '../src/components/actions/ActionsPanel';
-import {
-  createEngine,
-  getActionCosts,
-  PopulationRole,
-  Stat,
-} from '@kingdom-builder/engine';
+import { createEngine, PopulationRole, Stat } from '@kingdom-builder/engine';
 import {
   RESOURCES,
   ACTIONS,
@@ -40,16 +35,7 @@ const ctx = createEngine({
   start: GAME_START,
   rules: RULES,
 });
-const actionCostResource = (() => {
-  const reg = ACTIONS as unknown as {
-    map: Map<string, { system?: boolean }>;
-  };
-  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
-  if (!first) return '';
-  const [id] = first;
-  const costs = getActionCosts(id, ctx);
-  return (Object.keys(costs)[0] ?? '') as string;
-})();
+const actionCostResource = ctx.actionCostResource;
 const mockGame = {
   ctx,
   log: [],

--- a/packages/web/tests/HoverCard.test.tsx
+++ b/packages/web/tests/HoverCard.test.tsx
@@ -33,16 +33,7 @@ const ctx = createEngine({
   start: GAME_START,
   rules: RULES,
 });
-const actionCostResource = (() => {
-  const reg = ACTIONS as unknown as {
-    map: Map<string, { system?: boolean }>;
-  };
-  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
-  if (!first) return '';
-  const [id] = first;
-  const costs = getActionCosts(id, ctx);
-  return (Object.keys(costs)[0] ?? '') as string;
-})();
+const actionCostResource = ctx.actionCostResource;
 const mockGame = {
   ctx,
   log: [],

--- a/packages/web/tests/PhasePanel.test.tsx
+++ b/packages/web/tests/PhasePanel.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import PhasePanel from '../src/components/phases/PhasePanel';
-import { createEngine, getActionCosts } from '@kingdom-builder/engine';
+import { createEngine } from '@kingdom-builder/engine';
 import {
   ACTIONS,
   BUILDINGS,
@@ -28,16 +28,7 @@ const ctx = createEngine({
   start: GAME_START,
   rules: RULES,
 });
-const actionCostResource = (() => {
-  const reg = ACTIONS as unknown as {
-    map: Map<string, { system?: boolean }>;
-  };
-  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
-  if (!first) return '';
-  const [id] = first;
-  const costs = getActionCosts(id, ctx);
-  return (Object.keys(costs)[0] ?? '') as string;
-})();
+const actionCostResource = ctx.actionCostResource;
 const mockGame = {
   ctx,
   log: [],

--- a/packages/web/tests/PlayerPanel.test.tsx
+++ b/packages/web/tests/PlayerPanel.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import PlayerPanel from '../src/components/player/PlayerPanel';
-import { createEngine, getActionCosts } from '@kingdom-builder/engine';
+import { createEngine } from '@kingdom-builder/engine';
 import {
   RESOURCES,
   ACTIONS,
@@ -29,16 +29,7 @@ const ctx = createEngine({
   start: GAME_START,
   rules: RULES,
 });
-const actionCostResource = (() => {
-  const reg = ACTIONS as unknown as {
-    map: Map<string, { system?: boolean }>;
-  };
-  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
-  if (!first) return '';
-  const [id] = first;
-  const costs = getActionCosts(id, ctx);
-  return (Object.keys(costs)[0] ?? '') as string;
-})();
+const actionCostResource = ctx.actionCostResource;
 const mockGame = {
   ctx,
   log: [],


### PR DESCRIPTION
## Summary
- track default action cost resource in the engine context
- derive `actionCostResource` from content and apply dynamically
- update web context and tests to use the dynamic action cost resource

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5d635f0e0832588b0b0081d946894