### PR TITLE
feat(web): expose passive icon map

### DIFF
--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -5,6 +5,11 @@ import { describeEffects, splitSummary } from '../../translation';
 import type { EffectDef } from '@kingdom-builder/engine';
 import { useAnimate } from '../../utils/useAutoAnimate';
 
+export const ICON_MAP: Record<string, string> = {
+  cost_mod: modifierInfo.cost.icon,
+  result_mod: modifierInfo.result.icon,
+};
+
 export default function PassiveDisplay({
   player,
 }: {
@@ -33,9 +38,7 @@ export default function PassiveDisplay({
 
   const getIcon = (effects: EffectDef[] | undefined) => {
     const first = effects?.[0];
-    if (first?.type === 'cost_mod') return modifierInfo.cost.icon;
-    if (first?.type === 'result_mod') return modifierInfo.result.icon;
-    return '❔';
+    return ICON_MAP[first?.type as keyof typeof ICON_MAP] ?? '❔';
   };
 
   const animatePassives = useAnimate<HTMLDivElement>();


### PR DESCRIPTION
## Summary
- export passive `ICON_MAP` for registering icons
- reference map in `getIcon`

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1; tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b5eb37577c83258ca221d1f4339969