### PR TITLE
feat: add responsive layouts for panels

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -27,7 +27,7 @@ function GameLayout() {
         )}
       </div>
 
-      <div className="grid gap-x-4 gap-y-6 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_30rem]">
+      <div className="grid gap-x-4 gap-y-6 grid-cols-1 sm:grid-cols-1 lg:grid-cols-[minmax(0,1fr)_30rem]">
         <section className="border rounded bg-white dark:bg-gray-800 shadow flex min-h-[275px]">
           <div className="flex flex-1 items-stretch rounded overflow-hidden divide-x divide-black/10 dark:divide-white/10">
             {ctx.game.players.map((p, i) => {
@@ -50,13 +50,13 @@ function GameLayout() {
             })}
           </div>
         </section>
-        <div className="w-full lg:w-[30rem] lg:col-start-2">
+        <div className="w-full lg:col-start-2">
           <PhasePanel />
         </div>
         <div className="lg:col-start-1 lg:row-start-2">
           <ActionsPanel />
         </div>
-        <div className="w-full lg:w-[30rem] flex flex-col gap-6 lg:col-start-2 lg:row-start-2">
+        <div className="w-full flex flex-col gap-6 lg:col-start-2 lg:row-start-2">
           <LogPanel />
           <HoverCard />
         </div>

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -223,7 +223,7 @@ function BasicOptions({
           (Effects take place immediately, unless stated otherwise)
         </span>
       </h3>
-      <div className="grid grid-cols-4 gap-2 mt-1">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1">
         <GenericActions
           actions={actions}
           summaries={summaries}
@@ -269,7 +269,7 @@ function DevelopOptions({
           (Effects take place on build and last until development is removed)
         </span>
       </h3>
-      <div className="grid grid-cols-4 gap-2 mt-1">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1">
         {developments.map((d) => {
           const landIdForCost = ctx.activePlayer.lands[0]?.id as string;
           const costsBag = getActionCosts('develop', ctx, {
@@ -376,7 +376,7 @@ function BuildOptions({
           (Effects take place on build and last until building is removed)
         </span>
       </h3>
-      <div className="grid grid-cols-4 gap-2 mt-1">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1">
         {buildings.map((b) => {
           const costsBag = getActionCosts('build', ctx, { id: b.id });
           const costs: Record<string, number> = {};


### PR DESCRIPTION
## Summary
- use Tailwind responsive grid classes in Game layout
- switch ActionsPanel grids to responsive columns for small screens

## Testing
- `npm run test:coverage`
- `node -e "const { chromium } = require('playwright');(async () => {const browser = await chromium.launch();const page = await browser.newPage({ viewport: { width: 640, height: 800 }});await page.goto('http://localhost:4173');await page.waitForSelector('text=Start New Game');await page.click('text=Start New Game');await page.waitForSelector('text=Actions');const data = await page.evaluate(() => { const grid = document.querySelector('div.grid'); const children = Array.from(grid.children).map(el => { const r = el.getBoundingClientRect(); return { top: Math.round(r.top), left: Math.round(r.left), width: Math.round(r.width) };}); const gr = grid.getBoundingClientRect(); return { grid: { width: Math.round(gr.width) }, children };}); console.log(JSON.stringify(data, null, 2)); await browser.close();})();"

------
https://chatgpt.com/codex/tasks/task_e_68b71fe8d8008325aea5ec7fc1354d3b