### PR TITLE
refactor: unify translation helpers

### DIFF
--- a/packages/web/src/translation/effects/evaluators/population.ts
+++ b/packages/web/src/translation/effects/evaluators/population.ts
@@ -1,12 +1,14 @@
 import { POPULATION_ROLES } from '@kingdom-builder/contents';
 import { registerEvaluatorFormatter } from '../factory';
+import { getPopulationInfo } from '../helpers';
 
 registerEvaluatorFormatter('population', {
   summarize: (ev, sub) => {
     const role = (ev.params as Record<string, string>)?.['role'] as
       | keyof typeof POPULATION_ROLES
       | undefined;
-    const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
+    const { icon: generic } = getPopulationInfo();
+    const icon = role ? POPULATION_ROLES[role]?.icon || role : generic || '👥';
     return sub.map((s) =>
       typeof s === 'string'
         ? `${s} per ${icon}`
@@ -19,20 +21,22 @@ registerEvaluatorFormatter('population', {
       | undefined;
     if (role) {
       const info = POPULATION_ROLES[role];
+      const icon = info?.icon || '';
+      const label = info?.label || role;
       return sub.map((s) =>
         typeof s === 'string'
-          ? `${s} for each ${info?.icon || ''}${info?.label || role}`.trim()
+          ? `${s} for each ${icon} ${label}`.trim()
           : {
               ...s,
-              title:
-                `${s.title} for each ${info?.icon || ''}${info?.label || role}`.trim(),
+              title: `${s.title} for each ${icon} ${label}`.trim(),
             },
       );
     }
+    const { icon, name } = getPopulationInfo();
     return sub.map((s) =>
       typeof s === 'string'
-        ? `${s} for each population`
-        : { ...s, title: `${s.title} for each population` },
+        ? `${s} for each ${icon} ${name}`.trim()
+        : { ...s, title: `${s.title} for each ${icon} ${name}`.trim() },
     );
   },
 });

--- a/packages/web/src/translation/effects/formatters/action.ts
+++ b/packages/web/src/translation/effects/formatters/action.ts
@@ -1,31 +1,18 @@
-import type { EngineContext } from '@kingdom-builder/engine';
 import { describeContent } from '../../content';
 import { registerEffectFormatter, logEffects } from '../factory';
-
-function getActionLabel(id: string, ctx: EngineContext) {
-  let name = id;
-  let icon = '';
-  try {
-    const def = ctx.actions.get(id);
-    name = def.name;
-    icon = def.icon || '';
-  } catch {
-    // ignore missing action
-  }
-  return { icon, name };
-}
+import { getActionInfo } from '../helpers';
 
 registerEffectFormatter('action', 'add', {
   summarize: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
-    const { icon, name } = getActionLabel(id, ctx);
+    const { icon, name } = getActionInfo(ctx, id);
     return `Gain action ${icon} ${name}`;
   },
   describe: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
-    const { icon, name } = getActionLabel(id, ctx);
+    const { icon, name } = getActionInfo(ctx, id);
     const card = describeContent('action', id, ctx);
     let isSystem = false;
     try {
@@ -46,7 +33,7 @@ registerEffectFormatter('action', 'add', {
   log: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
-    const { icon, name } = getActionLabel(id, ctx);
+    const { icon, name } = getActionInfo(ctx, id);
     return `Unlocked ${icon} ${name}`;
   },
 });
@@ -55,19 +42,19 @@ registerEffectFormatter('action', 'remove', {
   summarize: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
-    const { icon, name } = getActionLabel(id, ctx);
+    const { icon, name } = getActionInfo(ctx, id);
     return `Lose ${icon} ${name}`;
   },
   describe: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
-    const { icon, name } = getActionLabel(id, ctx);
+    const { icon, name } = getActionInfo(ctx, id);
     return `Lose action ${icon} ${name}`;
   },
   log: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
-    const { icon, name } = getActionLabel(id, ctx);
+    const { icon, name } = getActionInfo(ctx, id);
     return `Lost ${icon} ${name}`;
   },
 });
@@ -76,13 +63,13 @@ registerEffectFormatter('action', 'perform', {
   summarize: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
-    const { icon, name } = getActionLabel(id, ctx);
+    const { icon, name } = getActionInfo(ctx, id);
     return `${icon} ${name}`;
   },
   describe: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
-    const { icon, name } = getActionLabel(id, ctx);
+    const { icon, name } = getActionInfo(ctx, id);
     const summary = describeContent('action', id, ctx);
     return [
       {
@@ -94,7 +81,7 @@ registerEffectFormatter('action', 'perform', {
   log: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
     if (!id) return null;
-    const { icon, name } = getActionLabel(id, ctx);
+    const { icon, name } = getActionInfo(ctx, id);
     const def = ctx.actions.get(id);
     const sub = logEffects(def.effects, ctx);
     return [{ title: `${icon} ${name}`, items: sub }];

--- a/packages/web/src/translation/effects/formatters/building.ts
+++ b/packages/web/src/translation/effects/formatters/building.ts
@@ -1,32 +1,17 @@
 import { registerEffectFormatter } from '../factory';
+import { getActionInfo, getBuildingInfo } from '../helpers';
 
 registerEffectFormatter('building', 'add', {
   summarize: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
-    let name = id;
-    let icon = '';
-    try {
-      const def = ctx.buildings.get(id);
-      name = def.name;
-      icon = def.icon || '';
-    } catch {
-      // ignore
-    }
-    if (!icon) icon = ctx.actions.get('build').icon || '';
-    return `${icon}${name}`;
+    const { icon, name } = getBuildingInfo(ctx, id);
+    const buildIcon = icon || getActionInfo(ctx, 'build').icon;
+    return `${buildIcon}${name}`;
   },
   describe: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
-    let name = id;
-    let icon = '';
-    try {
-      const def = ctx.buildings.get(id);
-      name = def.name;
-      icon = def.icon || '';
-    } catch {
-      // ignore
-    }
-    if (!icon) icon = ctx.actions.get('build').icon || '';
-    return `Construct ${icon}${name}`;
+    const { icon, name } = getBuildingInfo(ctx, id);
+    const buildIcon = icon || getActionInfo(ctx, 'build').icon;
+    return `Construct ${buildIcon}${name}`;
   },
 });

--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -1,51 +1,28 @@
 import { registerEffectFormatter } from '../factory';
+import { getDevelopmentInfo } from '../helpers';
 
 registerEffectFormatter('development', 'add', {
   summarize: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
-    let icon = id;
-    try {
-      icon = ctx.developments.get(id).icon || id;
-    } catch {
-      /* ignore */
-    }
-    return `${icon}`;
+    const { icon } = getDevelopmentInfo(ctx, id);
+    return icon || id;
   },
   describe: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
-    let def: { name: string; icon?: string | undefined } | undefined;
-    try {
-      def = ctx.developments.get(id);
-    } catch {
-      /* ignore */
-    }
-    const label = def?.name || id;
-    const icon = def?.icon || '';
-    return `Add ${icon}${label}`;
+    const { icon, name } = getDevelopmentInfo(ctx, id);
+    return `Add ${icon}${name}`;
   },
 });
 
 registerEffectFormatter('development', 'remove', {
   summarize: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
-    let icon = id;
-    try {
-      icon = ctx.developments.get(id).icon || id;
-    } catch {
-      /* ignore */
-    }
-    return `Remove ${icon}`;
+    const { icon } = getDevelopmentInfo(ctx, id);
+    return `Remove ${icon || id}`;
   },
   describe: (eff, ctx) => {
     const id = eff.params?.['id'] as string;
-    let def: { name: string; icon?: string | undefined } | undefined;
-    try {
-      def = ctx.developments.get(id);
-    } catch {
-      /* ignore */
-    }
-    const label = def?.name || id;
-    const icon = def?.icon || '';
-    return `Remove ${icon}${label}`;
+    const { icon, name } = getDevelopmentInfo(ctx, id);
+    return `Remove ${icon}${name}`;
   },
 });

--- a/packages/web/src/translation/effects/formatters/population.ts
+++ b/packages/web/src/translation/effects/formatters/population.ts
@@ -1,24 +1,29 @@
 import { POPULATION_ROLES } from '@kingdom-builder/contents';
 import type { EffectDef } from '@kingdom-builder/engine';
 import { registerEffectFormatter } from '../factory';
-import { signed } from '../helpers';
+import { getPopulationInfo, signed } from '../helpers';
 
 function summarizeChange(eff: EffectDef, delta: number) {
   const role = eff.params?.['role'] as
     | keyof typeof POPULATION_ROLES
     | undefined;
-  const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
-  return `👥(${icon}) ${signed(delta)}${Math.abs(delta)}`;
+  const { icon: popIcon } = getPopulationInfo();
+  const icon = role ? POPULATION_ROLES[role]?.icon || role : popIcon || '👥';
+  return `${popIcon || '👥'}(${icon}) ${signed(delta)}${Math.abs(delta)}`;
 }
 
 function describeChange(eff: EffectDef, verb: string) {
   const role = eff.params?.['role'] as
     | keyof typeof POPULATION_ROLES
     | undefined;
-  const info = role ? POPULATION_ROLES[role] : undefined;
-  const label = info?.label || role || 'population';
-  const icon = info?.icon || '';
-  return `${verb} ${icon} ${label}`;
+  if (role) {
+    const info = POPULATION_ROLES[role];
+    const icon = info?.icon || '';
+    const label = info?.label || role;
+    return `${verb} ${icon} ${label}`.trim();
+  }
+  const { icon, name } = getPopulationInfo();
+  return `${verb} ${icon} ${name}`.trim();
 }
 
 registerEffectFormatter('population', 'add', {

--- a/packages/web/src/translation/effects/formatters/population.ts
+++ b/packages/web/src/translation/effects/formatters/population.ts
@@ -1,40 +1,32 @@
 import { POPULATION_ROLES } from '@kingdom-builder/contents';
+import type { EffectDef } from '@kingdom-builder/engine';
 import { registerEffectFormatter } from '../factory';
+import { signed } from '../helpers';
+
+function summarizeChange(eff: EffectDef, delta: number) {
+  const role = eff.params?.['role'] as
+    | keyof typeof POPULATION_ROLES
+    | undefined;
+  const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
+  return `👥(${icon}) ${signed(delta)}${Math.abs(delta)}`;
+}
+
+function describeChange(eff: EffectDef, verb: string) {
+  const role = eff.params?.['role'] as
+    | keyof typeof POPULATION_ROLES
+    | undefined;
+  const info = role ? POPULATION_ROLES[role] : undefined;
+  const label = info?.label || role || 'population';
+  const icon = info?.icon || '';
+  return `${verb} ${icon} ${label}`;
+}
 
 registerEffectFormatter('population', 'add', {
-  summarize: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
-    return `👥(${icon}) +1`;
-  },
-  describe: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const info = role ? POPULATION_ROLES[role] : undefined;
-    const label = info?.label || role || 'population';
-    const icon = info?.icon || '';
-    return `Add ${icon} ${label}`;
-  },
+  summarize: (eff) => summarizeChange(eff, 1),
+  describe: (eff) => describeChange(eff, 'Add'),
 });
 
 registerEffectFormatter('population', 'remove', {
-  summarize: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const icon = role ? POPULATION_ROLES[role]?.icon || role : '👥';
-    return `👥(${icon}) -1`;
-  },
-  describe: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const info = role ? POPULATION_ROLES[role] : undefined;
-    const label = info?.label || role || 'population';
-    const icon = info?.icon || '';
-    return `Remove ${icon} ${label}`;
-  },
+  summarize: (eff) => summarizeChange(eff, -1),
+  describe: (eff) => describeChange(eff, 'Remove'),
 });

