### PR TITLE
feat(web): add tutorial button

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -50,6 +50,11 @@ export default function App() {
         setScreen('game');
       }}
       onOverview={() => setScreen('overview')}
+      onTutorial={() => {
+        setDevMode(false);
+        setGameKey((k) => k + 1);
+        setScreen('game');
+      }}
     />
   );
 }

--- a/packages/web/src/Menu.tsx
+++ b/packages/web/src/Menu.tsx
@@ -4,9 +4,15 @@ interface MenuProps {
   onStart: () => void;
   onStartDev: () => void;
   onOverview: () => void;
+  onTutorial: () => void;
 }
 
-export default function Menu({ onStart, onStartDev, onOverview }: MenuProps) {
+export default function Menu({
+  onStart,
+  onStartDev,
+  onOverview,
+  onTutorial,
+}: MenuProps) {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-yellow-100 via-red-100 to-blue-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
       <div className="flex flex-col gap-4 items-center justify-center p-8 rounded-lg shadow-lg bg-white dark:bg-gray-800">
@@ -23,6 +29,12 @@ export default function Menu({ onStart, onStartDev, onOverview }: MenuProps) {
           onClick={onStartDev}
         >
           Start Dev/Debug Game
+        </button>
+        <button
+          className="border px-4 py-2 hoverable cursor-pointer"
+          onClick={onTutorial}
+        >
+          Tutorial
         </button>
         <button
           className="border px-4 py-2 hoverable cursor-pointer"


### PR DESCRIPTION
## Summary
- expose `onTutorial` callback in `Menu` and render Tutorial button
- wire `onTutorial` handler in `App`

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 80 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b61a0680548325af759c532b648930