### PR TITLE
feat: mark capacity stats for summary bars

### DIFF
--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -360,6 +360,7 @@ export interface StatInfo extends InfoDef {
     prefix?: string;
     percent?: boolean;
   };
+  capacity?: boolean;
 }
 
 class StatBuilder extends InfoBuilder<StatInfo> {
@@ -372,6 +373,10 @@ class StatBuilder extends InfoBuilder<StatInfo> {
   }
   addFormat(format: { prefix?: string; percent?: boolean }) {
     this.config.addFormat = { ...this.config.addFormat, ...format };
+    return this;
+  }
+  capacity(flag = true) {
+    this.config.capacity = flag;
     return this;
   }
 }

--- a/packages/contents/src/stats.ts
+++ b/packages/contents/src/stats.ts
@@ -17,6 +17,7 @@ const defs: StatInfo[] = [
     .description(
       'Max Population determines how many subjects your kingdom can sustain. Expand infrastructure or build houses to increase it.',
     )
+    .capacity()
     .addFormat({ prefix: 'Max ' })
     .build(),
   stat(Stat.armyStrength)

--- a/packages/web/src/components/player/PopulationInfo.tsx
+++ b/packages/web/src/components/player/PopulationInfo.tsx
@@ -73,10 +73,10 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
         )}
       </span>
       {Object.entries(player.stats)
-        .filter(
-          ([k, v]) =>
-            k !== 'maxPopulation' && (v !== 0 || player.statsHistory?.[k]),
-        )
+        .filter(([k, v]) => {
+          const info = STATS[k as keyof typeof STATS];
+          return !info.capacity && (v !== 0 || player.statsHistory?.[k]);
+        })
         .map(([k, v]) => {
           const info = STATS[k as keyof typeof STATS];
           return (


### PR DESCRIPTION
## Summary
- allow stat definitions to mark capacity-oriented values
- tag maxPopulation as a capacity stat
- exclude capacity stats from player bar while keeping population summary

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4c1aefc8325b61b1b2de534533f