### PR TITLE
Ensure UI refresh ignores time scale delays

### DIFF
--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -479,6 +479,10 @@ export function GameProvider({
         return true;
       });
       const logLines = [...messages, ...filtered.map((c) => `  ${c}`)];
+
+      updateMainPhaseStep();
+      refresh();
+
       await logWithEffectDelay(logLines, player);
     } catch (e) {
       const icon = ctx.actions.get(action.id)?.icon || '';
@@ -488,8 +492,6 @@ export function GameProvider({
       );
       return;
     }
-    updateMainPhaseStep();
-    refresh();
   }
 
   const handlePerform = (action: Action, params?: Record<string, unknown>) =>


### PR DESCRIPTION
## Summary
- refresh the UI and phase progress immediately after resolving an action instead of waiting for delayed log rendering
- keep log output sequencing intact while ensuring animations start independently of the selected game speed

## Testing
- npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68daf48a97b08325afbcc5a44deb9639