### PR TITLE
Add dev mode badge and restore automatic turn advance

### DIFF
--- a/packages/web/src/components/common/TimeControl.tsx
+++ b/packages/web/src/components/common/TimeControl.tsx
@@ -2,10 +2,19 @@ import React from 'react';
 import { useGameEngine, TIME_SCALE_OPTIONS } from '../../state/GameContext';
 
 export default function TimeControl() {
-  const { timeScale, setTimeScale } = useGameEngine();
+  const { ctx, timeScale, setTimeScale } = useGameEngine();
+  const devMode = ctx.game.devMode;
 
   return (
     <div className="flex items-center gap-2" aria-label="Time control">
+      {devMode && (
+        <span
+          className="rounded bg-purple-600 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-white shadow"
+          title="Developer mode enabled"
+        >
+          Dev
+        </span>
+      )}
       <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
         Speed
       </span>

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -487,6 +487,13 @@ export function GameProvider({
       refresh();
 
       await logWithEffectDelay(logLines, player);
+
+      if (
+        ctx.game.devMode &&
+        (ctx.activePlayer.resources[actionCostResource] ?? 0) <= 0
+      ) {
+        await endTurn();
+      }
     } catch (e) {
       const icon = ctx.actions.get(action.id)?.icon || '';
       addLog(


### PR DESCRIPTION
## Summary
- surface a developer mode badge next to the time control so it is clearly visible
- trigger automatic turn advancement in developer mode once all action points are spent

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dc1611d90483259eb1d3829eff326e