### PR TITLE
Modularize app screens and refresh overview

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,15 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Game from './Game';
-import {
-  ACTIONS as actionInfo,
-  LAND_ICON as landIcon,
-  SLOT_ICON as slotIcon,
-  RESOURCES,
-  Resource,
-  PHASES,
-  POPULATION_ROLES,
-  PopulationRole,
-} from '@kingdom-builder/contents';
+import Menu from './Menu';
+import Overview from './Overview';
 
 type Screen = 'menu' | 'overview' | 'game';
 
@@ -29,124 +21,7 @@ export default function App() {
   }, []);
 
   if (screen === 'overview') {
-    const devIcon = PHASES.find((p) => p.id === 'growth')?.icon;
-    const upkeepIcon = PHASES.find((p) => p.id === 'upkeep')?.icon;
-    const mainIcon = PHASES.find((p) => p.id === 'main')?.icon;
-    return (
-      <div className="p-6 max-w-2xl mx-auto space-y-4">
-        <h1 className="text-3xl font-bold text-center mb-4">Game Overview</h1>
-        <p>
-          Welcome to <strong>Kingdom Builder</strong>, a brisk duel of wits
-          where {actionInfo.get('expand')?.icon} expansion,
-          {actionInfo.get('build')?.icon} clever construction and
-          {actionInfo.get('army_attack')?.icon} daring raids decide who rules
-          the realm.
-        </p>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">
-            Your Objective {RESOURCES[Resource.castleHP].icon}
-          </h2>
-          <p>
-            Keep your {RESOURCES[Resource.castleHP].icon} castle standing while
-            plotting your rival's downfall. A game ends when a stronghold
-            crumbles, a ruler can't sustain their realm, or the final round
-            closes with one monarch ahead.
-          </p>
-        </section>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">Turn Flow</h2>
-          <p>Each round flows through three phases:</p>
-          <ul className="list-disc list-inside">
-            <li>
-              <strong>{devIcon} Growth</strong> – your realm produces income and
-              triggered effects fire.
-            </li>
-            <li>
-              <strong>{upkeepIcon} Upkeep</strong> – pay wages and resolve
-              ongoing effects.
-            </li>
-            <li>
-              <strong>{mainIcon} Main</strong> – both players secretly queue
-              actions then reveal them.
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">Resources</h2>
-          <p className="mb-2">Juggle your economy to stay in power:</p>
-          <ul className="list-disc list-inside">
-            <li>
-              {RESOURCES[Resource.gold].icon} <strong>Gold</strong> funds
-              {actionInfo.get('build')?.icon} buildings and schemes.
-            </li>
-            <li>
-              {RESOURCES[Resource.ap].icon} <strong>Action Points</strong> fuel
-              every move in the {mainIcon} Main phase.
-            </li>
-            <li>
-              {RESOURCES[Resource.happiness].icon} <strong>Happiness</strong>
-              keeps the populace smiling (or rioting).
-            </li>
-            <li>
-              {RESOURCES[Resource.castleHP].icon} <strong>Castle HP</strong> is
-              your lifeline—lose it and the crown is gone.
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">
-            Land &amp; Developments
-          </h2>
-          <p>
-            Claim {landIcon} land and fill each {slotIcon} slot with
-            developments. Farms grow {RESOURCES[Resource.gold].icon} gold while
-            other projects unlock more slots or unique perks.
-          </p>
-        </section>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">Population</h2>
-          <p>Raise citizens and train them into specialists:</p>
-          <ul className="list-disc list-inside">
-            <li>
-              {POPULATION_ROLES[PopulationRole.Council].icon} Council – grants
-              extra {RESOURCES[Resource.ap].icon} AP each round.
-            </li>
-            <li>
-              {POPULATION_ROLES[PopulationRole.Commander].icon} Commander –
-              boosts your army for {actionInfo.get('army_attack')?.icon} raids.
-            </li>
-            <li>
-              {POPULATION_ROLES[PopulationRole.Fortifier].icon} Fortifier –
-              reinforces defenses around your castle.
-            </li>
-            <li>
-              {POPULATION_ROLES[PopulationRole.Citizen].icon} Citizens – future
-              specialists awaiting guidance.
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h2 className="text-xl font-semibold mt-4 mb-2">
-            Actions &amp; Strategy
-          </h2>
-          <p className="mb-4">
-            Spend {RESOURCES[Resource.ap].icon} AP on plays like
-            {actionInfo.get('expand')?.icon} expanding territory,
-            {actionInfo.get('develop')?.icon} developing land,
-            {actionInfo.get('raise_pop')?.icon} raising population, or
-            unleashing
-            {actionInfo.get('army_attack')?.icon} attacks. Mix and match to
-            outwit your foe!
-          </p>
-        </section>
-        <button
-          className="border px-4 py-2 hoverable cursor-pointer"
-          onClick={() => setScreen('menu')}
-        >
-          Back to Start
-        </button>
-      </div>
-    );
+    return <Overview onBack={() => setScreen('menu')} />;
   }
 
   if (screen === 'game') {
@@ -161,26 +36,12 @@ export default function App() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-yellow-100 via-red-100 to-blue-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
-      <div className="flex flex-col gap-4 items-center justify-center p-8 rounded-lg shadow-lg bg-white dark:bg-gray-800">
-        <div className="text-6xl">🏰</div>
-        <h1 className="text-3xl font-bold">Kingdom Builder</h1>
-        <button
-          className="border px-4 py-2 hoverable cursor-pointer"
-          onClick={() => {
-            setGameKey((k) => k + 1);
-            setScreen('game');
-          }}
-        >
-          Start New Game
-        </button>
-        <button
-          className="border px-4 py-2 hoverable cursor-pointer"
-          onClick={() => setScreen('overview')}
-        >
-          Game Overview
-        </button>
-      </div>
-    </div>
+    <Menu
+      onStart={() => {
+        setGameKey((k) => k + 1);
+        setScreen('game');
+      }}
+      onOverview={() => setScreen('overview')}
+    />
   );
 }

