### PR TITLE
Add dev-mode start button and move devMode into GameState

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -269,6 +269,7 @@ export function createEngine({
   start,
   rules,
   config,
+  devMode = false,
 }: {
   actions: Registry<ActionDef>;
   buildings: Registry<BuildingDef>;
@@ -278,6 +279,7 @@ export function createEngine({
   start: StartConfig;
   rules: RuleSet;
   config?: GameConfig;
+  devMode?: boolean;
 }) {
   registerCoreEffects();
   registerCoreEvaluators();
@@ -318,7 +320,7 @@ export function createEngine({
 
   const services = new Services(rules, developments);
   const passives = new PassiveManager();
-  const game = new GameState('Player A', 'Player B');
+  const game = new GameState('Player A', 'Player B', devMode);
 
   let actionCostResource: ResourceKey = '' as ResourceKey;
   let intersect: string[] | null = null;

--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -107,8 +107,10 @@ export class GameState {
   phaseIndex = 0;
   stepIndex = 0;
   players: PlayerState[];
-  constructor(aName = 'Player A', bName = 'Player B') {
+  devMode: boolean;
+  constructor(aName = 'Player A', bName = 'Player B', devMode = false) {
     this.players = [new PlayerState('A', aName), new PlayerState('B', bName)];
+    this.devMode = devMode;
   }
   get active(): PlayerState {
     return this.players[this.currentPlayerIndex]!;

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -17,6 +17,7 @@ export default function App() {
   const [screen, setScreen] = useState<Screen>('menu');
   const [gameKey, setGameKey] = useState(0);
   const [darkMode, setDarkMode] = useState(true);
+  const [devMode, setDevMode] = useState(false);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', darkMode);
@@ -156,6 +157,7 @@ export default function App() {
         onExit={() => setScreen('menu')}
         darkMode={darkMode}
         onToggleDark={() => setDarkMode((d) => !d)}
+        devMode={devMode}
       />
     );
   }
@@ -169,10 +171,21 @@ export default function App() {
           className="border px-4 py-2 hoverable cursor-pointer"
           onClick={() => {
             setGameKey((k) => k + 1);
+            setDevMode(false);
             setScreen('game');
           }}
         >
           Start New Game
+        </button>
+        <button
+          className="border px-4 py-2 hoverable cursor-pointer"
+          onClick={() => {
+            setGameKey((k) => k + 1);
+            setDevMode(true);
+            setScreen('game');
+          }}
+        >
+          Start Dev/Debug Game
         </button>
         <button
           className="border px-4 py-2 hoverable cursor-pointer"

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -8,8 +8,7 @@ import LogPanel from './components/LogPanel';
 import Button from './components/common/Button';
 
 function GameLayout() {
-  const { ctx, onExit, darkMode, onToggleDark, devMode, onToggleDev } =
-    useGameEngine();
+  const { ctx, onExit, darkMode, onToggleDark } = useGameEngine();
   return (
     <div className="p-4 w-full bg-slate-100 text-gray-900 dark:bg-slate-900 dark:text-gray-100 min-h-screen">
       <div className="flex items-center justify-between mb-6">
@@ -18,12 +17,6 @@ function GameLayout() {
         </h1>
         {onExit && (
           <div className="flex items-center gap-2 ml-4">
-            <Button
-              onClick={onToggleDev}
-              variant={devMode ? 'success' : 'secondary'}
-            >
-              {`Dev Mode${devMode ? ': On' : ': Off'}`}
-            </Button>
             <Button onClick={onToggleDark} variant="secondary">
               {darkMode ? 'Light Mode' : 'Dark Mode'}
             </Button>
@@ -77,16 +70,19 @@ export default function Game({
   onExit,
   darkMode = true,
   onToggleDark = () => {},
+  devMode = false,
 }: {
   onExit?: () => void;
   darkMode?: boolean;
   onToggleDark?: () => void;
+  devMode?: boolean;
 }) {
   return (
     <GameProvider
       {...(onExit ? { onExit } : {})}
       darkMode={darkMode}
       onToggleDark={onToggleDark}
+      devMode={devMode}
     >
       <GameLayout />
     </GameProvider>

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -99,7 +99,6 @@ interface GameEngineContextValue {
   darkMode: boolean;
   onToggleDark: () => void;
   devMode: boolean;
-  onToggleDev: () => void;
 }
 
 const GameEngineContext = createContext<GameEngineContextValue | null>(null);
@@ -109,11 +108,13 @@ export function GameProvider({
   onExit,
   darkMode = true,
   onToggleDark = () => {},
+  devMode = false,
 }: {
   children: React.ReactNode;
   onExit?: () => void;
   darkMode?: boolean;
   onToggleDark?: () => void;
+  devMode?: boolean;
 }) {
   const ctx = useMemo<EngineContext>(
     () =>
@@ -125,8 +126,9 @@ export function GameProvider({
         phases: PHASES,
         start: GAME_START,
         rules: RULES,
+        devMode,
       }),
-    [],
+    [devMode],
   );
   const [, setTick] = useState(0);
   const refresh = () => setTick((t) => t + 1);
@@ -139,8 +141,7 @@ export function GameProvider({
   const [phaseTimer, setPhaseTimer] = useState(0);
   const [phasePaused, setPhasePaused] = useState(false);
   const phasePausedRef = useRef(false);
-  const [devMode, setDevMode] = useState(true);
-  const onToggleDev = () => setDevMode((d) => !d);
+  const devModeValue = ctx.game.devMode;
   const [mainApStart, setMainApStart] = useState(0);
   const [displayPhase, setDisplayPhase] = useState(ctx.game.currentPhase);
   const [phaseHistories, setPhaseHistories] = useState<
@@ -254,7 +255,7 @@ export function GameProvider({
   }
 
   function runDelay(total: number) {
-    const speed = devMode ? 0.01 : 1;
+    const speed = devModeValue ? 0.01 : 1;
     const adjustedTotal = total * speed;
     const step = 100 * speed;
     setPhaseTimer(0);
@@ -477,12 +478,12 @@ export function GameProvider({
   }, []);
 
   useEffect(() => {
-    if (!devMode) return;
+    if (!devModeValue) return;
     const phaseDef = ctx.phases[ctx.game.phaseIndex];
     if (!phaseDef?.action) return;
     DEV_AUTOMATIONS[ctx.activePlayer.id]?.run(ctx, enqueue);
   }, [
-    devMode,
+    devModeValue,
     ctx.game.phaseIndex,
     ctx.activePlayer.id,
     ctx.activePlayer.resources[actionCostResource],
@@ -511,8 +512,7 @@ export function GameProvider({
     updateMainPhaseStep,
     darkMode,
     onToggleDark,
-    devMode,
-    onToggleDev,
+    devMode: devModeValue,
     ...(onExit ? { onExit } : {}),
   };
 


### PR DESCRIPTION
## Summary
- add "Start Dev/Debug Game" option on main menu
- remove in-game dev toggle and read devMode from GameState
- allow `createEngine` to initialize GameState with devMode flag

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b610d969b8832592e8a7aa2aae8685