### PR TITLE
feat(web): add tutorial screen and component

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2,11 +2,17 @@ import React, { useState, useEffect } from 'react';
 import Game from './Game';
 import Menu from './Menu';
 import Overview from './Overview';
+import Tutorial from './Tutorial';
 
-type Screen = 'menu' | 'overview' | 'game';
+enum Screen {
+  Menu = 'menu',
+  Overview = 'overview',
+  Tutorial = 'tutorial',
+  Game = 'game',
+}
 
 export default function App() {
-  const [screen, setScreen] = useState<Screen>('menu');
+  const [screen, setScreen] = useState<Screen>(Screen.Menu);
   const [gameKey, setGameKey] = useState(0);
   const [darkMode, setDarkMode] = useState(true);
   const [devMode, setDevMode] = useState(false);
@@ -21,40 +27,38 @@ export default function App() {
     }
   }, []);
 
-  if (screen === 'overview') {
-    return <Overview onBack={() => setScreen('menu')} />;
+  switch (screen) {
+    case Screen.Overview:
+      return <Overview onBack={() => setScreen(Screen.Menu)} />;
+    case Screen.Tutorial:
+      return <Tutorial onBack={() => setScreen(Screen.Menu)} />;
+    case Screen.Game:
+      return (
+        <Game
+          key={gameKey}
+          onExit={() => setScreen(Screen.Menu)}
+          darkMode={darkMode}
+          onToggleDark={() => setDarkMode((d) => !d)}
+          devMode={devMode}
+        />
+      );
+    case Screen.Menu:
+    default:
+      return (
+        <Menu
+          onStart={() => {
+            setDevMode(false);
+            setGameKey((k) => k + 1);
+            setScreen(Screen.Game);
+          }}
+          onStartDev={() => {
+            setDevMode(true);
+            setGameKey((k) => k + 1);
+            setScreen(Screen.Game);
+          }}
+          onOverview={() => setScreen(Screen.Overview)}
+          onTutorial={() => setScreen(Screen.Tutorial)}
+        />
+      );
   }
-
-  if (screen === 'game') {
-    return (
-      <Game
-        key={gameKey}
-        onExit={() => setScreen('menu')}
-        darkMode={darkMode}
-        onToggleDark={() => setDarkMode((d) => !d)}
-        devMode={devMode}
-      />
-    );
-  }
-
-  return (
-    <Menu
-      onStart={() => {
-        setDevMode(false);
-        setGameKey((k) => k + 1);
-        setScreen('game');
-      }}
-      onStartDev={() => {
-        setDevMode(true);
-        setGameKey((k) => k + 1);
-        setScreen('game');
-      }}
-      onOverview={() => setScreen('overview')}
-      onTutorial={() => {
-        setDevMode(false);
-        setGameKey((k) => k + 1);
-        setScreen('game');
-      }}
-    />
-  );
 }

--- a/packages/web/src/Tutorial.tsx
+++ b/packages/web/src/Tutorial.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface TutorialProps {
+  onBack: () => void;
+}
+
+export default function Tutorial({ onBack }: TutorialProps) {
+  return (
+    <div className="p-6 max-w-2xl mx-auto space-y-4">
+      <h1 className="text-3xl font-bold text-center mb-4">Tutorial</h1>
+      <p>
+        Learn the basics of <strong>Kingdom Builder</strong> and explore how to
+        grow your realm. More guided steps will be added soon.
+      </p>
+      <button
+        className="border px-4 py-2 hoverable cursor-pointer"
+        onClick={onBack}
+      >
+        Back to Start
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend main app with `tutorial` screen state and menu hook
- introduce basic `Tutorial` component rendered when `tutorial` screen is active
- centralize screen constants via `Screen` enum and switch-case render

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b61bc8f33483258ec547e22f96739a