### PR TITLE
feat: generic resource diff logging

### DIFF
--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -32,6 +32,8 @@ import {
   type Summary,
 } from '../translation';
 
+const RESOURCE_KEYS = Object.keys(RESOURCES) as ResourceKey[];
+
 interface Action {
   id: string;
   name: string;
@@ -202,7 +204,13 @@ export function GameProvider({
         before.resources[k] = (before.resources[k] || 0) - (v ?? 0);
       for (const [k, v] of Object.entries(comp.stats || {}))
         before.stats[k] = (before.stats[k] || 0) - (v ?? 0);
-      const lines = diffStepSnapshots(before, after, undefined, ctx);
+      const lines = diffStepSnapshots(
+        before,
+        after,
+        undefined,
+        ctx,
+        RESOURCE_KEYS,
+      );
       if (lines.length)
         addLog(
           ['Last-player compensation:', ...lines.map((l: string) => `  ${l}`)],
@@ -289,7 +297,13 @@ export function GameProvider({
         lastPhase = phase;
       }
       const after = snapshotPlayer(player, ctx);
-      const changes = diffStepSnapshots(before, after, stepDef, ctx);
+      const changes = diffStepSnapshots(
+        before,
+        after,
+        stepDef,
+        ctx,
+        RESOURCE_KEYS,
+      );
       if (changes.length) {
         addLog(
           changes.map((c) => `  ${c}`),
@@ -339,7 +353,13 @@ export function GameProvider({
 
       const after = snapshotPlayer(player, ctx);
       const stepDef = ctx.actions.get(action.id);
-      const changes = diffStepSnapshots(before, after, stepDef, ctx);
+      const changes = diffStepSnapshots(
+        before,
+        after,
+        stepDef,
+        ctx,
+        RESOURCE_KEYS,
+      );
       const messages = logContent('action', action.id, ctx, params);
       const costLines: string[] = [];
       for (const key of Object.keys(costs) as (keyof typeof RESOURCES)[]) {
@@ -364,6 +384,7 @@ export function GameProvider({
           trace.after,
           subStep,
           ctx,
+          RESOURCE_KEYS,
         );
         if (!subChanges.length) continue;
         subLines.push(...subChanges);

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -9,6 +9,7 @@ import {
   POPULATION_ROLES,
   LAND_ICON as landIcon,
   SLOT_ICON as slotIcon,
+  type ResourceKey,
 } from '@kingdom-builder/contents';
 import { formatStatValue, statDisplaysAsPercent } from '../utils/stats';
 interface StepDef {
@@ -61,13 +62,17 @@ export function diffSnapshots(
   before: PlayerSnapshot,
   after: PlayerSnapshot,
   ctx: EngineContext,
+  resourceKeys: ResourceKey[] = Object.keys({
+    ...before.resources,
+    ...after.resources,
+  }) as ResourceKey[],
 ): string[] {
   const changes: string[] = [];
-  for (const key of Object.keys(after.resources)) {
+  for (const key of resourceKeys) {
     const b = before.resources[key] ?? 0;
     const a = after.resources[key] ?? 0;
     if (a !== b) {
-      const info = RESOURCES[key as keyof typeof RESOURCES];
+      const info = RESOURCES[key];
       const icon = info?.icon ? `${info.icon} ` : '';
       const label = info?.label ?? key;
       const delta = a - b;
@@ -278,14 +283,18 @@ export function diffStepSnapshots(
   after: PlayerSnapshot,
   step: StepDef | undefined,
   ctx: EngineContext,
+  resourceKeys: ResourceKey[] = Object.keys({
+    ...before.resources,
+    ...after.resources,
+  }) as ResourceKey[],
 ): string[] {
   const changes: string[] = [];
   const sources = collectResourceSources(step, ctx);
-  for (const key of Object.keys(after.resources)) {
+  for (const key of resourceKeys) {
     const b = before.resources[key] ?? 0;
     const a = after.resources[key] ?? 0;
     if (a !== b) {
-      const info = RESOURCES[key as keyof typeof RESOURCES];
+      const info = RESOURCES[key];
       const icon = info?.icon ? `${info.icon} ` : '';
       const label = info?.label ?? key;
       const delta = a - b;

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -15,8 +15,11 @@ import {
   RULES,
   RESOURCES,
   Resource,
+  type ResourceKey,
 } from '@kingdom-builder/contents';
 import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
+
+const RESOURCE_KEYS = Object.keys(RESOURCES) as ResourceKey[];
 
 vi.mock('@kingdom-builder/engine', async () => {
   return await import('../../engine/src');
@@ -46,7 +49,7 @@ describe('log resource sources', () => {
     const before = snapshotPlayer(ctx.activePlayer, ctx);
     runEffects(step?.effects || [], ctx);
     const after = snapshotPlayer(ctx.activePlayer, ctx);
-    const lines = diffStepSnapshots(before, after, step, ctx);
+    const lines = diffStepSnapshots(before, after, step, ctx, RESOURCE_KEYS);
     const goldInfo = RESOURCES[Resource.gold];
     const farmIcon = DEVELOPMENTS.get('farm')?.icon || '';
     const b = before.resources[Resource.gold] ?? 0;
@@ -76,7 +79,7 @@ describe('log resource sources', () => {
     const before = snapshotPlayer(ctx.activePlayer, ctx);
     performAction('tax', ctx);
     const after = snapshotPlayer(ctx.activePlayer, ctx);
-    const lines = diffStepSnapshots(before, after, step, ctx);
+    const lines = diffStepSnapshots(before, after, step, ctx, RESOURCE_KEYS);
     const goldInfo = RESOURCES[Resource.gold];
     const populationIcon = '👥';
     const marketIcon = BUILDINGS.get('market')?.icon || '';

--- a/packages/web/tests/subaction-log.test.ts
+++ b/packages/web/tests/subaction-log.test.ts
@@ -16,12 +16,15 @@ import {
   RULES,
   RESOURCES,
   SLOT_ICON as slotIcon,
+  type ResourceKey,
 } from '@kingdom-builder/contents';
 import {
   snapshotPlayer,
   diffStepSnapshots,
   logContent,
 } from '../src/translation';
+
+const RESOURCE_KEYS = Object.keys(RESOURCES) as ResourceKey[];
 
 vi.mock('@kingdom-builder/engine', async () => {
   return await import('../../engine/src');
@@ -50,6 +53,7 @@ describe('sub-action logging', () => {
       after,
       ctx.actions.get('plow'),
       ctx,
+      RESOURCE_KEYS,
     );
     const messages = logContent('action', 'plow', ctx);
     const costLines: string[] = [];
@@ -73,6 +77,7 @@ describe('sub-action logging', () => {
         trace.after,
         ctx.actions.get(trace.id),
         ctx,
+        RESOURCE_KEYS,
       );
       if (!subChanges.length) continue;
       subLines.push(...subChanges);
@@ -104,6 +109,7 @@ describe('sub-action logging', () => {
       expandTrace.after,
       ctx.actions.get('expand'),
       ctx,
+      RESOURCE_KEYS,
     );
     expandDiff.forEach((line) => {
       expect(logLines).toContain(`    ${line}`);
@@ -115,6 +121,7 @@ describe('sub-action logging', () => {
       tillTrace.after,
       ctx.actions.get('till'),
       ctx,
+      RESOURCE_KEYS,
     );
     expect(tillDiff.length).toBeGreaterThan(0);
     expect(

--- a/packages/web/tests/tax-market-log.test.ts
+++ b/packages/web/tests/tax-market-log.test.ts
@@ -17,12 +17,15 @@ import {
   RULES,
   RESOURCES,
   Resource,
+  type ResourceKey,
 } from '@kingdom-builder/contents';
 import {
   snapshotPlayer,
   diffStepSnapshots,
   logContent,
 } from '../src/translation';
+
+const RESOURCE_KEYS = Object.keys(RESOURCES) as ResourceKey[];
 
 vi.mock('@kingdom-builder/engine', async () => {
   return await import('../../engine/src');
@@ -50,7 +53,13 @@ describe('tax action logging with market', () => {
     const costs = getActionCosts('tax', ctx);
     const traces: ActionTrace[] = performAction('tax', ctx);
     const after = snapshotPlayer(ctx.activePlayer, ctx);
-    const changes = diffStepSnapshots(before, after, action, ctx);
+    const changes = diffStepSnapshots(
+      before,
+      after,
+      action,
+      ctx,
+      RESOURCE_KEYS,
+    );
     const messages = logContent('action', 'tax', ctx);
     const costLines: string[] = [];
     for (const key of Object.keys(costs) as (keyof typeof RESOURCES)[]) {
@@ -73,6 +82,7 @@ describe('tax action logging with market', () => {
         trace.after,
         subStep,
         ctx,
+        RESOURCE_KEYS,
       );
       if (!subChanges.length) continue;
       subLines.push(...subChanges);


### PR DESCRIPTION
## Summary
- allow log diff utilities to compare arbitrary resource keys
- propagate resource key lists through game context and tests

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5ec9f589083258d2dc1fe03d48661