### PR TITLE
feat: support dynamic action cost resource

### DIFF
--- a/packages/engine/src/context.ts
+++ b/packages/engine/src/context.ts
@@ -21,6 +21,7 @@ export class EngineContext {
     public populations: Registry<PopulationDef>,
     public passives: PassiveManager,
     public phases: PhaseDef[],
+    public actionCostResource: ResourceKey,
     public compensations: Record<PlayerId, PlayerStartConfig> = {
       A: {},
       B: {},

--- a/packages/engine/src/registry.ts
+++ b/packages/engine/src/registry.ts
@@ -12,4 +12,13 @@ export class Registry<T> {
     if (!value) throw new Error(`Unknown id: ${id}`);
     return value;
   }
+  entries(): [string, T][] {
+    return Array.from(this.map.entries());
+  }
+  values(): T[] {
+    return Array.from(this.map.values());
+  }
+  keys(): string[] {
+    return Array.from(this.map.keys());
+  }
 }

--- a/packages/engine/tests/actions/build.test.ts
+++ b/packages/engine/tests/actions/build.test.ts
@@ -7,7 +7,6 @@ import {
   ACTIONS,
   BUILDINGS,
 } from '@kingdom-builder/contents';
-import { Resource as ctxResource } from '../../src/state';
 
 function clone<T>(v: T): T {
   return structuredClone(v);
@@ -53,7 +52,7 @@ describe('Build action', () => {
   it('rejects when resources are insufficient', () => {
     const ctx = setup();
     const cost = getActionCosts(buildId, ctx, { id: charterId });
-    const payKey = Object.keys(cost).find((k) => k !== ctxResource.ap)!;
+    const payKey = Object.keys(cost).find((k) => k !== ctx.actionCostResource)!;
     ctx.activePlayer.resources[payKey] = (cost[payKey] || 0) - 1;
     const expected = `Insufficient ${payKey}: need ${cost[payKey]}, have ${ctx.activePlayer.resources[payKey]}`;
     expect(() => performAction(buildId, ctx, { id: charterId })).toThrow(

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -140,16 +140,7 @@ export function GameProvider({
   const [tabsEnabled, setTabsEnabled] = useState(false);
   const enqueue = <T,>(task: () => Promise<T> | T) => ctx.enqueue(task);
 
-  const actionCostResource = useMemo<ResourceKey>(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-assertion
-    const reg = ctx.actions as any as { map: Map<string, Action> };
-    const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
-    if (!first) return '' as ResourceKey;
-    const [id] = first;
-    const costs = getActionCosts(id, ctx);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return (Object.keys(costs)[0] ?? '') as ResourceKey;
-  }, [ctx]);
+  const actionCostResource = ctx.actionCostResource as ResourceKey;
 
   const actionPhaseId = useMemo(
     () => ctx.phases.find((p) => p.action)?.id,
@@ -225,10 +216,10 @@ export function GameProvider({
     const spent = total - remaining;
     const steps = [
       {
-        title: `Step 1 - Spend all ${RESOURCES[actionCostResource].label}`,
+        title: `Step 1 - Spend all ${RESOURCES[actionCostResource]?.label ?? ''}`,
         items: [
           {
-            text: `${RESOURCES[actionCostResource].icon} ${spent}/${total} spent`,
+            text: `${RESOURCES[actionCostResource]?.icon ?? ''} ${spent}/${total} spent`,
             done: remaining === 0,
           },
         ],

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -4,12 +4,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import ActionsPanel from '../src/components/actions/ActionsPanel';
-import {
-  createEngine,
-  getActionCosts,
-  PopulationRole,
-  Stat,
-} from '@kingdom-builder/engine';
+import { createEngine, PopulationRole, Stat } from '@kingdom-builder/engine';
 import {
   RESOURCES,
   ACTIONS,
@@ -40,16 +35,7 @@ const ctx = createEngine({
   start: GAME_START,
   rules: RULES,
 });
-const actionCostResource = (() => {
-  const reg = ACTIONS as unknown as {
-    map: Map<string, { system?: boolean }>;
-  };
-  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
-  if (!first) return '';
-  const [id] = first;
-  const costs = getActionCosts(id, ctx);
-  return (Object.keys(costs)[0] ?? '') as string;
-})();
+const actionCostResource = ctx.actionCostResource;
 const mockGame = {
   ctx,
   log: [],

--- a/packages/web/tests/HoverCard.test.tsx
+++ b/packages/web/tests/HoverCard.test.tsx
@@ -33,16 +33,7 @@ const ctx = createEngine({
   start: GAME_START,
   rules: RULES,
 });
-const actionCostResource = (() => {
-  const reg = ACTIONS as unknown as {
-    map: Map<string, { system?: boolean }>;
-  };
-  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
-  if (!first) return '';
-  const [id] = first;
-  const costs = getActionCosts(id, ctx);
-  return (Object.keys(costs)[0] ?? '') as string;
-})();
+const actionCostResource = ctx.actionCostResource;
 
 const findActionWithReq = () => {
   for (const [id] of (ACTIONS as unknown as { map: Map<string, unknown> })

--- a/packages/web/tests/PhasePanel.test.tsx
+++ b/packages/web/tests/PhasePanel.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import PhasePanel from '../src/components/phases/PhasePanel';
-import { createEngine, getActionCosts } from '@kingdom-builder/engine';
+import { createEngine } from '@kingdom-builder/engine';
 import {
   ACTIONS,
   BUILDINGS,
@@ -28,16 +28,7 @@ const ctx = createEngine({
   start: GAME_START,
   rules: RULES,
 });
-const actionCostResource = (() => {
-  const reg = ACTIONS as unknown as {
-    map: Map<string, { system?: boolean }>;
-  };
-  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
-  if (!first) return '';
-  const [id] = first;
-  const costs = getActionCosts(id, ctx);
-  return (Object.keys(costs)[0] ?? '') as string;
-})();
+const actionCostResource = ctx.actionCostResource;
 const mockGame = {
   ctx,
   log: [],

--- a/packages/web/tests/PlayerPanel.test.tsx
+++ b/packages/web/tests/PlayerPanel.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import PlayerPanel from '../src/components/player/PlayerPanel';
-import { createEngine, getActionCosts } from '@kingdom-builder/engine';
+import { createEngine } from '@kingdom-builder/engine';
 import {
   RESOURCES,
   ACTIONS,
@@ -29,16 +29,7 @@ const ctx = createEngine({
   start: GAME_START,
   rules: RULES,
 });
-const actionCostResource = (() => {
-  const reg = ACTIONS as unknown as {
-    map: Map<string, { system?: boolean }>;
-  };
-  const first = Array.from(reg.map.entries()).find(([, a]) => !a.system);
-  if (!first) return '';
-  const [id] = first;
-  const costs = getActionCosts(id, ctx);
-  return (Object.keys(costs)[0] ?? '') as string;
-})();
+const actionCostResource = ctx.actionCostResource;
 const mockGame = {
   ctx,
   log: [],


### PR DESCRIPTION
## Summary
- derive default action cost resource across actions and expose as `actionCostResource`
- apply default costs using the dynamic resource instead of hard-coded AP
- update web state and tests to consume the engine-provided action cost resource

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 ; tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5daaefc508325a2388cbd4c9fa58c