### PR TITLE
docs: clarify formatting exceptions

### DIFF
--- a/CONTRIBUTING/AGENTS.md
+++ b/CONTRIBUTING/AGENTS.md
@@ -11,7 +11,12 @@ Thanks for your interest in improving Kingdom Builder! This guide describes the
 workflow for contributors so that changes remain consistent and easy to review.
 
 Please also review our [Code Standards](../docs/code_standards/AGENTS.md) for naming and
-style conventions used throughout the repository.
+style conventions used throughout the repository. Key highlights include tab-based
+indentation, 80-character lines, mandatory braces around every scope, and keeping
+files under 250 lines by splitting related helpers into focused modules. These
+formatting expectations apply to runtime code (engine, shared packages, web, and
+tests); Markdown documentation and peripheral utilities like the repository
+`overview.tsx` may follow context-specific formatting where that improves clarity.
 
 ## Development Setup
 

--- a/docs/code_standards/AGENTS.md
+++ b/docs/code_standards/AGENTS.md
@@ -15,9 +15,24 @@ maintainable.
   - Abbreviations should be expanded (`populationDefinition` instead of `def`).
 - Variables and functions use `camelCase`; classes and types use `PascalCase`.
 
-## Style
+## Formatting
 
-- The repository is formatted with Prettier; run `npm run lint` to format code.
+These formatting rules apply to source files that participate in the game
+runtime (engine packages, shared utilities, the web client, and automated
+tests). Documentation (`*.md`) and peripheral tooling that does not run in the
+game experience (e.g., `overview.tsx` used for repository overviews) can follow
+context-specific conventions.
+
+- **Indent with tabs.** Tabs keep indentation consistent across editors while
+  letting contributors choose their preferred display width.
+- **Limit lines to 80 characters.** Break up long expressions with intermediate
+  variables or helper functions.
+- **Wrap every scope in braces.** Conditionals, loops and other block
+  statements must always use braces even when the body is a single statement.
+- **Keep files under 250 lines.** When a module grows beyond this limit,
+  extract helpers into neighbouring files or dedicated utility modules. Splits
+  should follow logical boundaries (e.g., grouping related evaluators or
+  separating React components by concern).
 - Prefer clarity over brevity and keep functions focused on a single task.
 - Derive values from configuration or registries rather than hard coding
   numbers in tests.


### PR DESCRIPTION
## Summary
- clarify that the repository formatting rules apply to runtime code and not Markdown or ancillary tooling
- mirror the runtime-only formatting guidance in the contributing guide so contributor messaging stays aligned

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dc0cd42b9083259708960bed32c01d