### PR TITLE
refactor: grid-based land display

### DIFF
--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -80,7 +80,7 @@ const LandTile: React.FC<{
           return (
             <span
               key={i}
-              className="land-slot flex items-center justify-center"
+              className="land-slot italic"
               onMouseEnter={(e) => {
                 e.stopPropagation();
                 handleHoverCard({
@@ -98,7 +98,7 @@ const LandTile: React.FC<{
                 handleLeave();
               }}
             >
-              +
+              {slotIcon} -empty-
             </span>
           );
         })}
@@ -128,7 +128,7 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
   return (
     <div
       ref={animateLands}
-      className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2 w-fit"
+      className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2 mt-2 w-fit"
     >
       {player.lands.map((land) => (
         <LandTile

--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -34,7 +34,7 @@ const LandTile: React.FC<{
   const animateSlots = useAnimate<HTMLDivElement>();
   return (
     <div
-      className="relative panel-card p-2 text-center hoverable cursor-help"
+      className="land-tile"
       onMouseEnter={showLandCard}
       onMouseLeave={clearHoverCard}
     >
@@ -52,7 +52,7 @@ const LandTile: React.FC<{
             return (
               <span
                 key={i}
-                className="panel-card p-1 text-xs hoverable cursor-help"
+                className="land-slot"
                 onMouseEnter={(e) => {
                   e.stopPropagation();
                   const full = describeContent('development', devId, ctx, {
@@ -80,7 +80,7 @@ const LandTile: React.FC<{
           return (
             <span
               key={i}
-              className="panel-card p-1 text-xs hoverable cursor-help italic"
+              className="land-slot flex items-center justify-center"
               onMouseEnter={(e) => {
                 e.stopPropagation();
                 handleHoverCard({
@@ -98,7 +98,7 @@ const LandTile: React.FC<{
                 handleLeave();
               }}
             >
-              {slotIcon} -empty-
+              +
             </span>
           );
         })}
@@ -126,7 +126,10 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
   if (player.lands.length === 0) return null;
   const animateLands = useAnimate<HTMLDivElement>();
   return (
-    <div ref={animateLands} className="flex flex-wrap gap-2 mt-2 w-fit">
+    <div
+      ref={animateLands}
+      className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2 w-fit"
+    >
       {player.lands.map((land) => (
         <LandTile
           key={land.id}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -32,7 +32,7 @@
     @apply relative panel-card border border-black/10 dark:border-white/10 p-2 text-center hoverable cursor-help;
   }
   .land-slot {
-    @apply panel-card border border-black/10 dark:border-white/10 p-1 text-xs hoverable cursor-help;
+    @apply panel-card border border-black/10 dark:border-white/10 p-1 text-xs hoverable cursor-help inline-flex items-center justify-center gap-1 whitespace-nowrap shrink-0;
   }
   .player-bg {
     @apply relative overflow-hidden text-gray-900 dark:text-white;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -28,6 +28,12 @@
   .player-panel .panel-card {
     @apply bg-gray-50/40 dark:bg-gray-700/40;
   }
+  .land-tile {
+    @apply relative panel-card border border-black/10 dark:border-white/10 p-2 text-center hoverable cursor-help;
+  }
+  .land-slot {
+    @apply panel-card border border-black/10 dark:border-white/10 p-1 text-xs hoverable cursor-help;
+  }
   .player-bg {
     @apply relative overflow-hidden text-gray-900 dark:text-white;
     --stripe-color: rgba(0, 0, 0, 0.03);


### PR DESCRIPTION
## Summary
- align land tiles with CSS grid
- add reusable land-tile and land-slot styles with borders
- show centered plus icon for empty development slots

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b71fff362883259dd762bbc599e37e