### PR TITLE
Fix log panel auto-scroll after animations

### DIFF
--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -8,10 +8,34 @@ export default function LogPanel() {
   const listRef = useAnimate<HTMLUListElement>();
 
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    if (el.scrollHeight > el.clientHeight)
-      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    const container = containerRef.current;
+    const list = listRef.current;
+    if (!container || !list) return;
+
+    const scrollToBottom = (behavior: ScrollBehavior) => {
+      if (container.scrollHeight > container.clientHeight)
+        container.scrollTo({ top: container.scrollHeight, behavior });
+    };
+
+    const animations =
+      typeof list.getAnimations === 'function' ? list.getAnimations() : [];
+    if (animations.length === 0) {
+      scrollToBottom('smooth');
+      return;
+    }
+
+    let cancelled = false;
+    const finished = animations.map((animation) =>
+      animation.finished.catch(() => undefined),
+    );
+
+    void Promise.all(finished).then(() => {
+      if (!cancelled) scrollToBottom('smooth');
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [entries]);
 
   return (


### PR DESCRIPTION
## Summary
- wait for auto-animate transitions to finish before triggering the log panel scroll
- fall back to immediate scrolling when no animations run and cancel pending scroll callbacks on cleanup

## Testing
- npx eslint packages/web/src/components/LogPanel.tsx
- npm run typecheck
- npm run lint
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dab7a94e208325a45abb627a299823