### PR TITLE
Add friendly validation for content builders

### DIFF
--- a/packages/contents/README.md
+++ b/packages/contents/README.md
@@ -1,0 +1,62 @@
+# Contents Configuration Guide
+
+The builder helpers in `packages/contents/src/config/builders.ts` are designed so
+non-programmers can compose valid game data with descriptive, chainable calls.
+This guide highlights the most common gotchas and shows how the new validation
+messages point you to the fix.
+
+## Core patterns
+
+- **Every action, building, development and population needs an id and a name.**
+
+  ```ts
+  import { action } from './config/builders';
+
+  const expand = action().id('expand').name('Expand').icon('🪙');
+  ```
+
+- **Pick exactly one quantity helper for resource or stat changes.** Use
+  `.amount(x)` for flat adjustments or `.percent(x)` / `.percentFromStat(stat)`
+  for scaling rules.
+
+  ```ts
+  import {
+    effect,
+    resourceParams,
+    Types,
+    ResourceMethods,
+  } from './config/builders';
+  import { Resource } from './resources';
+
+  const gainGold = effect(Types.Resource, ResourceMethods.ADD)
+    .params(resourceParams().key(Resource.gold).amount(2))
+    .build();
+  ```
+
+- **Passives, developments, population effects and attacks all need a target id
+  of some sort.** The builders now stop early if you forget.
+
+## Friendly error messages
+
+When something is missing or duplicated, the builder throws a plain-language
+message explaining what to change. A few examples:
+
+| Situation                                                              | Message                                                                                                                  | Suggested fix                                                                 |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| Forgot to call `.id()` on an action                                    | `Action is missing id(). Call id('unique-id') before build().`                                                           | Add `.id('my_action')` once.                                                  |
+| Tried calling `.amount()` and `.percent()` on the same resource effect | `Resource change cannot use both amount() and percent(). Choose one of them.`                                            | Remove one of the calls and keep the approach you want.                       |
+| Built an effect wrapper without any nested effects or type             | `Effect is missing type() and method(). Call effect(Types.X, Methods.Y) or add nested effect(...) calls before build().` | Either supply a type/method or add a nested effect before calling `.build()`. |
+
+## Checklist before calling `.build()`
+
+- [ ] Did I call `.id()` and `.name()` exactly once?
+- [ ] For resource/stat tweaks, did I choose **one** of `.amount()`, `.percent()`
+      or `.percentFromStat()`?
+- [ ] Does every passive/development/population/attack reference include the id
+      or role it needs?
+- [ ] If I used `effect()`, does it either specify a type/method or contain at
+      least one nested `.effect(...)`?
+
+Following this checklist keeps the content registry clean and prevents confusing
+runtime failures. The tests in `packages/contents/tests/builder-validations.test.ts`
+cover the most common mistakes so new messages stay informative.

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -1,0 +1,86 @@
+import {
+  action,
+  resourceParams,
+  statParams,
+  effect,
+  requirement,
+  passiveParams,
+  attackParams,
+  transferParams,
+} from '../src/config/builders';
+import { RESOURCES, type ResourceKey } from '../src/resources';
+import { STATS, type StatKey } from '../src/stats';
+import { describe, expect, it } from 'vitest';
+
+const firstResourceKey = Object.keys(RESOURCES)[0] as ResourceKey;
+const firstStatKey = Object.keys(STATS)[0] as StatKey;
+
+describe('content builder safeguards', () => {
+  it('explains when an action id is missing', () => {
+    expect(() => action().name('Example').build()).toThrowError(
+      "Action is missing id(). Call id('unique-id') before build().",
+    );
+  });
+
+  it('blocks duplicate action ids', () => {
+    expect(() => action().id('demo').id('again')).toThrowError(
+      'Action already has an id(). Remove the extra id() call.',
+    );
+  });
+
+  it('reports missing action names', () => {
+    expect(() => action().id('example').build()).toThrowError(
+      "Action is missing name(). Call name('Readable name') before build().",
+    );
+  });
+
+  it('prevents mixing amount and percent for resource changes', () => {
+    const params = resourceParams().key(firstResourceKey).amount(2);
+    expect(() => params.percent(10)).toThrowError(
+      'Resource change cannot use both amount() and percent(). Choose one of them.',
+    );
+  });
+
+  it('requires an amount or percent for resource changes', () => {
+    expect(() => resourceParams().key(firstResourceKey).build()).toThrowError(
+      'Resource change needs exactly one of amount() or percent(). Pick how much the resource should change.',
+    );
+  });
+
+  it('explains stat change conflicts clearly', () => {
+    const params = statParams().key(firstStatKey).percent(10);
+    expect(() => params.amount(1)).toThrowError(
+      'Stat change cannot mix amount() with percent() or percentFromStat(). Pick one approach to describe the change.',
+    );
+  });
+
+  it('flags empty effects', () => {
+    expect(() => effect().build()).toThrowError(
+      'Effect is missing type() and method(). Call effect(Types.X, Methods.Y) or add nested effect(...) calls before build().',
+    );
+  });
+
+  it('guides requirement configuration mistakes', () => {
+    expect(() => requirement().method('compare').build()).toThrowError(
+      'Requirement is missing type(). Call type("your-requirement") before build().',
+    );
+  });
+
+  it('requires passives to declare an id', () => {
+    expect(() => passiveParams().build()).toThrowError(
+      'Passive effect is missing id(). Call id("your-passive-id") so it can be referenced later.',
+    );
+  });
+
+  it('ensures attacks have a single target', () => {
+    expect(() => attackParams().build()).toThrowError(
+      'Attack effect is missing a target. Call targetResource(...) or targetStat(...) once.',
+    );
+  });
+
+  it('demands transfer amounts', () => {
+    expect(() => transferParams().key(firstResourceKey).build()).toThrowError(
+      'Resource transfer is missing percent(). Call percent(amount) to choose how much to move.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add guardrails to the content builder helpers so duplicate calls and missing required fields throw human-friendly errors
- document common configuration patterns and error messages for content creators
- cover frequent misconfiguration scenarios with dedicated tests in the contents workspace

## Testing
- npm run test --workspace @kingdom-builder/contents
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dac40fb2a8832597831671afd98e75