### PR TITLE
feat: add dev-mode game launch option

### DIFF
--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -107,6 +107,7 @@ export class GameState {
   phaseIndex = 0;
   stepIndex = 0;
   players: PlayerState[];
+  devMode = false;
   constructor(aName = 'Player A', bName = 'Player B') {
     this.players = [new PlayerState('A', aName), new PlayerState('B', bName)];
   }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -17,6 +17,7 @@ export default function App() {
   const [screen, setScreen] = useState<Screen>('menu');
   const [gameKey, setGameKey] = useState(0);
   const [darkMode, setDarkMode] = useState(true);
+  const [devGame, setDevGame] = useState(false);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', darkMode);
@@ -156,6 +157,7 @@ export default function App() {
         onExit={() => setScreen('menu')}
         darkMode={darkMode}
         onToggleDark={() => setDarkMode((d) => !d)}
+        devMode={devGame}
       />
     );
   }
@@ -168,11 +170,22 @@ export default function App() {
         <button
           className="border px-4 py-2 hoverable cursor-pointer"
           onClick={() => {
+            setDevGame(false);
             setGameKey((k) => k + 1);
             setScreen('game');
           }}
         >
           Start New Game
+        </button>
+        <button
+          className="border px-4 py-2 hoverable cursor-pointer"
+          onClick={() => {
+            setDevGame(true);
+            setGameKey((k) => k + 1);
+            setScreen('game');
+          }}
+        >
+          Start Dev/Debug Game
         </button>
         <button
           className="border px-4 py-2 hoverable cursor-pointer"

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -7,8 +7,7 @@ import PhasePanel from './components/phases/PhasePanel';
 import LogPanel from './components/LogPanel';
 
 function GameLayout() {
-  const { ctx, onExit, darkMode, onToggleDark, devMode, onToggleDev } =
-    useGameEngine();
+  const { ctx, onExit, darkMode, onToggleDark } = useGameEngine();
   return (
     <div className="p-4 w-full bg-slate-100 text-gray-900 dark:bg-slate-900 dark:text-gray-100 min-h-screen">
       <div className="flex items-center justify-between mb-6">
@@ -17,14 +16,6 @@ function GameLayout() {
         </h1>
         {onExit && (
           <div className="flex items-center gap-2 ml-4">
-            <button
-              className={`px-3 py-1 rounded text-white hover:opacity-90 ${
-                devMode ? 'bg-green-600' : 'bg-gray-600'
-              }`}
-              onClick={onToggleDev}
-            >
-              {`Dev Mode${devMode ? ': On' : ': Off'}`}
-            </button>
             <button
               className="px-3 py-1 bg-gray-600 text-white rounded hover:bg-gray-700"
               onClick={onToggleDark}
@@ -84,16 +75,19 @@ export default function Game({
   onExit,
   darkMode = true,
   onToggleDark = () => {},
+  devMode = false,
 }: {
   onExit?: () => void;
   darkMode?: boolean;
   onToggleDark?: () => void;
+  devMode?: boolean;
 }) {
   return (
     <GameProvider
       {...(onExit ? { onExit } : {})}
       darkMode={darkMode}
       onToggleDark={onToggleDark}
+      devMode={devMode}
     >
       <GameLayout />
     </GameProvider>

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -98,8 +98,6 @@ interface GameEngineContextValue {
   onExit?: () => void;
   darkMode: boolean;
   onToggleDark: () => void;
-  devMode: boolean;
-  onToggleDev: () => void;
 }
 
 const GameEngineContext = createContext<GameEngineContextValue | null>(null);
@@ -109,11 +107,13 @@ export function GameProvider({
   onExit,
   darkMode = true,
   onToggleDark = () => {},
+  devMode = false,
 }: {
   children: React.ReactNode;
   onExit?: () => void;
   darkMode?: boolean;
   onToggleDark?: () => void;
+  devMode?: boolean;
 }) {
   const ctx = useMemo<EngineContext>(
     () =>
@@ -128,6 +128,7 @@ export function GameProvider({
       }),
     [],
   );
+  ctx.game.devMode = devMode;
   const [, setTick] = useState(0);
   const refresh = () => setTick((t) => t + 1);
 
@@ -139,8 +140,6 @@ export function GameProvider({
   const [phaseTimer, setPhaseTimer] = useState(0);
   const [phasePaused, setPhasePaused] = useState(false);
   const phasePausedRef = useRef(false);
-  const [devMode, setDevMode] = useState(true);
-  const onToggleDev = () => setDevMode((d) => !d);
   const [mainApStart, setMainApStart] = useState(0);
   const [displayPhase, setDisplayPhase] = useState(ctx.game.currentPhase);
   const [phaseHistories, setPhaseHistories] = useState<
@@ -254,7 +253,7 @@ export function GameProvider({
   }
 
   function runDelay(total: number) {
-    const speed = devMode ? 0.01 : 1;
+    const speed = ctx.game.devMode ? 0.01 : 1;
     const adjustedTotal = total * speed;
     const step = 100 * speed;
     setPhaseTimer(0);
@@ -477,12 +476,11 @@ export function GameProvider({
   }, []);
 
   useEffect(() => {
-    if (!devMode) return;
+    if (!ctx.game.devMode) return;
     const phaseDef = ctx.phases[ctx.game.phaseIndex];
     if (!phaseDef?.action) return;
     DEV_AUTOMATIONS[ctx.activePlayer.id]?.run(ctx, enqueue);
   }, [
-    devMode,
     ctx.game.phaseIndex,
     ctx.activePlayer.id,
     ctx.activePlayer.resources[actionCostResource],
@@ -511,8 +509,6 @@ export function GameProvider({
     updateMainPhaseStep,
     darkMode,
     onToggleDark,
-    devMode,
-    onToggleDev,
     ...(onExit ? { onExit } : {}),
   };
 

--- a/packages/web/tests/App.test.tsx
+++ b/packages/web/tests/App.test.tsx
@@ -55,5 +55,6 @@ describe('<App />', () => {
     const html = renderToString(<App />);
     expect(html).toContain('Kingdom Builder');
     expect(html).toContain('Start New Game');
+    expect(html).toContain('Start Dev/Debug Game');
   });
 });


### PR DESCRIPTION
## Summary
- add devMode flag to engine GameState and wire through GameProvider
- replace in-game Dev Mode toggle with separate Start Dev/Debug Game button
- gate dev automation on GameState.devMode for easier removal

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b605ef65708325ad85e5c3c47bda10