### PR TITLE
Document workspace dev command for screenshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,9 @@ fc.assert(
 - 2025-08-31: Registries can validate entries with Zod schemas; invalid data will throw during `add`.
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
 - 2025-08-31: `npm run dev` prebuilds `@kingdom-builder/contents` via a `predev` script to avoid missing dist files.
+- 2025-09-24: That prebuild currently fails in this environment (the contents TypeScript project rejects engine sources outside
+  its `rootDir`). To launch Vite for screenshots, run it from the web workspace instead:
+  `npm run --workspace @kingdom-builder/web dev -- --host 0.0.0.0 --port 4173`.
 - 2025-08-31: Player snapshots now require the engine context to include active passive IDs; use `snapshotPlayer(player, ctx)`.
 - 2025-08-31: `handleEndTurn` will not advance phases if a player has remaining AP; automated tests must spend or clear AP first.
 - 2025-08-31: Log entries include `playerId` so the web UI can style messages per player.


### PR DESCRIPTION
## Summary
- note that the root `npm run dev` command fails its contents prebuild in this environment
- document an alternative Vite command that runs the dev server from the web workspace for screenshots

## Testing
- `npm run --workspace @kingdom-builder/web dev -- --host 0.0.0.0 --port 4173`


------
https://chatgpt.com/codex/tasks/task_e_68dae03c0a5c8325b4912f57292986ca