### PR TITLE
Improve log panel readability and highlighting

### DIFF
--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -30,12 +30,21 @@ export default function LogPanel() {
               : entry.playerId === bId
                 ? 'log-entry-b'
                 : '';
+          const isLast = idx === entries.length - 1;
           return (
             <li
               key={idx}
-              className={`text-xs font-mono whitespace-pre-wrap ${colorClass}`}
+              className={`flex items-start gap-2 text-sm whitespace-pre-wrap ${colorClass} ${
+                isLast
+                  ? 'font-semibold bg-black/5 dark:bg-white/10 rounded'
+                  : ''
+              }`}
             >
-              [{entry.time}] {entry.text}
+              <span className="w-2 h-2 rounded-full bg-current mt-1 flex-shrink-0" />
+              <span>
+                <span className="font-mono tabular-nums">[{entry.time}]</span>{' '}
+                {entry.text}
+              </span>
             </li>
           );
         })}


### PR DESCRIPTION
## Summary
- Show player-colored badges for each log entry
- Use `text-sm` with monospace timestamps
- Highlight the latest log entry for quick scanning

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b71ff631208325a9cfb34efd593e03