### PR TITLE
Add parameter builders for contents definitions

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -21,6 +21,17 @@ import {
   ResultModMethods,
   BuildingMethods,
   StatMethods,
+  resourceParams,
+  statParams,
+  developmentParams,
+  resultModParams,
+  passiveParams,
+  costModParams,
+  developmentEvaluator,
+  populationEvaluator,
+  statEvaluator,
+  attackParams,
+  transferParams,
 } from './config/builders';
 import type { Focus } from './defs';
 
@@ -43,7 +54,7 @@ export function createActionRegistry() {
       .effect(effect(Types.Land, LandMethods.ADD).param('count', 1).build())
       .effect(
         effect(Types.Resource, ResourceMethods.ADD)
-          .params({ key: Resource.happiness, amount: 1 })
+          .params(resourceParams().key(Resource.happiness).amount(1))
           .build(),
       )
       .build(),
@@ -60,17 +71,17 @@ export function createActionRegistry() {
       .cost(Resource.ap, 1)
       .effect(
         effect()
-          .evaluator('development', { id: 'farm' })
+          .evaluator(developmentEvaluator().id('farm'))
           .effect(
             effect(Types.Resource, ResourceMethods.ADD)
               .round('down')
-              .params({ key: Resource.gold, amount: 2 })
+              .params(resourceParams().key(Resource.gold).amount(2))
               .build(),
           )
           .effect(
             effect(Types.Resource, ResourceMethods.ADD)
               .round('up')
-              .params({ key: Resource.happiness, amount: -0.5 })
+              .params(resourceParams().key(Resource.happiness).amount(-0.5))
               .build(),
           )
           .build(),
@@ -90,7 +101,7 @@ export function createActionRegistry() {
       .cost(Resource.gold, 3)
       .effect(
         effect(Types.Development, DevelopmentMethods.ADD)
-          .params({ id: '$id', landId: '$landId' })
+          .params(developmentParams().id('$id').landId('$landId'))
           .build(),
       )
       .build(),
@@ -107,16 +118,16 @@ export function createActionRegistry() {
       .cost(Resource.ap, 1)
       .effect(
         effect()
-          .evaluator('population', { id: 'tax' })
+          .evaluator(populationEvaluator().param('id', 'tax'))
           .effect(
             effect(Types.Resource, ResourceMethods.ADD)
-              .params({ key: Resource.gold, amount: 4 })
+              .params(resourceParams().key(Resource.gold).amount(4))
               .build(),
           )
           .effect(
             effect(Types.Resource, ResourceMethods.ADD)
               .round('up')
-              .params({ key: Resource.happiness, amount: -0.5 })
+              .params(resourceParams().key(Resource.happiness).amount(-0.5))
               .build(),
           )
           .build(),
@@ -149,9 +160,9 @@ export function createActionRegistry() {
       .cost(Resource.gold, 5)
       .requirement(
         requirement('evaluator', 'compare')
-          .param('left', { type: 'population' })
+          .param('left', populationEvaluator().build())
           .param('operator', 'lt')
-          .param('right', { type: 'stat', params: { key: Stat.maxPopulation } })
+          .param('right', statEvaluator().key(Stat.maxPopulation).build())
           .message('Free space for 👥')
           .build(),
       )
@@ -162,7 +173,7 @@ export function createActionRegistry() {
       )
       .effect(
         effect(Types.Resource, ResourceMethods.ADD)
-          .params({ key: Resource.happiness, amount: 1 })
+          .params(resourceParams().key(Resource.happiness).amount(1))
           .build(),
       )
       .build(),
@@ -192,12 +203,12 @@ export function createActionRegistry() {
       .cost(Resource.ap, 1)
       .requirement(
         requirement('evaluator', 'compare')
-          .param('left', { type: 'stat', params: { key: Stat.warWeariness } })
+          .param('left', statEvaluator().key(Stat.warWeariness).build())
           .param('operator', 'lt')
-          .param('right', {
-            type: 'population',
-            params: { role: PopulationRole.Legion },
-          })
+          .param(
+            'right',
+            populationEvaluator().role(PopulationRole.Legion).build(),
+          )
           .message(
             `${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be lower than ${POPULATION_ROLES[PopulationRole.Legion].icon} ${POPULATION_ROLES[PopulationRole.Legion].label}`,
           )
@@ -205,27 +216,28 @@ export function createActionRegistry() {
       )
       .effect(
         effect('attack', 'perform')
-          .param('target', { type: 'resource', key: Resource.castleHP })
-          .param('onDamage', {
-            attacker: [
-              effect(Types.Resource, ResourceMethods.ADD)
-                .params({ key: Resource.happiness, amount: 1 })
-                .build(),
-              effect(Types.Action, ActionMethods.PERFORM)
-                .param('id', 'plunder')
-                .build(),
-            ],
-            defender: [
-              effect(Types.Resource, ResourceMethods.ADD)
-                .params({ key: Resource.happiness, amount: -1 })
-                .build(),
-            ],
-          })
+          .params(
+            attackParams()
+              .targetResource(Resource.castleHP)
+              .onDamageAttacker(
+                effect(Types.Resource, ResourceMethods.ADD)
+                  .params(resourceParams().key(Resource.happiness).amount(1))
+                  .build(),
+                effect(Types.Action, ActionMethods.PERFORM)
+                  .param('id', 'plunder')
+                  .build(),
+              )
+              .onDamageDefender(
+                effect(Types.Resource, ResourceMethods.ADD)
+                  .params(resourceParams().key(Resource.happiness).amount(-1))
+                  .build(),
+              ),
+          )
           .build(),
       )
       .effect(
         effect(Types.Stat, StatMethods.ADD)
-          .params({ key: Stat.warWeariness, amount: 1 })
+          .params(statParams().key(Stat.warWeariness).amount(1))
           .build(),
       )
       .build(),
@@ -243,7 +255,7 @@ export function createActionRegistry() {
       .cost(Resource.gold, 3)
       .requirement(
         requirement('evaluator', 'compare')
-          .param('left', { type: 'stat', params: { key: Stat.warWeariness } })
+          .param('left', statEvaluator().key(Stat.warWeariness).build())
           .param('operator', 'eq')
           .param('right', 0)
           .message(
@@ -253,33 +265,35 @@ export function createActionRegistry() {
       )
       .effect(
         effect(Types.Resource, ResourceMethods.ADD)
-          .params({ key: Resource.happiness, amount: 3 })
+          .params(resourceParams().key(Resource.happiness).amount(3))
           .build(),
       )
       .effect(
         effect(Types.Stat, StatMethods.REMOVE)
-          .params({ key: Stat.fortificationStrength, amount: 3 })
+          .params(statParams().key(Stat.fortificationStrength).amount(3))
           .build(),
       )
       .effect(
         effect(Types.Passive, PassiveMethods.ADD)
-          .params({
-            id: 'hold_festival_penalty',
-            onUpkeepPhase: [
-              effect(Types.Passive, PassiveMethods.REMOVE)
-                .param('id', 'hold_festival_penalty')
-                .build(),
-            ],
-          })
+          .params(
+            passiveParams()
+              .id('hold_festival_penalty')
+              .onUpkeepPhase(
+                effect(Types.Passive, PassiveMethods.REMOVE)
+                  .param('id', 'hold_festival_penalty')
+                  .build(),
+              ),
+          )
           .effect(
             effect(Types.ResultMod, ResultModMethods.ADD)
-              .params({
-                id: 'hold_festival_attack_happiness_penalty',
-                actionId: 'army_attack',
-              })
+              .params(
+                resultModParams()
+                  .id('hold_festival_attack_happiness_penalty')
+                  .actionId('army_attack'),
+              )
               .effect(
                 effect(Types.Resource, ResourceMethods.ADD)
-                  .params({ key: Resource.happiness, amount: -3 })
+                  .params(resourceParams().key(Resource.happiness).amount(-3))
                   .build(),
               )
               .build(),
@@ -303,7 +317,7 @@ export function createActionRegistry() {
       // evaluation { type: 'transfer_pct', id: 'percent' } with an `adjust` value.
       .effect(
         effect(Types.Resource, ResourceMethods.TRANSFER)
-          .params({ key: Resource.gold, percent: 25 })
+          .params(transferParams().key(Resource.gold).percent(25))
           .build(),
       )
       .build(),
@@ -328,21 +342,23 @@ export function createActionRegistry() {
       )
       .effect(
         effect(Types.Passive, PassiveMethods.ADD)
-          .params({
-            id: 'plow_cost_mod',
-            onUpkeepPhase: [
-              effect(Types.Passive, PassiveMethods.REMOVE)
-                .param('id', 'plow_cost_mod')
-                .build(),
-            ],
-          })
+          .params(
+            passiveParams()
+              .id('plow_cost_mod')
+              .onUpkeepPhase(
+                effect(Types.Passive, PassiveMethods.REMOVE)
+                  .param('id', 'plow_cost_mod')
+                  .build(),
+              ),
+          )
           .effect(
             effect(Types.CostMod, CostModMethods.ADD)
-              .params({
-                id: 'plow_cost_all',
-                key: Resource.gold,
-                amount: 2,
-              })
+              .params(
+                costModParams()
+                  .id('plow_cost_all')
+                  .key(Resource.gold)
+                  .amount(2),
+              )
               .build(),
           )
           .build(),

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -1,4 +1,8 @@
 import { Registry } from '@kingdom-builder/engine/registry';
+import {
+  TRANSFER_PCT_EVALUATION_ID,
+  TRANSFER_PCT_EVALUATION_TYPE,
+} from '@kingdom-builder/engine/effects/resource_transfer';
 import { Resource } from './resources';
 import { Stat } from './stats';
 import { buildingSchema } from '@kingdom-builder/engine/config/schema';
@@ -12,6 +16,11 @@ import {
   ActionMethods,
   PassiveMethods,
   StatMethods,
+  resourceParams,
+  resultModParams,
+  evaluationTarget,
+  costModParams,
+  statParams,
 } from './config/builders';
 import type { BuildingDef } from './defs';
 
@@ -28,20 +37,21 @@ export function createBuildingRegistry() {
       .cost(Resource.gold, 5)
       .onBuild(
         effect(Types.CostMod, CostModMethods.ADD)
-          .params({
-            id: 'tc_expand_cost',
-            actionId: 'expand',
-            key: Resource.gold,
-            amount: 2,
-          })
+          .params(
+            costModParams()
+              .id('tc_expand_cost')
+              .actionId('expand')
+              .key(Resource.gold)
+              .amount(2),
+          )
           .build(),
       )
       .onBuild(
         effect(Types.ResultMod, ResultModMethods.ADD)
-          .params({ id: 'tc_expand_result', actionId: 'expand' })
+          .params(resultModParams().id('tc_expand_result').actionId('expand'))
           .effect(
             effect(Types.Resource, ResourceMethods.ADD)
-              .params({ key: Resource.happiness, amount: 1 })
+              .params(resourceParams().key(Resource.happiness).amount(1))
               .build(),
           )
           .build(),
@@ -59,11 +69,12 @@ export function createBuildingRegistry() {
       .cost(Resource.gold, 7)
       .onBuild(
         effect(Types.ResultMod, ResultModMethods.ADD)
-          .params({
-            id: 'mill_farm_bonus',
-            evaluation: { type: 'development', id: 'farm' },
-            amount: 1,
-          })
+          .params(
+            resultModParams()
+              .id('mill_farm_bonus')
+              .evaluation(evaluationTarget('development').id('farm'))
+              .amount(1),
+          )
           .build(),
       )
       .build(),
@@ -78,11 +89,16 @@ export function createBuildingRegistry() {
       .cost(Resource.ap, 1)
       .onBuild(
         effect(Types.ResultMod, ResultModMethods.ADD)
-          .params({
-            id: 'raiders_guild_plunder_bonus',
-            evaluation: { type: 'transfer_pct', id: 'percent' },
-            adjust: 25,
-          })
+          .params(
+            resultModParams()
+              .id('raiders_guild_plunder_bonus')
+              .evaluation(
+                evaluationTarget(TRANSFER_PCT_EVALUATION_TYPE).id(
+                  TRANSFER_PCT_EVALUATION_ID,
+                ),
+              )
+              .adjust(25),
+          )
           .build(),
       )
       .build(),
@@ -108,11 +124,12 @@ export function createBuildingRegistry() {
       .cost(Resource.gold, 10)
       .onBuild(
         effect(Types.ResultMod, ResultModMethods.ADD)
-          .params({
-            id: 'market_tax_bonus',
-            evaluation: { type: 'population', id: 'tax' },
-            amount: 1,
-          })
+          .params(
+            resultModParams()
+              .id('market_tax_bonus')
+              .evaluation(evaluationTarget('population').id('tax'))
+              .amount(1),
+          )
           .build(),
       )
       .build(),
@@ -147,12 +164,12 @@ export function createBuildingRegistry() {
           .param('id', 'castle_walls_bonus')
           .effect(
             effect(Types.Stat, StatMethods.ADD)
-              .params({ key: Stat.fortificationStrength, amount: 5 })
+              .params(statParams().key(Stat.fortificationStrength).amount(5))
               .build(),
           )
           .effect(
             effect(Types.Stat, StatMethods.ADD)
-              .params({ key: Stat.absorption, amount: 0.2 })
+              .params(statParams().key(Stat.absorption).amount(0.2))
               .build(),
           )
           .build(),

--- a/packages/contents/src/developments.ts
+++ b/packages/contents/src/developments.ts
@@ -9,6 +9,10 @@ import {
   StatMethods,
   DevelopmentMethods,
   ResourceMethods,
+  resourceParams,
+  statParams,
+  developmentParams,
+  developmentEvaluator,
 } from './config/builders';
 import type { DevelopmentDef } from './defs';
 
@@ -26,10 +30,10 @@ export function createDevelopmentRegistry() {
       .icon('🌾')
       .onGainIncomeStep(
         effect()
-          .evaluator('development', { id: '$id' })
+          .evaluator(developmentEvaluator().id('$id'))
           .effect(
             effect(Types.Resource, ResourceMethods.ADD)
-              .params({ key: Resource.gold, amount: 2 })
+              .params(resourceParams().key(Resource.gold).amount(2))
               .build(),
           )
           .build(),
@@ -47,7 +51,7 @@ export function createDevelopmentRegistry() {
       .populationCap(1)
       .onBuild(
         effect(Types.Stat, StatMethods.ADD)
-          .params({ key: Stat.maxPopulation, amount: 1 })
+          .params(statParams().key(Stat.maxPopulation).amount(1))
           .build(),
       )
       .build(),
@@ -62,12 +66,12 @@ export function createDevelopmentRegistry() {
       .icon('🏹')
       .onBuild(
         effect(Types.Stat, StatMethods.ADD)
-          .params({ key: Stat.armyStrength, amount: 1 })
+          .params(statParams().key(Stat.armyStrength).amount(1))
           .build(),
       )
       .onBuild(
         effect(Types.Stat, StatMethods.ADD)
-          .params({ key: Stat.fortificationStrength, amount: 1 })
+          .params(statParams().key(Stat.fortificationStrength).amount(1))
           .build(),
       )
       .build(),
@@ -82,17 +86,17 @@ export function createDevelopmentRegistry() {
       .icon('🗼')
       .onBuild(
         effect(Types.Stat, StatMethods.ADD)
-          .params({ key: Stat.fortificationStrength, amount: 2 })
+          .params(statParams().key(Stat.fortificationStrength).amount(2))
           .build(),
       )
       .onBuild(
         effect(Types.Stat, StatMethods.ADD)
-          .params({ key: Stat.absorption, amount: 0.5 })
+          .params(statParams().key(Stat.absorption).amount(0.5))
           .build(),
       )
       .onAttackResolved(
         effect(Types.Development, DevelopmentMethods.REMOVE)
-          .params({ id: 'watchtower', landId: '$landId' })
+          .params(developmentParams().id('watchtower').landId('$landId'))
           .build(),
       )
       .build(),

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -6,6 +6,10 @@ import {
   StatMethods,
   phase,
   step,
+  populationEvaluator,
+  statParams,
+  compareEvaluator,
+  statEvaluator,
   type PhaseDef,
 } from './config/builders';
 import {
@@ -35,10 +39,14 @@ export const PHASES: PhaseDef[] = [
         .title('Raise Strength')
         .effect(
           effect()
-            .evaluator('population', { role: PopulationRole.Legion })
+            .evaluator(populationEvaluator().role(PopulationRole.Legion))
             .effect(
               effect(Types.Stat, StatMethods.ADD_PCT)
-                .params({ key: Stat.armyStrength, percentStat: Stat.growth })
+                .params(
+                  statParams()
+                    .key(Stat.armyStrength)
+                    .percentFromStat(Stat.growth),
+                )
                 .round('up')
                 .build(),
             )
@@ -46,13 +54,14 @@ export const PHASES: PhaseDef[] = [
         )
         .effect(
           effect()
-            .evaluator('population', { role: PopulationRole.Fortifier })
+            .evaluator(populationEvaluator().role(PopulationRole.Fortifier))
             .effect(
               effect(Types.Stat, StatMethods.ADD_PCT)
-                .params({
-                  key: Stat.fortificationStrength,
-                  percentStat: Stat.growth,
-                })
+                .params(
+                  statParams()
+                    .key(Stat.fortificationStrength)
+                    .percentFromStat(Stat.growth),
+                )
                 .round('up')
                 .build(),
             )
@@ -74,14 +83,15 @@ export const PHASES: PhaseDef[] = [
         .title('War recovery')
         .effect(
           effect()
-            .evaluator('compare', {
-              left: { type: 'stat', params: { key: Stat.warWeariness } },
-              operator: 'gt',
-              right: 0,
-            })
+            .evaluator(
+              compareEvaluator()
+                .left(statEvaluator().key(Stat.warWeariness))
+                .operator('gt')
+                .right(0),
+            )
             .effect(
               effect(Types.Stat, StatMethods.REMOVE)
-                .params({ key: Stat.warWeariness, amount: 1 })
+                .params(statParams().key(Stat.warWeariness).amount(1))
                 .build(),
             )
             .build(),

--- a/packages/contents/src/populations.ts
+++ b/packages/contents/src/populations.ts
@@ -10,6 +10,8 @@ import {
   ResourceMethods,
   PassiveMethods,
   StatMethods,
+  resourceParams,
+  statParams,
 } from './config/builders';
 import type { PopulationDef } from './defs';
 
@@ -27,7 +29,7 @@ export function createPopulationRegistry() {
       .upkeep(Resource.gold, 2)
       .onGainAPStep(
         effect(Types.Resource, ResourceMethods.ADD)
-          .params({ key: Resource.ap, amount: 1 })
+          .params(resourceParams().key(Resource.ap).amount(1))
           .build(),
       )
       .build(),
@@ -45,7 +47,7 @@ export function createPopulationRegistry() {
           .param('id', 'legion_$player_$index')
           .effect(
             effect(Types.Stat, StatMethods.ADD)
-              .params({ key: Stat.armyStrength, amount: 1 })
+              .params(statParams().key(Stat.armyStrength).amount(1))
               .build(),
           )
           .build(),
@@ -70,7 +72,7 @@ export function createPopulationRegistry() {
           .param('id', 'fortifier_$player_$index')
           .effect(
             effect(Types.Stat, StatMethods.ADD)
-              .params({ key: Stat.fortificationStrength, amount: 1 })
+              .params(statParams().key(Stat.fortificationStrength).amount(1))
               .build(),
           )
           .build(),

--- a/packages/engine/src/effects/resource_transfer.ts
+++ b/packages/engine/src/effects/resource_transfer.ts
@@ -2,6 +2,10 @@ import type { EffectHandler } from '.';
 import type { ResourceKey } from '../state';
 import type { ResourceGain } from '../services';
 
+export const TRANSFER_PCT_EVALUATION_TYPE = 'transfer_pct';
+export const TRANSFER_PCT_EVALUATION_ID = 'percent';
+export const TRANSFER_PCT_EVALUATION_TARGET = `${TRANSFER_PCT_EVALUATION_TYPE}:${TRANSFER_PCT_EVALUATION_ID}`;
+
 interface TransferParams extends Record<string, unknown> {
   key: ResourceKey;
   percent?: number;
@@ -15,7 +19,7 @@ export const resourceTransfer: EffectHandler<TransferParams> = (
   const { key, percent } = effect.params!;
   const base = percent ?? 25;
   const mods: ResourceGain[] = [{ key, amount: base }];
-  ctx.passives.runEvaluationMods('transfer_pct:percent', ctx, mods);
+  ctx.passives.runEvaluationMods(TRANSFER_PCT_EVALUATION_TARGET, ctx, mods);
   const pct = mods[0]!.amount;
   const defender = ctx.opponent;
   const attacker = ctx.activePlayer;

--- a/packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts
+++ b/packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { runEffects, advance, Resource } from '../../src/index.ts';
+import {
+  TRANSFER_PCT_EVALUATION_ID,
+  TRANSFER_PCT_EVALUATION_TYPE,
+} from '../../src/effects/resource_transfer.ts';
 import { createTestEngine } from '../helpers.ts';
 import type { EffectDef } from '../../src/effects/index.ts';
 
@@ -19,7 +23,10 @@ describe('resource:transfer percent bounds', () => {
       method: 'add',
       params: {
         id: 'boost',
-        evaluation: { type: 'transfer_pct', id: 'percent' },
+        evaluation: {
+          type: TRANSFER_PCT_EVALUATION_TYPE,
+          id: TRANSFER_PCT_EVALUATION_ID,
+        },
         adjust: 80,
       },
     };
@@ -28,7 +35,10 @@ describe('resource:transfer percent bounds', () => {
       method: 'remove',
       params: {
         id: 'boost',
-        evaluation: { type: 'transfer_pct', id: 'percent' },
+        evaluation: {
+          type: TRANSFER_PCT_EVALUATION_TYPE,
+          id: TRANSFER_PCT_EVALUATION_ID,
+        },
       },
     };
     const addNerf: EffectDef<{ id: string }> = {
@@ -36,7 +46,10 @@ describe('resource:transfer percent bounds', () => {
       method: 'add',
       params: {
         id: 'nerf',
-        evaluation: { type: 'transfer_pct', id: 'percent' },
+        evaluation: {
+          type: TRANSFER_PCT_EVALUATION_TYPE,
+          id: TRANSFER_PCT_EVALUATION_ID,
+        },
         adjust: -200,
       },
     };


### PR DESCRIPTION
## Summary
- add parameter builder helpers for effect and evaluator configs used by contents
- update actions, phases, buildings, developments, and populations to rely on the builders instead of manual objects
- expose a transfer percent evaluation constant and update dependent tests

## Testing
- `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68dabda3c734832586d9b32e729b1368