### PR TITLE
feat: improve hover card accessibility

### DIFF
--- a/packages/web/src/components/player/PopulationInfo.tsx
+++ b/packages/web/src/components/player/PopulationInfo.tsx
@@ -30,10 +30,20 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
   return (
     <>
       <div className="h-4 border-l border-black/10 dark:border-white/10" />
-      <span
+      <div
+        role="button"
+        tabIndex={0}
         className="bar-item hoverable cursor-help rounded px-1"
         onMouseEnter={showPopulationCard}
         onMouseLeave={clearHoverCard}
+        onFocus={showPopulationCard}
+        onBlur={clearHoverCard}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            showPopulationCard();
+          }
+        }}
       >
         👥{currentPop}/{player.maxPopulation}
         {popDetails.length > 0 && (
@@ -45,7 +55,8 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
               return (
                 <React.Fragment key={role}>
                   {i > 0 && ','}
-                  <span
+                  <button
+                    type="button"
                     className="cursor-help hoverable rounded px-1"
                     onMouseEnter={(e) => {
                       e.stopPropagation();
@@ -61,17 +72,41 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
                       e.stopPropagation();
                       showPopulationCard();
                     }}
+                    onFocus={(e) => {
+                      e.stopPropagation();
+                      handleHoverCard({
+                        title: `${info.icon} ${info.label}`,
+                        effects: [],
+                        requirements: [],
+                        description: info.description,
+                        bgClass: 'bg-gray-100 dark:bg-gray-700',
+                      });
+                    }}
+                    onBlur={(e) => {
+                      e.stopPropagation();
+                      showPopulationCard();
+                    }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleHoverCard({
+                        title: `${info.icon} ${info.label}`,
+                        effects: [],
+                        requirements: [],
+                        description: info.description,
+                        bgClass: 'bg-gray-100 dark:bg-gray-700',
+                      });
+                    }}
                   >
                     {info.icon}
                     {count}
-                  </span>
+                  </button>
                 </React.Fragment>
               );
             })}
             {')'}
           </>
         )}
-      </span>
+      </div>
       {Object.entries(player.stats)
         .filter(([k, v]) => {
           const info = STATS[k as keyof typeof STATS];
@@ -80,8 +115,9 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
         .map(([k, v]) => {
           const info = STATS[k as keyof typeof STATS];
           return (
-            <span
+            <button
               key={k}
+              type="button"
               className="bar-item hoverable cursor-help rounded px-1"
               onMouseEnter={() =>
                 handleHoverCard({
@@ -93,10 +129,29 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
                 })
               }
               onMouseLeave={clearHoverCard}
+              onFocus={() =>
+                handleHoverCard({
+                  title: `${info.icon} ${info.label}`,
+                  effects: [],
+                  requirements: [],
+                  description: info.description,
+                  bgClass: 'bg-gray-100 dark:bg-gray-700',
+                })
+              }
+              onBlur={clearHoverCard}
+              onClick={() =>
+                handleHoverCard({
+                  title: `${info.icon} ${info.label}`,
+                  effects: [],
+                  requirements: [],
+                  description: info.description,
+                  bgClass: 'bg-gray-100 dark:bg-gray-700',
+                })
+              }
             >
               {info.icon}
               {formatStatValue(k, v)}
-            </span>
+            </button>
           );
         })}
     </>

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -13,24 +13,28 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
     <>
       {Object.entries(player.resources).map(([k, v]) => {
         const info = RESOURCES[k as keyof typeof RESOURCES];
+        const showResourceCard = () =>
+          handleHoverCard({
+            title: `${info.icon} ${info.label}`,
+            effects: [],
+            requirements: [],
+            description: info.description,
+            bgClass: 'bg-gray-100 dark:bg-gray-700',
+          });
         return (
-          <span
+          <button
             key={k}
+            type="button"
             className="bar-item hoverable cursor-help rounded px-1"
-            onMouseEnter={() =>
-              handleHoverCard({
-                title: `${info.icon} ${info.label}`,
-                effects: [],
-                requirements: [],
-                description: info.description,
-                bgClass: 'bg-gray-100 dark:bg-gray-700',
-              })
-            }
+            onMouseEnter={showResourceCard}
             onMouseLeave={clearHoverCard}
+            onFocus={showResourceCard}
+            onBlur={clearHoverCard}
+            onClick={showResourceCard}
           >
             {info.icon}
             {v}
-          </span>
+          </button>
         );
       })}
     </>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -17,7 +17,7 @@
 
 @layer components {
   .bar-item {
-    @apply flex items-center gap-1 tabular-nums whitespace-nowrap;
+    @apply flex items-center gap-1 tabular-nums whitespace-nowrap appearance-none bg-transparent border-0 p-0;
   }
   .hoverable {
     @apply transition-colors transition-transform duration-150 hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-105;


### PR DESCRIPTION
## Summary
- use button or role="button" elements for resource and population hover cards
- show hover cards on focus and keyboard activation
- reset bar-item styles for button elements

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b60531334083258568f689195c8727