### PR TITLE
refactor: support upkeep and growth triggers

### DIFF
--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -222,6 +222,11 @@ export class BuildingBuilder extends BaseBuilder<BuildingConfig> {
     this.config.costs[key] = amount;
     return this;
   }
+  upkeep(key: ResourceKey, amount: number) {
+    this.config.upkeep = this.config.upkeep || {};
+    (this.config.upkeep as Record<ResourceKey, number>)[key] = amount;
+    return this;
+  }
   onBuild(effect: EffectConfig) {
     this.config.onBuild = this.config.onBuild || [];
     this.config.onBuild.push(effect);
@@ -235,6 +240,21 @@ export class BuildingBuilder extends BaseBuilder<BuildingConfig> {
   onUpkeepPhase(effect: EffectConfig) {
     this.config.onUpkeepPhase = this.config.onUpkeepPhase || [];
     this.config.onUpkeepPhase.push(effect);
+    return this;
+  }
+  onPayUpkeepStep(effect: EffectConfig) {
+    this.config.onPayUpkeepStep = this.config.onPayUpkeepStep || [];
+    this.config.onPayUpkeepStep.push(effect);
+    return this;
+  }
+  onGainIncomeStep(effect: EffectConfig) {
+    this.config.onGainIncomeStep = this.config.onGainIncomeStep || [];
+    this.config.onGainIncomeStep.push(effect);
+    return this;
+  }
+  onGainAPStep(effect: EffectConfig) {
+    this.config.onGainAPStep = this.config.onGainAPStep || [];
+    this.config.onGainAPStep.push(effect);
     return this;
   }
   onBeforeAttacked(effect: EffectConfig) {
@@ -253,6 +273,11 @@ export class DevelopmentBuilder extends BaseBuilder<DevelopmentConfig> {
   constructor() {
     super({});
   }
+  upkeep(key: ResourceKey, amount: number) {
+    this.config.upkeep = this.config.upkeep || {};
+    (this.config.upkeep as Record<ResourceKey, number>)[key] = amount;
+    return this;
+  }
   populationCap(amount: number) {
     this.config.populationCap = amount;
     return this;
@@ -265,6 +290,21 @@ export class DevelopmentBuilder extends BaseBuilder<DevelopmentConfig> {
   onGrowthPhase(effect: EffectConfig) {
     this.config.onGrowthPhase = this.config.onGrowthPhase || [];
     this.config.onGrowthPhase.push(effect);
+    return this;
+  }
+  onPayUpkeepStep(effect: EffectConfig) {
+    this.config.onPayUpkeepStep = this.config.onPayUpkeepStep || [];
+    this.config.onPayUpkeepStep.push(effect);
+    return this;
+  }
+  onGainIncomeStep(effect: EffectConfig) {
+    this.config.onGainIncomeStep = this.config.onGainIncomeStep || [];
+    this.config.onGainIncomeStep.push(effect);
+    return this;
+  }
+  onGainAPStep(effect: EffectConfig) {
+    this.config.onGainAPStep = this.config.onGainAPStep || [];
+    this.config.onGainAPStep.push(effect);
     return this;
   }
   onBeforeAttacked(effect: EffectConfig) {
@@ -287,6 +327,11 @@ export class PopulationBuilder extends BaseBuilder<PopulationConfig> {
   constructor() {
     super({});
   }
+  upkeep(key: ResourceKey, amount: number) {
+    this.config.upkeep = this.config.upkeep || {};
+    (this.config.upkeep as Record<ResourceKey, number>)[key] = amount;
+    return this;
+  }
   onAssigned(effect: EffectConfig) {
     this.config.onAssigned = this.config.onAssigned || [];
     this.config.onAssigned.push(effect);
@@ -305,6 +350,21 @@ export class PopulationBuilder extends BaseBuilder<PopulationConfig> {
   onUpkeepPhase(effect: EffectConfig) {
     this.config.onUpkeepPhase = this.config.onUpkeepPhase || [];
     this.config.onUpkeepPhase.push(effect);
+    return this;
+  }
+  onPayUpkeepStep(effect: EffectConfig) {
+    this.config.onPayUpkeepStep = this.config.onPayUpkeepStep || [];
+    this.config.onPayUpkeepStep.push(effect);
+    return this;
+  }
+  onGainIncomeStep(effect: EffectConfig) {
+    this.config.onGainIncomeStep = this.config.onGainIncomeStep || [];
+    this.config.onGainIncomeStep.push(effect);
+    return this;
+  }
+  onGainAPStep(effect: EffectConfig) {
+    this.config.onGainAPStep = this.config.onGainAPStep || [];
+    this.config.onGainAPStep.push(effect);
     return this;
   }
 }

--- a/packages/contents/src/defs.ts
+++ b/packages/contents/src/defs.ts
@@ -5,11 +5,20 @@ import type {
 } from '@kingdom-builder/engine/config/schema';
 import type { EffectDef } from '@kingdom-builder/engine/effects';
 
+export const ON_PAY_UPKEEP_STEP = 'onPayUpkeepStep';
+export const ON_GAIN_INCOME_STEP = 'onGainIncomeStep';
+export const ON_GAIN_AP_STEP = 'onGainAPStep';
+
+export const BROOM_ICON = '🧹';
+
 export interface Triggered {
   onGrowthPhase?: EffectDef[] | undefined;
   onUpkeepPhase?: EffectDef[] | undefined;
   onBeforeAttacked?: EffectDef[] | undefined;
   onAttackResolved?: EffectDef[] | undefined;
+  onPayUpkeepStep?: EffectDef[] | undefined;
+  onGainIncomeStep?: EffectDef[] | undefined;
+  onGainAPStep?: EffectDef[] | undefined;
 }
 
 export interface PopulationDef extends PopulationConfig, Triggered {}

--- a/packages/contents/src/developments.ts
+++ b/packages/contents/src/developments.ts
@@ -1,5 +1,6 @@
 import { Registry } from '@kingdom-builder/engine/registry';
 import { Stat } from './stats';
+import { Resource } from './resources';
 import { developmentSchema } from '@kingdom-builder/engine/config/schema';
 import {
   development,
@@ -7,6 +8,7 @@ import {
   Types,
   StatMethods,
   DevelopmentMethods,
+  ResourceMethods,
 } from './config/builders';
 import type { DevelopmentDef } from './defs';
 
@@ -18,7 +20,21 @@ export function createDevelopmentRegistry() {
   );
 
   registry.add('farm', {
-    ...development().id('farm').name('Farm').icon('🌾').build(),
+    ...development()
+      .id('farm')
+      .name('Farm')
+      .icon('🌾')
+      .onGainIncomeStep(
+        effect()
+          .evaluator('development', { id: '$id' })
+          .effect(
+            effect(Types.Resource, ResourceMethods.ADD)
+              .params({ key: Resource.gold, amount: 2 })
+              .build(),
+          )
+          .build(),
+      )
+      .build(),
     order: 2,
   });
 

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -22,3 +22,9 @@ export type { ActionDef } from './actions';
 export type { BuildingDef } from './buildings';
 export type { DevelopmentDef } from './developments';
 export type { PopulationDef, TriggerKey } from './defs';
+export {
+  ON_PAY_UPKEEP_STEP,
+  ON_GAIN_INCOME_STEP,
+  ON_GAIN_AP_STEP,
+  BROOM_ICON,
+} from './defs';

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -1,15 +1,18 @@
-import { Resource } from './resources';
 import { Stat } from './stats';
 import { PopulationRole } from './populationRoles';
 import {
   effect,
   Types,
-  ResourceMethods,
   StatMethods,
   phase,
   step,
   type PhaseDef,
 } from './config/builders';
+import {
+  ON_GAIN_AP_STEP,
+  ON_GAIN_INCOME_STEP,
+  ON_PAY_UPKEEP_STEP,
+} from './defs';
 
 export const PHASES: PhaseDef[] = [
   phase('growth')
@@ -24,31 +27,9 @@ export const PHASES: PhaseDef[] = [
       step('gain-income')
         .title('Gain Income')
         .icon('💰')
-        .effect(
-          effect()
-            .evaluator('development', { id: 'farm' })
-            .effect(
-              effect(Types.Resource, ResourceMethods.ADD)
-                .params({ key: Resource.gold, amount: 2 })
-                .build(),
-            )
-            .build(),
-        ),
+        .triggers(ON_GAIN_INCOME_STEP),
     )
-    .step(
-      step('gain-ap')
-        .title('Gain Action Points')
-        .effect(
-          effect()
-            .evaluator('population', { role: PopulationRole.Council })
-            .effect(
-              effect(Types.Resource, ResourceMethods.ADD)
-                .params({ key: Resource.ap, amount: 1 })
-                .build(),
-            )
-            .build(),
-        ),
-    )
+    .step(step('gain-ap').title('Gain Action Points').triggers(ON_GAIN_AP_STEP))
     .step(
       step('raise-strength')
         .title('Raise Strength')
@@ -87,40 +68,7 @@ export const PHASES: PhaseDef[] = [
         .title('Resolve dynamic triggers')
         .triggers('onUpkeepPhase'),
     )
-    .step(
-      step('pay-upkeep')
-        .title('Pay Upkeep')
-        .effect(
-          effect()
-            .evaluator('population', { role: PopulationRole.Council })
-            .effect(
-              effect(Types.Resource, ResourceMethods.REMOVE)
-                .params({ key: Resource.gold, amount: 2 })
-                .build(),
-            )
-            .build(),
-        )
-        .effect(
-          effect()
-            .evaluator('population', { role: PopulationRole.Commander })
-            .effect(
-              effect(Types.Resource, ResourceMethods.REMOVE)
-                .params({ key: Resource.gold, amount: 1 })
-                .build(),
-            )
-            .build(),
-        )
-        .effect(
-          effect()
-            .evaluator('population', { role: PopulationRole.Fortifier })
-            .effect(
-              effect(Types.Resource, ResourceMethods.REMOVE)
-                .params({ key: Resource.gold, amount: 1 })
-                .build(),
-            )
-            .build(),
-        ),
-    )
+    .step(step('pay-upkeep').title('Pay Upkeep').triggers(ON_PAY_UPKEEP_STEP))
     .step(
       step('war-recovery')
         .title('War recovery')

--- a/packages/contents/src/populations.ts
+++ b/packages/contents/src/populations.ts
@@ -24,14 +24,10 @@ export function createPopulationRegistry() {
       .id(PopulationRole.Council)
       .name('Council')
       .icon('⚖️')
-      .onAssigned(
+      .upkeep(Resource.gold, 2)
+      .onGainAPStep(
         effect(Types.Resource, ResourceMethods.ADD)
-          .params({ key: Resource.ap, amount: 1 })
-          .build(),
-      )
-      .onUnassigned(
-        effect(Types.Resource, ResourceMethods.REMOVE)
-          .params({ key: Resource.ap, amount: 1 })
+          .params({ key: Resource.ap, amount: 2 })
           .build(),
       )
       .build(),
@@ -43,6 +39,7 @@ export function createPopulationRegistry() {
       .id(PopulationRole.Commander)
       .name('Commander')
       .icon('🎖️')
+      .upkeep(Resource.gold, 1)
       .onAssigned(
         effect(Types.Passive, PassiveMethods.ADD)
           .param('id', 'commander_$player_$index')
@@ -67,6 +64,7 @@ export function createPopulationRegistry() {
       .id(PopulationRole.Fortifier)
       .name('Fortifier')
       .icon('🔧')
+      .upkeep(Resource.gold, 1)
       .onAssigned(
         effect(Types.Passive, PassiveMethods.ADD)
           .param('id', 'fortifier_$player_$index')

--- a/packages/contents/src/triggers.ts
+++ b/packages/contents/src/triggers.ts
@@ -27,6 +27,21 @@ export const TRIGGER_INFO = {
     future: 'After having been attacked',
     past: 'After attack',
   },
+  onPayUpkeepStep: {
+    icon: '🧹',
+    future: 'During upkeep step',
+    past: 'Upkeep step',
+  },
+  onGainIncomeStep: {
+    icon: '💰',
+    future: 'During income step',
+    past: 'Income step',
+  },
+  onGainAPStep: {
+    icon: '⚡',
+    future: 'During AP step',
+    past: 'AP step',
+  },
   mainPhase: {
     icon: PHASES.find((p) => p.id === 'main')?.icon || '🎯',
     future: '',

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -51,11 +51,15 @@ export const buildingSchema = z.object({
   name: z.string(),
   icon: z.string().optional(),
   costs: costBagSchema,
+  upkeep: costBagSchema.optional(),
   onBuild: z.array(effectSchema).optional(),
   onGrowthPhase: z.array(effectSchema).optional(),
   onUpkeepPhase: z.array(effectSchema).optional(),
   onBeforeAttacked: z.array(effectSchema).optional(),
   onAttackResolved: z.array(effectSchema).optional(),
+  onPayUpkeepStep: z.array(effectSchema).optional(),
+  onGainIncomeStep: z.array(effectSchema).optional(),
+  onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type BuildingConfig = z.infer<typeof buildingSchema>;
@@ -65,10 +69,14 @@ export const developmentSchema = z.object({
   id: z.string(),
   name: z.string(),
   icon: z.string().optional(),
+  upkeep: costBagSchema.optional(),
   onBuild: z.array(effectSchema).optional(),
   onGrowthPhase: z.array(effectSchema).optional(),
   onBeforeAttacked: z.array(effectSchema).optional(),
   onAttackResolved: z.array(effectSchema).optional(),
+  onPayUpkeepStep: z.array(effectSchema).optional(),
+  onGainIncomeStep: z.array(effectSchema).optional(),
+  onGainAPStep: z.array(effectSchema).optional(),
   system: z.boolean().optional(),
   populationCap: z.number().optional(),
 });
@@ -80,10 +88,14 @@ export const populationSchema = z.object({
   id: z.string(),
   name: z.string(),
   icon: z.string().optional(),
+  upkeep: costBagSchema.optional(),
   onAssigned: z.array(effectSchema).optional(),
   onUnassigned: z.array(effectSchema).optional(),
   onGrowthPhase: z.array(effectSchema).optional(),
   onUpkeepPhase: z.array(effectSchema).optional(),
+  onPayUpkeepStep: z.array(effectSchema).optional(),
+  onGainIncomeStep: z.array(effectSchema).optional(),
+  onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type PopulationConfig = z.infer<typeof populationSchema>;
@@ -94,6 +106,10 @@ const landStartSchema = z.object({
   slotsMax: z.number().optional(),
   slotsUsed: z.number().optional(),
   tilled: z.boolean().optional(),
+  upkeep: costBagSchema.optional(),
+  onPayUpkeepStep: z.array(effectSchema).optional(),
+  onGainIncomeStep: z.array(effectSchema).optional(),
+  onGainAPStep: z.array(effectSchema).optional(),
 });
 
 const playerStartSchema = z.object({

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -231,6 +231,13 @@ function applyPlayerStart(
       );
       if (landCfg.developments) land.developments.push(...landCfg.developments);
       land.slotsUsed = landCfg.slotsUsed ?? land.developments.length;
+      if (landCfg.upkeep) land.upkeep = { ...landCfg.upkeep };
+      if (landCfg.onPayUpkeepStep)
+        land.onPayUpkeepStep = landCfg.onPayUpkeepStep.map((e) => ({ ...e }));
+      if (landCfg.onGainIncomeStep)
+        land.onGainIncomeStep = landCfg.onGainIncomeStep.map((e) => ({ ...e }));
+      if (landCfg.onGainAPStep)
+        land.onGainAPStep = landCfg.onGainAPStep.map((e) => ({ ...e }));
       player.lands.push(land);
     });
 }

--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -1,3 +1,5 @@
+import type { EffectDef } from '../effects';
+
 export const Resource: Record<string, string> = {};
 export type ResourceKey = string;
 export function setResourceKeys(keys: string[]) {
@@ -35,6 +37,10 @@ export class Land {
   slotsUsed = 0;
   developments: string[] = [];
   tilled = false;
+  upkeep?: Record<ResourceKey, number>;
+  onPayUpkeepStep?: EffectDef[];
+  onGainIncomeStep?: EffectDef[];
+  onGainAPStep?: EffectDef[];
   constructor(id: string, slotsMax: number, tilled = false) {
     this.id = id;
     this.slotsMax = slotsMax;

--- a/packages/engine/src/triggers.ts
+++ b/packages/engine/src/triggers.ts
@@ -16,14 +16,50 @@ export function collectTriggerEffects(
   const effects: EffectDef[] = [];
   for (const [role, count] of Object.entries(player.population)) {
     const populationDefinition = ctx.populations.get(role);
+    if (trigger === 'onPayUpkeepStep' && populationDefinition?.upkeep) {
+      for (const [key, amount] of Object.entries(populationDefinition.upkeep)) {
+        effects.push({
+          type: 'resource',
+          method: 'remove',
+          params: { key, amount: amount * Number(count) },
+        });
+      }
+    }
     const list = getEffects(populationDefinition, trigger);
-    if (!list) continue;
-    for (let i = 0; i < Number(count); i++)
-      effects.push(...list.map((e) => ({ ...e })));
+    if (list)
+      for (let i = 0; i < Number(count); i++)
+        effects.push(...list.map((e) => ({ ...e })));
   }
   for (const land of player.lands) {
+    if (trigger === 'onPayUpkeepStep' && land.upkeep) {
+      for (const [key, amount] of Object.entries(land.upkeep)) {
+        effects.push({
+          type: 'resource',
+          method: 'remove',
+          params: { key, amount },
+        });
+      }
+    }
+    const landList = getEffects(land, trigger);
+    if (landList)
+      effects.push(
+        ...applyParamsToEffects(landList, { landId: land.id }).map((e) => ({
+          ...e,
+        })),
+      );
     for (const id of land.developments) {
       const developmentDefinition = ctx.developments.get(id);
+      if (trigger === 'onPayUpkeepStep' && developmentDefinition?.upkeep) {
+        for (const [key, amount] of Object.entries(
+          developmentDefinition.upkeep,
+        )) {
+          effects.push({
+            type: 'resource',
+            method: 'remove',
+            params: { key, amount },
+          });
+        }
+      }
       const list = getEffects(developmentDefinition, trigger);
       if (!list) continue;
       effects.push(
@@ -35,6 +71,15 @@ export function collectTriggerEffects(
   }
   for (const id of player.buildings) {
     const buildingDefinition = ctx.buildings.get(id);
+    if (trigger === 'onPayUpkeepStep' && buildingDefinition?.upkeep) {
+      for (const [key, amount] of Object.entries(buildingDefinition.upkeep)) {
+        effects.push({
+          type: 'resource',
+          method: 'remove',
+          params: { key, amount },
+        });
+      }
+    }
     const list = getEffects(buildingDefinition, trigger);
     if (list) effects.push(...list.map((e) => ({ ...e })));
   }

--- a/packages/engine/tests/phases/growth.test.ts
+++ b/packages/engine/tests/phases/growth.test.ts
@@ -6,29 +6,25 @@ import {
   Resource as CResource,
   Stat as CStat,
   PopulationRole,
+  DEVELOPMENTS,
+  POPULATIONS,
 } from '@kingdom-builder/contents';
 import { createTestEngine } from '../helpers.ts';
 
 const growthPhase = PHASES[0];
 const growthId = growthPhase.id;
-const incomeStep = growthPhase.steps.find((s) => s.id === 'gain-income');
+const farmId = Array.from(
+  (DEVELOPMENTS as unknown as { map: Map<string, unknown> }).map.keys(),
+).find((id) => DEVELOPMENTS.get(id)?.onGainIncomeStep) as string;
 const farmGoldGain = Number(
-  incomeStep?.effects?.[0]?.effects?.find(
-    (e) =>
-      e.type === 'resource' &&
-      e.method === 'add' &&
-      (e as { params: { key: string } }).params.key === CResource.gold,
-  )?.params.amount ?? 0,
+  DEVELOPMENTS.get(farmId)?.onGainIncomeStep?.[0]?.effects?.find(
+    (e) => e.type === 'resource' && e.method === 'add',
+  )?.params?.amount ?? 0,
 );
-
-const apStep = growthPhase.steps.find((s) => s.id === 'gain-ap');
 const councilApGain = Number(
-  apStep?.effects?.[0]?.effects?.find(
-    (e) =>
-      e.type === 'resource' &&
-      e.method === 'add' &&
-      (e as { params: { key: string } }).params.key === CResource.ap,
-  )?.params.amount ?? 0,
+  POPULATIONS.get(PopulationRole.Council)?.onGainAPStep?.find(
+    (e) => e.type === 'resource' && e.method === 'add',
+  )?.params?.amount ?? 0,
 );
 
 describe('Growth phase', () => {

--- a/packages/engine/tests/phases/upkeep.test.ts
+++ b/packages/engine/tests/phases/upkeep.test.ts
@@ -4,6 +4,7 @@ import {
   PHASES,
   Resource as CResource,
   PopulationRole,
+  POPULATIONS,
 } from '@kingdom-builder/contents';
 import { createTestEngine } from '../helpers.ts';
 
@@ -12,16 +13,7 @@ const payStep = upkeepPhase.steps.find((s) => s.id === 'pay-upkeep')!;
 const warStep = upkeepPhase.steps.find((s) => s.id === 'war-recovery')!;
 
 function getUpkeep(role: PopulationRole) {
-  return Number(
-    payStep.effects
-      ?.find((e) => e.evaluator?.params?.role === role)
-      ?.effects?.find(
-        (eff) =>
-          eff.type === 'resource' &&
-          eff.method === 'remove' &&
-          eff.params.key === CResource.gold,
-      )?.params.amount ?? 0,
-  );
+  return Number(POPULATIONS.get(role)?.upkeep?.[CResource.gold] ?? 0);
 }
 
 const councilUpkeep = getUpkeep(PopulationRole.Council);

--- a/packages/web/src/components/HoverCard.tsx
+++ b/packages/web/src/components/HoverCard.tsx
@@ -24,6 +24,7 @@ export default function HoverCard() {
             data.costs,
             ctx.activePlayer.resources,
             actionCostResource,
+            data.upkeep,
           )}
         </span>
       </div>

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -13,6 +13,7 @@ export type ActionCardProps = {
   costs: Record<string, number>;
   playerResources: Record<string, number>;
   actionCostResource: string;
+  upkeep?: Record<string, number> | undefined;
   summary?: Summary | undefined;
   implemented?: boolean;
   enabled: boolean;
@@ -29,6 +30,7 @@ export default function ActionCard({
   costs,
   playerResources,
   actionCostResource,
+  upkeep,
   summary,
   implemented = true,
   enabled,
@@ -51,7 +53,7 @@ export default function ActionCard({
     >
       <span className="text-base font-medium">{title}</span>
       <span className="absolute top-2 right-2 text-sm text-gray-600 dark:text-gray-300">
-        {renderCosts(costs, playerResources, actionCostResource)}
+        {renderCosts(costs, playerResources, actionCostResource, upkeep)}
       </span>
       {requirements.length > 0 && requirementIcons.length > 0 && (
         <span className="absolute top-7 right-2 text-xs text-red-600">

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -145,6 +145,7 @@ function RaisePopOptions({
         const costsBag = getActionCosts(action.id, ctx);
         const costs: Record<string, number> = {};
         for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
+        const upkeep = ctx.populations.get(role)?.upkeep;
         const requirements = getActionRequirements(action.id, ctx).map(
           formatRequirement,
         );
@@ -173,6 +174,7 @@ function RaisePopOptions({
               </>
             }
             costs={costs}
+            upkeep={upkeep}
             playerResources={ctx.activePlayer.resources}
             actionCostResource={actionCostResource}
             requirements={requirements}
@@ -192,6 +194,7 @@ function RaisePopOptions({
                 effects,
                 requirements,
                 costs,
+                upkeep,
                 ...(description && { description }),
                 bgClass: 'bg-gray-100 dark:bg-gray-700',
               });
@@ -278,6 +281,7 @@ function DevelopOptions({
           });
           const costs: Record<string, number> = {};
           for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
+          const upkeep = ctx.developments.get(d.id)?.upkeep;
           const requirements = hasDevelopLand
             ? []
             : [
@@ -307,6 +311,7 @@ function DevelopOptions({
                 </>
               }
               costs={costs}
+              upkeep={upkeep}
               playerResources={ctx.activePlayer.resources}
               actionCostResource={actionCostResource}
               requirements={requirements}
@@ -331,6 +336,7 @@ function DevelopOptions({
                   effects,
                   requirements,
                   costs,
+                  upkeep,
                   ...(description && { description }),
                   ...(!implemented && {
                     description: 'Not implemented yet',
@@ -394,6 +400,7 @@ function BuildOptions({
             : !canPay
               ? 'Cannot pay costs'
               : undefined;
+          const upkeep = ctx.buildings.get(b.id)?.upkeep;
           return (
             <ActionCard
               key={b.id}
@@ -403,6 +410,7 @@ function BuildOptions({
                 </>
               }
               costs={costs}
+              upkeep={upkeep}
               playerResources={ctx.activePlayer.resources}
               actionCostResource={actionCostResource}
               requirements={requirements}
@@ -424,6 +432,7 @@ function BuildOptions({
                   effects,
                   requirements,
                   costs,
+                  upkeep,
                   ...(description && { description }),
                   ...(!implemented && {
                     description: 'Not implemented yet',

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -24,6 +24,7 @@ import {
   GAME_START,
   RULES,
   type ResourceKey,
+  type StepDef,
 } from '@kingdom-builder/contents';
 import {
   snapshotPlayer,
@@ -51,6 +52,7 @@ interface HoverCard {
   effects: Summary;
   requirements: string[];
   costs?: Record<string, number>;
+  upkeep?: Record<string, number> | undefined;
   description?: string | Summary;
   descriptionTitle?: string;
   descriptionClass?: string;
@@ -284,7 +286,7 @@ export function GameProvider({
     let lastPhase: string | null = null;
     while (!ctx.phases[ctx.game.phaseIndex]?.action) {
       const before = snapshotPlayer(ctx.activePlayer, ctx);
-      const { phase, step, player } = advance(ctx);
+      const { phase, step, player, effects } = advance(ctx);
       const phaseDef = ctx.phases.find((p) => p.id === phase)!;
       const stepDef = phaseDef.steps.find((s) => s.id === step);
       if (phase !== lastPhase) {
@@ -295,10 +297,13 @@ export function GameProvider({
         lastPhase = phase;
       }
       const after = snapshotPlayer(player, ctx);
+      const stepWithEffects: StepDef | undefined = stepDef
+        ? ({ ...(stepDef as StepDef), effects } as StepDef)
+        : undefined;
       const changes = diffStepSnapshots(
         before,
         after,
-        stepDef,
+        stepWithEffects,
         ctx,
         RESOURCE_KEYS,
       );

--- a/packages/web/src/translation/content/phased.ts
+++ b/packages/web/src/translation/content/phased.ts
@@ -26,6 +26,17 @@ export class PhasedTranslator {
         });
       }
     }
+    for (const key of [
+      'onPayUpkeepStep',
+      'onGainIncomeStep',
+      'onGainAPStep',
+    ] as const) {
+      const eff = summarizeEffects(def[key], ctx);
+      if (eff.length) {
+        const info = triggerInfo[key];
+        root.push({ title: `${info.icon} ${info.future}`, items: eff });
+      }
+    }
     const pre = summarizeEffects(def.onBeforeAttacked, ctx);
     if (pre.length)
       root.push({
@@ -54,6 +65,17 @@ export class PhasedTranslator {
           title: `${phase.icon} On each ${phase.label} Phase`,
           items: eff,
         });
+      }
+    }
+    for (const key of [
+      'onPayUpkeepStep',
+      'onGainIncomeStep',
+      'onGainAPStep',
+    ] as const) {
+      const eff = describeEffects(def[key], ctx);
+      if (eff.length) {
+        const info = triggerInfo[key];
+        root.push({ title: `${info.icon} ${info.future}`, items: eff });
       }
     }
     const pre = describeEffects(def.onBeforeAttacked, ctx);

--- a/packages/web/src/translation/effects/formatters/resource.ts
+++ b/packages/web/src/translation/effects/formatters/resource.ts
@@ -21,6 +21,24 @@ registerEffectFormatter('resource', 'add', {
   },
 });
 
+registerEffectFormatter('resource', 'remove', {
+  summarize: (eff) => {
+    const key = eff.params?.['key'] as string;
+    const res = RESOURCES[key as ResourceKey];
+    const icon = res ? res.icon : key;
+    const amount = Number(eff.params?.['amount']);
+    return `${icon}${signed(-amount)}${-amount}`;
+  },
+  describe: (eff) => {
+    const key = eff.params?.['key'] as string;
+    const res = RESOURCES[key as ResourceKey];
+    const label = res?.label || key;
+    const icon = res?.icon || key;
+    const amount = Number(eff.params?.['amount']);
+    return `${icon}${signed(-amount)}${-amount} ${label}`;
+  },
+});
+
 registerEffectFormatter('resource', 'transfer', {
   summarize: (eff) => {
     const key = eff.params?.['key'] as string;

--- a/packages/web/src/translation/render.tsx
+++ b/packages/web/src/translation/render.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RESOURCES } from '@kingdom-builder/contents';
+import { RESOURCES, BROOM_ICON } from '@kingdom-builder/contents';
 import type { ResourceKey } from '@kingdom-builder/contents';
 import type { Summary } from './content';
 
@@ -22,12 +22,13 @@ export function renderCosts(
   costs: Record<string, number | undefined> | undefined,
   resources: Record<string, number>,
   actionCostResource?: string,
+  upkeep?: Record<string, number | undefined> | undefined,
 ) {
-  if (!costs) return null;
-  const entries = Object.entries(costs).filter(
+  const entries = Object.entries(costs || {}).filter(
     ([k]) => !actionCostResource || k !== actionCostResource,
   );
-  if (entries.length === 0)
+  const upkeepEntries = Object.entries(upkeep || {});
+  if (entries.length === 0 && upkeepEntries.length === 0)
     return (
       <span className="mr-1 text-gray-400 dark:text-gray-500 italic">Free</span>
     );
@@ -42,6 +43,14 @@ export function renderCosts(
           {v ?? 0}
         </span>
       ))}
+      {upkeepEntries.length > 0 && (
+        <span className="block text-xs text-gray-600 dark:text-gray-300">
+          {BROOM_ICON}{' '}
+          {upkeepEntries
+            .map(([k, v]) => `${RESOURCES[k as ResourceKey]?.icon}${v ?? 0}`)
+            .join(' ')}
+        </span>
+      )}
     </>
   );
 }

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -4,6 +4,7 @@ import {
   runEffects,
   performAction,
   advance,
+  collectTriggerEffects,
 } from '@kingdom-builder/engine';
 import {
   ACTIONS,
@@ -16,6 +17,7 @@ import {
   RESOURCES,
   Resource,
   type ResourceKey,
+  ON_GAIN_INCOME_STEP,
 } from '@kingdom-builder/contents';
 import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
 
@@ -47,9 +49,16 @@ describe('log resource sources', () => {
     const growthPhase = ctx.phases.find((p) => p.id === 'growth');
     const step = growthPhase?.steps.find((s) => s.id === 'gain-income');
     const before = snapshotPlayer(ctx.activePlayer, ctx);
-    runEffects(step?.effects || [], ctx);
+    const effects = collectTriggerEffects(ON_GAIN_INCOME_STEP, ctx);
+    runEffects(effects, ctx);
     const after = snapshotPlayer(ctx.activePlayer, ctx);
-    const lines = diffStepSnapshots(before, after, step, ctx, RESOURCE_KEYS);
+    const lines = diffStepSnapshots(
+      before,
+      after,
+      { ...step, effects } as typeof step,
+      ctx,
+      RESOURCE_KEYS,
+    );
     const goldInfo = RESOURCES[Resource.gold];
     const farmIcon = DEVELOPMENTS.get('farm')?.icon || '';
     const b = before.resources[Resource.gold] ?? 0;


### PR DESCRIPTION
## Summary
- add shared ON_PAY_UPKEEP_STEP, ON_GAIN_INCOME_STEP and ON_GAIN_AP_STEP constants
- move growth/AP and upkeep effects into content definitions
- surface upkeep costs in UI and format resource removal logs
- remove council baseline AP grant to avoid extra action points

## Testing
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b74fc12f948325a54e04358f3a5a77