### PR TITLE
test: cap absorption at 100 percent

### DIFF
--- a/packages/engine/tests/absorption-cap.test.ts
+++ b/packages/engine/tests/absorption-cap.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAttack } from '../src/index.ts';
+import { createTestEngine } from './helpers.ts';
+import { Resource } from '../src/state/index.ts';
+
+describe('absorption cap', () => {
+  it('caps absorption at 100%', () => {
+    const ctx = createTestEngine();
+    const defender = ctx.game.opponent;
+    defender.absorption = 1.5;
+    const start = defender.resources[Resource.castleHP];
+    const dmg = resolveAttack(defender, 5, ctx);
+    expect(dmg).toBe(0);
+    expect(defender.resources[Resource.castleHP]).toBe(start);
+  });
+});


### PR DESCRIPTION
## Summary
- add test ensuring absorption over 100% prevents castle damage

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b734ce51f883259866d6e4b0515a58