### PR TITLE
test(engine): cover zero-resource plunder transfers

### DIFF
--- a/packages/engine/tests/plunder-zero-gold.test.ts
+++ b/packages/engine/tests/plunder-zero-gold.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { performAction, advance } from '../src';
+import { Resource as CResource } from '@kingdom-builder/contents';
+import { createContentFactory } from './factories/content';
+import { createTestEngine } from './helpers';
+
+function toMain(ctx: ReturnType<typeof createTestEngine>) {
+  while (ctx.game.currentPhase !== 'main') advance(ctx);
+}
+
+describe('plunder action with zero opponent resource', () => {
+  it("doesn't modify resources when opponent has none", () => {
+    const content = createContentFactory();
+    const action = content.action({
+      baseCosts: { [CResource.ap]: 0 },
+      effects: [
+        {
+          type: 'resource',
+          method: 'transfer',
+          params: { key: CResource.gold },
+        },
+      ],
+    });
+    const ctx = createTestEngine(content);
+    toMain(ctx);
+    ctx.opponent.resources[CResource.gold] = 0;
+    const beforeAttacker = ctx.activePlayer.resources[CResource.gold] ?? 0;
+    const beforeDefender = ctx.opponent.resources[CResource.gold] ?? 0;
+    expect(() => performAction(action.id, ctx)).not.toThrow();
+    expect(ctx.activePlayer.resources[CResource.gold]).toBe(beforeAttacker);
+    expect(ctx.opponent.resources[CResource.gold]).toBe(beforeDefender);
+  });
+});


### PR DESCRIPTION
## Summary
- add test ensuring resource transfer does nothing when opponent lacks resources

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b734f0da5083259e9b6656ed568580