### PR TITLE
Add building target helper for attack params

### DIFF
--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -456,6 +456,9 @@ class AttackParamsBuilder extends ParamsBuilder<{
   targetStat(key: StatKey) {
     return this.set('target', { type: 'stat', key });
   }
+  targetBuilding(id: string) {
+    return this.set('target', { type: 'building', id });
+  }
   ignoreAbsorption(flag = true) {
     return this.set('ignoreAbsorption', flag);
   }
@@ -478,7 +481,7 @@ class AttackParamsBuilder extends ParamsBuilder<{
   override build() {
     if (!this.wasSet('target'))
       throw new Error(
-        'Attack effect is missing a target. Call targetResource(...) or targetStat(...) once.',
+        'Attack effect is missing a target. Call targetResource(...), targetStat(...), or targetBuilding(...) once.',
       );
     return super.build();
   }

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -74,8 +74,15 @@ describe('content builder safeguards', () => {
 
   it('ensures attacks have a single target', () => {
     expect(() => attackParams().build()).toThrowError(
-      'Attack effect is missing a target. Call targetResource(...) or targetStat(...) once.',
+      'Attack effect is missing a target. Call targetResource(...), targetStat(...), or targetBuilding(...) once.',
     );
+  });
+
+  it('supports building targets for attacks', () => {
+    const params = attackParams().targetBuilding('test-building').build();
+    expect(params).toEqual({
+      target: { type: 'building', id: 'test-building' },
+    });
   });
 
   it('demands transfer amounts', () => {


### PR DESCRIPTION
## Summary
- add a targetBuilding helper to the attack params builder and update its validation guidance
- extend the builder validation tests to reference the new guidance and cover the building target shape

## Testing
- npx vitest run packages/contents/tests/builder-validations.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc01f82ee08325879a4916f3723f5c