### PR TITLE
feat(web): centralize evaluator icons

### DIFF
--- a/packages/web/src/utils/getRequirementIcons.ts
+++ b/packages/web/src/utils/getRequirementIcons.ts
@@ -11,17 +11,24 @@ interface EvalConfig {
   params?: Record<string, unknown>;
 }
 
+export type EvaluatorIconGetter = (
+  params?: Record<string, unknown>,
+) => string[];
+
+export const EVALUATOR_ICON_MAP: Record<string, EvaluatorIconGetter> = {
+  stat: (params) => {
+    const key = params?.['key'] as StatKey | undefined;
+    return key ? [STATS[key]?.icon || ''] : [];
+  },
+  population: (params) => {
+    const role = params?.['role'] as PopulationRoleId | undefined;
+    return role ? [POPULATION_ROLES[role]?.icon || ''] : [];
+  },
+};
+
 function collectEvaluatorIcons(evaluator?: EvalConfig): string[] {
   if (!evaluator) return [];
-  if (evaluator.type === 'stat') {
-    const key = evaluator.params?.['key'] as StatKey | undefined;
-    return key ? [STATS[key]?.icon || ''] : [];
-  }
-  if (evaluator.type === 'population') {
-    const role = evaluator.params?.['role'] as PopulationRoleId | undefined;
-    return role ? [POPULATION_ROLES[role]?.icon || ''] : [];
-  }
-  return [];
+  return EVALUATOR_ICON_MAP[evaluator.type]?.(evaluator.params) ?? [];
 }
 
 interface RequirementConfig {


### PR DESCRIPTION
## Summary
- centralize evaluator icon retrieval with `EVALUATOR_ICON_MAP`
- use lookup map in `collectEvaluatorIcons` and `getRequirementIcons`

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4fc6a108325935709c0f617d5c9