### PR TITLE
Prevent rebuilding already owned structures

### DIFF
--- a/packages/engine/src/effects/building_add.ts
+++ b/packages/engine/src/effects/building_add.ts
@@ -1,8 +1,12 @@
 import type { EffectHandler, EffectCostCollector } from '.';
 
 export const buildingAdd: EffectHandler = (effect, ctx, mult = 1) => {
-  const id = effect.params!['id'] as string;
-  for (let index = 0; index < Math.floor(mult); index++) {
+  const id = effect.params?.['id'] as string;
+  if (!id) throw new Error('building:add requires id');
+  const iterations = Math.floor(mult);
+  for (let index = 0; index < iterations; index++) {
+    if (ctx.activePlayer.buildings.has(id))
+      throw new Error(`Building ${id} already built`);
     ctx.activePlayer.buildings.add(id);
     const building = ctx.buildings.get(id);
     if (building.onBuild)

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -139,6 +139,14 @@ export function performAction<T extends string>(
   }
   const base = { ...(actionDefinition.baseCosts || {}) };
   const resolved = applyParamsToEffects(actionDefinition.effects, params || {});
+  const attemptedBuildingAdds = resolved
+    .filter((effect) => effect.type === 'building' && effect.method === 'add')
+    .map((effect) => effect.params?.['id'])
+    .filter((id): id is string => typeof id === 'string');
+  for (const id of attemptedBuildingAdds) {
+    if (ctx.activePlayer.buildings.has(id))
+      throw new Error(`Building ${id} already built`);
+  }
   for (const effect of resolved) {
     if (!effect.type || !effect.method) continue;
     const key = `${effect.type}:${effect.method}`;

--- a/packages/engine/tests/effects/add_building.test.ts
+++ b/packages/engine/tests/effects/add_building.test.ts
@@ -42,4 +42,59 @@ describe('building:add effect', () => {
     expect(ctx.activePlayer.buildings.has(building.id)).toBe(true);
     expect(after).toBe(before + bonus);
   });
+
+  it('throws before paying costs when building already owned', () => {
+    const content = createContentFactory();
+    const building = content.building({ costs: { [CResource.gold]: 2 } });
+    const grant = content.action({
+      effects: [
+        { type: 'building', method: 'add', params: { id: building.id } },
+      ],
+    });
+    const ctx = createTestEngine(content);
+    while (ctx.game.currentPhase !== 'main') advance(ctx);
+    const cost = getActionCosts(grant.id, ctx, { id: building.id });
+    for (const [key, value] of Object.entries(cost))
+      ctx.activePlayer.resources[key] = (value ?? 0) * 2;
+
+    performAction(grant.id, ctx, { id: building.id });
+
+    const actionKey = ctx.actionCostResource as string;
+    ctx.activePlayer.resources[actionKey] = 5;
+    ctx.activePlayer.resources[CResource.gold] = 10;
+    expect(() => performAction(grant.id, ctx, { id: building.id })).toThrow(
+      `Building ${building.id} already built`,
+    );
+    expect(ctx.activePlayer.resources[actionKey]).toBe(5);
+    expect(ctx.activePlayer.resources[CResource.gold]).toBe(10);
+  });
+
+  it('allows rebuilding after the structure is removed', () => {
+    const content = createContentFactory();
+    const building = content.building();
+    const build = content.action({
+      effects: [
+        { type: 'building', method: 'add', params: { id: building.id } },
+      ],
+    });
+    const demolish = content.action({
+      effects: [
+        { type: 'building', method: 'remove', params: { id: building.id } },
+      ],
+    });
+    const ctx = createTestEngine(content);
+    while (ctx.game.currentPhase !== 'main') advance(ctx);
+    const cost = getActionCosts(build.id, ctx, { id: building.id });
+    const actionKey = ctx.actionCostResource as string;
+    for (const [key, value] of Object.entries(cost))
+      ctx.activePlayer.resources[key] = (value ?? 0) * 3;
+
+    performAction(build.id, ctx, { id: building.id });
+    performAction(demolish.id, ctx, { id: building.id });
+
+    ctx.activePlayer.resources[actionKey] = 5;
+    performAction(build.id, ctx, { id: building.id });
+
+    expect(ctx.activePlayer.buildings.has(building.id)).toBe(true);
+  });
 });

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -421,7 +421,9 @@ function BuildOptions({
     actionCostResource,
   } = useGameEngine();
   const entries = useMemo(() => {
+    const owned = ctx.activePlayer.buildings;
     return buildings
+      .filter((b) => !owned.has(b.id))
       .map((b) => {
         const costsBag = getActionCosts(action.id, ctx, { id: b.id });
         const costs: Record<string, number> = {};
@@ -433,7 +435,13 @@ function BuildOptions({
         return { b, costs, total };
       })
       .sort((a, b) => a.total - b.total);
-  }, [buildings, ctx, action.id, actionCostResource]);
+  }, [
+    buildings,
+    ctx,
+    action.id,
+    actionCostResource,
+    ctx.activePlayer.buildings.size,
+  ]);
   return (
     <div>
       <h3 className="font-medium">


### PR DESCRIPTION
## Summary
- stop the engine from paying costs when attempting to build a structure a player already owns and guard the effect itself
- hide purchased buildings from the web build options to avoid offering duplicate buys
- add regression coverage ensuring duplicate builds throw and that rebuilding works after removal

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dab85cec5c83259ce064600a0d7594