### PR TITLE
Clarify Growth stat scaling

### DIFF
--- a/packages/contents/src/stats.ts
+++ b/packages/contents/src/stats.ts
@@ -47,7 +47,7 @@ const defs: StatInfo[] = [
     .icon('📈')
     .label('Growth')
     .description(
-      'Growth increases Army and Fortification Strength during the Raise Strength step.',
+      'Growth increases Army and Fortification Strength during the Raise Strength step. Its effect scales with active Legions and Fortifiers—if you lack Legions or Fortifiers, that side will not gain Strength during the Growth phase.',
     )
     .displayAsPercent()
     .addFormat({ percent: true })


### PR DESCRIPTION
## Summary
- clarify the Growth stat description to explain its scaling with Legion and Fortifier roles
- note that lacking Legions or Fortifiers prevents Growth from increasing the respective strength during the phase

## Testing
- not run (hooks require eslint-plugin-import which is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dae3da81fc8325874d59e37194c264