### PR TITLE
Use shared passive icon for passive display

### DIFF
--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -50,7 +50,7 @@ export default function PassiveDisplay({
 
   const getIcon = (effects: EffectDef[] | undefined) => {
     const first = effects?.[0];
-    return ICON_MAP[first?.type as keyof typeof ICON_MAP] ?? '✨';
+    return ICON_MAP[first?.type as keyof typeof ICON_MAP] ?? PASSIVE_INFO.icon;
   };
 
   const animatePassives = useAnimate<HTMLDivElement>();


### PR DESCRIPTION
## Summary
- update the passive display fallback icon to use the shared passive icon definition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae49a90c08325b696acd39acf9e43