### PR TITLE
Unify resource and population translation formats

### DIFF
--- a/packages/web/src/translation/effects/evaluators/development.ts
+++ b/packages/web/src/translation/effects/evaluators/development.ts
@@ -3,32 +3,36 @@ import { registerEvaluatorFormatter } from '../factory';
 registerEvaluatorFormatter('development', {
   summarize: (ev, sub, ctx) => {
     const devId = (ev.params as Record<string, string>)['id']!;
-    let icon = devId;
-    try {
-      icon = ctx.developments.get(devId).icon || devId;
-    } catch {
-      /* ignore */
-    }
-    return sub.map((s) =>
-      typeof s === 'string'
-        ? `${s} per ${icon}`
-        : { ...s, title: `${s.title} per ${icon}` },
-    );
-  },
-  describe: (ev, sub, ctx) => {
-    const devId = (ev.params as Record<string, string>)['id']!;
-    let def: { name: string; icon?: string | undefined } | undefined;
+    let def: { name?: string; icon?: string | undefined } | undefined;
     try {
       def = ctx.developments.get(devId);
     } catch {
       /* ignore */
     }
+    const icon = def?.icon || devId;
+    const label = def?.name || devId;
     return sub.map((s) =>
       typeof s === 'string'
-        ? `${s} for each ${def?.icon || ''}${def?.name || devId}`
+        ? `${s} per ${icon} ${label}`.trim()
+        : { ...s, title: `${s.title} per ${icon} ${label}`.trim() },
+    );
+  },
+  describe: (ev, sub, ctx) => {
+    const devId = (ev.params as Record<string, string>)['id']!;
+    let def: { name?: string; icon?: string | undefined } | undefined;
+    try {
+      def = ctx.developments.get(devId);
+    } catch {
+      /* ignore */
+    }
+    const icon = def?.icon || '';
+    const label = def?.name || devId;
+    return sub.map((s) =>
+      typeof s === 'string'
+        ? `${s} for each ${icon} ${label}`.trim()
         : {
             ...s,
-            title: `${s.title} for each ${def?.icon || ''}${def?.name || devId}`,
+            title: `${s.title} for each ${icon} ${label}`.trim(),
           },
     );
   },

--- a/packages/web/src/translation/effects/evaluators/population.ts
+++ b/packages/web/src/translation/effects/evaluators/population.ts
@@ -6,38 +6,26 @@ registerEvaluatorFormatter('population', {
     const role = (ev.params as Record<string, string>)?.['role'] as
       | keyof typeof POPULATION_ROLES
       | undefined;
-    const icon = role
-      ? POPULATION_ROLES[role]?.icon || role
-      : POPULATION_INFO.icon;
+    const info = role ? POPULATION_ROLES[role] : undefined;
+    const icon = info?.icon || POPULATION_INFO.icon;
+    const label = info?.label || role || POPULATION_INFO.label;
     return sub.map((s) =>
       typeof s === 'string'
-        ? `${s} per ${icon}`
-        : { ...s, title: `${s.title} per ${icon}` },
+        ? `${s} per ${icon} ${label}`.trim()
+        : { ...s, title: `${s.title} per ${icon} ${label}`.trim() },
     );
   },
   describe: (ev, sub) => {
     const role = (ev.params as Record<string, string>)?.['role'] as
       | keyof typeof POPULATION_ROLES
       | undefined;
-    if (role) {
-      const info = POPULATION_ROLES[role];
-      return sub.map((s) =>
-        typeof s === 'string'
-          ? `${s} for each ${info?.icon || ''}${info?.label || role}`.trim()
-          : {
-              ...s,
-              title:
-                `${s.title} for each ${info?.icon || ''}${info?.label || role}`.trim(),
-            },
-      );
-    }
+    const info = role ? POPULATION_ROLES[role] : undefined;
+    const icon = info?.icon || '';
+    const label = info?.label || role || POPULATION_INFO.label;
     return sub.map((s) =>
       typeof s === 'string'
-        ? `${s} for each ${POPULATION_INFO.label.toLowerCase()}`
-        : {
-            ...s,
-            title: `${s.title} for each ${POPULATION_INFO.label.toLowerCase()}`,
-          },
+        ? `${s} for each ${icon} ${label}`.trim()
+        : { ...s, title: `${s.title} for each ${icon} ${label}`.trim() },
     );
   },
 });

--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -58,6 +58,19 @@ function getDevelopmentInfo(ctx: EngineContext, id: string) {
   }
 }
 
