### PR TITLE
feat(engine): generalize tiered resource service

### DIFF
--- a/packages/contents/src/rules.ts
+++ b/packages/contents/src/rules.ts
@@ -1,10 +1,12 @@
 import type { RuleSet } from '@kingdom-builder/engine/services';
+import { Resource } from './resources';
 
 export const RULES: RuleSet = {
   defaultActionAPCost: 1,
   absorptionCapPct: 1,
   absorptionRounding: 'down',
-  happinessTiers: [
+  tieredResourceKey: Resource.happiness,
+  tierDefinitions: [
     { threshold: 0, effect: { incomeMultiplier: 1 } },
     { threshold: 3, effect: { incomeMultiplier: 1.25 } },
     {

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -4,7 +4,7 @@ import { runEffects, type EffectDef } from '../effects';
 import type { DevelopmentConfig } from '../config/schema';
 import type { Registry } from '../registry';
 
-export type HappinessTierEffect = {
+export type TierEffect = {
   incomeMultiplier: number;
   buildingDiscountPct?: number; // 0.2 = 20%
   growthBonusPct?: number;
@@ -17,18 +17,22 @@ export type RuleSet = {
   defaultActionAPCost: number;
   absorptionCapPct: number;
   absorptionRounding: 'down' | 'up' | 'nearest';
-  happinessTiers: { threshold: number; effect: HappinessTierEffect }[];
+  tieredResourceKey: ResourceKey;
+  tierDefinitions: { threshold: number; effect: TierEffect }[];
   slotsPerNewLand: number;
   maxSlotsPerLand: number;
   basePopulationCap: number;
 };
 
-class HappinessService {
-  constructor(private rules: RuleSet) {}
-  tier(happiness: number): HappinessTierEffect | undefined {
-    let last: HappinessTierEffect | undefined;
-    for (const tier of this.rules.happinessTiers)
-      if (happiness >= tier.threshold) last = tier.effect;
+class TieredResourceService {
+  resourceKey: ResourceKey;
+  constructor(private rules: RuleSet) {
+    this.resourceKey = rules.tieredResourceKey;
+  }
+  tier(value: number): TierEffect | undefined {
+    let last: TierEffect | undefined;
+    for (const tier of this.rules.tierDefinitions)
+      if (value >= tier.threshold) last = tier.effect;
       else break;
     return last;
   }
@@ -181,13 +185,13 @@ function reverseEffect(effect: EffectDef): EffectDef {
 }
 
 export class Services {
-  happiness: HappinessService;
+  tieredResource: TieredResourceService;
   popcap: PopCapService;
   constructor(
     public rules: RuleSet,
     developments: Registry<DevelopmentConfig>,
   ) {
-    this.happiness = new HappinessService(rules);
+    this.tieredResource = new TieredResourceService(rules);
     this.popcap = new PopCapService(rules, developments);
   }
 }

--- a/packages/engine/tests/services/rules.test.ts
+++ b/packages/engine/tests/services/rules.test.ts
@@ -10,21 +10,21 @@ import {
 import { getActionCosts } from '../../src/index.ts';
 
 describe('Services', () => {
-  it('evaluates happiness tiers correctly', () => {
+  it('evaluates resource tiers correctly', () => {
     const services = new Services(RULES, DEVELOPMENTS);
     const getTierEffect = (value: number) =>
-      RULES.happinessTiers.filter((t) => t.threshold <= value).at(-1)?.effect ||
-      {};
-    expect(services.happiness.tier(0)?.incomeMultiplier).toBe(
+      RULES.tierDefinitions.filter((t) => t.threshold <= value).at(-1)
+        ?.effect || {};
+    expect(services.tieredResource.tier(0)?.incomeMultiplier).toBe(
       getTierEffect(0).incomeMultiplier,
     );
-    expect(services.happiness.tier(4)?.incomeMultiplier).toBe(
+    expect(services.tieredResource.tier(4)?.incomeMultiplier).toBe(
       getTierEffect(4).incomeMultiplier,
     );
-    expect(services.happiness.tier(5)?.buildingDiscountPct).toBe(
+    expect(services.tieredResource.tier(5)?.buildingDiscountPct).toBe(
       getTierEffect(5).buildingDiscountPct,
     );
-    expect(services.happiness.tier(8)?.incomeMultiplier).toBe(
+    expect(services.tieredResource.tier(8)?.incomeMultiplier).toBe(
       getTierEffect(8).incomeMultiplier,
     );
   });


### PR DESCRIPTION
## Summary
- generalize happiness service into tiered resource service driven by rules
- allow rules to specify resource and tier definitions generically
- update tests and content rules to use new tiered resource structure

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5e36e10388325b57fe5cfcb5e1e9f