### PR TITLE
feat(web): add in-game help modal

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -6,25 +6,39 @@ import ActionsPanel from './components/actions/ActionsPanel';
 import PhasePanel from './components/phases/PhasePanel';
 import LogPanel from './components/LogPanel';
 import Button from './components/common/Button';
+import Tooltip from './components/common/Tooltip';
+import HelpModal from './components/HelpModal';
 
 function GameLayout() {
   const { ctx, onExit, darkMode, onToggleDark } = useGameEngine();
+  const [helpOpen, setHelpOpen] = React.useState(false);
   return (
     <div className="p-4 w-full bg-slate-100 text-gray-900 dark:bg-slate-900 dark:text-gray-100 min-h-screen">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-center flex-1">
           Kingdom Builder
         </h1>
-        {onExit && (
-          <div className="flex items-center gap-2 ml-4">
-            <Button onClick={onToggleDark} variant="secondary">
-              {darkMode ? 'Light Mode' : 'Dark Mode'}
+        <div className="flex items-center gap-2 ml-4">
+          <Tooltip content="Game overview">
+            <Button
+              variant="ghost"
+              onClick={() => setHelpOpen(true)}
+              aria-label="Show help"
+            >
+              ?
             </Button>
-            <Button onClick={onExit} variant="danger">
-              Quit
-            </Button>
-          </div>
-        )}
+          </Tooltip>
+          {onExit && (
+            <>
+              <Button onClick={onToggleDark} variant="secondary">
+                {darkMode ? 'Light Mode' : 'Dark Mode'}
+              </Button>
+              <Button onClick={onExit} variant="danger">
+                Quit
+              </Button>
+            </>
+          )}
+        </div>
       </div>
 
       <div className="grid gap-x-4 gap-y-6 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_30rem]">
@@ -61,6 +75,7 @@ function GameLayout() {
           <HoverCard />
         </div>
       </div>
+      <HelpModal open={helpOpen} onClose={() => setHelpOpen(false)} />
     </div>
   );
 }

--- a/packages/web/src/Overview.tsx
+++ b/packages/web/src/Overview.tsx
@@ -16,7 +16,7 @@ interface OverviewProps {
   onBack: () => void;
 }
 
-export default function Overview({ onBack }: OverviewProps) {
+export function OverviewContent() {
   const icons = {
     expand: actionInfo.get('expand')?.icon,
     build: actionInfo.get('build')?.icon,
@@ -37,7 +37,7 @@ export default function Overview({ onBack }: OverviewProps) {
   };
 
   return (
-    <div className="p-6 max-w-2xl mx-auto space-y-4">
+    <>
       <h1 className="text-3xl font-bold text-center mb-4">Game Overview</h1>
       <p>
         Welcome to <strong>Kingdom Builder</strong>, a brisk duel of wits where
@@ -138,6 +138,14 @@ export default function Overview({ onBack }: OverviewProps) {
           foe!
         </p>
       </section>
+    </>
+  );
+}
+
+export default function Overview({ onBack }: OverviewProps) {
+  return (
+    <div className="p-6 max-w-2xl mx-auto space-y-4">
+      <OverviewContent />
       <button
         className="border px-4 py-2 hoverable cursor-pointer"
         onClick={onBack}

--- a/packages/web/src/components/HelpModal.tsx
+++ b/packages/web/src/components/HelpModal.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Button from './common/Button';
+import { OverviewContent } from '../Overview';
+
+interface HelpModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function HelpModal({ open, onClose }: HelpModalProps) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="relative w-full max-w-2xl overflow-y-auto rounded bg-white p-4 text-gray-900 shadow dark:bg-gray-800 dark:text-gray-100 max-h-full">
+        <Button
+          variant="ghost"
+          className="absolute right-2 top-2"
+          onClick={onClose}
+          aria-label="Close help"
+        >
+          ✕
+        </Button>
+        <OverviewContent />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/common/Tooltip.tsx
+++ b/packages/web/src/components/common/Tooltip.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface TooltipProps {
+  content: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Tooltip({
+  content,
+  children,
+  className = '',
+}: TooltipProps) {
+  return (
+    <div className={`relative group inline-block ${className}`}>
+      {children}
+      <div className="pointer-events-none absolute z-10 hidden -translate-x-1/2 whitespace-nowrap rounded bg-gray-700 px-2 py-1 text-xs text-white group-hover:block dark:bg-gray-200 dark:text-gray-900 top-full left-1/2 mt-1">
+        {content}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add tooltip "?" button in header to open help overlay
- reuse overview content in new HelpModal component
- introduce shared Tooltip component

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b72009e4048325830b65c3443a97a7