### PR TITLE
test: verify stacked result modifiers

### DIFF
--- a/packages/engine/tests/result-mod-stack.test.ts
+++ b/packages/engine/tests/result-mod-stack.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { Resource as CResource } from '@kingdom-builder/contents';
+import { performAction, advance } from '../src';
+import { createContentFactory } from './factories/content';
+import { createTestEngine } from './helpers';
+
+describe('result modifiers', () => {
+  it('stack for the same action', () => {
+    const resourceKey = Object.values(CResource)[0];
+    const baseGain = 1;
+    const modGainA = 2;
+    const modGainB = 3;
+
+    const content = createContentFactory();
+    const action = content.action({
+      effects: [
+        {
+          type: 'resource',
+          method: 'add',
+          params: { key: resourceKey, amount: baseGain },
+        },
+      ],
+    });
+
+    const passiveA = {
+      id: 'pa',
+      effects: [
+        {
+          type: 'result_mod',
+          method: 'add',
+          params: { id: 'ma', actionId: action.id },
+          effects: [
+            {
+              type: 'resource',
+              method: 'add',
+              params: { key: resourceKey, amount: modGainA },
+            },
+          ],
+        },
+      ],
+    };
+
+    const passiveB = {
+      id: 'pb',
+      effects: [
+        {
+          type: 'result_mod',
+          method: 'add',
+          params: { id: 'mb', actionId: action.id },
+          effects: [
+            {
+              type: 'resource',
+              method: 'add',
+              params: { key: resourceKey, amount: modGainB },
+            },
+          ],
+        },
+      ],
+    };
+
+    const ctx = createTestEngine(content);
+    while (ctx.game.currentPhase !== 'main') advance(ctx);
+
+    ctx.passives.addPassive(passiveA, ctx);
+    ctx.passives.addPassive(passiveB, ctx);
+
+    const before = ctx.activePlayer.resources[resourceKey] ?? 0;
+    performAction(action.id, ctx);
+    const after = ctx.activePlayer.resources[resourceKey] ?? 0;
+
+    expect(after).toBe(before + baseGain + modGainA + modGainB);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test ensuring multiple passives stack their result modifiers on an action

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 80 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b734b29620832590d74a3bbdcb0cad