### PR TITLE
fix: improve land slot responsiveness

### DIFF
--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -75,7 +75,10 @@ const LandTile: React.FC<{
                   handleLeave();
                 }}
               >
-                {ctx.developments.get(devId)?.icon} {name}
+                <span className="flex-none">
+                  {ctx.developments.get(devId)?.icon}
+                </span>
+                <span className="flex-1 truncate">{name}</span>
               </span>
             );
           }
@@ -101,7 +104,8 @@ const LandTile: React.FC<{
                 handleLeave();
               }}
             >
-              {SLOT_INFO.icon} -empty-
+              <span className="flex-none">{SLOT_INFO.icon}</span>
+              <span className="flex-1 truncate">-empty-</span>
             </span>
           );
         })}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -32,7 +32,7 @@
     @apply relative panel-card border border-black/10 dark:border-white/10 p-2 text-center hoverable cursor-help;
   }
   .land-slot {
-    @apply panel-card border border-black/10 dark:border-white/10 p-1 text-xs hoverable cursor-help inline-flex items-center justify-center gap-1 whitespace-nowrap overflow-hidden text-ellipsis min-w-0;
+    @apply panel-card border border-black/10 dark:border-white/10 p-1 text-xs hoverable cursor-help flex items-center justify-center gap-1 min-w-0;
   }
   .player-bg {
     @apply relative overflow-hidden text-gray-900 dark:text-white;


### PR DESCRIPTION
## Summary
- prevent land slot icons and labels from being clipped on narrow screens
- tidy land slot styling to rely on flex layout

## Testing
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b751a385248325932905d4b3b889d6