### PR TITLE
Add building upkeep configuration and surface in UI

### DIFF
--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -142,7 +142,6 @@ export function createBuildingRegistry() {
       .name('Barracks')
       .icon('🪖')
       .cost(Resource.gold, 12)
-      .upkeep(Resource.gold, 2)
       .build(),
     focus: 'aggressive',
   });
@@ -152,7 +151,6 @@ export function createBuildingRegistry() {
       .name('Citadel')
       .icon('🏯')
       .cost(Resource.gold, 12)
-      .upkeep(Resource.gold, 3)
       .build(),
     focus: 'defense',
   });
@@ -162,7 +160,6 @@ export function createBuildingRegistry() {
       .name('Castle Walls')
       .icon('🧱')
       .cost(Resource.gold, 12)
-      .upkeep(Resource.gold, 1)
       .onBuild(
         effect(Types.Passive, PassiveMethods.ADD)
           .param('id', 'castle_walls_bonus')
@@ -187,7 +184,6 @@ export function createBuildingRegistry() {
       .name('Castle Gardens')
       .icon('🌷')
       .cost(Resource.gold, 15)
-      .upkeep(Resource.gold, 2)
       .build(),
     focus: 'economy',
   });
@@ -197,7 +193,6 @@ export function createBuildingRegistry() {
       .name('Temple')
       .icon('⛪')
       .cost(Resource.gold, 16)
-      .upkeep(Resource.gold, 2)
       .build(),
     focus: 'other',
   });
@@ -207,7 +202,6 @@ export function createBuildingRegistry() {
       .name('Palace')
       .icon('👑')
       .cost(Resource.gold, 20)
-      .upkeep(Resource.gold, 3)
       .build(),
     focus: 'other',
   });
@@ -217,7 +211,6 @@ export function createBuildingRegistry() {
       .name('Great Hall')
       .icon('🏟️')
       .cost(Resource.gold, 22)
-      .upkeep(Resource.gold, 3)
       .build(),
     focus: 'other',
   });

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -87,6 +87,7 @@ export function createBuildingRegistry() {
       .icon('🏴‍☠️')
       .cost(Resource.gold, 8)
       .cost(Resource.ap, 1)
+      .upkeep(Resource.gold, 1)
       .onBuild(
         effect(Types.ResultMod, ResultModMethods.ADD)
           .params(
@@ -141,6 +142,7 @@ export function createBuildingRegistry() {
       .name('Barracks')
       .icon('🪖')
       .cost(Resource.gold, 12)
+      .upkeep(Resource.gold, 2)
       .build(),
     focus: 'aggressive',
   });
@@ -150,6 +152,7 @@ export function createBuildingRegistry() {
       .name('Citadel')
       .icon('🏯')
       .cost(Resource.gold, 12)
+      .upkeep(Resource.gold, 3)
       .build(),
     focus: 'defense',
   });
@@ -159,6 +162,7 @@ export function createBuildingRegistry() {
       .name('Castle Walls')
       .icon('🧱')
       .cost(Resource.gold, 12)
+      .upkeep(Resource.gold, 1)
       .onBuild(
         effect(Types.Passive, PassiveMethods.ADD)
           .param('id', 'castle_walls_bonus')
@@ -183,6 +187,7 @@ export function createBuildingRegistry() {
       .name('Castle Gardens')
       .icon('🌷')
       .cost(Resource.gold, 15)
+      .upkeep(Resource.gold, 2)
       .build(),
     focus: 'economy',
   });
@@ -192,6 +197,7 @@ export function createBuildingRegistry() {
       .name('Temple')
       .icon('⛪')
       .cost(Resource.gold, 16)
+      .upkeep(Resource.gold, 2)
       .build(),
     focus: 'other',
   });
@@ -201,6 +207,7 @@ export function createBuildingRegistry() {
       .name('Palace')
       .icon('👑')
       .cost(Resource.gold, 20)
+      .upkeep(Resource.gold, 3)
       .build(),
     focus: 'other',
   });
@@ -210,6 +217,7 @@ export function createBuildingRegistry() {
       .name('Great Hall')
       .icon('🏟️')
       .cost(Resource.gold, 22)
+      .upkeep(Resource.gold, 3)
       .build(),
     focus: 'other',
   });

--- a/packages/web/src/components/player/BuildingDisplay.tsx
+++ b/packages/web/src/components/player/BuildingDisplay.tsx
@@ -17,6 +17,7 @@ const BuildingDisplay: React.FC<BuildingDisplayProps> = ({ player }) => {
       {Array.from(player.buildings).map((b) => {
         const name = ctx.buildings.get(b)?.name || b;
         const icon = ctx.buildings.get(b)?.icon || '';
+        const upkeep = ctx.buildings.get(b)?.upkeep;
         const title = `${icon} ${name}`;
         return (
           <div
@@ -31,6 +32,7 @@ const BuildingDisplay: React.FC<BuildingDisplayProps> = ({ player }) => {
                 title,
                 effects,
                 requirements: [],
+                upkeep,
                 ...(description && { description }),
                 bgClass: 'bg-gray-100 dark:bg-gray-700',
               });

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -114,7 +114,7 @@ describe('log resource sources', () => {
       rules: RULES,
     });
     runEffects(
-      [{ type: 'building', method: 'add', params: { id: 'barracks' } }],
+      [{ type: 'building', method: 'add', params: { id: 'raiders_guild' } }],
       ctx,
     );
     const upkeepPhase = ctx.phases.find((p) => p.id === 'upkeep');
@@ -171,9 +171,9 @@ describe('log resource sources', () => {
       .filter(Boolean)
       .join('');
     expect(icons).not.toBe('');
-    const barracksIcon = BUILDINGS.get('barracks')?.icon || '';
-    expect(barracksIcon).not.toBe('');
-    expect(icons).toContain(barracksIcon);
+    const raidersGuildIcon = BUILDINGS.get('raiders_guild')?.icon || '';
+    expect(raidersGuildIcon).not.toBe('');
+    expect(icons).toContain(raidersGuildIcon);
     const zeroPopulationIcons = Object.entries(ctx.activePlayer.population)
       .filter(([, count]) => count === 0)
       .map(([role]) => POPULATIONS.get(role)?.icon)

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -113,6 +113,10 @@ describe('log resource sources', () => {
       start: GAME_START,
       rules: RULES,
     });
+    runEffects(
+      [{ type: 'building', method: 'add', params: { id: 'barracks' } }],
+      ctx,
+    );
     const upkeepPhase = ctx.phases.find((p) => p.id === 'upkeep');
     const step = upkeepPhase?.steps.find((s) => s.id === 'pay-upkeep');
     const before = snapshotPlayer(ctx.activePlayer, ctx);
@@ -167,6 +171,9 @@ describe('log resource sources', () => {
       .filter(Boolean)
       .join('');
     expect(icons).not.toBe('');
+    const barracksIcon = BUILDINGS.get('barracks')?.icon || '';
+    expect(barracksIcon).not.toBe('');
+    expect(icons).toContain(barracksIcon);
     const zeroPopulationIcons = Object.entries(ctx.activePlayer.population)
       .filter(([, count]) => count === 0)
       .map(([role]) => POPULATIONS.get(role)?.icon)


### PR DESCRIPTION
## Summary
- configure multiple buildings with upkeep costs so the upkeep phase automatically deducts resources
- surface building upkeep on the owned-building hover card for ongoing visibility
- extend the upkeep log test to ensure building upkeep sources show their icons

## Testing
- npm run test:coverage
- npx vitest packages/web/tests/log-source.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dadefbf3e0832584563553c3537473