### PR TITLE
test: ensure stat:add_pct cache resets each step

### DIFF
--- a/packages/engine/tests/effects/stat-add-pct-step-reset.test.ts
+++ b/packages/engine/tests/effects/stat-add-pct-step-reset.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { runEffects } from '../../src/effects/index.ts';
+import { createTestEngine } from '../helpers.ts';
+import { Stat } from '../../src/state/index.ts';
+
+describe('stat:add_pct effect', () => {
+  it('resets cached base between steps', () => {
+    const ctx = createTestEngine();
+    ctx.activePlayer.stats[Stat.absorption] = 0.2;
+    ctx.game.currentStep = 's1';
+    const effect = {
+      type: 'stat',
+      method: 'add_pct',
+      params: { key: Stat.absorption, percent: 0.5 },
+    } as const;
+    runEffects([effect], ctx);
+    expect(ctx.activePlayer.stats[Stat.absorption]).toBeCloseTo(0.3);
+    ctx.game.currentStep = 's2';
+    runEffects([effect], ctx);
+    expect(ctx.activePlayer.stats[Stat.absorption]).toBeCloseTo(0.45);
+  });
+});


### PR DESCRIPTION
## Summary
- add test confirming `stat:add_pct` recalculates from updated base when step changes

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b736aefc448325ad13caea1992dc96