### PR TITLE
feat(web): centralize tooltip handling

### DIFF
--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { type Summary } from '../../translation';
 import { renderSummary, renderCosts } from '../../translation/render';
+import Tooltip from '../common/Tooltip';
 
 function stripSummary(summary: Summary | undefined): Summary | undefined {
   const first = summary?.[0];
@@ -16,12 +17,10 @@ export type ActionCardProps = {
   summary?: Summary | undefined;
   implemented?: boolean;
   enabled: boolean;
-  tooltip?: string | undefined;
+  tooltip?: React.ReactNode;
   requirements?: string[];
   requirementIcons?: string[];
   onClick?: () => void;
-  onMouseEnter?: () => void;
-  onMouseLeave?: () => void;
 };
 
 export default function ActionCard({
@@ -36,18 +35,13 @@ export default function ActionCard({
   requirements = [],
   requirementIcons = [],
   onClick,
-  onMouseEnter,
-  onMouseLeave,
 }: ActionCardProps) {
-  return (
+  const card = (
     <button
       className={`relative panel-card border border-black/10 dark:border-white/10 p-2 flex flex-col items-start gap-1 h-full shadow-sm ${
         enabled ? 'hoverable cursor-pointer' : 'opacity-50 cursor-not-allowed'
       }`}
-      title={tooltip}
       onClick={enabled ? onClick : undefined}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
     >
       <span className="text-base font-medium">{title}</span>
       <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
@@ -67,4 +61,5 @@ export default function ActionCard({
       </ul>
     </button>
   );
+  return tooltip ? <Tooltip content={tooltip}>{card}</Tooltip> : card;
 }

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -9,12 +9,7 @@ import {
   LAND_ICON as landIcon,
   LAND_LABEL as landLabel,
 } from '@kingdom-builder/contents';
-import {
-  describeContent,
-  summarizeContent,
-  splitSummary,
-  type Summary,
-} from '../../translation';
+import { summarizeContent, type Summary } from '../../translation';
 import ActionCard from './ActionCard';
 import { useGameEngine } from '../../state/GameContext';
 import { isActionPhaseActive } from '../../utils/isActionPhaseActive';
@@ -47,13 +42,7 @@ function GenericActions({
   summaries: Map<string, Summary>;
   isActionPhase: boolean;
 }) {
-  const {
-    ctx,
-    handlePerform,
-    handleHoverCard,
-    clearHoverCard,
-    actionCostResource,
-  } = useGameEngine();
+  const { ctx, handlePerform, actionCostResource } = useGameEngine();
   const formatRequirement = (req: string) => req;
   return (
     <>
@@ -97,23 +86,6 @@ function GenericActions({
             enabled={enabled}
             tooltip={title}
             onClick={() => void handlePerform(action)}
-            onMouseEnter={() => {
-              const full = describeContent('action', action.id, ctx);
-              const { effects, description } = splitSummary(full);
-              handleHoverCard({
-                title: `${ctx.actions.get(action.id)?.icon || ''} ${action.name}`,
-                effects,
-                requirements,
-                costs,
-                ...(description && { description }),
-                ...(!implemented && {
-                  description: 'Not implemented yet',
-                  descriptionClass: 'italic text-red-600',
-                }),
-                bgClass: 'bg-gray-100 dark:bg-gray-700',
-              });
-            }}
-            onMouseLeave={clearHoverCard}
           />
         );
       })}
@@ -128,13 +100,7 @@ function RaisePopOptions({
   action: Action;
   isActionPhase: boolean;
 }) {
-  const {
-    ctx,
-    handlePerform,
-    handleHoverCard,
-    clearHoverCard,
-    actionCostResource,
-  } = useGameEngine();
+  const { ctx, handlePerform, actionCostResource } = useGameEngine();
   const formatRequirement = (req: string) => req;
   const requirementIcons = getRequirementIcons(action.id, ctx);
   return (
@@ -160,7 +126,6 @@ function RaisePopOptions({
           : !canPay
             ? 'Cannot pay costs'
             : undefined;
-        const summary = describeContent('action', action.id, ctx, { role });
         const shortSummary = summarizeContent('action', action.id, ctx, {
           role,
         });
@@ -183,20 +148,6 @@ function RaisePopOptions({
             enabled={enabled}
             tooltip={title}
             onClick={() => void handlePerform(action, { role })}
-            onMouseEnter={() => {
-              const { effects, description } = splitSummary(summary);
-              handleHoverCard({
-                title: `${ctx.actions.get(action.id).icon || ''}${
-                  POPULATION_ROLES[role]?.icon
-                } Hire ${POPULATION_ROLES[role]?.label || ''}`,
-                effects,
-                requirements,
-                costs,
-                ...(description && { description }),
-                bgClass: 'bg-gray-100 dark:bg-gray-700',
-              });
-            }}
-            onMouseLeave={clearHoverCard}
           />
         );
       })}
@@ -253,13 +204,7 @@ function DevelopOptions({
   summaries: Map<string, Summary>;
   hasDevelopLand: boolean;
 }) {
-  const {
-    ctx,
-    handlePerform,
-    handleHoverCard,
-    clearHoverCard,
-    actionCostResource,
-  } = useGameEngine();
+  const { ctx, handlePerform, actionCostResource } = useGameEngine();
   return (
     <div>
       <h3 className="font-medium">
@@ -321,25 +266,6 @@ function DevelopOptions({
                 )?.id;
                 void handlePerform(action, { id: d.id, landId });
               }}
-              onMouseEnter={() => {
-                const full = describeContent('development', d.id, ctx);
-                const { effects, description } = splitSummary(full);
-                handleHoverCard({
-                  title: `${ctx.actions.get('develop').icon || ''} ${
-                    ctx.actions.get('develop').name
-                  } - ${ctx.developments.get(d.id)?.icon} ${d.name}`,
-                  effects,
-                  requirements,
-                  costs,
-                  ...(description && { description }),
-                  ...(!implemented && {
-                    description: 'Not implemented yet',
-                    descriptionClass: 'italic text-red-600',
-                  }),
-                  bgClass: 'bg-gray-100 dark:bg-gray-700',
-                });
-              }}
-              onMouseLeave={clearHoverCard}
             />
           );
         })}
@@ -353,21 +279,13 @@ function BuildOptions({
   isActionPhase,
   buildings,
   summaries,
-  descriptions,
 }: {
   action: Action;
   isActionPhase: boolean;
   buildings: Building[];
   summaries: Map<string, Summary>;
-  descriptions: Map<string, Summary>;
 }) {
-  const {
-    ctx,
-    handlePerform,
-    handleHoverCard,
-    clearHoverCard,
-    actionCostResource,
-  } = useGameEngine();
+  const { ctx, handlePerform, actionCostResource } = useGameEngine();
   return (
     <div>
       <h3 className="font-medium">
@@ -416,25 +334,6 @@ function BuildOptions({
               enabled={enabled}
               tooltip={title}
               onClick={() => void handlePerform(action, { id: b.id })}
-              onMouseEnter={() => {
-                const full = descriptions.get(b.id) ?? [];
-                const { effects, description } = splitSummary(full);
-                handleHoverCard({
-                  title: `${ctx.actions.get('build').icon || ''} ${
-                    ctx.actions.get('build').name
-                  } - ${ctx.buildings.get(b.id)?.icon || ''} ${b.name}`,
-                  effects,
-                  requirements,
-                  costs,
-                  ...(description && { description }),
-                  ...(!implemented && {
-                    description: 'Not implemented yet',
-                    descriptionClass: 'italic text-red-600',
-                  }),
-                  bgClass: 'bg-gray-100 dark:bg-gray-700',
-                });
-              }}
-              onMouseLeave={clearHoverCard}
             />
           );
         })}
@@ -507,13 +406,6 @@ export default function ActionsPanel() {
     );
     return map;
   }, [buildingOptions, ctx]);
-  const buildingDescriptions = useMemo(() => {
-    const map = new Map<string, Summary>();
-    buildingOptions.forEach((b) =>
-      map.set(b.id, describeContent('building', b.id, ctx)),
-    );
-    return map;
-  }, [buildingOptions, ctx]);
 
   const hasDevelopLand = ctx.activePlayer.lands.some((l) => l.slotsFree > 0);
   const developAction = actions.find((a) => a.category === 'development');
@@ -562,7 +454,6 @@ export default function ActionsPanel() {
             isActionPhase={isActionPhase}
             buildings={buildingOptions}
             summaries={buildingSummaries}
-            descriptions={buildingDescriptions}
           />
         )}
       </div>

--- a/packages/web/src/components/common/Tooltip.tsx
+++ b/packages/web/src/components/common/Tooltip.tsx
@@ -1,0 +1,33 @@
+import React, { useId, useState } from 'react';
+
+interface TooltipProps {
+  content: React.ReactNode;
+  children: React.ReactElement;
+}
+
+export default function Tooltip({ content, children }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const id = useId();
+  const show = () => setVisible(true);
+  const hide = () => setVisible(false);
+  return (
+    <span
+      className="relative inline-block"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      {React.cloneElement(children, { 'aria-describedby': id })}
+      {visible && (
+        <span
+          role="tooltip"
+          id={id}
+          className="pointer-events-none absolute left-1/2 top-full z-10 mt-1 -translate-x-1/2 rounded bg-black px-2 py-1 text-xs text-white shadow"
+        >
+          {content}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/web/src/components/player/BuildingDisplay.tsx
+++ b/packages/web/src/components/player/BuildingDisplay.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { describeContent, splitSummary } from '../../translation';
+import { renderSummary } from '../../translation/render';
 import { useGameEngine } from '../../state/GameContext';
 import { useAnimate } from '../../utils/useAutoAnimate';
+import Tooltip from '../common/Tooltip';
 
 interface BuildingDisplayProps {
   player: EngineContext['activePlayer'];
 }
 
 const BuildingDisplay: React.FC<BuildingDisplayProps> = ({ player }) => {
-  const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
+  const { ctx } = useGameEngine();
   if (player.buildings.size === 0) return null;
   const animateBuildings = useAnimate<HTMLDivElement>();
   return (
@@ -19,29 +21,33 @@ const BuildingDisplay: React.FC<BuildingDisplayProps> = ({ player }) => {
         const icon =
           ctx.buildings.get(b)?.icon || ctx.actions.get('build').icon || '';
         const title = `${icon} ${name}`;
-        return (
-          <div
-            key={b}
-            className="panel-card p-2 text-center hoverable cursor-help"
-            onMouseEnter={() => {
-              const full = describeContent('building', b, ctx, {
-                installed: true,
-              });
-              const { effects, description } = splitSummary(full);
-              handleHoverCard({
-                title,
-                effects,
-                requirements: [],
-                ...(description && { description }),
-                bgClass: 'bg-gray-100 dark:bg-gray-700',
-              });
-            }}
-            onMouseLeave={clearHoverCard}
-          >
-            <span className="font-medium">
-              {icon} {name}
-            </span>
+        const full = describeContent('building', b, ctx, {
+          installed: true,
+        });
+        const split = splitSummary(full);
+        const content = (
+          <div>
+            <div className="font-medium">{title}</div>
+            {split.description && (
+              <ul className="mt-1 list-disc pl-4">
+                {renderSummary(split.description)}
+              </ul>
+            )}
+            {split.effects.length > 0 && (
+              <ul className="mt-1 list-disc pl-4">
+                {renderSummary(split.effects)}
+              </ul>
+            )}
           </div>
+        );
+        return (
+          <Tooltip key={b} content={content}>
+            <div className="panel-card p-2 text-center hoverable cursor-default">
+              <span className="font-medium">
+                {icon} {name}
+              </span>
+            </div>
+          </Tooltip>
         );
       })}
     </div>

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { useGameEngine } from '../../state/GameContext';
 import { MODIFIER_INFO as modifierInfo } from '@kingdom-builder/contents';
 import { describeEffects, splitSummary } from '../../translation';
+import { renderSummary } from '../../translation/render';
 import type { EffectDef } from '@kingdom-builder/engine';
 import { useAnimate } from '../../utils/useAutoAnimate';
+import Tooltip from '../common/Tooltip';
 
 export const ICON_MAP: Record<string, string> = {
   cost_mod: modifierInfo.cost.icon,
@@ -15,7 +17,7 @@ export default function PassiveDisplay({
 }: {
   player: ReturnType<typeof useGameEngine>['ctx']['activePlayer'];
 }) {
-  const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
+  const { ctx } = useGameEngine();
   const ids = ctx.passives.list(player.id);
   const defs = ctx.passives.values(player.id) as {
     effects?: EffectDef[];
@@ -53,24 +55,26 @@ export default function PassiveDisplay({
         const summary = def.onUpkeepPhase
           ? [{ title: 'Until your next Upkeep Phase', items }]
           : items;
+        const split = splitSummary(summary);
+        const content = (
+          <div>
+            <div className="font-medium">{icon} Passive</div>
+            {split.description && (
+              <ul className="mt-1 list-disc pl-4">
+                {renderSummary(split.description)}
+              </ul>
+            )}
+            {split.effects.length > 0 && (
+              <ul className="mt-1 list-disc pl-4">
+                {renderSummary(split.effects)}
+              </ul>
+            )}
+          </div>
+        );
         return (
-          <span
-            key={id}
-            className="hoverable cursor-pointer"
-            onMouseEnter={() => {
-              const { effects, description } = splitSummary(summary);
-              handleHoverCard({
-                title: `${icon} Passive`,
-                effects,
-                requirements: [],
-                ...(description && { description }),
-                bgClass: 'bg-gray-100 dark:bg-gray-700',
-              });
-            }}
-            onMouseLeave={clearHoverCard}
-          >
-            {icon}
-          </span>
+          <Tooltip key={id} content={content}>
+            <span className="hoverable cursor-pointer">{icon}</span>
+          </Tooltip>
         );
       })}
     </div>

--- a/packages/web/src/components/player/PopulationInfo.tsx
+++ b/packages/web/src/components/player/PopulationInfo.tsx
@@ -2,111 +2,71 @@ import React from 'react';
 import { POPULATION_ROLES, STATS } from '@kingdom-builder/contents';
 import { formatStatValue } from '../../utils/stats';
 import type { EngineContext } from '@kingdom-builder/engine';
-import { useGameEngine } from '../../state/GameContext';
+import Tooltip from '../common/Tooltip';
 
 interface PopulationInfoProps {
   player: EngineContext['activePlayer'];
 }
 
 const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
-  const { handleHoverCard, clearHoverCard } = useGameEngine();
   const popEntries = Object.entries(player.population).filter(([, v]) => v > 0);
   const currentPop = popEntries.reduce((sum, [, v]) => sum + v, 0);
   const popDetails = popEntries.map(([role, count]) => ({ role, count }));
-
-  const showPopulationCard = () =>
-    handleHoverCard({
-      title: '👥 Population',
-      effects: Object.values(POPULATION_ROLES).map(
-        (r) => `${r.icon} ${r.label} - ${r.description}`,
-      ),
-      effectsTitle: 'Archetypes',
-      requirements: [],
-      description:
-        'Population represents the people of your kingdom. Manage them wisely and assign roles to benefit your realm.',
-      bgClass: 'bg-gray-100 dark:bg-gray-700',
-    });
+  const popTooltip = (
+    <div>
+      <div className="font-medium">👥 Population</div>
+      <ul className="mt-1 list-disc pl-4">
+        {Object.values(POPULATION_ROLES).map((r) => (
+          <li key={r.label}>
+            {r.icon} {r.label} - {r.description}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 
   return (
     <>
       <div className="h-4 border-l border-black/10 dark:border-white/10" />
-      <div
-        role="button"
-        tabIndex={0}
-        className="bar-item hoverable cursor-help rounded px-1"
-        onMouseEnter={showPopulationCard}
-        onMouseLeave={clearHoverCard}
-        onFocus={showPopulationCard}
-        onBlur={clearHoverCard}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            showPopulationCard();
-          }
-        }}
-      >
-        👥{currentPop}/{player.maxPopulation}
-        {popDetails.length > 0 && (
-          <>
-            {' ('}
-            {popDetails.map(({ role, count }, i) => {
-              const info =
-                POPULATION_ROLES[role as keyof typeof POPULATION_ROLES];
-              return (
-                <React.Fragment key={role}>
-                  {i > 0 && ','}
-                  <button
-                    type="button"
-                    className="cursor-help hoverable rounded px-1"
-                    onMouseEnter={(e) => {
-                      e.stopPropagation();
-                      handleHoverCard({
-                        title: `${info.icon} ${info.label}`,
-                        effects: [],
-                        requirements: [],
-                        description: info.description,
-                        bgClass: 'bg-gray-100 dark:bg-gray-700',
-                      });
-                    }}
-                    onMouseLeave={(e) => {
-                      e.stopPropagation();
-                      showPopulationCard();
-                    }}
-                    onFocus={(e) => {
-                      e.stopPropagation();
-                      handleHoverCard({
-                        title: `${info.icon} ${info.label}`,
-                        effects: [],
-                        requirements: [],
-                        description: info.description,
-                        bgClass: 'bg-gray-100 dark:bg-gray-700',
-                      });
-                    }}
-                    onBlur={(e) => {
-                      e.stopPropagation();
-                      showPopulationCard();
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleHoverCard({
-                        title: `${info.icon} ${info.label}`,
-                        effects: [],
-                        requirements: [],
-                        description: info.description,
-                        bgClass: 'bg-gray-100 dark:bg-gray-700',
-                      });
-                    }}
-                  >
-                    {info.icon}
-                    {count}
-                  </button>
-                </React.Fragment>
-              );
-            })}
-            {')'}
-          </>
-        )}
-      </div>
+      <Tooltip content={popTooltip}>
+        <div
+          role="button"
+          tabIndex={0}
+          className="bar-item hoverable cursor-default rounded px-1"
+        >
+          👥{currentPop}/{player.maxPopulation}
+          {popDetails.length > 0 && (
+            <>
+              {' ('}
+              {popDetails.map(({ role, count }, i) => {
+                const info =
+                  POPULATION_ROLES[role as keyof typeof POPULATION_ROLES];
+                return (
+                  <React.Fragment key={role}>
+                    {i > 0 && ','}
+                    <Tooltip
+                      content={
+                        <span>
+                          {info.icon} {info.label} - {info.description}
+                        </span>
+                      }
+                    >
+                      <button
+                        type="button"
+                        className="cursor-default hoverable rounded px-1"
+                      >
+                        {info.icon}
+                        {count}
+                      </button>
+                    </Tooltip>
+                  </React.Fragment>
+                );
+              })}
+              {')'}
+            </>
+          )}
+        </div>
+      </Tooltip>
       {Object.entries(player.stats)
         .filter(([k, v]) => {
           const info = STATS[k as keyof typeof STATS];
@@ -115,43 +75,22 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
         .map(([k, v]) => {
           const info = STATS[k as keyof typeof STATS];
           return (
-            <button
+            <Tooltip
               key={k}
-              type="button"
-              className="bar-item hoverable cursor-help rounded px-1"
-              onMouseEnter={() =>
-                handleHoverCard({
-                  title: `${info.icon} ${info.label}`,
-                  effects: [],
-                  requirements: [],
-                  description: info.description,
-                  bgClass: 'bg-gray-100 dark:bg-gray-700',
-                })
-              }
-              onMouseLeave={clearHoverCard}
-              onFocus={() =>
-                handleHoverCard({
-                  title: `${info.icon} ${info.label}`,
-                  effects: [],
-                  requirements: [],
-                  description: info.description,
-                  bgClass: 'bg-gray-100 dark:bg-gray-700',
-                })
-              }
-              onBlur={clearHoverCard}
-              onClick={() =>
-                handleHoverCard({
-                  title: `${info.icon} ${info.label}`,
-                  effects: [],
-                  requirements: [],
-                  description: info.description,
-                  bgClass: 'bg-gray-100 dark:bg-gray-700',
-                })
+              content={
+                <span>
+                  {info.icon} {info.label} - {info.description}
+                </span>
               }
             >
-              {info.icon}
-              {formatStatValue(k, v)}
-            </button>
+              <button
+                type="button"
+                className="bar-item hoverable cursor-default rounded px-1"
+              >
+                {info.icon}
+                {formatStatValue(k, v)}
+              </button>
+            </Tooltip>
           );
         })}
     </>

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -1,40 +1,32 @@
 import React from 'react';
 import { RESOURCES } from '@kingdom-builder/contents';
 import type { EngineContext } from '@kingdom-builder/engine';
-import { useGameEngine } from '../../state/GameContext';
+import Tooltip from '../common/Tooltip';
 
 interface ResourceBarProps {
   player: EngineContext['activePlayer'];
 }
 
 const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
-  const { handleHoverCard, clearHoverCard } = useGameEngine();
   return (
     <>
       {Object.entries(player.resources).map(([k, v]) => {
         const info = RESOURCES[k as keyof typeof RESOURCES];
-        const showResourceCard = () =>
-          handleHoverCard({
-            title: `${info.icon} ${info.label}`,
-            effects: [],
-            requirements: [],
-            description: info.description,
-            bgClass: 'bg-gray-100 dark:bg-gray-700',
-          });
+        const content = (
+          <span>
+            {info.icon} {info.label} - {info.description}
+          </span>
+        );
         return (
-          <button
-            key={k}
-            type="button"
-            className="bar-item hoverable cursor-help rounded px-1"
-            onMouseEnter={showResourceCard}
-            onMouseLeave={clearHoverCard}
-            onFocus={showResourceCard}
-            onBlur={clearHoverCard}
-            onClick={showResourceCard}
-          >
-            {info.icon}
-            {v}
-          </button>
+          <Tooltip key={k} content={content}>
+            <button
+              type="button"
+              className="bar-item hoverable cursor-default rounded px-1"
+            >
+              {info.icon}
+              {v}
+            </button>
+          </Tooltip>
         );
       })}
     </>

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import ActionsPanel from '../src/components/actions/ActionsPanel';
@@ -81,15 +82,18 @@ describe('<ActionsPanel />', () => {
     expect(screen.getAllByText(`Req ${popIcon}`)[0]).toBeInTheDocument();
   });
 
-  it('shows development slot requirement indicator when no slots are free', () => {
+  it('shows development slot requirement indicator when no slots are free', async () => {
     const originalSlots = ctx.activePlayer.lands.map((l) => l.slotsUsed);
     ctx.activePlayer.lands.forEach((l) => (l.slotsUsed = l.slotsMax));
     render(<ActionsPanel />);
     expect(screen.getAllByText(`Req ${SLOT_ICON}`)[0]).toBeInTheDocument();
+    const user = userEvent.setup();
+    const card = screen.getAllByText(`Req ${SLOT_ICON}`)[0].closest('button');
+    if (card) await user.hover(card);
     expect(
-      screen.getAllByTitle(
-        `No ${LAND_ICON} ${LAND_LABEL} with free ${SLOT_ICON} ${SLOT_LABEL}`,
-      )[0],
+      screen.getByRole('tooltip', {
+        name: `No ${LAND_ICON} ${LAND_LABEL} with free ${SLOT_ICON} ${SLOT_LABEL}`,
+      }),
     ).toBeInTheDocument();
     ctx.activePlayer.lands.forEach((l, i) => (l.slotsUsed = originalSlots[i]));
   });


### PR DESCRIPTION
## Summary
- add reusable Tooltip component
- replace title props with Tooltip in action, resource and player displays
- adapt ActionsPanel test for Tooltip usage

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b72012cb8c83259b147410aaa0614c