### PR TITLE
feat: sort actions by cost and color by focus

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -22,10 +22,12 @@ import {
   BuildingMethods,
   StatMethods,
 } from './config/builders';
+import type { Focus } from './defs';
 
 export interface ActionDef extends ActionConfig {
   category?: string;
   order?: number;
+  focus?: Focus;
 }
 
 export function createActionRegistry() {
@@ -47,6 +49,7 @@ export function createActionRegistry() {
       .build(),
     category: 'basic',
     order: 1,
+    focus: 'economy',
   });
 
   registry.add('overwork', {
@@ -75,6 +78,7 @@ export function createActionRegistry() {
       .build(),
     category: 'basic',
     order: 2,
+    focus: 'economy',
   });
 
   registry.add('develop', {
@@ -92,6 +96,7 @@ export function createActionRegistry() {
       .build(),
     category: 'development',
     order: 1,
+    focus: 'economy',
   });
 
   registry.add('tax', {
@@ -119,6 +124,7 @@ export function createActionRegistry() {
       .build(),
     category: 'basic',
     order: 3,
+    focus: 'economy',
   });
 
   registry.add('reallocate', {
@@ -131,6 +137,7 @@ export function createActionRegistry() {
       .build(),
     category: 'basic',
     order: 4,
+    focus: 'economy',
   });
 
   registry.add('raise_pop', {
@@ -161,6 +168,7 @@ export function createActionRegistry() {
       .build(),
     category: 'population',
     order: 1,
+    focus: 'economy',
   });
 
   registry.add('royal_decree', {
@@ -173,6 +181,7 @@ export function createActionRegistry() {
       .build(),
     category: 'basic',
     order: 5,
+    focus: 'other',
   });
 
   registry.add('army_attack', {
@@ -222,6 +231,7 @@ export function createActionRegistry() {
       .build(),
     category: 'basic',
     order: 6,
+    focus: 'aggressive',
   });
 
   registry.add('hold_festival', {
@@ -279,6 +289,7 @@ export function createActionRegistry() {
       .build(),
     category: 'basic',
     order: 7,
+    focus: 'economy',
   });
 
   registry.add(
@@ -361,6 +372,7 @@ export function createActionRegistry() {
       .build(),
     category: 'building',
     order: 1,
+    focus: 'other',
   });
 
   return registry;

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -18,11 +18,10 @@ import type { BuildingDef } from './defs';
 export type { BuildingDef } from './defs';
 
 export function createBuildingRegistry() {
-  const registry = new Registry<BuildingDef>(buildingSchema);
+  const registry = new Registry<BuildingDef>(buildingSchema.passthrough());
 
-  registry.add(
-    'town_charter',
-    building()
+  registry.add('town_charter', {
+    ...building()
       .id('town_charter')
       .name('Town Charter')
       .icon('🏘️')
@@ -48,12 +47,12 @@ export function createBuildingRegistry() {
           .build(),
       )
       .build(),
-  );
+    focus: 'economy',
+  });
 
   // TODO: remaining buildings from original manual config
-  registry.add(
-    'mill',
-    building()
+  registry.add('mill', {
+    ...building()
       .id('mill')
       .name('Mill')
       .icon('⚙️')
@@ -68,10 +67,10 @@ export function createBuildingRegistry() {
           .build(),
       )
       .build(),
-  );
-  registry.add(
-    'raiders_guild',
-    building()
+    focus: 'economy',
+  });
+  registry.add('raiders_guild', {
+    ...building()
       .id('raiders_guild')
       .name("Raider's Guild")
       .icon('🏴‍☠️')
@@ -87,10 +86,10 @@ export function createBuildingRegistry() {
           .build(),
       )
       .build(),
-  );
-  registry.add(
-    'plow_workshop',
-    building()
+    focus: 'aggressive',
+  });
+  registry.add('plow_workshop', {
+    ...building()
       .id('plow_workshop')
       .name('Plow Workshop')
       .icon('🏭')
@@ -99,10 +98,10 @@ export function createBuildingRegistry() {
         effect(Types.Action, ActionMethods.ADD).param('id', 'plow').build(),
       )
       .build(),
-  );
-  registry.add(
-    'market',
-    building()
+    focus: 'economy',
+  });
+  registry.add('market', {
+    ...building()
       .id('market')
       .name('Market')
       .icon('🏪')
@@ -117,28 +116,28 @@ export function createBuildingRegistry() {
           .build(),
       )
       .build(),
-  );
-  registry.add(
-    'barracks',
-    building()
+    focus: 'economy',
+  });
+  registry.add('barracks', {
+    ...building()
       .id('barracks')
       .name('Barracks')
       .icon('🪖')
       .cost(Resource.gold, 12)
       .build(),
-  );
-  registry.add(
-    'citadel',
-    building()
+    focus: 'aggressive',
+  });
+  registry.add('citadel', {
+    ...building()
       .id('citadel')
       .name('Citadel')
       .icon('🏯')
       .cost(Resource.gold, 12)
       .build(),
-  );
-  registry.add(
-    'castle_walls',
-    building()
+    focus: 'defense',
+  });
+  registry.add('castle_walls', {
+    ...building()
       .id('castle_walls')
       .name('Castle Walls')
       .icon('🧱')
@@ -159,43 +158,44 @@ export function createBuildingRegistry() {
           .build(),
       )
       .build(),
-  );
-  registry.add(
-    'castle_gardens',
-    building()
+    focus: 'defense',
+  });
+  registry.add('castle_gardens', {
+    ...building()
       .id('castle_gardens')
       .name('Castle Gardens')
       .icon('🌷')
       .cost(Resource.gold, 15)
       .build(),
-  );
-  registry.add(
-    'temple',
-    building()
+    focus: 'economy',
+  });
+  registry.add('temple', {
+    ...building()
       .id('temple')
       .name('Temple')
       .icon('⛪')
       .cost(Resource.gold, 16)
       .build(),
-  );
-  registry.add(
-    'palace',
-    building()
+    focus: 'other',
+  });
+  registry.add('palace', {
+    ...building()
       .id('palace')
       .name('Palace')
       .icon('👑')
       .cost(Resource.gold, 20)
       .build(),
-  );
-  registry.add(
-    'great_hall',
-    building()
+    focus: 'other',
+  });
+  registry.add('great_hall', {
+    ...building()
       .id('great_hall')
       .name('Great Hall')
       .icon('🏟️')
       .cost(Resource.gold, 22)
       .build(),
-  );
+    focus: 'other',
+  });
 
   return registry;
 }

--- a/packages/contents/src/defs.ts
+++ b/packages/contents/src/defs.ts
@@ -11,6 +11,8 @@ export const ON_GAIN_AP_STEP = 'onGainAPStep';
 
 export const BROOM_ICON = '🧹';
 
+export type Focus = 'economy' | 'aggressive' | 'defense' | 'other';
+
 export interface Triggered {
   onGrowthPhase?: EffectDef[] | undefined;
   onUpkeepPhase?: EffectDef[] | undefined;
@@ -24,7 +26,10 @@ export interface Triggered {
 export interface PopulationDef extends PopulationConfig, Triggered {}
 export interface DevelopmentDef extends DevelopmentConfig, Triggered {
   order?: number;
+  focus?: Focus;
 }
-export interface BuildingDef extends BuildingConfig, Triggered {}
+export interface BuildingDef extends BuildingConfig, Triggered {
+  focus?: Focus;
+}
 
 export type TriggerKey = keyof Triggered;

--- a/packages/contents/src/developments.ts
+++ b/packages/contents/src/developments.ts
@@ -36,6 +36,7 @@ export function createDevelopmentRegistry() {
       )
       .build(),
     order: 2,
+    focus: 'economy',
   });
 
   registry.add('house', {
@@ -51,6 +52,7 @@ export function createDevelopmentRegistry() {
       )
       .build(),
     order: 1,
+    focus: 'economy',
   });
 
   registry.add('outpost', {
@@ -70,6 +72,7 @@ export function createDevelopmentRegistry() {
       )
       .build(),
     order: 3,
+    focus: 'defense',
   });
 
   registry.add('watchtower', {
@@ -94,6 +97,7 @@ export function createDevelopmentRegistry() {
       )
       .build(),
     order: 4,
+    focus: 'defense',
   });
 
   registry.add(

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -21,7 +21,7 @@ export { RULES } from './rules';
 export type { ActionDef } from './actions';
 export type { BuildingDef } from './buildings';
 export type { DevelopmentDef } from './developments';
-export type { PopulationDef, TriggerKey } from './defs';
+export type { PopulationDef, TriggerKey, Focus } from './defs';
 export {
   ON_PAY_UPKEEP_STEP,
   ON_GAIN_INCOME_STEP,

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { type Summary } from '../../translation';
 import { renderSummary, renderCosts } from '../../translation/render';
+import type { Focus } from '@kingdom-builder/contents';
 
 function stripSummary(summary: Summary | undefined): Summary | undefined {
   const first = summary?.[0];
@@ -23,6 +24,7 @@ export type ActionCardProps = {
   onClick?: () => void;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
+  focus?: Focus | undefined;
 };
 
 export default function ActionCard({
@@ -40,12 +42,25 @@ export default function ActionCard({
   onClick,
   onMouseEnter,
   onMouseLeave,
+  focus,
 }: ActionCardProps) {
+  const focusClass = (() => {
+    switch (focus) {
+      case 'economy':
+        return 'bg-green-100 dark:bg-green-900/40 hover:bg-green-200 dark:hover:bg-green-900/60';
+      case 'aggressive':
+        return 'bg-orange-100 dark:bg-orange-900/40 hover:bg-orange-200 dark:hover:bg-orange-900/60';
+      case 'defense':
+        return 'bg-blue-100 dark:bg-blue-900/40 hover:bg-blue-200 dark:hover:bg-blue-900/60';
+      default:
+        return 'bg-yellow-100 dark:bg-yellow-900/40 hover:bg-yellow-200 dark:hover:bg-yellow-900/60';
+    }
+  })();
   return (
     <button
       className={`relative panel-card border border-black/10 dark:border-white/10 p-2 flex flex-col items-start gap-1 h-full shadow-sm ${
         enabled ? 'hoverable cursor-pointer' : 'opacity-50 cursor-not-allowed'
-      }`}
+      } ${focusClass}`}
       title={tooltip}
       onClick={enabled ? onClick : undefined}
       onMouseEnter={onMouseEnter}


### PR DESCRIPTION
## Summary
- order actions, developments, and buildings by resource cost
- color action cards with pastel focus backgrounds

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b76090717883258f1386c6aa71fbdc