### PR TITLE
feat: highlight active player

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -44,7 +44,8 @@ function GameLayout() {
                 <PlayerPanel
                   key={p.id}
                   player={p}
-                  className={`flex-1 p-4 ${bgClass} ${isActive ? 'active-player-glow' : ''}`}
+                  className={`flex-1 p-4 ${bgClass}`}
+                  isActive={isActive}
                 />
               );
             })}

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -44,7 +44,7 @@ function GameLayout() {
                 <PlayerPanel
                   key={p.id}
                   player={p}
-                  className={`flex-1 p-4 ${bgClass}`}
+                  className={`flex-1 p-4 ${bgClass} ${isActive ? 'active-player-glow' : ''}`}
                 />
               );
             })}

--- a/packages/web/src/components/player/PlayerPanel.tsx
+++ b/packages/web/src/components/player/PlayerPanel.tsx
@@ -10,17 +10,26 @@ import { useAnimate } from '../../utils/useAutoAnimate';
 interface PlayerPanelProps {
   player: EngineContext['activePlayer'];
   className?: string;
+  isActive?: boolean;
 }
 
 const PlayerPanel: React.FC<PlayerPanelProps> = ({
   player,
   className = '',
+  isActive = false,
 }) => {
   const animateBar = useAnimate<HTMLDivElement>();
   const animateSections = useAnimate<HTMLDivElement>();
   return (
     <div className={`player-panel h-full flex flex-col space-y-1 ${className}`}>
-      <h3 className="font-semibold">{player.name}</h3>
+      <h3 className="font-semibold">
+        {isActive && (
+          <span role="img" aria-label="active player" className="mr-1">
+            👑
+          </span>
+        )}
+        {player.name}
+      </h3>
       <div
         ref={animateBar}
         className="panel-card flex flex-wrap items-center gap-2 px-3 py-2 w-fit"

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -15,17 +15,6 @@
   }
 }
 
-@keyframes active-player-glow {
-  0%, 100% {
-    outline-color: rgba(250, 204, 21, 0.6);
-    outline-offset: 0;
-  }
-  50% {
-    outline-color: rgba(250, 204, 21, 0.9);
-    outline-offset: 2px;
-  }
-}
-
 @layer components {
   .bar-item {
     @apply flex items-center gap-1 tabular-nums whitespace-nowrap appearance-none bg-transparent border-0 p-0;
@@ -38,11 +27,6 @@
   }
   .player-panel .panel-card {
     @apply bg-gray-50/40 dark:bg-gray-700/40;
-  }
-  .active-player-glow {
-    outline: 2px solid rgba(250, 204, 21, 0.6);
-    border-radius: 0.375rem;
-    animation: active-player-glow 1s ease-in-out infinite;
   }
   .player-bg {
     @apply relative overflow-hidden text-gray-900 dark:text-white;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -15,6 +15,17 @@
   }
 }
 
+@keyframes active-player-glow {
+  0%, 100% {
+    outline-color: rgba(250, 204, 21, 0.6);
+    outline-offset: 0;
+  }
+  50% {
+    outline-color: rgba(250, 204, 21, 0.9);
+    outline-offset: 2px;
+  }
+}
+
 @layer components {
   .bar-item {
     @apply flex items-center gap-1 tabular-nums whitespace-nowrap appearance-none bg-transparent border-0 p-0;
@@ -27,6 +38,11 @@
   }
   .player-panel .panel-card {
     @apply bg-gray-50/40 dark:bg-gray-700/40;
+  }
+  .active-player-glow {
+    outline: 2px solid rgba(250, 204, 21, 0.6);
+    border-radius: 0.375rem;
+    animation: active-player-glow 1s ease-in-out infinite;
   }
   .player-bg {
     @apply relative overflow-hidden text-gray-900 dark:text-white;


### PR DESCRIPTION
## Summary
- add `active-player-glow` class to emphasize active player's panel
- animate player panel outline to glow using CSS keyframes

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b71fe1782c8325996f7db30c0517ce