### PR TITLE
refactor: use synthetic content in translation tests

### DIFF
--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -166,47 +166,6 @@ export function getBuildingWithStatBonuses() {
   throw new Error('No building with stat bonuses found');
 }
 
-export function getBuildingWithPopulationBonus() {
-  for (const [id, def] of BUILDINGS.entries()) {
-    const effect = findEffect(
-      def.onBuild ?? [],
-      (e) =>
-        e.type === 'result_mod' &&
-        typeof (e.params as { evaluation?: unknown }).evaluation === 'object' &&
-        (e.params as { evaluation: { type?: string } }).evaluation.type ===
-          'population' &&
-        typeof (e.params as { evaluation: { id?: unknown } }).evaluation.id ===
-          'string',
-    );
-    if (effect) {
-      return {
-        buildingId: id,
-        actionId: (effect.params as { evaluation: { id: string } }).evaluation
-          .id,
-      };
-    }
-  }
-  throw new Error('No building with population bonus found');
-}
-
-export function getActionWithPopulationEvaluator(ctx: EngineContext) {
-  for (const [id, def] of ctx.actions.entries()) {
-    if (
-      findEffect(
-        def.effects,
-        (e) =>
-          typeof (e as { evaluator?: { type?: string } }).evaluator ===
-            'object' &&
-          (e as { evaluator: { type: string } }).evaluator.type ===
-            'population',
-      )
-    ) {
-      return id;
-    }
-  }
-  throw new Error('No action with population evaluator found');
-}
-
 export function getActionWithMultipleCosts(ctx: EngineContext) {
   for (const [id] of ctx.actions.entries()) {
     const costs = getActionCosts(id, ctx);

--- a/tests/integration/tax-translation.test.ts
+++ b/tests/integration/tax-translation.test.ts
@@ -2,30 +2,42 @@ import { describe, it, expect } from 'vitest';
 import { createEngine } from '@kingdom-builder/engine';
 import { summarizeContent } from '@kingdom-builder/web/translation/content';
 import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
   PHASES,
+  POPULATIONS,
   GAME_START,
   RULES,
+  Resource,
 } from '@kingdom-builder/contents';
-import { getActionWithPopulationEvaluator } from './fixtures';
+import { createContentFactory } from '../../packages/engine/tests/factories/content';
 
 describe('Action translation with population scaling', () => {
   it('mentions population scaling', () => {
+    const content = createContentFactory();
+    const action = content.action({
+      effects: [
+        {
+          evaluator: { type: 'population' },
+          effects: [
+            {
+              type: 'resource',
+              method: 'add',
+              params: { key: Resource.gold, amount: 1 },
+            },
+          ],
+        },
+      ],
+    });
     const ctx = createEngine({
-      actions: ACTIONS,
-      buildings: BUILDINGS,
-      developments: DEVELOPMENTS,
+      actions: content.actions,
+      buildings: content.buildings,
+      developments: content.developments,
       populations: POPULATIONS,
       phases: PHASES,
       start: GAME_START,
       rules: RULES,
     });
-    const actionId = getActionWithPopulationEvaluator(ctx);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const summary = summarizeContent('action', actionId, ctx) as (
+    const summary = summarizeContent('action', action.id, ctx) as (
       | string
       | { title: string; items: unknown[] }
     )[];


### PR DESCRIPTION
## Summary
- generate synthetic action and building definitions in integration translation tests
- remove population-specific fixtures tied to production content

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b5f810f5cc83258c45dc117d313ccc