### PR TITLE
refactor: consolidate content info objects

### DIFF
--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -12,7 +12,9 @@ export {
 export { Resource, type ResourceKey, RESOURCES } from './resources';
 export { Stat, type StatKey, STATS } from './stats';
 export { TRIGGER_INFO } from './triggers';
-export { LAND_ICON, LAND_LABEL, SLOT_ICON, SLOT_LABEL } from './land';
+export { LAND_INFO, SLOT_INFO, DEVELOPMENTS_INFO } from './land';
+export { POPULATION_INFO, POPULATION_ARCHETYPE_INFO } from './population';
+export { PASSIVE_INFO } from './passive';
 export { MODIFIER_INFO } from './modifiers';
 export { GAME_START } from './game';
 export { RULES } from './rules';

--- a/packages/contents/src/land.ts
+++ b/packages/contents/src/land.ts
@@ -1,4 +1,14 @@
-export const LAND_ICON = '🗺️';
-export const LAND_LABEL = 'Land';
-export const SLOT_ICON = '🧩';
-export const SLOT_LABEL = 'Development Slot';
+export const LAND_INFO = {
+  icon: '🗺️',
+  label: 'Land',
+} as const;
+
+export const SLOT_INFO = {
+  icon: '🧩',
+  label: 'Development Slot',
+} as const;
+
+export const DEVELOPMENTS_INFO = {
+  icon: '🏗️',
+  label: 'Developments',
+} as const;

--- a/packages/contents/src/passive.ts
+++ b/packages/contents/src/passive.ts
@@ -1,0 +1,4 @@
+export const PASSIVE_INFO = {
+  icon: '♾️',
+  label: 'Passive',
+} as const;

--- a/packages/contents/src/population.ts
+++ b/packages/contents/src/population.ts
@@ -1,0 +1,11 @@
+export const POPULATION_INFO = {
+  icon: '👥',
+  label: 'Population',
+  description:
+    'Population represents the people of your kingdom. Manage them wisely and assign roles to benefit your realm.',
+} as const;
+
+export const POPULATION_ARCHETYPE_INFO = {
+  icon: '🎭',
+  label: 'Archetypes',
+} as const;

--- a/packages/web/src/Overview.tsx
+++ b/packages/web/src/Overview.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Button from './components/common/Button';
 import {
   ACTIONS as actionInfo,
-  LAND_ICON as landIcon,
-  SLOT_ICON as slotIcon,
+  LAND_INFO,
+  SLOT_INFO,
   RESOURCES,
   Resource,
   PHASES,
@@ -27,8 +27,8 @@ export default function Overview({ onBack }: OverviewProps) {
     growth: PHASES.find((p) => p.id === 'growth')?.icon,
     upkeep: PHASES.find((p) => p.id === 'upkeep')?.icon,
     main: PHASES.find((p) => p.id === 'main')?.icon,
-    land: landIcon,
-    slot: slotIcon,
+    land: LAND_INFO.icon,
+    slot: SLOT_INFO.icon,
     gold: RESOURCES[Resource.gold].icon,
     ap: RESOURCES[Resource.ap].icon,
     happiness: RESOURCES[Resource.happiness].icon,

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -4,10 +4,8 @@ import {
   RESOURCES,
   POPULATION_ROLES,
   PopulationRole,
-  SLOT_ICON as slotIcon,
-  SLOT_LABEL as slotLabel,
-  LAND_ICON as landIcon,
-  LAND_LABEL as landLabel,
+  SLOT_INFO,
+  LAND_INFO,
 } from '@kingdom-builder/contents';
 import {
   describeContent,
@@ -170,8 +168,8 @@ function RaisePopOptions({
             title={
               <>
                 {ctx.actions.get(action.id).icon || ''}
-                {POPULATION_ROLES[role]?.icon} Hire{' '}
-                {POPULATION_ROLES[role]?.label}
+                {POPULATION_ROLES[role]?.icon} {ctx.actions.get(action.id).name}
+                : {POPULATION_ROLES[role]?.label}
               </>
             }
             costs={costs}
@@ -188,7 +186,9 @@ function RaisePopOptions({
               handleHoverCard({
                 title: `${ctx.actions.get(action.id).icon || ''}${
                   POPULATION_ROLES[role]?.icon
-                } Hire ${POPULATION_ROLES[role]?.label || ''}`,
+                } ${ctx.actions.get(action.id).name}: ${
+                  POPULATION_ROLES[role]?.label || ''
+                }`,
                 effects,
                 requirements,
                 costs,
@@ -263,8 +263,8 @@ function DevelopOptions({
   return (
     <div>
       <h3 className="font-medium">
-        {ctx.actions.get('develop').icon || ''}{' '}
-        {ctx.actions.get('develop').name}{' '}
+        {ctx.actions.get(action.id)?.icon || ''}{' '}
+        {ctx.actions.get(action.id)?.name}{' '}
         <span className="italic text-sm font-normal">
           (Effects take place on build and last until development is removed)
         </span>
@@ -272,7 +272,7 @@ function DevelopOptions({
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1">
         {developments.map((d) => {
           const landIdForCost = ctx.activePlayer.lands[0]?.id as string;
-          const costsBag = getActionCosts('develop', ctx, {
+          const costsBag = getActionCosts(action.id, ctx, {
             id: d.id,
             landId: landIdForCost,
           });
@@ -281,7 +281,7 @@ function DevelopOptions({
           const requirements = hasDevelopLand
             ? []
             : [
-                `Requires ${landIcon} ${landLabel} with free ${slotIcon} ${slotLabel}`,
+                `Requires ${LAND_INFO.icon} ${LAND_INFO.label} with free ${SLOT_INFO.icon} ${SLOT_INFO.label}`,
               ];
           const canPay =
             hasDevelopLand &&
@@ -294,7 +294,7 @@ function DevelopOptions({
           const title = !implemented
             ? 'Not implemented yet'
             : !hasDevelopLand
-              ? `No ${landIcon} ${landLabel} with free ${slotIcon} ${slotLabel}`
+              ? `No ${LAND_INFO.icon} ${LAND_INFO.label} with free ${SLOT_INFO.icon} ${SLOT_INFO.label}`
               : !canPay
                 ? 'Cannot pay costs'
                 : undefined;
@@ -310,7 +310,7 @@ function DevelopOptions({
               playerResources={ctx.activePlayer.resources}
               actionCostResource={actionCostResource}
               requirements={requirements}
-              requirementIcons={[slotIcon]}
+              requirementIcons={[SLOT_INFO.icon]}
               summary={summary}
               implemented={implemented}
               enabled={enabled}
@@ -325,9 +325,9 @@ function DevelopOptions({
                 const full = describeContent('development', d.id, ctx);
                 const { effects, description } = splitSummary(full);
                 handleHoverCard({
-                  title: `${ctx.actions.get('develop').icon || ''} ${
-                    ctx.actions.get('develop').name
-                  } - ${ctx.developments.get(d.id)?.icon} ${d.name}`,
+                  title: `${ctx.actions.get(action.id)?.icon || ''} ${
+                    ctx.actions.get(action.id)?.name
+                  } - ${ctx.developments.get(d.id)?.icon || ''} ${d.name}`,
                   effects,
                   requirements,
                   costs,
@@ -371,14 +371,15 @@ function BuildOptions({
   return (
     <div>
       <h3 className="font-medium">
-        {ctx.actions.get('build').icon || ''} {ctx.actions.get('build').name}{' '}
+        {ctx.actions.get(action.id)?.icon || ''}{' '}
+        {ctx.actions.get(action.id)?.name}{' '}
         <span className="italic text-sm font-normal">
           (Effects take place on build and last until building is removed)
         </span>
       </h3>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1">
         {buildings.map((b) => {
-          const costsBag = getActionCosts('build', ctx, { id: b.id });
+          const costsBag = getActionCosts(action.id, ctx, { id: b.id });
           const costs: Record<string, number> = {};
           for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
           const requirements: string[] = [];
@@ -398,10 +399,7 @@ function BuildOptions({
               key={b.id}
               title={
                 <>
-                  {ctx.buildings.get(b.id)?.icon ||
-                    ctx.actions.get('build').icon ||
-                    ''}{' '}
-                  {b.name}
+                  {ctx.buildings.get(b.id)?.icon || ''} {b.name}
                 </>
               }
               costs={costs}
@@ -420,8 +418,8 @@ function BuildOptions({
                 const full = descriptions.get(b.id) ?? [];
                 const { effects, description } = splitSummary(full);
                 handleHoverCard({
-                  title: `${ctx.actions.get('build').icon || ''} ${
-                    ctx.actions.get('build').name
+                  title: `${ctx.actions.get(action.id)?.icon || ''} ${
+                    ctx.actions.get(action.id)?.name
                   } - ${ctx.buildings.get(b.id)?.icon || ''} ${b.name}`,
                   effects,
                   requirements,

--- a/packages/web/src/components/player/BuildingDisplay.tsx
+++ b/packages/web/src/components/player/BuildingDisplay.tsx
@@ -16,8 +16,7 @@ const BuildingDisplay: React.FC<BuildingDisplayProps> = ({ player }) => {
     <div ref={animateBuildings} className="flex flex-wrap gap-2 mt-2 w-fit">
       {Array.from(player.buildings).map((b) => {
         const name = ctx.buildings.get(b)?.name || b;
-        const icon =
-          ctx.buildings.get(b)?.icon || ctx.actions.get('build').icon || '';
+        const icon = ctx.buildings.get(b)?.icon || '';
         const title = `${icon} ${name}`;
         return (
           <div

--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react';
 import {
-  LAND_ICON as landIcon,
-  SLOT_ICON as slotIcon,
+  LAND_INFO,
+  SLOT_INFO,
+  DEVELOPMENTS_INFO,
 } from '@kingdom-builder/contents';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { describeContent, splitSummary } from '../../translation';
@@ -23,10 +24,10 @@ const LandTile: React.FC<{
     const full = describeContent('land', land, ctx);
     const { effects, description } = splitSummary(full);
     handleHoverCard({
-      title: `${landIcon} Land`,
+      title: `${LAND_INFO.icon} ${LAND_INFO.label}`,
       effects,
       requirements: [],
-      effectsTitle: 'Developments',
+      effectsTitle: DEVELOPMENTS_INFO.label,
       ...(description && { description }),
       bgClass: 'bg-gray-100 dark:bg-gray-700',
     });
@@ -38,7 +39,9 @@ const LandTile: React.FC<{
       onMouseEnter={showLandCard}
       onMouseLeave={clearHoverCard}
     >
-      <span className="font-medium">{landIcon} Land</span>
+      <span className="font-medium">
+        {LAND_INFO.icon} {LAND_INFO.label}
+      </span>
       <div
         ref={animateSlots}
         className="mt-1 flex flex-wrap justify-center gap-1"
@@ -84,7 +87,7 @@ const LandTile: React.FC<{
               onMouseEnter={(e) => {
                 e.stopPropagation();
                 handleHoverCard({
-                  title: `${slotIcon} Development Slot (empty)`,
+                  title: `${SLOT_INFO.icon} ${SLOT_INFO.label} (empty)`,
                   effects: [],
                   ...(developAction && {
                     description: `Use ${developAction.icon || ''} ${developAction.name} to build here`,
@@ -98,7 +101,7 @@ const LandTile: React.FC<{
                 handleLeave();
               }}
             >
-              {slotIcon} -empty-
+              {SLOT_INFO.icon} -empty-
             </span>
           );
         })}

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { useGameEngine } from '../../state/GameContext';
-import { MODIFIER_INFO as modifierInfo } from '@kingdom-builder/contents';
+import {
+  MODIFIER_INFO as modifierInfo,
+  PHASES,
+  PASSIVE_INFO,
+} from '@kingdom-builder/contents';
 import { describeEffects, splitSummary } from '../../translation';
 import type { EffectDef } from '@kingdom-builder/engine';
 import { useAnimate } from '../../utils/useAutoAnimate';
@@ -50,8 +54,10 @@ export default function PassiveDisplay({
       {entries.map(([id, def]) => {
         const icon = getIcon(def.effects);
         const items = describeEffects(def.effects || [], ctx);
+        const upkeepLabel =
+          PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
         const summary = def.onUpkeepPhase
-          ? [{ title: 'Until your next Upkeep Phase', items }]
+          ? [{ title: `Until your next ${upkeepLabel} Phase`, items }]
           : items;
         return (
           <span
@@ -60,7 +66,7 @@ export default function PassiveDisplay({
             onMouseEnter={() => {
               const { effects, description } = splitSummary(summary);
               handleHoverCard({
-                title: `${icon} Passive`,
+                title: `${icon} ${PASSIVE_INFO.label}`,
                 effects,
                 requirements: [],
                 ...(description && { description }),

--- a/packages/web/src/components/player/PopulationInfo.tsx
+++ b/packages/web/src/components/player/PopulationInfo.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { POPULATION_ROLES, STATS } from '@kingdom-builder/contents';
+import {
+  POPULATION_ROLES,
+  STATS,
+  POPULATION_INFO,
+  POPULATION_ARCHETYPE_INFO,
+} from '@kingdom-builder/contents';
 import { formatStatValue } from '../../utils/stats';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { useGameEngine } from '../../state/GameContext';
@@ -16,14 +21,13 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
 
   const showPopulationCard = () =>
     handleHoverCard({
-      title: '👥 Population',
+      title: `${POPULATION_INFO.icon} ${POPULATION_INFO.label}`,
       effects: Object.values(POPULATION_ROLES).map(
         (r) => `${r.icon} ${r.label} - ${r.description}`,
       ),
-      effectsTitle: 'Archetypes',
+      effectsTitle: POPULATION_ARCHETYPE_INFO.label,
       requirements: [],
-      description:
-        'Population represents the people of your kingdom. Manage them wisely and assign roles to benefit your realm.',
+      description: POPULATION_INFO.description,
       bgClass: 'bg-gray-100 dark:bg-gray-700',
     });
 
@@ -45,7 +49,8 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
           }
         }}
       >
-        👥{currentPop}/{player.maxPopulation}
+        {POPULATION_INFO.icon}
+        {currentPop}/{player.maxPopulation}
         {popDetails.length > 0 && (
           <>
             {' ('}

--- a/packages/web/src/translation/content/land.ts
+++ b/packages/web/src/translation/content/land.ts
@@ -1,8 +1,5 @@
 import type { EngineContext } from '@kingdom-builder/engine';
-import {
-  SLOT_ICON as slotIcon,
-  SLOT_LABEL as slotLabel,
-} from '@kingdom-builder/contents';
+import { SLOT_INFO } from '@kingdom-builder/contents';
 import {
   describeContent,
   summarizeContent,
@@ -31,7 +28,7 @@ function translate(
         items: fn('development', devId, ctx, { installed: true }),
       });
     } else {
-      items.push(`${slotIcon} Empty ${slotLabel}`);
+      items.push(`${SLOT_INFO.icon} Empty ${SLOT_INFO.label}`);
     }
   }
   return items;

--- a/packages/web/src/translation/effects/evaluators/population.ts
+++ b/packages/web/src/translation/effects/evaluators/population.ts
@@ -1,4 +1,4 @@
-import { POPULATION_ROLES } from '@kingdom-builder/contents';
+import { POPULATION_ROLES, POPULATION_INFO } from '@kingdom-builder/contents';
 import { registerEvaluatorFormatter } from '../factory';
 
 registerEvaluatorFormatter('population', {
@@ -6,7 +6,9 @@ registerEvaluatorFormatter('population', {
     const role = (ev.params as Record<string, string>)?.['role'] as
       | keyof typeof POPULATION_ROLES
       | undefined;
-    const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
+    const icon = role
+      ? POPULATION_ROLES[role]?.icon || role
+      : POPULATION_INFO.icon;
     return sub.map((s) =>
       typeof s === 'string'
         ? `${s} per ${icon}`
@@ -31,8 +33,11 @@ registerEvaluatorFormatter('population', {
     }
     return sub.map((s) =>
       typeof s === 'string'
-        ? `${s} for each population`
-        : { ...s, title: `${s.title} for each population` },
+        ? `${s} for each ${POPULATION_INFO.label.toLowerCase()}`
+        : {
+            ...s,
+            title: `${s.title} for each ${POPULATION_INFO.label.toLowerCase()}`,
+          },
     );
   },
 });

--- a/packages/web/src/translation/effects/formatters/land.ts
+++ b/packages/web/src/translation/effects/formatters/land.ts
@@ -1,22 +1,20 @@
-import {
-  LAND_ICON as landIcon,
-  SLOT_ICON as slotIcon,
-} from '@kingdom-builder/contents';
+import { LAND_INFO, SLOT_INFO } from '@kingdom-builder/contents';
 import { gainOrLose, signed } from '../helpers';
 import { registerEffectFormatter } from '../factory';
 
 registerEffectFormatter('land', 'add', {
   summarize: (eff) => {
     const count = Number(eff.params?.['count'] ?? 1);
-    return `${landIcon}${signed(count)}${count}`;
+    return `${LAND_INFO.icon}${signed(count)}${count}`;
   },
   describe: (eff) => {
     const count = Number(eff.params?.['count'] ?? 1);
-    return `${gainOrLose(count)} ${count} ${landIcon} Land`;
+    return `${gainOrLose(count)} ${count} ${LAND_INFO.icon} ${LAND_INFO.label}`;
   },
 });
 
 registerEffectFormatter('land', 'till', {
-  summarize: () => `${slotIcon}+1`,
-  describe: () => `Till ${landIcon} to unlock ${slotIcon} slot`,
+  summarize: () => `${SLOT_INFO.icon}+1`,
+  describe: () =>
+    `Till ${LAND_INFO.icon} ${LAND_INFO.label} to unlock ${SLOT_INFO.icon} ${SLOT_INFO.label}`,
 });

--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -1,6 +1,7 @@
 import {
   MODIFIER_INFO as modifierInfo,
   RESOURCES,
+  POPULATION_INFO,
 } from '@kingdom-builder/contents';
 import type {
   ActionDef,
@@ -86,7 +87,7 @@ function formatPopulation(
 ) {
   const { icon, name } = getActionInfo(ctx, evaluation.id);
   const amount = Number(eff.params?.['amount'] ?? 0);
-  return `${modifierInfo.result.icon} Every time you gain resources from 👥 Population through ${icon} ${name}, gain +${amount} more of that resource`;
+  return `${modifierInfo.result.icon} Every time you gain resources from ${POPULATION_INFO.icon} ${POPULATION_INFO.label} through ${icon} ${name}, gain +${amount} more of that resource`;
 }
 
 registerModifierEvalHandler('development', {

--- a/packages/web/src/translation/effects/formatters/passive.ts
+++ b/packages/web/src/translation/effects/formatters/passive.ts
@@ -3,25 +3,44 @@ import {
   summarizeEffects,
   describeEffects,
 } from '../factory';
+import { PHASES, PASSIVE_INFO } from '@kingdom-builder/contents';
 
 registerEffectFormatter('passive', 'add', {
   summarize: (eff, ctx) => {
     const inner = summarizeEffects(eff.effects || [], ctx);
+    const upkeepLabel =
+      PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
     return eff.params?.['onUpkeepPhase']
-      ? [{ title: '♾️ Until next Upkeep', items: inner }]
+      ? [
+          {
+            title: `${PASSIVE_INFO.icon} Until next ${upkeepLabel}`,
+            items: inner,
+          },
+        ]
       : inner;
   },
   describe: (eff, ctx) => {
     const inner = describeEffects(eff.effects || [], ctx);
+    const upkeepLabel =
+      PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
     return eff.params?.['onUpkeepPhase']
-      ? [{ title: '♾️ Until your next Upkeep Phase', items: inner }]
+      ? [
+          {
+            title: `${PASSIVE_INFO.icon} Until your next ${upkeepLabel} Phase`,
+            items: inner,
+          },
+        ]
       : inner;
   },
   log: (eff, ctx) => {
     const inner = describeEffects(eff.effects || [], ctx);
     const items = [...(inner.length ? inner : [])];
+    const upkeepLabel =
+      PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
     if (eff.params?.['onUpkeepPhase'])
-      items.push("♾️ Passive duration: Until player's next Upkeep Phase");
-    return { title: '♾️ Passive added', items };
+      items.push(
+        `${PASSIVE_INFO.icon} ${PASSIVE_INFO.label} duration: Until player's next ${upkeepLabel} Phase`,
+      );
+    return { title: `${PASSIVE_INFO.icon} ${PASSIVE_INFO.label} added`, items };
   },
 });

--- a/packages/web/src/translation/effects/formatters/population.ts
+++ b/packages/web/src/translation/effects/formatters/population.ts
@@ -1,4 +1,4 @@
-import { POPULATION_ROLES } from '@kingdom-builder/contents';
+import { POPULATION_ROLES, POPULATION_INFO } from '@kingdom-builder/contents';
 import { registerEffectFormatter } from '../factory';
 
 registerEffectFormatter('population', 'add', {
@@ -6,15 +6,17 @@ registerEffectFormatter('population', 'add', {
     const role = eff.params?.['role'] as
       | keyof typeof POPULATION_ROLES
       | undefined;
-    const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
-    return `👥(${icon}) +1`;
+    const icon = role
+      ? POPULATION_ROLES[role]?.icon || role
+      : POPULATION_INFO.icon;
+    return `${POPULATION_INFO.icon}(${icon}) +1`;
   },
   describe: (eff) => {
     const role = eff.params?.['role'] as
       | keyof typeof POPULATION_ROLES
       | undefined;
     const info = role ? POPULATION_ROLES[role] : undefined;
-    const label = info?.label || role || 'population';
+    const label = info?.label || role || POPULATION_INFO.label;
     const icon = info?.icon || '';
     return `Add ${icon} ${label}`;
   },
@@ -25,15 +27,17 @@ registerEffectFormatter('population', 'remove', {
     const role = eff.params?.['role'] as
       | keyof typeof POPULATION_ROLES
       | undefined;
-    const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
-    return `👥(${icon}) -1`;
+    const icon = role
+      ? POPULATION_ROLES[role]?.icon || role
+      : POPULATION_INFO.icon;
+    return `${POPULATION_INFO.icon}(${icon}) -1`;
   },
   describe: (eff) => {
     const role = eff.params?.['role'] as
       | keyof typeof POPULATION_ROLES
       | undefined;
     const info = role ? POPULATION_ROLES[role] : undefined;
-    const label = info?.label || role || 'population';
+    const label = info?.label || role || POPULATION_INFO.label;
     const icon = info?.icon || '';
     return `Remove ${icon} ${label}`;
   },

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -7,8 +7,10 @@ import {
   RESOURCES,
   STATS,
   POPULATION_ROLES,
-  LAND_ICON as landIcon,
-  SLOT_ICON as slotIcon,
+  LAND_INFO,
+  SLOT_INFO,
+  PASSIVE_INFO,
+  POPULATION_INFO,
   type ResourceKey,
 } from '@kingdom-builder/contents';
 import { formatStatValue, statDisplaysAsPercent } from '../utils/stats';
@@ -113,13 +115,13 @@ export function diffSnapshots(
   for (const land of after.lands) {
     const prev = before.lands.find((l) => l.id === land.id);
     if (!prev) {
-      changes.push(`${landIcon} New land`);
+      changes.push(`${LAND_INFO.icon} New ${LAND_INFO.label}`);
       continue;
     }
     for (const dev of land.developments)
       if (!prev.developments.includes(dev)) {
         const label = logContent('development', dev, ctx)[0] ?? dev;
-        changes.push(`${landIcon} +${label}`);
+        changes.push(`${LAND_INFO.icon} +${label}`);
       }
   }
   const beforeSlots = before.lands.reduce((sum, l) => sum + l.slotsMax, 0);
@@ -130,12 +132,12 @@ export function diffSnapshots(
   const slotDelta = afterSlots - newLandSlots - beforeSlots;
   if (slotDelta !== 0)
     changes.push(
-      `${slotIcon} Development Slot ${slotDelta >= 0 ? '+' : ''}${slotDelta} (${beforeSlots}→${beforeSlots + slotDelta})`,
+      `${SLOT_INFO.icon} ${SLOT_INFO.label} ${slotDelta >= 0 ? '+' : ''}${slotDelta} (${beforeSlots}→${beforeSlots + slotDelta})`,
     );
   const beforeP = new Set(before.passives);
   const afterP = new Set(after.passives);
   for (const id of beforeP)
-    if (!afterP.has(id)) changes.push(`Passive ${id} removed`);
+    if (!afterP.has(id)) changes.push(`${PASSIVE_INFO.label} ${id} removed`);
   return changes;
 }
 
@@ -178,7 +180,9 @@ function renderPopulationIcons(
   const role = (ev.params as Record<string, string> | undefined)?.['role'] as
     | keyof typeof POPULATION_ROLES
     | undefined;
-  const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
+  const icon = role
+    ? POPULATION_ROLES[role]?.icon || role
+    : POPULATION_INFO.icon;
   entry.icons += icon.repeat(count);
 }
 
@@ -344,13 +348,13 @@ export function diffStepSnapshots(
   for (const land of after.lands) {
     const prev = before.lands.find((l) => l.id === land.id);
     if (!prev) {
-      changes.push(`${landIcon} New land`);
+      changes.push(`${LAND_INFO.icon} New ${LAND_INFO.label}`);
       continue;
     }
     for (const dev of land.developments)
       if (!prev.developments.includes(dev)) {
         const label = logContent('development', dev, ctx)[0] ?? dev;
-        changes.push(`${landIcon} +${label}`);
+        changes.push(`${LAND_INFO.icon} +${label}`);
       }
   }
   const beforeSlots = before.lands.reduce((sum, l) => sum + l.slotsMax, 0);
@@ -361,11 +365,11 @@ export function diffStepSnapshots(
   const slotDelta = afterSlots - newLandSlots - beforeSlots;
   if (slotDelta !== 0)
     changes.push(
-      `${slotIcon} Development Slot ${slotDelta >= 0 ? '+' : ''}${slotDelta} (${beforeSlots}→${beforeSlots + slotDelta})`,
+      `${SLOT_INFO.icon} ${SLOT_INFO.label} ${slotDelta >= 0 ? '+' : ''}${slotDelta} (${beforeSlots}→${beforeSlots + slotDelta})`,
     );
   const beforeP = new Set(before.passives);
   const afterP = new Set(after.passives);
   for (const id of beforeP)
-    if (!afterP.has(id)) changes.push(`Passive ${id} removed`);
+    if (!afterP.has(id)) changes.push(`${PASSIVE_INFO.label} ${id} removed`);
   return changes;
 }

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -16,10 +16,8 @@ import {
   RULES,
   POPULATION_ROLES,
   STATS,
-  SLOT_ICON,
-  LAND_ICON,
-  LAND_LABEL,
-  SLOT_LABEL,
+  SLOT_INFO,
+  LAND_INFO,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -85,10 +83,10 @@ describe('<ActionsPanel />', () => {
     const originalSlots = ctx.activePlayer.lands.map((l) => l.slotsUsed);
     ctx.activePlayer.lands.forEach((l) => (l.slotsUsed = l.slotsMax));
     render(<ActionsPanel />);
-    expect(screen.getAllByText(`Req ${SLOT_ICON}`)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(`Req ${SLOT_INFO.icon}`)[0]).toBeInTheDocument();
     expect(
       screen.getAllByTitle(
-        `No ${LAND_ICON} ${LAND_LABEL} with free ${SLOT_ICON} ${SLOT_LABEL}`,
+        `No ${LAND_INFO.icon} ${LAND_INFO.label} with free ${SLOT_INFO.icon} ${SLOT_INFO.label}`,
       )[0],
     ).toBeInTheDocument();
     ctx.activePlayer.lands.forEach((l, i) => (l.slotsUsed = originalSlots[i]));

--- a/packages/web/tests/land-till-formatter.test.ts
+++ b/packages/web/tests/land-till-formatter.test.ts
@@ -10,7 +10,7 @@ import {
   PHASES,
   GAME_START,
   RULES,
-  SLOT_ICON as slotIcon,
+  SLOT_INFO,
 } from '@kingdom-builder/contents';
 import { LandMethods } from '@kingdom-builder/contents/config/builders';
 
@@ -37,7 +37,7 @@ describe('land till formatter', () => {
       [{ type: 'land', method: LandMethods.TILL }],
       ctx,
     );
-    expect(summary).toContain(`${slotIcon}+1`);
+    expect(summary).toContain(`${SLOT_INFO.icon}+1`);
   });
 
   it('summarizes till action', () => {
@@ -56,7 +56,7 @@ describe('land till formatter', () => {
     )?.[0] as string;
     const summary = summarizeContent('action', tillId, ctx);
     const hasIcon = summary.some(
-      (i) => typeof i === 'string' && i.includes(slotIcon),
+      (i) => typeof i === 'string' && i.includes(SLOT_INFO.icon),
     );
     expect(hasIcon).toBe(true);
   });

--- a/packages/web/tests/plow-action-translation.test.ts
+++ b/packages/web/tests/plow-action-translation.test.ts
@@ -15,9 +15,8 @@ import {
   RULES,
   RESOURCES,
   Resource,
-  LAND_ICON,
-  LAND_LABEL,
-  SLOT_ICON,
+  LAND_INFO,
+  SLOT_INFO,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -98,13 +97,15 @@ describe('plow action translation', () => {
       {
         title: `${expand.icon} ${expand.name}`,
         items: [
-          `Gain ${landCount} ${LAND_ICON} ${LAND_LABEL}`,
+          `Gain ${landCount} ${LAND_INFO.icon} ${LAND_INFO.label}`,
           `${hapInfo.icon}+${hapAmt} ${hapInfo.label}`,
         ],
       },
       {
         title: `${till.icon} ${till.name}`,
-        items: [`Till ${LAND_ICON} to unlock ${SLOT_ICON} slot`],
+        items: [
+          `Till ${LAND_INFO.icon} ${LAND_INFO.label} to unlock ${SLOT_INFO.icon} ${SLOT_INFO.label}`,
+        ],
       },
       {
         title: '♾️ Until your next Upkeep Phase',

--- a/packages/web/tests/subaction-log.test.ts
+++ b/packages/web/tests/subaction-log.test.ts
@@ -15,7 +15,7 @@ import {
   GAME_START,
   RULES,
   RESOURCES,
-  SLOT_ICON as slotIcon,
+  SLOT_INFO,
   type ResourceKey,
 } from '@kingdom-builder/contents';
 import {
@@ -125,7 +125,9 @@ describe('sub-action logging', () => {
     );
     expect(tillDiff.length).toBeGreaterThan(0);
     expect(
-      tillDiff.some((line) => line.startsWith(`${slotIcon} Development Slot`)),
+      tillDiff.some((line) =>
+        line.startsWith(`${SLOT_INFO.icon} Development Slot`),
+      ),
     ).toBe(true);
     tillDiff.forEach((line) => {
       expect(logLines).toContain(`    ${line}`);


### PR DESCRIPTION
## Summary
- define LAND_INFO, SLOT_INFO, POPULATION_INFO and PASSIVE_INFO to expose shared icons/labels
- update web components, translations and tests to pull metadata from these content objects

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b72fab4950832581c87287bb71d289