### PR TITLE
test: ensure stat add pct is additive

### DIFF
--- a/packages/engine/tests/additive-stat-pct.test.ts
+++ b/packages/engine/tests/additive-stat-pct.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { runEffects, type EffectDef } from '../src/index.ts';
+import { Stat } from '../src/state/index.ts';
+import { createTestEngine } from './helpers.ts';
+
+describe('stat:add_pct additive scaling', () => {
+  it('adds multiple percentages from the original base in the same step', () => {
+    const ctx = createTestEngine();
+    const base = 10;
+    ctx.activePlayer.stats[Stat.armyStrength] = base;
+
+    const pct1 = 0.2;
+    const pct2 = 0.4;
+    const effects: EffectDef[] = [
+      {
+        type: 'stat',
+        method: 'add_pct',
+        params: { key: Stat.armyStrength, percent: pct1 },
+      },
+      {
+        type: 'stat',
+        method: 'add_pct',
+        params: { key: Stat.armyStrength, percent: pct2 },
+      },
+    ];
+
+    runEffects(effects, ctx);
+
+    const expected = base * (1 + pct1 + pct2);
+    expect(ctx.activePlayer.stats[Stat.armyStrength]).toBeCloseTo(expected);
+    const sequential = base * (1 + pct1) * (1 + pct2);
+    expect(ctx.activePlayer.stats[Stat.armyStrength]).not.toBeCloseTo(
+      sequential,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add test verifying `stat:add_pct` effects stack additively within the same step

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b734e0335083258d9b8d866f657481