### PR TITLE
test: verify resource transfer percent bounds

### DIFF
--- a/packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts
+++ b/packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { runEffects, advance, Resource } from '../../src/index.ts';
+import { createTestEngine } from '../helpers.ts';
+import type { EffectDef } from '../../src/effects/index.ts';
+
+describe('resource:transfer percent bounds', () => {
+  it('adjusts transfer percentage within bounds', () => {
+    const ctx = createTestEngine();
+    while (ctx.game.currentPhase !== 'main') advance(ctx);
+    ctx.game.currentPlayerIndex = 0;
+
+    const transfer: EffectDef<{ key: string; percent: number }> = {
+      type: 'resource',
+      method: 'transfer',
+      params: { key: Resource.gold, percent: 50 },
+    };
+    const addBoost: EffectDef<{ id: string }> = {
+      type: 'result_mod',
+      method: 'add',
+      params: {
+        id: 'boost',
+        evaluation: { type: 'transfer_pct', id: 'percent' },
+        adjust: 80,
+      },
+    };
+    const removeBoost: EffectDef<{ id: string }> = {
+      type: 'result_mod',
+      method: 'remove',
+      params: {
+        id: 'boost',
+        evaluation: { type: 'transfer_pct', id: 'percent' },
+      },
+    };
+    const addNerf: EffectDef<{ id: string }> = {
+      type: 'result_mod',
+      method: 'add',
+      params: {
+        id: 'nerf',
+        evaluation: { type: 'transfer_pct', id: 'percent' },
+        adjust: -200,
+      },
+    };
+
+    ctx.activePlayer.gold = 0;
+    ctx.opponent.gold = 10;
+    const total = ctx.opponent.gold;
+
+    runEffects([addBoost], ctx);
+    runEffects([transfer], ctx);
+    expect(ctx.activePlayer.gold).toBe(total);
+    expect(ctx.opponent.gold).toBe(0);
+
+    runEffects([removeBoost], ctx);
+    ctx.activePlayer.gold = 0;
+    ctx.opponent.gold = total;
+
+    runEffects([addNerf], ctx);
+    runEffects([transfer], ctx);
+    expect(ctx.activePlayer.gold).toBe(0);
+    expect(ctx.opponent.gold).toBe(total);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for resource transfer percentage adjustments via result modifiers

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b736b30568832589ff67245d20c51a