### PR TITLE
Generalize attack targeting and annotate special resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ fc.assert(
 - 2025-10-28: Dynamic PlayerState properties required disabling `noPropertyAccessFromIndexSignature` in `tsconfig.base.json`.
 - 2025-10-28: Missing `eslint-plugin-import` causes eslint to fail; install with `npm install --no-save eslint-plugin-import`.
 - 2025-10-28: Engine `Resource` and `Stat` constants are empty until `setResourceKeys`/`setStatKeys` run; use content-side keys when configuring tests before engine creation.
-- 2025-08-31: `attack:perform` effect parameters `ignoreAbsorption`, `ignoreFortification` and nested `onCastleDamage` effects require dedicated web formatter for player-facing text.
+- 2025-08-31: `attack:perform` effect parameters `ignoreAbsorption`, `ignoreFortification` and nested `onDamage` effects require dedicated web formatter for player-facing text.
 - 2025-08-31: Merge attacker and defender on-damage summaries by tagging items "for you" or "for opponent" instead of separate groups.
 - 2025-08-31: Compact on-damage summaries further by prefixing entries with "You" or "Opponent".
 - 2025-08-31: Suffix on-damage summary items with "for you"/"for opponent" to keep icons leading each line.

--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -196,7 +196,8 @@ export function createActionRegistry() {
       )
       .effect(
         effect('attack', 'perform')
-          .param('onCastleDamage', {
+          .param('target', { type: 'resource', key: Resource.castleHP })
+          .param('onDamage', {
             attacker: [
               effect(Types.Resource, ResourceMethods.ADD)
                 .params({ key: Resource.happiness, amount: 1 })

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -398,11 +398,21 @@ class InfoBuilder<T extends InfoDef> {
   }
 }
 
-export interface ResourceInfo extends InfoDef {}
+export interface ResourceInfo extends InfoDef {
+  /**
+   * Arbitrary tags to mark special behaviours or rules for the resource.
+   * These tags are interpreted by the engine or other systems at runtime.
+   */
+  tags?: string[];
+}
 
 class ResourceBuilder extends InfoBuilder<ResourceInfo> {
   constructor(key: ResourceKey) {
     super(key);
+  }
+  tag(tag: string) {
+    this.config.tags = [...(this.config.tags || []), tag];
+    return this;
   }
 }
 

--- a/packages/contents/src/resources.ts
+++ b/packages/contents/src/resources.ts
@@ -15,6 +15,7 @@ const defs: ResourceInfo[] = [
     .description(
       'Gold is the foundational currency of the realm. It is earned through developments and actions and spent to fund buildings, recruit population or pay for powerful plays. A healthy treasury keeps your options open.',
     )
+    .tag('bankruptcy-check')
     .build(),
   resource(Resource.ap)
     .icon('⚡')
@@ -36,6 +37,8 @@ const defs: ResourceInfo[] = [
     .description(
       'Castle HP represents the durability of your stronghold. If it ever drops to zero, your kingdom falls and the game is lost.',
     )
+    .tag('attack-target')
+    .tag('win-condition-zero')
     .build(),
 ];
 

--- a/packages/engine/tests/absorption-cap.test.ts
+++ b/packages/engine/tests/absorption-cap.test.ts
@@ -9,7 +9,10 @@ describe('absorption cap', () => {
     const defender = ctx.game.opponent;
     defender.absorption = 1.5;
     const start = defender.resources[Resource.castleHP];
-    const dmg = resolveAttack(defender, 5, ctx);
+    const dmg = resolveAttack(defender, 5, ctx, {
+      type: 'resource',
+      key: Resource.castleHP,
+    });
     expect(dmg).toBe(0);
     expect(defender.resources[Resource.castleHP]).toBe(start);
   });

--- a/packages/engine/tests/attack-zero-damage-no-effects.test.ts
+++ b/packages/engine/tests/attack-zero-damage-no-effects.test.ts
@@ -4,7 +4,7 @@ import { Resource } from '../src/state/index.ts';
 import { createTestEngine } from './helpers.ts';
 
 describe('attack:perform', () => {
-  it('does not run onCastleDamage effects when damage is fully absorbed', () => {
+  it('does not run onDamage effects when damage is fully absorbed', () => {
     const ctx = createTestEngine();
     const attacker = ctx.activePlayer;
     const defender = ctx.opponent;
@@ -30,7 +30,8 @@ describe('attack:perform', () => {
       type: 'attack',
       method: 'perform',
       params: {
-        onCastleDamage: {
+        target: { type: 'resource', key: Resource.castleHP },
+        onDamage: {
           attacker: [
             {
               type: 'resource',

--- a/packages/engine/tests/resolveAttack.test.ts
+++ b/packages/engine/tests/resolveAttack.test.ts
@@ -24,7 +24,10 @@ describe('resolveAttack', () => {
       },
       ctx,
     );
-    const dmg = resolveAttack(defender, 10, ctx);
+    const dmg = resolveAttack(defender, 10, ctx, {
+      type: 'resource',
+      key: Resource.castleHP,
+    });
     expect(dmg).toBe(5);
   });
 
@@ -37,7 +40,10 @@ describe('resolveAttack', () => {
     attacker.gold = 0;
     const startHP = defender.resources[Resource.castleHP];
     const startGold = defender.gold;
-    const dmg = resolveAttack(defender, 5, ctx);
+    const dmg = resolveAttack(defender, 5, ctx, {
+      type: 'resource',
+      key: Resource.castleHP,
+    });
     expect(dmg).toBe(4);
     expect(defender.resources[Resource.castleHP]).toBe(startHP - dmg);
     expect(defender.fortificationStrength).toBe(0);
@@ -55,7 +61,10 @@ describe('resolveAttack', () => {
     ctx.services.rules.absorptionRounding = 'up';
     defender.absorption = 0.5;
     const start = defender.resources[Resource.castleHP];
-    const dmg = resolveAttack(defender, 1, ctx);
+    const dmg = resolveAttack(defender, 1, ctx, {
+      type: 'resource',
+      key: Resource.castleHP,
+    });
     expect(dmg).toBe(1);
     expect(defender.resources[Resource.castleHP]).toBe(start - 1);
   });
@@ -65,7 +74,10 @@ describe('resolveAttack', () => {
     const defender = ctx.game.opponent;
     ctx.services.rules.absorptionRounding = 'nearest';
     defender.absorption = 0.6;
-    const dmg = resolveAttack(defender, 1, ctx);
+    const dmg = resolveAttack(defender, 1, ctx, {
+      type: 'resource',
+      key: Resource.castleHP,
+    });
     expect(dmg).toBe(0);
   });
 
@@ -74,10 +86,16 @@ describe('resolveAttack', () => {
     const defender = ctx.game.opponent;
     defender.absorption = 0.5;
     defender.stats[Stat.fortificationStrength] = 5;
-    const dmg = resolveAttack(defender, 10, ctx, {
-      ignoreAbsorption: true,
-      ignoreFortification: true,
-    });
+    const dmg = resolveAttack(
+      defender,
+      10,
+      ctx,
+      { type: 'resource', key: Resource.castleHP },
+      {
+        ignoreAbsorption: true,
+        ignoreFortification: true,
+      },
+    );
     expect(dmg).toBe(10);
     expect(defender.fortificationStrength).toBe(5);
     expect(defender.resources[Resource.castleHP]).toBe(0);
@@ -117,7 +135,10 @@ describe('resolveAttack', () => {
     );
     ctx.game.currentPlayerIndex = 0; // attacker turn
     const beforeGold = defender.gold;
-    const dmg = resolveAttack(defender, 4, ctx);
+    const dmg = resolveAttack(defender, 4, ctx, {
+      type: 'resource',
+      key: Resource.castleHP,
+    });
     expect(dmg).toBe(0);
     expect(defender.resources[Resource.castleHP]).toBe(10);
     expect(defender.fortificationStrength).toBe(0);
@@ -174,7 +195,10 @@ describe('resolveAttack', () => {
       ctx,
     );
     const startHP = defender.resources[Resource.castleHP];
-    const dmg = resolveAttack(defender, attacker.armyStrength as number, ctx);
+    const dmg = resolveAttack(defender, attacker.armyStrength as number, ctx, {
+      type: 'resource',
+      key: Resource.castleHP,
+    });
     const rounding = ctx.services.rules.absorptionRounding;
     const base = attacker.armyStrength as number;
     const reduced =

--- a/packages/web/tests/army-attack-translation.test.ts
+++ b/packages/web/tests/army-attack-translation.test.ts
@@ -48,7 +48,7 @@ describe('army attack translation', () => {
     const attackEffect = armyAttack.effects.find(
       (e: EffectDef) => e.type === 'attack',
     );
-    const onDamage = attackEffect?.params?.['onCastleDamage'] as {
+    const onDamage = attackEffect?.params?.['onDamage'] as {
       attacker: EffectDef[];
       defender: EffectDef[];
     };


### PR DESCRIPTION
## Summary
- Allow resources to carry descriptive tags for special rules
- Mark castle health and gold with attack/bankruptcy tags in content
- Make attack effect accept dynamic resource/stat targets with optional on-damage effects
- Update Army Attack and translations to use new target-based attack

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b7587cf2088325aac28da047ac90f6