--- a/packages/web/src/Menu.tsx
+++ b/packages/web/src/Menu.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface MenuProps {
+  onStart: () => void;
+  onOverview: () => void;
+}
+
+export default function Menu({ onStart, onOverview }: MenuProps) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-yellow-100 via-red-100 to-blue-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
+      <div className="flex flex-col gap-4 items-center justify-center p-8 rounded-lg shadow-lg bg-white dark:bg-gray-800">
+        <div className="text-6xl">🏰</div>
+        <h1 className="text-3xl font-bold">Kingdom Builder</h1>
+        <button
+          className="border px-4 py-2 hoverable cursor-pointer"
+          onClick={onStart}
+        >
+          Start New Game
+        </button>
+        <button
+          className="border px-4 py-2 hoverable cursor-pointer"
+          onClick={onOverview}
+        >
+          Game Overview
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/Overview.tsx
+++ b/packages/web/src/Overview.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import {
+  ACTIONS as actionInfo,
+  LAND_ICON as landIcon,
+  SLOT_ICON as slotIcon,
+  RESOURCES,
+  Resource,
+  PHASES,
+  POPULATION_ROLES,
+  PopulationRole,
+  STATS,
+  Stat,
+} from '@kingdom-builder/contents';
+
+interface OverviewProps {
+  onBack: () => void;
+}
+
+export default function Overview({ onBack }: OverviewProps) {
+  const icons = {
+    expand: actionInfo.get('expand')?.icon,
+    build: actionInfo.get('build')?.icon,
+    attack: actionInfo.get('army_attack')?.icon,
+    develop: actionInfo.get('develop')?.icon,
+    raisePop: actionInfo.get('raise_pop')?.icon,
+    growth: PHASES.find((p) => p.id === 'growth')?.icon,
+    upkeep: PHASES.find((p) => p.id === 'upkeep')?.icon,
+    main: PHASES.find((p) => p.id === 'main')?.icon,
+    land: landIcon,
+    slot: slotIcon,
+    gold: RESOURCES[Resource.gold].icon,
+    ap: RESOURCES[Resource.ap].icon,
+    happiness: RESOURCES[Resource.happiness].icon,
+    castle: RESOURCES[Resource.castleHP].icon,
+    army: STATS[Stat.armyStrength].icon,
+    fort: STATS[Stat.fortificationStrength].icon,
+  };
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto space-y-4">
+      <h1 className="text-3xl font-bold text-center mb-4">Game Overview</h1>
+      <p>
+        Welcome to <strong>Kingdom Builder</strong>, a brisk duel of wits where
+        {icons.expand} expansion, {icons.build} clever construction and
+        {icons.attack} daring raids decide who rules the realm.
+      </p>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">
+          Your Objective {icons.castle}
+        </h2>
+        <p>
+          Keep your {icons.castle} castle standing while plotting your rival's
+          downfall. A game ends when a stronghold crumbles, a ruler can't
+          sustain their realm, or the final round closes with one monarch ahead.
+        </p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">Turn Flow</h2>
+        <p>Each round flows through three phases:</p>
+        <ul className="list-disc list-inside">
+          <li>
+            <strong>{icons.growth} Growth</strong> – your realm produces income,
+            raises {icons.army} Army and {icons.fort} Fortification Strength,
+            and triggered effects fire.
+          </li>
+          <li>
+            <strong>{icons.upkeep} Upkeep</strong> – pay wages and resolve
+            ongoing effects.
+          </li>
+          <li>
+            <strong>{icons.main} Main</strong> – both players secretly queue
+            actions then reveal them.
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">Resources</h2>
+        <p className="mb-2">Juggle your economy to stay in power:</p>
+        <ul className="list-disc list-inside">
+          <li>
+            {icons.gold} <strong>Gold</strong> funds {icons.build} buildings and
+            schemes.
+          </li>
+          <li>
+            {icons.ap} <strong>Action Points</strong> fuel every move in the
+            {icons.main} Main phase.
+          </li>
+          <li>
+            {icons.happiness} <strong>Happiness</strong> keeps the populace
+            smiling (or rioting).
+          </li>
+          <li>
+            {icons.castle} <strong>Castle HP</strong> is your lifeline—lose it
+            and the crown is gone.
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">
+          Land &amp; Developments
+        </h2>
+        <p>
+          Claim {icons.land} land and fill each {icons.slot} slot with
+          developments. Farms grow {icons.gold} gold while other projects unlock
+          more slots or unique perks.
+        </p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">Population</h2>
+        <p>Raise citizens and train them into specialists:</p>
+        <ul className="list-disc list-inside">
+          <li>
+            {POPULATION_ROLES[PopulationRole.Council].icon} Council – grants
+            extra {icons.ap} AP each round.
+          </li>
+          <li>
+            {POPULATION_ROLES[PopulationRole.Commander].icon} Commander – boosts
+            your army for {icons.attack} raids.
+          </li>
+          <li>
+            {POPULATION_ROLES[PopulationRole.Fortifier].icon} Fortifier –
+            reinforces defenses around your castle.
+          </li>
+          <li>
+            {POPULATION_ROLES[PopulationRole.Citizen].icon} Citizens – future
+            specialists awaiting guidance.
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mt-4 mb-2">
+          Actions &amp; Strategy
+        </h2>
+        <p className="mb-4">
+          Spend {icons.ap} AP on plays like {icons.expand} expanding territory,
+          {icons.develop} developing land, {icons.raisePop} raising population,
+          or unleashing {icons.attack} attacks. Mix and match to outwit your
+          foe!
+        </p>
+      </section>
+      <button
+        className="border px-4 py-2 hoverable cursor-pointer"
+        onClick={onBack}
+      >
+        Back to Start
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Move menu and overview screens into their own components
- Simplify App screen switching
- Update overview to mention Growth raising Army and Fortification Strength

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b610dfcfa48325ab9ab905e1a22101