### PR TITLE
fix: constrain land slots in player panel

### DIFF
--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -131,7 +131,7 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
   return (
     <div
       ref={animateLands}
-      className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2 mt-2 w-fit"
+      className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2 mt-2 w-full"
     >
       {player.lands.map((land) => (
         <LandTile

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -32,7 +32,7 @@
     @apply relative panel-card border border-black/10 dark:border-white/10 p-2 text-center hoverable cursor-help;
   }
   .land-slot {
-    @apply panel-card border border-black/10 dark:border-white/10 p-1 text-xs hoverable cursor-help inline-flex items-center justify-center gap-1 whitespace-nowrap shrink-0;
+    @apply panel-card border border-black/10 dark:border-white/10 p-1 text-xs hoverable cursor-help inline-flex items-center justify-center gap-1 whitespace-nowrap overflow-hidden text-ellipsis min-w-0;
   }
   .player-bg {
     @apply relative overflow-hidden text-gray-900 dark:text-white;


### PR DESCRIPTION
## Summary
- prevent land slot labels from overflowing their cards
- ensure land grids use full panel width for responsive wrapping

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b74e56751c832582c37da49bc48dc3