### PR TITLE
Animate active player background stripes

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -32,14 +32,23 @@ function GameLayout() {
           <div className="flex flex-1 items-stretch rounded overflow-hidden divide-x divide-black/10 dark:divide-white/10">
             {ctx.game.players.map((p, i) => {
               const isActive = p.id === ctx.activePlayer.id;
-              const bgClass =
+              const sideClass = i === 0 ? 'pr-6' : 'pl-6';
+              const colorClass =
                 i === 0
                   ? isActive
-                    ? 'player-bg player-bg-blue-active pr-6'
-                    : 'player-bg player-bg-blue pr-6'
+                    ? 'player-bg-blue-active'
+                    : 'player-bg-blue'
                   : isActive
-                    ? 'player-bg player-bg-red-active pl-6'
-                    : 'player-bg player-bg-red pl-6';
+                    ? 'player-bg-red-active'
+                    : 'player-bg-red';
+              const bgClass = [
+                'player-bg',
+                sideClass,
+                colorClass,
+                isActive ? 'player-bg-animated' : null,
+              ]
+                .filter(Boolean)
+                .join(' ');
               return (
                 <PlayerPanel
                   key={p.id}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -36,8 +36,17 @@
   }
   .player-bg {
     @apply relative overflow-hidden text-gray-900 dark:text-white;
-    --stripe-color: rgba(0, 0, 0, 0.03);
+    --stripe-color: rgba(0, 0, 0, 0.04);
     background-color: var(--player-color);
+  }
+  .dark .player-bg {
+    --stripe-color: rgba(255, 255, 255, 0.04);
+  }
+  .player-bg::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 0;
     background-image: linear-gradient(
       45deg,
       var(--stripe-color) 25%,
@@ -48,13 +57,23 @@
       transparent 75%,
       transparent
     );
-    background-size: 20px 20px;
+    background-size: 32px 32px;
+    background-position: 0 0;
+    background-repeat: repeat;
+    opacity: 0.9;
+    will-change: background-position;
+    transition: opacity 150ms ease-in-out;
   }
-  .dark .player-bg {
-    --stripe-color: rgba(255, 255, 255, 0.03);
+  .player-bg > * {
+    position: relative;
+    z-index: 1;
   }
   .player-bg-animated {
-    animation: player-bg-slide 60s linear infinite;
+    animation: none;
+  }
+  .player-bg-animated::before {
+    opacity: 1;
+    animation: player-bg-slide 18s linear infinite;
   }
   .player-bg-blue {
     --player-color: rgba(219, 234, 254, 0.5);

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -7,11 +7,8 @@
 }
 
 @keyframes player-bg-slide {
-  from {
-    background-position: 0 0;
-  }
   to {
-    background-position: 40px 40px;
+    background-position: -32px 32px;
   }
 }
 
@@ -73,7 +70,7 @@
   }
   .player-bg-animated::before {
     opacity: 1;
-    animation: player-bg-slide 18s linear infinite;
+    animation: player-bg-slide 2s linear infinite;
   }
   .player-bg-blue {
     --player-color: rgba(219, 234, 254, 0.5);

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -49,10 +49,12 @@
       transparent
     );
     background-size: 20px 20px;
-    animation: player-bg-slide 60s linear infinite;
   }
   .dark .player-bg {
     --stripe-color: rgba(255, 255, 255, 0.03);
+  }
+  .player-bg-animated {
+    animation: player-bg-slide 60s linear infinite;
   }
   .player-bg-blue {
     --player-color: rgba(219, 234, 254, 0.5);


### PR DESCRIPTION
## Summary
- move the diagonal background animation into a dedicated utility class
- apply the animation class only to the currently active player panel so inactive players remain static

## Testing
- npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68dab962ebc883259d5981e7a74518d7