### PR TITLE
Animate resource and stat changes

### DIFF
--- a/packages/web/src/components/AnimatedValue.tsx
+++ b/packages/web/src/components/AnimatedValue.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type { MutableRefObject } from 'react';
+import { useAnimate } from '../utils/useAutoAnimate';
+
+interface AnimatedValueProps {
+  value: number;
+  format?: (value: number) => string;
+}
+
+const AnimatedValue: React.FC<AnimatedValueProps> = ({
+  value,
+  format = String,
+}) => {
+  const [delta, setDelta] = useState(0);
+  const prev = useRef(value);
+  const ref: MutableRefObject<HTMLSpanElement | null> = useAnimate();
+
+  useEffect(() => {
+    const diff = value - prev.current;
+    if (diff !== 0) {
+      setDelta(diff);
+      const timer = setTimeout(() => setDelta(0), 800);
+      prev.current = value;
+      return () => clearTimeout(timer);
+    }
+  }, [value]);
+
+  const formatted = format(value);
+  const diffFormatted = format(Math.abs(delta));
+
+  return (
+    <span ref={ref} className="relative inline-block">
+      <span key={formatted}>{formatted}</span>
+      {delta !== 0 && (
+        <span className={delta > 0 ? 'gain-bubble' : 'loss-bubble'}>
+          {delta > 0 ? `+${diffFormatted}` : `-${diffFormatted}`}
+        </span>
+      )}
+    </span>
+  );
+};
+
+export default AnimatedValue;

--- a/packages/web/src/components/player/PopulationInfo.tsx
+++ b/packages/web/src/components/player/PopulationInfo.tsx
@@ -3,6 +3,7 @@ import { POPULATION_ROLES, STATS } from '@kingdom-builder/contents';
 import { formatStatValue } from '../../utils/stats';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { useGameEngine } from '../../state/GameContext';
+import AnimatedValue from '../AnimatedValue';
 
 interface PopulationInfoProps {
   player: EngineContext['activePlayer'];
@@ -95,7 +96,10 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
               onMouseLeave={clearHoverCard}
             >
               {info.icon}
-              {formatStatValue(k, v)}
+              <AnimatedValue
+                value={v}
+                format={(val) => formatStatValue(k, val)}
+              />
             </span>
           );
         })}

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { RESOURCES } from '@kingdom-builder/contents';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { useGameEngine } from '../../state/GameContext';
+import AnimatedValue from '../AnimatedValue';
 
 interface ResourceBarProps {
   player: EngineContext['activePlayer'];
@@ -29,7 +30,7 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
             onMouseLeave={clearHoverCard}
           >
             {info.icon}
-            {v}
+            <AnimatedValue value={v} />
           </span>
         );
       })}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -15,6 +15,28 @@
   }
 }
 
+@keyframes value-rise {
+  from {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  to {
+    opacity: 0;
+    transform: translate(-50%, -0.75rem);
+  }
+}
+
+@keyframes value-fall {
+  from {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  to {
+    opacity: 0;
+    transform: translate(-50%, 0.75rem);
+  }
+}
+
 @layer components {
   .bar-item {
     @apply flex items-center gap-1 tabular-nums whitespace-nowrap;
@@ -83,5 +105,13 @@
   }
   .dark .log-entry-b {
     color: rgb(254, 226, 226);
+  }
+  .gain-bubble {
+    @apply absolute left-1/2 -translate-x-1/2 text-green-600 text-sm;
+    animation: value-rise 0.8s forwards;
+  }
+  .loss-bubble {
+    @apply absolute left-1/2 -translate-x-1/2 text-red-600 text-sm;
+    animation: value-fall 0.8s forwards;
   }
 }

--- a/packages/web/tests/PlayerPanel.test.tsx
+++ b/packages/web/tests/PlayerPanel.test.tsx
@@ -65,7 +65,8 @@ describe('<PlayerPanel />', () => {
     expect(screen.getByText(ctx.activePlayer.name)).toBeInTheDocument();
     for (const [key, info] of Object.entries(RESOURCES)) {
       const amount = ctx.activePlayer.resources[key] ?? 0;
-      expect(screen.getByText(`${info.icon}${amount}`)).toBeInTheDocument();
+      const iconEl = screen.getByText(info.icon);
+      expect(iconEl.parentElement).toHaveTextContent(String(amount));
     }
   });
 });


### PR DESCRIPTION
## Summary
- Animate resource and stat values with new `AnimatedValue` component showing green gains and red losses
- Update player panels to use animated numbers for resources and stats
- Add CSS keyframes and styles for rising and falling change indicators

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b604631b2c83259e507927014e791f