### PR TITLE
refactor: modularize dev automation strategies

### DIFF
--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -62,6 +62,13 @@ type PhaseStep = {
   active: boolean;
 };
 
+interface DevAutomation {
+  run: (
+    ctx: EngineContext,
+    enqueue: <T>(task: () => Promise<T> | T) => Promise<T>,
+  ) => void;
+}
+
 interface GameEngineContextValue {
   ctx: EngineContext;
   log: LogEntry[];
@@ -141,6 +148,9 @@ export function GameProvider({
   const enqueue = <T,>(task: () => Promise<T> | T) => ctx.enqueue(task);
 
   const actionCostResource = ctx.actionCostResource as ResourceKey;
+
+  const playerA = ctx.game.players[0]!;
+  const playerB = ctx.game.players[1]!;
 
   const actionPhaseId = useMemo(
     () => ctx.phases.find((p) => p.action)?.id,
@@ -408,6 +418,30 @@ export function GameProvider({
 
   const handleEndTurn = () => enqueue(endTurn);
 
+  const DEV_AUTOMATIONS: Record<string, DevAutomation> = {
+    [playerA.id]: {
+      run(ctx, enqueue) {
+        const key = ctx.actionCostResource as ResourceKey;
+        if ((ctx.activePlayer.resources[key] ?? 0) === 0) {
+          void enqueue(endTurn);
+        }
+      },
+    },
+    [playerB.id]: {
+      run(ctx, enqueue) {
+        const key = ctx.actionCostResource as ResourceKey;
+        const taxName = ctx.actions.get('tax').name;
+        const ap = ctx.activePlayer.resources[key] as number;
+        for (let i = 0; i < ap; i++) {
+          void enqueue(() =>
+            perform({ id: 'tax', name: taxName, system: true }),
+          );
+        }
+        void enqueue(endTurn);
+      },
+    },
+  };
+
   // Update main phase steps once action phase becomes active
   useEffect(() => {
     if (ctx.phases[ctx.game.phaseIndex]?.action) {
@@ -425,22 +459,7 @@ export function GameProvider({
     if (!devMode) return;
     const phaseDef = ctx.phases[ctx.game.phaseIndex];
     if (!phaseDef?.action) return;
-    const playerA = ctx.game.players[0]!;
-    const playerB = ctx.game.players[1]!;
-    const active = ctx.activePlayer;
-    const taxName = ctx.actions.get('tax').name;
-    if (active.id === playerB.id) {
-      const ap = active.resources[actionCostResource] as number;
-      for (let i = 0; i < ap; i++) {
-        void enqueue(() => perform({ id: 'tax', name: taxName, system: true }));
-      }
-      void enqueue(endTurn);
-    } else if (
-      active.id === playerA.id &&
-      (active.resources[actionCostResource] ?? 0) === 0
-    ) {
-      void enqueue(endTurn);
-    }
+    DEV_AUTOMATIONS[ctx.activePlayer.id]?.run(ctx, enqueue);
   }, [
     devMode,
     ctx.game.phaseIndex,


### PR DESCRIPTION
## Summary
- define `DevAutomation` interface for player-specific automation
- encapsulate Player A and Player B automation logic in lookup table
- simplify dev-mode effect to run selected automation strategy

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5e2b963c88325a0c63e93262aa309