### PR TITLE
Add synthetic game flow test

### DIFF
--- a/tests/integration/random-game-flow.test.ts
+++ b/tests/integration/random-game-flow.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  performAction,
+  advance,
+  getActionCosts,
+} from '@kingdom-builder/engine';
+import { createSyntheticContext } from './synthetic';
+
+function createRng(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+describe('random action flow', () => {
+  it('advances phases, pays costs and applies effects across turns', () => {
+    const { ctx, actions, phases, costKey, gainKey } = createSyntheticContext();
+    const actionIds = actions.map((a) => a.id);
+    const mainPhase = phases[0].id;
+    const endPhase = phases[1].id;
+    const endStep = phases[1].steps[0];
+    const effects = endStep.effects as
+      | { type?: string; method?: string; params?: { amount: number } }[]
+      | undefined;
+    const regenEffect = (effects || []).find(
+      (e) => e.type === 'resource' && e.method === 'add',
+    );
+    const regenAmount = (regenEffect?.params as { amount: number }).amount;
+    const rng = createRng(42);
+    const initialTurn = ctx.game.turn;
+    const turns = 3;
+
+    for (let t = 0; t < turns; t++) {
+      for (let p = 0; p < ctx.game.players.length; p++) {
+        expect(ctx.game.currentPhase).toBe(mainPhase);
+        while ((ctx.activePlayer.resources[costKey] ?? 0) > 0) {
+          const actionId = actionIds[Math.floor(rng() * actionIds.length)];
+          const costs = getActionCosts(actionId, ctx);
+          const beforeCost = ctx.activePlayer.resources[costKey];
+          const beforeGain = ctx.activePlayer.resources[gainKey];
+          const action = ctx.actions.get(actionId)!;
+          const gain = (
+            action.effects.find(
+              (e) => e.type === 'resource' && e.method === 'add',
+            )!.params as { amount: number }
+          ).amount;
+          performAction(actionId, ctx);
+          expect(ctx.activePlayer.resources[costKey]).toBe(
+            beforeCost - (costs[costKey] ?? 0),
+          );
+          expect(ctx.activePlayer.resources[gainKey]).toBe(beforeGain + gain);
+        }
+        const currentIndex = ctx.game.currentPlayerIndex;
+        advance(ctx);
+        expect(ctx.game.currentPhase).toBe(endPhase);
+        expect(ctx.game.currentPlayerIndex).toBe(currentIndex);
+        const player = ctx.activePlayer;
+        const beforeRegen = player.resources[costKey];
+        advance(ctx);
+        expect(player.resources[costKey]).toBe(beforeRegen + regenAmount);
+        expect(ctx.game.currentPhase).toBe(mainPhase);
+        expect(ctx.game.currentPlayerIndex).toBe(
+          (currentIndex + 1) % ctx.game.players.length,
+        );
+      }
+    }
+    expect(ctx.game.turn).toBe(initialTurn + turns);
+  });
+});

--- a/tests/integration/synthetic.ts
+++ b/tests/integration/synthetic.ts
@@ -1,0 +1,117 @@
+import { createEngine } from '@kingdom-builder/engine';
+import { Registry } from '@kingdom-builder/engine/registry';
+import {
+  actionSchema,
+  buildingSchema,
+  developmentSchema,
+  populationSchema,
+  type ActionConfig,
+  type BuildingConfig,
+  type DevelopmentConfig,
+  type PopulationConfig,
+  type StartConfig,
+} from '@kingdom-builder/engine/config/schema';
+import type { PhaseDef } from '@kingdom-builder/engine';
+import type { RuleSet } from '@kingdom-builder/engine/services';
+
+export function createSyntheticContext() {
+  const costKey = 'r0';
+  const gainKey = 'r1';
+  const startAp = 3;
+
+  const actionsReg = new Registry<ActionConfig>(actionSchema);
+  const actions: ActionConfig[] = [
+    {
+      id: 'a1',
+      name: 'a1',
+      baseCosts: { [costKey]: 1 },
+      effects: [
+        {
+          type: 'resource',
+          method: 'add',
+          params: { key: gainKey, amount: 1 },
+        },
+      ],
+    },
+    {
+      id: 'a2',
+      name: 'a2',
+      baseCosts: { [costKey]: 1 },
+      effects: [
+        {
+          type: 'resource',
+          method: 'add',
+          params: { key: gainKey, amount: 2 },
+        },
+      ],
+    },
+    {
+      id: 'a3',
+      name: 'a3',
+      baseCosts: { [costKey]: 1 },
+      effects: [
+        {
+          type: 'resource',
+          method: 'add',
+          params: { key: gainKey, amount: 3 },
+        },
+      ],
+    },
+  ];
+  actions.forEach((a) => actionsReg.add(a.id, a));
+
+  const buildings = new Registry<BuildingConfig>(buildingSchema);
+  const developments = new Registry<DevelopmentConfig>(developmentSchema);
+  const populations = new Registry<PopulationConfig>(populationSchema);
+
+  const phases: PhaseDef[] = [
+    { id: 'main', action: true, steps: [{ id: 'main' }] },
+    {
+      id: 'end',
+      steps: [
+        {
+          id: 'refresh',
+          effects: [
+            {
+              type: 'resource',
+              method: 'add',
+              params: { key: costKey, amount: startAp },
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const start: StartConfig = {
+    player: {
+      resources: { [costKey]: startAp, [gainKey]: 0 },
+      stats: {},
+      population: {},
+      lands: [],
+    },
+  };
+
+  const rules: RuleSet = {
+    defaultActionAPCost: 1,
+    absorptionCapPct: 1,
+    absorptionRounding: 'down',
+    tieredResourceKey: gainKey,
+    tierDefinitions: [{ threshold: 0, effect: { incomeMultiplier: 1 } }],
+    slotsPerNewLand: 1,
+    maxSlotsPerLand: 1,
+    basePopulationCap: 1,
+  };
+
+  const ctx = createEngine({
+    actions: actionsReg,
+    buildings,
+    developments,
+    populations,
+    phases,
+    start,
+    rules,
+  });
+
+  return { ctx, actions, phases, costKey, gainKey, start };
+}


### PR DESCRIPTION
## Summary
- add helper to build synthetic actions and phases for tests
- cover multi-turn flow with random actions and phase transitions

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b60131d0d88325b79d075cff8168be