### PR TITLE
Add fast-check and engine property tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-unused-imports": "^3.1.0",
+        "fast-check": "^3.23.2",
         "husky": "^9.1.7",
         "jsdom": "^26.1.0",
         "lint-staged": "^16.1.5",
@@ -3544,6 +3545,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5805,6 +5829,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -10114,6 +10155,15 @@
       "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
       "dev": true
     },
+    "fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^6.1.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -11634,6 +11684,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true
+    },
+    "pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
       "dev": true
     },
     "queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-unused-imports": "^3.1.0",
+    "fast-check": "^3.23.2",
     "husky": "^9.1.7",
     "jsdom": "^26.1.0",
     "lint-staged": "^16.1.5",

--- a/packages/engine/tests/engine.property.test.ts
+++ b/packages/engine/tests/engine.property.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { Resource as CResource } from '@kingdom-builder/contents';
+import { createTestEngine } from './helpers';
+import { createContentFactory } from './factories/content';
+import { advance, performAction, getActionCosts, snapshotPlayer } from '../src';
+
+function toMain(ctx: ReturnType<typeof createTestEngine>) {
+  while (ctx.game.currentPhase !== 'main') advance(ctx);
+}
+
+const resourceKeys = Object.values(CResource);
+const resourceKeyArb = fc.constantFrom(...resourceKeys);
+const resourceMapArb = fc.dictionary(
+  resourceKeyArb,
+  fc.integer({ min: 1, max: 5 }),
+);
+
+function toResourceEffects(map: Record<string, number>) {
+  return Object.entries(map).map(([key, amount]) => ({
+    type: 'resource' as const,
+    method: 'add' as const,
+    params: { key, amount },
+  }));
+}
+
+describe('engine property invariants', () => {
+  it('pays costs, executes triggers, keeps resources non-negative and preserves snapshots', () => {
+    fc.assert(
+      fc.property(
+        resourceMapArb, // action base costs
+        resourceMapArb, // building costs
+        resourceMapArb, // onBuild gains
+        (baseCosts, buildingCosts, gains) => {
+          const content = createContentFactory();
+          const building = content.building({
+            costs: buildingCosts,
+            onBuild: toResourceEffects(gains),
+          });
+          const action = content.action({
+            baseCosts,
+            effects: [
+              { type: 'building', method: 'add', params: { id: building.id } },
+            ],
+          });
+          const ctx = createTestEngine(content);
+          toMain(ctx);
+          const costs = getActionCosts(action.id, ctx, { id: building.id });
+          for (const [key, amount] of Object.entries(costs)) {
+            ctx.activePlayer.resources[key] = amount;
+          }
+          const before = snapshotPlayer(ctx.activePlayer, ctx);
+          const beforeCopy = JSON.parse(JSON.stringify(before));
+          performAction(action.id, ctx, { id: building.id });
+          expect(ctx.activePlayer.buildings.has(building.id)).toBe(true);
+          for (const key of Object.keys(ctx.activePlayer.resources)) {
+            expect(ctx.activePlayer.resources[key]).toBeGreaterThanOrEqual(0);
+          }
+          for (const key of new Set([
+            ...Object.keys(costs),
+            ...Object.keys(gains),
+          ])) {
+            const expected =
+              (before.resources[key] ?? 0) -
+              (costs[key] ?? 0) +
+              (gains[key] ?? 0);
+            expect(ctx.activePlayer.resources[key]).toBe(expected);
+          }
+          expect(before).toEqual(beforeCopy);
+          expect(before.buildings.includes(building.id)).toBe(false);
+        },
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add fast-check dev dependency
- add property-based engine invariant test using synthetic content factory

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b5f7fd59808325b7407c54d9f613a1