### PR TITLE
refactor: split screens and update overview

### DIFF
--- a/packages/engine/tests/engine.property.test.ts
+++ b/packages/engine/tests/engine.property.test.ts
@@ -25,12 +25,14 @@ function toResourceEffects(map: Record<string, number>) {
 }
 
 describe('engine property invariants', () => {
-  it('pays costs, executes triggers, keeps resources non-negative and preserves snapshots', () => {
-    fc.assert(
-      fc.property(
-        resourceMapArb, // action base costs
-        resourceMapArb, // building costs
-        resourceMapArb, // onBuild gains
+  it(
+    'pays costs, executes triggers, keeps resources non-negative and preserves snapshots',
+    () => {
+      fc.assert(
+        fc.property(
+          resourceMapArb, // action base costs
+          resourceMapArb, // building costs
+          resourceMapArb, // onBuild gains
         (baseCosts, buildingCosts, gains) => {
           const content = createContentFactory();
           const building = content.building({
@@ -69,7 +71,9 @@ describe('engine property invariants', () => {
           expect(before).toEqual(beforeCopy);
           expect(before.buildings.includes(building.id)).toBe(false);
         },
-      ),
-    );
-  });
+        ),
+      );
+    },
+    10000,
+  );
 });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,15 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import Game from './Game';
-import {
-  ACTIONS as actionInfo,
-  LAND_ICON as landIcon,
-  SLOT_ICON as slotIcon,
-  RESOURCES,
-  Resource,
-  PHASES,
-  POPULATION_ROLES,
-  PopulationRole,
-} from '@kingdom-builder/contents';
+import Game from './screens/Game';
+import Menu from './screens/Menu';
+import Overview from './screens/Overview';
 
 type Screen = 'menu' | 'overview' | 'game';
 
@@ -27,126 +19,8 @@ export default function App() {
       window.history.replaceState(null, '', '/');
     }
   }, []);
-
   if (screen === 'overview') {
-    const devIcon = PHASES.find((p) => p.id === 'growth')?.icon;
-    const upkeepIcon = PHASES.find((p) => p.id === 'upkeep')?.icon;
-    const mainIcon = PHASES.find((p) => p.id === 'main')?.icon;
-    return (
-      <div className="p-6 max-w-2xl mx-auto space-y-4">
-        <h1 className="text-3xl font-bold text-center mb-4">Game Overview</h1>
-        <p>
-          Welcome to <strong>Kingdom Builder</strong>, a brisk duel of wits
-          where {actionInfo.get('expand')?.icon} expansion,
-          {actionInfo.get('build')?.icon} clever construction and
-          {actionInfo.get('army_attack')?.icon} daring raids decide who rules
-          the realm.
-        </p>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">
-            Your Objective {RESOURCES[Resource.castleHP].icon}
-          </h2>
-          <p>
-            Keep your {RESOURCES[Resource.castleHP].icon} castle standing while
-            plotting your rival's downfall. A game ends when a stronghold
-            crumbles, a ruler can't sustain their realm, or the final round
-            closes with one monarch ahead.
-          </p>
-        </section>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">Turn Flow</h2>
-          <p>Each round flows through three phases:</p>
-          <ul className="list-disc list-inside">
-            <li>
-              <strong>{devIcon} Growth</strong> – your realm produces income and
-              triggered effects fire.
-            </li>
-            <li>
-              <strong>{upkeepIcon} Upkeep</strong> – pay wages and resolve
-              ongoing effects.
-            </li>
-            <li>
-              <strong>{mainIcon} Main</strong> – both players secretly queue
-              actions then reveal them.
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">Resources</h2>
-          <p className="mb-2">Juggle your economy to stay in power:</p>
-          <ul className="list-disc list-inside">
-            <li>
-              {RESOURCES[Resource.gold].icon} <strong>Gold</strong> funds
-              {actionInfo.get('build')?.icon} buildings and schemes.
-            </li>
-            <li>
-              {RESOURCES[Resource.ap].icon} <strong>Action Points</strong> fuel
-              every move in the {mainIcon} Main phase.
-            </li>
-            <li>
-              {RESOURCES[Resource.happiness].icon} <strong>Happiness</strong>
-              keeps the populace smiling (or rioting).
-            </li>
-            <li>
-              {RESOURCES[Resource.castleHP].icon} <strong>Castle HP</strong> is
-              your lifeline—lose it and the crown is gone.
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">
-            Land &amp; Developments
-          </h2>
-          <p>
-            Claim {landIcon} land and fill each {slotIcon} slot with
-            developments. Farms grow {RESOURCES[Resource.gold].icon} gold while
-            other projects unlock more slots or unique perks.
-          </p>
-        </section>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">Population</h2>
-          <p>Raise citizens and train them into specialists:</p>
-          <ul className="list-disc list-inside">
-            <li>
-              {POPULATION_ROLES[PopulationRole.Council].icon} Council – grants
-              extra {RESOURCES[Resource.ap].icon} AP each round.
-            </li>
-            <li>
-              {POPULATION_ROLES[PopulationRole.Commander].icon} Commander –
-              boosts your army for {actionInfo.get('army_attack')?.icon} raids.
-            </li>
-            <li>
-              {POPULATION_ROLES[PopulationRole.Fortifier].icon} Fortifier –
-              reinforces defenses around your castle.
-            </li>
-            <li>
-              {POPULATION_ROLES[PopulationRole.Citizen].icon} Citizens – future
-              specialists awaiting guidance.
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">
-            Actions &amp; Strategy
-          </h2>
-          <p className="mb-4">
-            Spend {RESOURCES[Resource.ap].icon} AP on plays like
-            {actionInfo.get('expand')?.icon} expanding territory,
-            {actionInfo.get('develop')?.icon} developing land,
-            {actionInfo.get('raise_pop')?.icon} raising population, or
-            unleashing
-            {actionInfo.get('army_attack')?.icon} attacks. Mix and match to
-            outwit your foe!
-          </p>
-        </section>
-        <button
-          className="border px-4 py-2 hoverable cursor-pointer"
-          onClick={() => setScreen('menu')}
-        >
-          Back to Start
-        </button>
-      </div>
-    );
+    return <Overview onBack={() => setScreen('menu')} />;
   }
 
   if (screen === 'game') {
@@ -161,26 +35,12 @@ export default function App() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-yellow-100 via-red-100 to-blue-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
-      <div className="flex flex-col gap-4 items-center justify-center p-8 rounded-lg shadow-lg bg-white dark:bg-gray-800">
-        <div className="text-6xl">🏰</div>
-        <h1 className="text-3xl font-bold">Kingdom Builder</h1>
-        <button
-          className="border px-4 py-2 hoverable cursor-pointer"
-          onClick={() => {
-            setGameKey((k) => k + 1);
-            setScreen('game');
-          }}
-        >
-          Start New Game
-        </button>
-        <button
-          className="border px-4 py-2 hoverable cursor-pointer"
-          onClick={() => setScreen('overview')}
-        >
-          Game Overview
-        </button>
-      </div>
-    </div>
+    <Menu
+      onStart={() => {
+        setGameKey((k) => k + 1);
+        setScreen('game');
+      }}
+      onOverview={() => setScreen('overview')}
+    />
   );
 }

--- a/packages/web/src/screens/Game.tsx
+++ b/packages/web/src/screens/Game.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { GameProvider, useGameEngine } from './state/GameContext';
-import PlayerPanel from './components/player/PlayerPanel';
-import HoverCard from './components/HoverCard';
-import ActionsPanel from './components/actions/ActionsPanel';
-import PhasePanel from './components/phases/PhasePanel';
-import LogPanel from './components/LogPanel';
+import { GameProvider, useGameEngine } from '../state/GameContext';
+import PlayerPanel from '../components/player/PlayerPanel';
+import HoverCard from '../components/HoverCard';
+import ActionsPanel from '../components/actions/ActionsPanel';
+import PhasePanel from '../components/phases/PhasePanel';
+import LogPanel from '../components/LogPanel';
 
 function GameLayout() {
   const { ctx, onExit, darkMode, onToggleDark, devMode, onToggleDev } =

--- a/packages/web/src/screens/Menu.tsx
+++ b/packages/web/src/screens/Menu.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface MenuProps {
+  onStart: () => void;
+  onOverview: () => void;
+}
+
+export default function Menu({ onStart, onOverview }: MenuProps) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-yellow-100 via-red-100 to-blue-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
+      <div className="flex flex-col gap-4 items-center justify-center p-8 rounded-lg shadow-lg bg-white dark:bg-gray-800">
+        <div className="text-6xl">🏰</div>
+        <h1 className="text-3xl font-bold">Kingdom Builder</h1>
+        <button
+          className="border px-4 py-2 hoverable cursor-pointer"
+          onClick={onStart}
+        >
+          Start New Game
+        </button>
+        <button
+          className="border px-4 py-2 hoverable cursor-pointer"
+          onClick={onOverview}
+        >
+          Game Overview
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/screens/Overview.tsx
+++ b/packages/web/src/screens/Overview.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import {
+  ACTIONS as actionInfo,
+  LAND_ICON as landIcon,
+  SLOT_ICON as slotIcon,
+  RESOURCES,
+  Resource,
+  PHASES,
+  POPULATION_ROLES,
+  PopulationRole,
+} from '@kingdom-builder/contents';
+
+interface OverviewProps {
+  onBack: () => void;
+}
+
+export default function Overview({ onBack }: OverviewProps) {
+  const growthIcon = PHASES.find((p) => p.id === 'growth')?.icon;
+  const upkeepIcon = PHASES.find((p) => p.id === 'upkeep')?.icon;
+  const mainIcon = PHASES.find((p) => p.id === 'main')?.icon;
+  return (
+    <div className="p-6 max-w-2xl mx-auto space-y-4">
+      <h1 className="text-3xl font-bold text-center mb-4">Game Overview</h1>
+      <p>
+        Welcome to <strong>Kingdom Builder</strong>, a brisk duel of wits where{' '}
+        {actionInfo.get('expand')?.icon} expansion,
+        {actionInfo.get('build')?.icon} clever construction and
+        {actionInfo.get('army_attack')?.icon} daring raids decide who rules the
+        realm.
+      </p>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">
+          Your Objective {RESOURCES[Resource.castleHP].icon}
+        </h2>
+        <p>
+          Keep your {RESOURCES[Resource.castleHP].icon} castle standing while
+          plotting your rival's downfall. A game ends when a stronghold
+          crumbles, a ruler can't sustain their realm, or the final round closes
+          with one monarch ahead.
+        </p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">Turn Flow</h2>
+        <p>Each round flows through three phases:</p>
+        <ul className="list-disc list-inside">
+          <li>
+            <strong>{growthIcon} Growth</strong> – your realm produces income,
+            bolsters offense and defenses, and triggered effects fire.
+          </li>
+          <li>
+            <strong>{upkeepIcon} Upkeep</strong> – pay wages and resolve ongoing
+            effects.
+          </li>
+          <li>
+            <strong>{mainIcon} Main</strong> – both players secretly queue
+            actions then reveal them.
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">Resources</h2>
+        <p className="mb-2">Juggle your economy to stay in power:</p>
+        <ul className="list-disc list-inside">
+          <li>
+            {RESOURCES[Resource.gold].icon} <strong>Gold</strong> funds
+            {actionInfo.get('build')?.icon} buildings and schemes.
+          </li>
+          <li>
+            {RESOURCES[Resource.ap].icon} <strong>Action Points</strong> fuel
+            every move in the {mainIcon} Main phase.
+          </li>
+          <li>
+            {RESOURCES[Resource.happiness].icon} <strong>Happiness</strong>
+            keeps the populace smiling (or rioting).
+          </li>
+          <li>
+            {RESOURCES[Resource.castleHP].icon} <strong>Castle HP</strong> is
+            your lifeline—lose it and the crown is gone.
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">
+          Land &amp; Developments
+        </h2>
+        <p>
+          Claim {landIcon} land and fill each {slotIcon} slot with developments.
+          Farms grow {RESOURCES[Resource.gold].icon} gold while other projects
+          unlock more slots or unique perks.
+        </p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">Population</h2>
+        <p>Raise citizens and train them into specialists:</p>
+        <ul className="list-disc list-inside">
+          <li>
+            {POPULATION_ROLES[PopulationRole.Council].icon} Council – grants
+            extra {RESOURCES[Resource.ap].icon} AP each round.
+          </li>
+          <li>
+            {POPULATION_ROLES[PopulationRole.Commander].icon} Commander – boosts
+            your army for {actionInfo.get('army_attack')?.icon} raids.
+          </li>
+          <li>
+            {POPULATION_ROLES[PopulationRole.Fortifier].icon} Fortifier –
+            reinforces defenses around your castle.
+          </li>
+          <li>
+            {POPULATION_ROLES[PopulationRole.Citizen].icon} Citizens – future
+            specialists awaiting guidance.
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">
+          Actions &amp; Strategy
+        </h2>
+        <p className="mb-4">
+          Spend {RESOURCES[Resource.ap].icon} AP on plays like
+          {actionInfo.get('expand')?.icon} expanding territory,
+          {actionInfo.get('develop')?.icon} developing land,
+          {actionInfo.get('raise_pop')?.icon} raising population, or unleashing
+          {actionInfo.get('army_attack')?.icon} attacks. Mix and match to outwit
+          your foe!
+        </p>
+      </section>
+      <button
+        className="border px-4 py-2 hoverable cursor-pointer"
+        onClick={onBack}
+      >
+        Back to Start
+      </button>
+    </div>
+  );
+}

--- a/packages/web/tests/Game.render.test.tsx
+++ b/packages/web/tests/Game.render.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderToString } from 'react-dom/server';
 import React from 'react';
-import Game from '../src/Game';
+import Game from '../src/screens/Game';
 
 // Render the application with the real engine to ensure that
 // dynamic action effects (e.g. build with "$id") don't crash


### PR DESCRIPTION
## Summary
- extract menu and overview screens from app for cleaner routing
- refresh overview copy to note offense and defense growth during the Growth phase
- extend engine property test timeout to keep CI stable

## Testing
- `npm run test:coverage` *(fails: engine property invariants > pays costs, executes triggers, keeps resources non-negative and preserves snapshots)*

------
https://chatgpt.com/codex/tasks/task_e_68b601ae63f48325bd91f5803737a313