### PR TITLE
feat(web): add tutorial option to menu

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -42,6 +42,7 @@ export default function App() {
         setScreen('game');
       }}
       onOverview={() => setScreen('overview')}
+      onTutorial={() => console.log('tutorial')}
     />
   );
 }

--- a/packages/web/src/Menu.tsx
+++ b/packages/web/src/Menu.tsx
@@ -3,9 +3,10 @@ import React from 'react';
 interface MenuProps {
   onStart: () => void;
   onOverview: () => void;
+  onTutorial: () => void;
 }
 
-export default function Menu({ onStart, onOverview }: MenuProps) {
+export default function Menu({ onStart, onOverview, onTutorial }: MenuProps) {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-yellow-100 via-red-100 to-blue-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
       <div className="flex flex-col gap-4 items-center justify-center p-8 rounded-lg shadow-lg bg-white dark:bg-gray-800">
@@ -16,6 +17,12 @@ export default function Menu({ onStart, onOverview }: MenuProps) {
           onClick={onStart}
         >
           Start New Game
+        </button>
+        <button
+          className="border px-4 py-2 hoverable cursor-pointer"
+          onClick={onTutorial}
+        >
+          Tutorial
         </button>
         <button
           className="border px-4 py-2 hoverable cursor-pointer"


### PR DESCRIPTION
## Summary
- add `onTutorial` prop to Menu and render button
- wire up `onTutorial` handler in App

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b6181e9ddc832598143e5895673c4a