### PR TITLE
feat: improve ResourceBar ordering and accessibility

### DIFF
--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -11,8 +11,9 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
   const { handleHoverCard, clearHoverCard } = useGameEngine();
   return (
     <>
-      {Object.entries(player.resources).map(([k, v]) => {
-        const info = RESOURCES[k as keyof typeof RESOURCES];
+      {(Object.keys(RESOURCES) as (keyof typeof RESOURCES)[]).map((k) => {
+        const info = RESOURCES[k];
+        const v = player.resources[k] ?? 0;
         const showResourceCard = () =>
           handleHoverCard({
             title: `${info.icon} ${info.label}`,
@@ -31,6 +32,7 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
             onFocus={showResourceCard}
             onBlur={clearHoverCard}
             onClick={showResourceCard}
+            aria-label={`${info.label}: ${v}`}
           >
             {info.icon}
             {v}


### PR DESCRIPTION
## Summary
- iterate over RESOURCES keys for stable resource ordering
- add aria-label for resource values to aid screen readers

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b72a53469883258d73844bc8a9385a