+function formatGainFrom(
+  source: string,
+  amount: number,
+  options: { key?: string; detailed?: boolean } = {},
+) {
+  const { key, detailed } = options;
+  const resIcon = key ? RESOURCES[key as ResourceKey]?.icon || key : undefined;
+  const more = resIcon
+    ? `${resIcon}+${amount} more${detailed ? ' of that resource' : ''}`
+    : `+${amount} more of that resource`;
+  return `${modifierInfo.result.icon} Every time you gain resources from ${source}, gain ${more}`;
+}
+
 function formatDevelopment(
   eff: EffectDef,
   evaluation: { id: string },
@@ -71,13 +84,11 @@ function formatDevelopment(
   );
   if (resource) {
     const key = resource.params?.['key'] as string;
-    const resIcon = RESOURCES[key as ResourceKey]?.icon || key;
     const amount = Number(resource.params?.['amount']);
-    const suffix = detailed ? ' of that resource' : '';
-    return `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${name}, gain ${resIcon}+${amount} more${suffix}`;
+    return formatGainFrom(`${icon} ${name}`, amount, { key, detailed });
   }
   const amount = Number(eff.params?.['amount'] ?? 0);
-  return `${modifierInfo.result.icon} Every time you gain resources from ${icon} ${name}, gain +${amount} more of that resource`;
+  return formatGainFrom(`${icon} ${name}`, amount);
 }
 
 function formatPopulation(
@@ -87,7 +98,10 @@ function formatPopulation(
 ) {
   const { icon, name } = getActionInfo(ctx, evaluation.id);
   const amount = Number(eff.params?.['amount'] ?? 0);
-  return `${modifierInfo.result.icon} Every time you gain resources from ${POPULATION_INFO.icon} ${POPULATION_INFO.label} through ${icon} ${name}, gain +${amount} more of that resource`;
+  return formatGainFrom(
+    `${POPULATION_INFO.icon} ${POPULATION_INFO.label} through ${icon} ${name}`,
+    amount,
+  );
 }
 
 registerModifierEvalHandler('development', {

--- a/packages/web/tests/development-summary.test.ts
+++ b/packages/web/tests/development-summary.test.ts
@@ -51,13 +51,17 @@ describe('development translation', () => {
       s.effects?.some((e) => e.evaluator?.type === 'development'),
     ) as StepDef | undefined;
     const devEffect = step?.effects?.find((e) => e.evaluator);
-    const devId = devEffect?.evaluator?.params?.['id'];
+    const devId = devEffect?.evaluator?.params?.['id'] as string;
     const summary = summarizeContent('development', devId, ctx);
     const flat = flatten(summary);
     const goldIcon = RESOURCES[Resource.gold].icon;
-    const devIcon = DEVELOPMENTS.get(devId)?.icon || '';
+    const dev = DEVELOPMENTS.get(devId);
+    const devIcon = dev?.icon || '';
+    const devLabel = dev?.name || devId;
     const inner = devEffect?.effects?.find((e) => e.type === 'resource');
     const amt = (inner?.params as { amount?: number })?.amount ?? 0;
-    expect(flat).toContain(`${goldIcon}+${amt} per ${devIcon}`);
+    expect(flat).toContain(
+      `${goldIcon}+${amt} per ${devIcon} ${devLabel}`.trim(),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- centralize resource gain modifier text to avoid drift
- include population icon and label in per-population evaluations
- align development evaluators and tests with new formatting

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 150 /tmp/unit.log | sed -n '41,120p'`


------
https://chatgpt.com/codex/tasks/task_e_68b74117a1e8832592f0576c2216e1f5