### PR TITLE
Centralize resource transfer icon in contents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,14 @@ fc.assert(
 - [ ] Tests fetch expected values dynamically from content or mock registries.
 - [ ] New features are reviewed for adherence to content-driven design.
 
+## 🧩 Uniform Solutions
+
+- When adjusting UI text, icons, or formatting conventions, prefer a single
+  uniform solution that can be reused everywhere that pattern appears. Update
+  helper utilities or shared formatters rather than patching isolated strings.
+- If a divergence from an established uniform solution is unavoidable, call it
+  out explicitly in your PR description so reviewers understand the rationale.
+
 ## 🔁 Enforcement
 
 - Pull requests touching engine, web, or tests will be reviewed for compliance with these rules.

--- a/packages/contents/src/defs.ts
+++ b/packages/contents/src/defs.ts
@@ -10,6 +10,7 @@ export const ON_GAIN_INCOME_STEP = 'onGainIncomeStep';
 export const ON_GAIN_AP_STEP = 'onGainAPStep';
 
 export const BROOM_ICON = '🧹';
+export const RESOURCE_TRANSFER_ICON = '🔁';
 
 export type Focus = 'economy' | 'aggressive' | 'defense' | 'other';
 

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -27,4 +27,5 @@ export {
   ON_GAIN_INCOME_STEP,
   ON_GAIN_AP_STEP,
   BROOM_ICON,
+  RESOURCE_TRANSFER_ICON,
 } from './defs';

--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -2,6 +2,7 @@ import {
   MODIFIER_INFO as modifierInfo,
   RESOURCES,
   POPULATION_INFO,
+  RESOURCE_TRANSFER_ICON,
 } from '@kingdom-builder/contents';
 import type {
   ActionDef,
@@ -120,25 +121,31 @@ registerModifierEvalHandler('population', {
 
 registerModifierEvalHandler('transfer_pct', {
   summarize: (eff, _evaluation, ctx) => {
-    const { icon, name } = getActionInfo(ctx, 'plunder');
+    const { icon } = getActionInfo(ctx, 'plunder');
     const amount = Number(eff.params?.['adjust'] ?? 0);
     return [
-      `${modifierInfo.result.icon} ${icon} ${name}: ${signed(amount)}${Math.abs(
+      `${modifierInfo.result.icon} ${icon}: ${RESOURCE_TRANSFER_ICON}${signed(
         amount,
-      )}% transfer`,
+      )}${Math.abs(amount)}%`,
     ];
   },
   describe: (eff, _evaluation, ctx) => {
     const { icon, name } = getActionInfo(ctx, 'plunder');
     const amount = Number(eff.params?.['adjust'] ?? 0);
     const card = describeContent('action', 'plunder', ctx);
+    const summary = `${modifierInfo.result.icon} ${icon}: ${RESOURCE_TRANSFER_ICON}${signed(
+      amount,
+    )}${Math.abs(amount)}%`;
     return [
-      `${modifierInfo.result.icon} ${modifierInfo.result.label} on ${icon} ${name}: ${increaseOrDecrease(
-        amount,
-      )} transfer by ${Math.abs(amount)}%`,
+      summary,
       {
         title: `${icon} ${name}`,
-        items: card,
+        items: [
+          `${modifierInfo.result.icon} ${modifierInfo.result.label} on ${icon} ${name}: ${RESOURCE_TRANSFER_ICON} ${increaseOrDecrease(
+            amount,
+          )} transfer by ${Math.abs(amount)}%`,
+          ...card,
+        ],
         _hoist: true,
         _desc: true,
       },

--- a/packages/web/tests/raiders-guild-translation.test.ts
+++ b/packages/web/tests/raiders-guild-translation.test.ts
@@ -38,9 +38,7 @@ describe('raiders guild translation', () => {
     const { effects, description } = splitSummary(summary);
     expect(effects).toHaveLength(1);
     const build = effects[0] as { title: string; items?: unknown[] };
-    expect(build.items?.[0]).toBe(
-      '✨ Result Modifier on 🏴‍☠️ Plunder: Increase transfer by 25%',
-    );
+    expect(build.items?.[0]).toBe('✨ 🏴‍☠️: 🔁+25%');
     expect(description).toBeDefined();
     const actionCard = (description as Summary)[0] as { title: string };
     expect(actionCard.title).toBe('🏴‍☠️ Plunder');


### PR DESCRIPTION
## Summary
- expose the shared resource transfer icon from the contents package for reuse across formatters
- import the new contents export in the modifier formatter so Raider Guild summaries still use the shared icon

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dc05c1ea948325b6af5b24f11181de