### PR TITLE
Show only development icons in land slots

### DIFF
--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -56,6 +56,7 @@ const LandTile: React.FC<{
               <span
                 key={i}
                 className="land-slot"
+                aria-label={name}
                 onMouseEnter={(e) => {
                   e.stopPropagation();
                   const full = describeContent('development', devId, ctx, {
@@ -75,10 +76,9 @@ const LandTile: React.FC<{
                   handleLeave();
                 }}
               >
-                <span className="flex-none">
+                <span aria-hidden="true">
                   {ctx.developments.get(devId)?.icon}
                 </span>
-                <span className="flex-1 min-w-0 truncate">{name}</span>
               </span>
             );
           }
@@ -87,6 +87,7 @@ const LandTile: React.FC<{
             <span
               key={i}
               className="land-slot italic"
+              aria-label={`${SLOT_INFO.label} (empty)`}
               onMouseEnter={(e) => {
                 e.stopPropagation();
                 handleHoverCard({
@@ -104,8 +105,7 @@ const LandTile: React.FC<{
                 handleLeave();
               }}
             >
-              <span className="flex-none">{SLOT_INFO.icon}</span>
-              <span className="flex-1 min-w-0 truncate">-empty-</span>
+              <span aria-hidden="true">{SLOT_INFO.icon}</span>
             </span>
           );
         })}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -32,7 +32,7 @@
     @apply relative panel-card border border-black/10 dark:border-white/10 p-2 text-center hoverable cursor-help;
   }
   .land-slot {
-    @apply panel-card border border-black/10 dark:border-white/10 p-1 text-xs hoverable cursor-help flex items-center justify-center gap-1 shrink-0;
+    @apply panel-card border border-black/10 dark:border-white/10 p-1 text-lg leading-none hoverable cursor-help flex items-center justify-center gap-1 shrink-0 min-w-8 min-h-8;
   }
   .player-bg {
     @apply relative overflow-hidden text-gray-900 dark:text-white;


### PR DESCRIPTION
## Summary
- display only development icons within land slots on the player panel while keeping hover cards for details
- enlarge land slot styling so the standalone icons remain legible and consistently sized

## Testing
- npm run check
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dab0f132f48325815c72e8a4df448d