### PR TITLE
feat(web): add castle hp favicon

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kingdom Builder</title>
+    <link id="favicon" rel="icon" />
   </head>
   <body class="bg-slate-100 dark:bg-slate-900 text-gray-900 dark:text-gray-100">
     <div id="root"></div>

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,6 +1,17 @@
 import './index.css';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { RESOURCES, Resource } from '@kingdom-builder/contents';
+
+const castleIcon = RESOURCES[Resource.castleHP].icon;
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">${castleIcon}</text></svg>`;
+const link =
+  document.querySelector<HTMLLinkElement>('#favicon') ??
+  document.createElement('link');
+link.id = 'favicon';
+link.rel = 'icon';
+link.href = `data:image/svg+xml,${encodeURIComponent(svg)}`;
+document.head.appendChild(link);
 
 const root = createRoot(document.getElementById('root')!);
 root.render(<App />);


### PR DESCRIPTION
## Summary
- set castle HP as favicon

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b6014ff8488325b0168a8d16de7ced