--- a/packages/web/src/translation/effects/helpers.ts
+++ b/packages/web/src/translation/effects/helpers.ts
@@ -1,4 +1,47 @@
+import {
+  STATS,
+  Stat,
+  type ActionDef,
+  type DevelopmentDef,
+  type BuildingDef,
+} from '@kingdom-builder/contents';
+import type { EngineContext } from '@kingdom-builder/engine';
+
 export const signed = (n: number): string => (n >= 0 ? '+' : '');
 export const gainOrLose = (n: number): string => (n >= 0 ? 'Gain' : 'Lose');
 export const increaseOrDecrease = (n: number): string =>
   n >= 0 ? 'Increase' : 'Decrease';
+
+export function getActionInfo(ctx: EngineContext, id: string) {
+  try {
+    const action: ActionDef = ctx.actions.get(id);
+    return { icon: action.icon ?? id, name: action.name ?? id };
+  } catch {
+    return { icon: id, name: id };
+  }
+}
+
+export function getDevelopmentInfo(ctx: EngineContext, id: string) {
+  try {
+    const dev: DevelopmentDef = ctx.developments.get(id);
+    return { icon: dev.icon ?? '', name: dev.name ?? id };
+  } catch {
+    return { icon: '', name: id };
+  }
+}
+
+export function getBuildingInfo(ctx: EngineContext, id: string) {
+  try {
+    const b: BuildingDef = ctx.buildings.get(id);
+    return { icon: b.icon ?? '', name: b.name ?? id };
+  } catch {
+    return { icon: '', name: id };
+  }
+}
+
+export function getPopulationInfo() {
+  const info = STATS[Stat.maxPopulation];
+  const icon = info?.icon || '';
+  const name = (info?.label || 'Population').replace(/^Max\s+/i, '');
+  return { icon, name };
+}


### PR DESCRIPTION
## Summary
- centralize action, development, building and population info lookups
- unify resource modifier text handling and avoid hardcoded population strings
- deduplicate population and development formatter logic

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b737ef63fc8325850caac1baf8ed89