### PR TITLE
feat: add dev mode start option

### DIFF
--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -106,6 +106,7 @@ export class GameState {
   currentStep = '';
   phaseIndex = 0;
   stepIndex = 0;
+  devMode = false;
   players: PlayerState[];
   constructor(aName = 'Player A', bName = 'Player B') {
     this.players = [new PlayerState('A', aName), new PlayerState('B', bName)];

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -9,6 +9,7 @@ export default function App() {
   const [screen, setScreen] = useState<Screen>('menu');
   const [gameKey, setGameKey] = useState(0);
   const [darkMode, setDarkMode] = useState(true);
+  const [devMode, setDevMode] = useState(false);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', darkMode);
@@ -31,6 +32,7 @@ export default function App() {
         onExit={() => setScreen('menu')}
         darkMode={darkMode}
         onToggleDark={() => setDarkMode((d) => !d)}
+        devMode={devMode}
       />
     );
   }
@@ -38,6 +40,12 @@ export default function App() {
   return (
     <Menu
       onStart={() => {
+        setDevMode(false);
+        setGameKey((k) => k + 1);
+        setScreen('game');
+      }}
+      onStartDev={() => {
+        setDevMode(true);
         setGameKey((k) => k + 1);
         setScreen('game');
       }}

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -8,8 +8,7 @@ import LogPanel from './components/LogPanel';
 import Button from './components/common/Button';
 
 function GameLayout() {
-  const { ctx, onExit, darkMode, onToggleDark, devMode, onToggleDev } =
-    useGameEngine();
+  const { ctx, onExit, darkMode, onToggleDark } = useGameEngine();
   return (
     <div className="p-4 w-full bg-slate-100 text-gray-900 dark:bg-slate-900 dark:text-gray-100 min-h-screen">
       <div className="flex items-center justify-between mb-6">
@@ -18,12 +17,6 @@ function GameLayout() {
         </h1>
         {onExit && (
           <div className="flex items-center gap-2 ml-4">
-            <Button
-              onClick={onToggleDev}
-              variant={devMode ? 'success' : 'secondary'}
-            >
-              {`Dev Mode${devMode ? ': On' : ': Off'}`}
-            </Button>
             <Button onClick={onToggleDark} variant="secondary">
               {darkMode ? 'Light Mode' : 'Dark Mode'}
             </Button>
@@ -77,16 +70,19 @@ export default function Game({
   onExit,
   darkMode = true,
   onToggleDark = () => {},
+  devMode = false,
 }: {
   onExit?: () => void;
   darkMode?: boolean;
   onToggleDark?: () => void;
+  devMode?: boolean;
 }) {
   return (
     <GameProvider
       {...(onExit ? { onExit } : {})}
       darkMode={darkMode}
       onToggleDark={onToggleDark}
+      devMode={devMode}
     >
       <GameLayout />
     </GameProvider>

--- a/packages/web/src/Menu.tsx
+++ b/packages/web/src/Menu.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 
 interface MenuProps {
   onStart: () => void;
+  onStartDev: () => void;
   onOverview: () => void;
 }
 
-export default function Menu({ onStart, onOverview }: MenuProps) {
+export default function Menu({ onStart, onStartDev, onOverview }: MenuProps) {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-yellow-100 via-red-100 to-blue-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
       <div className="flex flex-col gap-4 items-center justify-center p-8 rounded-lg shadow-lg bg-white dark:bg-gray-800">
@@ -16,6 +17,12 @@ export default function Menu({ onStart, onOverview }: MenuProps) {
           onClick={onStart}
         >
           Start New Game
+        </button>
+        <button
+          className="border px-4 py-2 hoverable cursor-pointer"
+          onClick={onStartDev}
+        >
+          Start Dev/Debug Game
         </button>
         <button
           className="border px-4 py-2 hoverable cursor-pointer"

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -98,8 +98,6 @@ interface GameEngineContextValue {
   onExit?: () => void;
   darkMode: boolean;
   onToggleDark: () => void;
-  devMode: boolean;
-  onToggleDev: () => void;
 }
 
 const GameEngineContext = createContext<GameEngineContextValue | null>(null);
@@ -109,25 +107,27 @@ export function GameProvider({
   onExit,
   darkMode = true,
   onToggleDark = () => {},
+  devMode = false,
 }: {
   children: React.ReactNode;
   onExit?: () => void;
   darkMode?: boolean;
   onToggleDark?: () => void;
+  devMode?: boolean;
 }) {
-  const ctx = useMemo<EngineContext>(
-    () =>
-      createEngine({
-        actions: ACTIONS,
-        buildings: BUILDINGS,
-        developments: DEVELOPMENTS,
-        populations: POPULATIONS,
-        phases: PHASES,
-        start: GAME_START,
-        rules: RULES,
-      }),
-    [],
-  );
+  const ctx = useMemo<EngineContext>(() => {
+    const engine = createEngine({
+      actions: ACTIONS,
+      buildings: BUILDINGS,
+      developments: DEVELOPMENTS,
+      populations: POPULATIONS,
+      phases: PHASES,
+      start: GAME_START,
+      rules: RULES,
+    });
+    engine.game.devMode = devMode;
+    return engine;
+  }, [devMode]);
   const [, setTick] = useState(0);
   const refresh = () => setTick((t) => t + 1);
 
@@ -139,8 +139,6 @@ export function GameProvider({
   const [phaseTimer, setPhaseTimer] = useState(0);
   const [phasePaused, setPhasePaused] = useState(false);
   const phasePausedRef = useRef(false);
-  const [devMode, setDevMode] = useState(true);
-  const onToggleDev = () => setDevMode((d) => !d);
   const [mainApStart, setMainApStart] = useState(0);
   const [displayPhase, setDisplayPhase] = useState(ctx.game.currentPhase);
   const [phaseHistories, setPhaseHistories] = useState<
@@ -254,7 +252,7 @@ export function GameProvider({
   }
 
   function runDelay(total: number) {
-    const speed = devMode ? 0.01 : 1;
+    const speed = ctx.game.devMode ? 0.01 : 1;
     const adjustedTotal = total * speed;
     const step = 100 * speed;
     setPhaseTimer(0);
@@ -477,12 +475,12 @@ export function GameProvider({
   }, []);
 
   useEffect(() => {
-    if (!devMode) return;
+    if (!ctx.game.devMode) return;
     const phaseDef = ctx.phases[ctx.game.phaseIndex];
     if (!phaseDef?.action) return;
     DEV_AUTOMATIONS[ctx.activePlayer.id]?.run(ctx, enqueue);
   }, [
-    devMode,
+    ctx.game.devMode,
     ctx.game.phaseIndex,
     ctx.activePlayer.id,
     ctx.activePlayer.resources[actionCostResource],
@@ -511,8 +509,6 @@ export function GameProvider({
     updateMainPhaseStep,
     darkMode,
     onToggleDark,
-    devMode,
-    onToggleDev,
     ...(onExit ? { onExit } : {}),
   };
 

--- a/packages/web/tests/App.test.tsx
+++ b/packages/web/tests/App.test.tsx
@@ -55,5 +55,6 @@ describe('<App />', () => {
     const html = renderToString(<App />);
     expect(html).toContain('Kingdom Builder');
     expect(html).toContain('Start New Game');
+    expect(html).toContain('Start Dev/Debug Game');
   });
 });


### PR DESCRIPTION
## Summary
- add `devMode` flag to game state
- remove runtime dev toggle and drive automation from start menu
- expose dev/debug start option in UI and tests

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b613861d348325ad26b4c6cccaa4cb