### PR TITLE
Fix development translation placeholders

### DIFF
--- a/packages/web/tests/development-translation.test.ts
+++ b/packages/web/tests/development-translation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createEngine,
+  type EffectDef,
+  type EngineContext,
+} from '@kingdom-builder/engine';
+import {
+  ACTIONS,
+  BUILDINGS,
+  DEVELOPMENTS,
+  POPULATIONS,
+  PHASES,
+  GAME_START,
+  RULES,
+  type DevelopmentDef,
+} from '@kingdom-builder/contents';
+import {
+  describeContent,
+  summarizeContent,
+  type SummaryEntry,
+} from '../src/translation';
+
+vi.mock('@kingdom-builder/engine', async () => {
+  return await import('../../engine/src');
+});
+
+const ctx = createEngine({
+  actions: ACTIONS,
+  buildings: BUILDINGS,
+  developments: DEVELOPMENTS,
+  populations: POPULATIONS,
+  phases: PHASES,
+  start: GAME_START,
+  rules: RULES,
+});
+
+function flatten(entries: SummaryEntry[]): string[] {
+  const result: string[] = [];
+  for (const entry of entries) {
+    if (typeof entry === 'string') {
+      result.push(entry);
+    } else {
+      result.push(entry.title);
+      result.push(...flatten(entry.items));
+    }
+  }
+  return result;
+}
+
+function hasSelfEvaluator(effects: EffectDef[] | undefined): boolean {
+  if (!effects) return false;
+  for (const effect of effects) {
+    const params = effect.evaluator?.params as
+      | Record<string, unknown>
+      | undefined;
+    if (effect.evaluator?.type === 'development' && params?.['id'] === '$id') {
+      return true;
+    }
+    if (hasSelfEvaluator(effect.effects as EffectDef[] | undefined))
+      return true;
+  }
+  return false;
+}
+
+function findSelfReferentialDevelopment(
+  registry: Iterable<[string, DevelopmentDef]>,
+): string {
+  for (const [id, def] of registry) {
+    const values = def as unknown as Record<string, unknown>;
+    for (const value of Object.values(values)) {
+      if (Array.isArray(value) && hasSelfEvaluator(value as EffectDef[])) {
+        return id;
+      }
+    }
+  }
+  throw new Error('Expected development with self-referential evaluator');
+}
+
+describe('development translation', () => {
+  it('replaces self-referential placeholders when describing developments', () => {
+    const id = findSelfReferentialDevelopment(DEVELOPMENTS.entries());
+    const summary = summarizeContent('development', id, ctx as EngineContext);
+    const description = describeContent(
+      'development',
+      id,
+      ctx as EngineContext,
+    );
+    const strings = [...flatten(summary), ...flatten(description)];
+
+    expect(strings.some((line) => line.includes('$id'))).toBe(false);
+
+    const def = ctx.developments.get(id);
+    const icon = def.icon || '';
+    expect(strings.some((line) => line.includes(def.name))).toBe(true);
+    if (icon) {
+      expect(strings.some((line) => line.includes(icon))).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- ensure development translations apply self parameters so evaluator placeholders resolve to real ids
- use the same substitution when merging phase effects into development summaries
- add a regression test covering self-referential development translations to guard against `$id` leakage

## Testing
- npx vitest run packages/web/tests/development-translation.test.ts
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68daaffb167083259518d71cf0f8de52