### PR TITLE
feat(web): add reusable button component

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -5,6 +5,7 @@ import HoverCard from './components/HoverCard';
 import ActionsPanel from './components/actions/ActionsPanel';
 import PhasePanel from './components/phases/PhasePanel';
 import LogPanel from './components/LogPanel';
+import Button from './components/common/Button';
 
 function GameLayout() {
   const { ctx, onExit, darkMode, onToggleDark, devMode, onToggleDev } =
@@ -17,26 +18,18 @@ function GameLayout() {
         </h1>
         {onExit && (
           <div className="flex items-center gap-2 ml-4">
-            <button
-              className={`px-3 py-1 rounded text-white hover:opacity-90 ${
-                devMode ? 'bg-green-600' : 'bg-gray-600'
-              }`}
+            <Button
               onClick={onToggleDev}
+              variant={devMode ? 'success' : 'secondary'}
             >
               {`Dev Mode${devMode ? ': On' : ': Off'}`}
-            </button>
-            <button
-              className="px-3 py-1 bg-gray-600 text-white rounded hover:bg-gray-700"
-              onClick={onToggleDark}
-            >
+            </Button>
+            <Button onClick={onToggleDark} variant="secondary">
               {darkMode ? 'Light Mode' : 'Dark Mode'}
-            </button>
-            <button
-              className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700"
-              onClick={onExit}
-            >
+            </Button>
+            <Button onClick={onExit} variant="danger">
               Quit
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/packages/web/src/components/common/Button.tsx
+++ b/packages/web/src/components/common/Button.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'ghost';
+};
+
+const VARIANT_CLASSES: Record<string, string> = {
+  primary: 'bg-blue-600 text-white hover:bg-blue-700',
+  secondary: 'bg-gray-600 text-white hover:bg-gray-700',
+  success: 'bg-green-600 text-white hover:bg-green-700',
+  danger: 'bg-red-600 text-white hover:bg-red-700',
+  ghost: '',
+};
+
+export default function Button({
+  variant = 'secondary',
+  disabled,
+  className = '',
+  type = 'button',
+  ...rest
+}: ButtonProps) {
+  const variantClass = VARIANT_CLASSES[variant] ?? VARIANT_CLASSES.secondary;
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      className={`px-3 py-1 rounded disabled:opacity-50 disabled:cursor-not-allowed ${disabled ? '' : 'hoverable'} ${variantClass} ${className}`}
+      {...rest}
+    />
+  );
+}

--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -3,6 +3,7 @@ import TimerCircle from '../TimerCircle';
 import { useGameEngine } from '../../state/GameContext';
 import { isActionPhaseActive } from '../../utils/isActionPhaseActive';
 import { useAnimate } from '../../utils/useAutoAnimate';
+import Button from '../common/Button';
 
 const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
   const {
@@ -52,7 +53,7 @@ const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
         {ctx.phases.map((p) => {
           const isSelected = displayPhase === p.id;
           return (
-            <button
+            <Button
               key={p.id}
               type="button"
               disabled={!tabsEnabled}
@@ -61,7 +62,8 @@ const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
                 setDisplayPhase(p.id);
                 setPhaseSteps(phaseHistories[p.id] ?? []);
               }}
-              className={`px-3 py-1 text-sm flex items-center gap-1 border-b-2 ${
+              variant="ghost"
+              className={`text-sm flex items-center gap-1 border-b-2 rounded-none ${
                 isSelected
                   ? 'border-blue-500 font-semibold'
                   : 'border-transparent text-gray-500'
@@ -72,7 +74,7 @@ const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
               }`}
             >
               {p.icon} {p.label}
-            </button>
+            </Button>
           );
         })}
       </div>
@@ -105,8 +107,8 @@ const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
       )}
       {isActionPhase && (
         <div className="mt-2 text-right">
-          <button
-            className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+          <Button
+            variant="primary"
             disabled={Boolean(
               actionPhaseId &&
                 phaseHistories[actionPhaseId]?.some((s) => s.active),
@@ -114,7 +116,7 @@ const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
             onClick={() => void handleEndTurn()}
           >
             Next Turn
-          </button>
+          </Button>
         </div>
       )}
     </section>


### PR DESCRIPTION
## Summary
- add reusable `<Button>` with Tailwind classes, color variants and disabled styling
- migrate Game and PhasePanel to use `<Button>`

## Testing
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b604be3d1c83259acee72e7154ffb7