### PR TITLE
Align upkeep resource logging with growth details

### DIFF
--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -27,6 +27,7 @@ export const effectSchema: z.ZodType<EffectDef> = z.lazy(() =>
     effects: z.array(effectSchema).optional(),
     evaluator: evaluatorSchema.optional(),
     round: z.enum(['up', 'down']).optional(),
+    meta: z.record(z.unknown()).optional(),
   }),
 );
 

--- a/packages/engine/src/effects/index.ts
+++ b/packages/engine/src/effects/index.ts
@@ -35,6 +35,7 @@ export interface EffectDef<
   effects?: EffectDef[] | undefined;
   evaluator?: EvaluatorDef | undefined;
   round?: 'up' | 'down' | undefined;
+  meta?: Record<string, unknown> | undefined;
 }
 
 export interface EffectHandler<

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -215,8 +215,20 @@ function appendMetaSourceIcons(
       const icon = role
         ? POPULATION_ROLES[role]?.icon || role
         : POPULATION_INFO.icon;
-      const count = Math.max(0, Number(meta.count ?? 1));
-      if (icon) entry.icons += icon.repeat(count || 1);
+      if (!icon) break;
+      if (meta.count === undefined) {
+        entry.icons += icon;
+        break;
+      }
+      const rawCount = Number(meta.count);
+      if (!Number.isFinite(rawCount)) {
+        entry.icons += icon;
+        break;
+      }
+      const normalizedCount =
+        rawCount > 0 ? Math.max(1, Math.round(rawCount)) : 0;
+      if (normalizedCount === 0) break;
+      entry.icons += icon.repeat(normalizedCount);
       break;
     }
     case 'development': {

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -18,6 +18,9 @@ import {
   Resource,
   type ResourceKey,
   ON_GAIN_INCOME_STEP,
+  ON_PAY_UPKEEP_STEP,
+  LAND_INFO,
+  POPULATION_INFO,
 } from '@kingdom-builder/contents';
 import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
 
@@ -97,6 +100,68 @@ describe('log resource sources', () => {
     );
     expect(goldLine).toMatch(
       new RegExp(`from ${populationIcon}\\+${marketIcon}\\)$`),
+    );
+  });
+
+  it('includes upkeep sources when paying upkeep', () => {
+    const ctx = createEngine({
+      actions: ACTIONS,
+      buildings: BUILDINGS,
+      developments: DEVELOPMENTS,
+      populations: POPULATIONS,
+      phases: PHASES,
+      start: GAME_START,
+      rules: RULES,
+    });
+    const upkeepPhase = ctx.phases.find((p) => p.id === 'upkeep');
+    const step = upkeepPhase?.steps.find((s) => s.id === 'pay-upkeep');
+    const before = snapshotPlayer(ctx.activePlayer, ctx);
+    const effects = collectTriggerEffects(ON_PAY_UPKEEP_STEP, ctx);
+    runEffects(effects, ctx);
+    const after = snapshotPlayer(ctx.activePlayer, ctx);
+    const lines = diffStepSnapshots(
+      before,
+      after,
+      { ...step, effects } as typeof step,
+      ctx,
+      RESOURCE_KEYS,
+    );
+    const goldInfo = RESOURCES[Resource.gold];
+    const goldLine = lines.find((l) =>
+      l.startsWith(`${goldInfo.icon} ${goldInfo.label}`),
+    );
+    expect(goldLine).toBeTruthy();
+    const b = before.resources[Resource.gold] ?? 0;
+    const a = after.resources[Resource.gold] ?? 0;
+    const delta = a - b;
+    const icons = effects
+      .filter((eff) => eff.params?.['key'] === Resource.gold)
+      .map((eff) => {
+        const source = (
+          eff.meta as {
+            source?: { type?: string; id?: string; count?: number };
+          }
+        )?.source;
+        if (!source?.type) return '';
+        if (source.type === 'population') {
+          const role = source.id;
+          const icon = role
+            ? POPULATIONS.get(role)?.icon || role
+            : POPULATION_INFO.icon;
+          const count = Number(source.count ?? 1);
+          return icon.repeat(count || 1);
+        }
+        if (source.type === 'development' && source.id)
+          return ctx.developments.get(source.id)?.icon || '';
+        if (source.type === 'building' && source.id)
+          return ctx.buildings.get(source.id)?.icon || '';
+        if (source.type === 'land') return LAND_INFO.icon || '';
+        return '';
+      })
+      .join('');
+    expect(icons).not.toBe('');
+    expect(goldLine).toContain(
+      `${goldInfo.icon}${delta >= 0 ? '+' : ''}${delta} from ${icons}`,
     );
   });
 });


### PR DESCRIPTION
## Summary
- add optional meta metadata to engine effects and propagate upkeep sources through `collectTriggerEffects`
- enhance web log translation to render meta-based resource source icons and handle upkeep breakdowns
- add a regression test ensuring upkeep logs include source icons for resource changes

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dacf1918648325b286886c78667033