### PR TITLE
Adjust land gain translations

### DIFF
--- a/packages/web/src/translation/effects/formatters/land.ts
+++ b/packages/web/src/translation/effects/formatters/land.ts
@@ -1,5 +1,5 @@
 import { LAND_INFO, SLOT_INFO } from '@kingdom-builder/contents';
-import { gainOrLose, signed } from '../helpers';
+import { signed } from '../helpers';
 import { registerEffectFormatter } from '../factory';
 
 registerEffectFormatter('land', 'add', {
@@ -9,7 +9,7 @@ registerEffectFormatter('land', 'add', {
   },
   describe: (eff) => {
     const count = Number(eff.params?.['count'] ?? 1);
-    return `${gainOrLose(count)} ${count} ${LAND_INFO.icon} ${LAND_INFO.label}`;
+    return `${LAND_INFO.icon} ${signed(count)}${count} ${LAND_INFO.label}`;
   },
 });
 

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -115,7 +115,7 @@ export function diffSnapshots(
   for (const land of after.lands) {
     const prev = before.lands.find((l) => l.id === land.id);
     if (!prev) {
-      changes.push(`${LAND_INFO.icon} New ${LAND_INFO.label}`);
+      changes.push(`${LAND_INFO.icon} +1 ${LAND_INFO.label}`);
       continue;
     }
     for (const dev of land.developments)
@@ -419,7 +419,7 @@ export function diffStepSnapshots(
   for (const land of after.lands) {
     const prev = before.lands.find((l) => l.id === land.id);
     if (!prev) {
-      changes.push(`${LAND_INFO.icon} New ${LAND_INFO.label}`);
+      changes.push(`${LAND_INFO.icon} +1 ${LAND_INFO.label}`);
       continue;
     }
     for (const dev of land.developments)

--- a/packages/web/tests/plow-action-translation.test.ts
+++ b/packages/web/tests/plow-action-translation.test.ts
@@ -97,7 +97,7 @@ describe('plow action translation', () => {
       {
         title: `${expand.icon} ${expand.name}`,
         items: [
-          `Gain ${landCount} ${LAND_INFO.icon} ${LAND_INFO.label}`,
+          `${LAND_INFO.icon} ${landCount >= 0 ? '+' : ''}${landCount} ${LAND_INFO.label}`,
           `${hapInfo.icon}+${hapAmt} ${hapInfo.label}`,
         ],
       },


### PR DESCRIPTION
## Summary
- update the land:add effect description to use the "🗺️ +1 Land" wording
- align land log entries with the new icon-first land gain format
- refresh the plow action translation test expectation to reflect the revised land wording

## Testing
- npm run lint
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dae22192c483259ac5e2258274eb22