### PR TITLE
Animate action availability transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "autoprefixer": "^10.4.21",
         "eslint": "^8.57.0",
-        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-unused-imports": "^3.1.0",
         "fast-check": "^3.23.2",
         "husky": "^9.1.7",
@@ -3302,6 +3302,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.21",
     "eslint": "^8.57.0",
-    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-unused-imports": "^3.1.0",
     "fast-check": "^3.23.2",
     "husky": "^9.1.7",

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -18,6 +18,7 @@ import ActionCard from './ActionCard';
 import { useGameEngine } from '../../state/GameContext';
 import { isActionPhaseActive } from '../../utils/isActionPhaseActive';
 import { getRequirementIcons } from '../../utils/getRequirementIcons';
+import { useAnimate } from '../../utils/useAutoAnimate';
 
 interface Action {
   id: string;
@@ -234,6 +235,7 @@ function BasicOptions({
   summaries: Map<string, Summary>;
   isActionPhase: boolean;
 }) {
+  const listRef = useAnimate<HTMLDivElement>();
   return (
     <div>
       <h3 className="font-medium">
@@ -242,7 +244,10 @@ function BasicOptions({
           (Effects take place immediately, unless stated otherwise)
         </span>
       </h3>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1">
+      <div
+        ref={listRef}
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+      >
         <GenericActions
           actions={actions}
           summaries={summaries}
@@ -260,6 +265,7 @@ function HireOptions({
   action: Action;
   isActionPhase: boolean;
 }) {
+  const listRef = useAnimate<HTMLDivElement>();
   return (
     <div>
       <h3 className="font-medium">
@@ -269,7 +275,10 @@ function HireOptions({
           they remain)
         </span>
       </h3>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1">
+      <div
+        ref={listRef}
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+      >
         <RaisePopOptions action={action} isActionPhase={isActionPhase} />
       </div>
     </div>
@@ -289,6 +298,7 @@ function DevelopOptions({
   summaries: Map<string, Summary>;
   hasDevelopLand: boolean;
 }) {
+  const listRef = useAnimate<HTMLDivElement>();
   const {
     ctx,
     handlePerform,
@@ -323,7 +333,10 @@ function DevelopOptions({
           (Effects take place on build and last until development is removed)
         </span>
       </h3>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1">
+      <div
+        ref={listRef}
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+      >
         {entries.map(({ d, costs }) => {
           const upkeep = ctx.developments.get(d.id)?.upkeep;
           const requirements = hasDevelopLand
@@ -414,6 +427,7 @@ function BuildOptions({
   summaries: Map<string, Summary>;
   descriptions: Map<string, Summary>;
 }) {
+  const listRef = useAnimate<HTMLDivElement>();
   const {
     ctx,
     handlePerform,
@@ -452,7 +466,10 @@ function BuildOptions({
           (Effects take place on build and last until building is removed)
         </span>
       </h3>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1">
+      <div
+        ref={listRef}
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+      >
         {entries.map(({ b, costs }) => {
           const requirements: string[] = [];
           const canPay = Object.entries(costs).every(
@@ -524,6 +541,7 @@ function DemolishOptions({
   action: Action;
   isActionPhase: boolean;
 }) {
+  const listRef = useAnimate<HTMLDivElement>();
   const {
     ctx,
     handlePerform,
@@ -572,7 +590,10 @@ function DemolishOptions({
           (Removes a structure and its ongoing benefits)
         </span>
       </h3>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1">
+      <div
+        ref={listRef}
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+      >
         {entries.map(({ id, building, costs }) => {
           const requirements: string[] = [];
           const canPay = Object.entries(costs).every(
@@ -641,6 +662,7 @@ function DemolishOptions({
 
 export default function ActionsPanel() {
   const { ctx, tabsEnabled, actionCostResource } = useGameEngine();
+  const sectionRef = useAnimate<HTMLDivElement>();
 
   const actionPhaseId = useMemo(
     () => ctx.phases.find((p) => p.action)?.id,
@@ -735,7 +757,7 @@ export default function ActionsPanel() {
           </span>
         )}
       </div>
-      <div className="space-y-3">
+      <div ref={sectionRef} className="space-y-3">
         {otherActions.length > 0 && (
           <BasicOptions
             actions={otherActions}


### PR DESCRIPTION
## Summary
- add auto-animate refs to each action list so unlocking or spending actions animates their entry and removal
- animate the actions panel section stack to ease section-level appearance changes
- bump eslint-plugin-import to the latest release so linting succeeds under the existing configuration

## Testing
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68daef2888fc8325879b9eb2495baf96