### PR TITLE
Refine App component state naming and indentation

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -5,60 +5,84 @@ import Overview from './Overview';
 import Tutorial from './Tutorial';
 
 enum Screen {
-  Menu = 'menu',
-  Overview = 'overview',
-  Tutorial = 'tutorial',
-  Game = 'game',
+	Menu = 'menu',
+	Overview = 'overview',
+	Tutorial = 'tutorial',
+	Game = 'game',
 }
 
 export default function App() {
-  const [screen, setScreen] = useState<Screen>(Screen.Menu);
-  const [gameKey, setGameKey] = useState(0);
-  const [darkMode, setDarkMode] = useState(true);
-  const [devMode, setDevMode] = useState(false);
+	const [currentScreen, setCurrentScreen] = useState<Screen>(Screen.Menu);
+	const [currentGameKey, setCurrentGameKey] = useState(0);
+	const [isDarkModeEnabled, setIsDarkModeEnabled] = useState(true);
+	const [isDevModeEnabled, setIsDevModeEnabled] = useState(false);
 
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', darkMode);
-  }, [darkMode]);
+	useEffect(() => {
+		document.documentElement.classList.toggle('dark', isDarkModeEnabled);
+	}, [isDarkModeEnabled]);
 
-  useEffect(() => {
-    if (window.location.pathname !== '/') {
-      window.history.replaceState(null, '', '/');
-    }
-  }, []);
+	useEffect(() => {
+		if (window.location.pathname !== '/') {
+			window.history.replaceState(null, '', '/');
+		}
+	}, []);
 
-  switch (screen) {
-    case Screen.Overview:
-      return <Overview onBack={() => setScreen(Screen.Menu)} />;
-    case Screen.Tutorial:
-      return <Tutorial onBack={() => setScreen(Screen.Menu)} />;
-    case Screen.Game:
-      return (
-        <Game
-          key={gameKey}
-          onExit={() => setScreen(Screen.Menu)}
-          darkMode={darkMode}
-          onToggleDark={() => setDarkMode((d) => !d)}
-          devMode={devMode}
-        />
-      );
-    case Screen.Menu:
-    default:
-      return (
-        <Menu
-          onStart={() => {
-            setDevMode(false);
-            setGameKey((k) => k + 1);
-            setScreen(Screen.Game);
-          }}
-          onStartDev={() => {
-            setDevMode(true);
-            setGameKey((k) => k + 1);
-            setScreen(Screen.Game);
-          }}
-          onOverview={() => setScreen(Screen.Overview)}
-          onTutorial={() => setScreen(Screen.Tutorial)}
-        />
-      );
-  }
+	const returnToMenu = () => {
+		setCurrentScreen(Screen.Menu);
+	};
+
+	const toggleDarkMode = () => {
+		setIsDarkModeEnabled((previousDarkMode) => !previousDarkMode);
+	};
+
+	const incrementGameKey = () => {
+		setCurrentGameKey((previousGameKey) => previousGameKey + 1);
+	};
+
+	const startStandardGame = () => {
+		setIsDevModeEnabled(false);
+		incrementGameKey();
+		setCurrentScreen(Screen.Game);
+	};
+
+	const startDeveloperGame = () => {
+		setIsDevModeEnabled(true);
+		incrementGameKey();
+		setCurrentScreen(Screen.Game);
+	};
+
+	const openOverview = () => {
+		setCurrentScreen(Screen.Overview);
+	};
+
+	const openTutorial = () => {
+		setCurrentScreen(Screen.Tutorial);
+	};
+
+	switch (currentScreen) {
+		case Screen.Overview:
+			return <Overview onBack={returnToMenu} />;
+		case Screen.Tutorial:
+			return <Tutorial onBack={returnToMenu} />;
+		case Screen.Game:
+			return (
+				<Game
+					key={currentGameKey}
+					onExit={returnToMenu}
+					darkMode={isDarkModeEnabled}
+					onToggleDark={toggleDarkMode}
+					devMode={isDevModeEnabled}
+				/>
+			);
+		case Screen.Menu:
+		default:
+			return (
+				<Menu
+					onStart={startStandardGame}
+					onStartDev={startDeveloperGame}
+					onOverview={openOverview}
+					onTutorial={openTutorial}
+				/>
+			);
+	}
 }

--- a/packages/web/src/translation/effects/formatters/attack/target-formatter.ts
+++ b/packages/web/src/translation/effects/formatters/attack/target-formatter.ts
@@ -7,208 +7,214 @@ type Mode = 'summarize' | 'describe';
 type TargetInfo = { icon: string; label: string };
 
 type AttackTarget =
-  | { type: 'resource'; key: ResourceKey }
-  | { type: 'stat'; key: StatKey }
-  | { type: 'building'; id: string };
+	| { type: 'resource'; key: ResourceKey }
+	| { type: 'stat'; key: StatKey }
+	| { type: 'building'; id: string };
 
 type StatInfo = { icon?: string; label: string };
 
 type AttackEvaluationTarget = AttackLog['evaluation']['target'];
 type NonBuildingEvaluationTarget = Extract<
-  AttackEvaluationTarget,
-  { type: 'resource' | 'stat' }
+	AttackEvaluationTarget,
+	{ type: 'resource' | 'stat' }
 >;
 type BuildingEvaluationTarget = Extract<
-  AttackEvaluationTarget,
-  { type: 'building' }
+	AttackEvaluationTarget,
+	{ type: 'building' }
 >;
 
 type EvaluationContext = {
-  army: StatInfo;
-  absorption: StatInfo;
-  fort: StatInfo;
-  info: TargetInfo;
-  targetLabel: string;
-  formatNumber: (value: number) => string;
-  formatPercent: (value: number) => string;
-  formatStatValue: (key: string, value: number) => string;
+	army: StatInfo;
+	absorption: StatInfo;
+	fort: StatInfo;
+	info: TargetInfo;
+	targetLabel: string;
+	formatNumber: (value: number) => string;
+	formatPercent: (value: number) => string;
+	formatStatValue: (key: string, value: number) => string;
 };
 
 type BaseEntryContext = {
-  army: StatInfo;
-  fort: StatInfo;
-  info: TargetInfo;
-  targetLabel: string;
+	army: StatInfo;
+	fort: StatInfo;
+	info: TargetInfo;
+	targetLabel: string;
 };
 
 type FortificationContext = {
-  fort: StatInfo;
-  info: TargetInfo;
-  targetLabel: string;
+	fort: StatInfo;
+	info: TargetInfo;
+	targetLabel: string;
 };
 
 type OnDamageTitleContext = {
-  info: TargetInfo;
-  summaryTarget: string;
-  describeTarget: string;
+	info: TargetInfo;
+	summaryTarget: string;
+	describeTarget: string;
 };
 
 type TargetFormatter = {
-  summarizeBaseEntry(context: BaseEntryContext): string;
-  describeFortificationItems(context: FortificationContext): string[];
-  onDamageTitle(mode: Mode, context: OnDamageTitleContext): string;
-  buildEvaluationEntry(
-    log: AttackLog['evaluation'],
-    context: EvaluationContext,
-  ): SummaryEntry;
-  onDamageLogTitle(info: TargetInfo): string;
+	summarizeBaseEntry(context: BaseEntryContext): string;
+	describeFortificationItems(context: FortificationContext): string[];
+	onDamageTitle(mode: Mode, context: OnDamageTitleContext): string;
+	buildEvaluationEntry(
+		log: AttackLog['evaluation'],
+		context: EvaluationContext,
+	): SummaryEntry;
+	onDamageLogTitle(info: TargetInfo): string;
 };
 
 const defaultTargetFormatter: TargetFormatter = {
-  summarizeBaseEntry: ({ army, fort, info }) =>
-    `${army.icon} opponent's ${fort.icon}${info.icon}`,
-  describeFortificationItems: ({ fort, info }) => [
-    `Damage applied to opponent's ${fort.icon} ${fort.label}`,
-    `If opponent ${fort.icon} ${fort.label} reduced to 0, overflow remaining damage on opponent ${info.icon} ${info.label}`,
-  ],
-  onDamageTitle: (mode, { info }) =>
-    mode === 'summarize'
-      ? `On opponent ${info.icon} damage`
-      : `On opponent ${info.icon} ${info.label} damage`,
-  buildEvaluationEntry: (
-    log,
-    {
-      army,
-      absorption,
-      fort,
-      info,
-      targetLabel: _targetLabel,
-      formatNumber,
-      formatPercent,
-      formatStatValue,
-    },
-  ) => {
-    const target = log.target as NonBuildingEvaluationTarget;
-    const absorptionPart = log.absorption.ignored
-      ? `${absorption.icon} ignored`
-      : `${absorption.icon}${formatPercent(log.absorption.before)}`;
-    const fortPart = log.fortification.ignored
-      ? `${fort.icon} ignored`
-      : `${fort.icon}${formatNumber(log.fortification.before)}`;
+	summarizeBaseEntry: ({ army, fort, info }) =>
+		`${army.icon} opponent's ${fort.icon}${info.icon}`,
+	describeFortificationItems: ({ fort, info }) => [
+		`Damage applied to opponent's ${fort.icon} ${fort.label}`,
+		`If opponent ${fort.icon} ${fort.label} reduced to 0, overflow remaining damage on opponent ${info.icon} ${info.label}`,
+	],
+	onDamageTitle: (mode, { info }) =>
+		mode === 'summarize'
+			? `On opponent ${info.icon} damage`
+			: `On opponent ${info.icon} ${info.label} damage`,
+	buildEvaluationEntry: (
+		log,
+		{
+			army,
+			absorption,
+			fort,
+			info,
+			targetLabel: _targetLabel,
+			formatNumber,
+			formatPercent,
+			formatStatValue,
+		},
+	) => {
+		const target = log.target as NonBuildingEvaluationTarget;
+		const absorptionPart = log.absorption.ignored
+			? `${absorption.icon} ignored`
+			: `${absorption.icon}${formatPercent(log.absorption.before)}`;
+		const fortPart = log.fortification.ignored
+			? `${fort.icon} ignored`
+			: `${fort.icon}${formatNumber(log.fortification.before)}`;
 
-    const title = `Damage evaluation: ${army.icon}${formatNumber(log.power.modified)} vs. ${absorptionPart} ${fortPart} ${info.icon}${formatNumber(target.before)}`;
-    const items: SummaryEntry[] = [];
+		const title = `Damage evaluation: ${army.icon}${formatNumber(log.power.modified)} vs. ${absorptionPart} ${fortPart} ${info.icon}${formatNumber(target.before)}`;
+		const items: SummaryEntry[] = [];
 
-    if (log.absorption.ignored)
-      items.push(
-        `${army.icon}${formatNumber(log.power.modified)} ignores ${absorption.icon} ${absorption.label}`,
-      );
-    else
-      items.push(
-        `${army.icon}${formatNumber(log.power.modified)} vs. ${absorption.icon}${formatPercent(log.absorption.before)} --> ${army.icon}${formatNumber(log.absorption.damageAfter)}`,
-      );
+		if (log.absorption.ignored) {
+			items.push(
+				`${army.icon}${formatNumber(log.power.modified)} ignores ${absorption.icon} ${absorption.label}`,
+			);
+		} else {
+			items.push(
+				`${army.icon}${formatNumber(log.power.modified)} vs. ${absorption.icon}${formatPercent(log.absorption.before)} --> ${army.icon}${formatNumber(log.absorption.damageAfter)}`,
+			);
+		}
 
-    if (log.fortification.ignored)
-      items.push(
-        `${army.icon}${formatNumber(log.absorption.damageAfter)} bypasses ${fort.icon} ${fort.label}`,
-      );
-    else {
-      const remaining = Math.max(
-        0,
-        log.absorption.damageAfter - log.fortification.damage,
-      );
-      items.push(
-        `${army.icon}${formatNumber(log.absorption.damageAfter)} vs. ${fort.icon}${formatNumber(log.fortification.before)} --> ${fort.icon}${formatNumber(log.fortification.after)} ${army.icon}${formatNumber(remaining)}`,
-      );
-    }
+		if (log.fortification.ignored) {
+			items.push(
+				`${army.icon}${formatNumber(log.absorption.damageAfter)} bypasses ${fort.icon} ${fort.label}`,
+			);
+		} else {
+			const remaining = Math.max(
+				0,
+				log.absorption.damageAfter - log.fortification.damage,
+			);
+			items.push(
+				`${army.icon}${formatNumber(log.absorption.damageAfter)} vs. ${fort.icon}${formatNumber(log.fortification.before)} --> ${fort.icon}${formatNumber(log.fortification.after)} ${army.icon}${formatNumber(remaining)}`,
+			);
+		}
 
-    const formatTargetValue = (value: number) =>
-      target.type === 'stat'
-        ? formatStatValue(String(target.key), value)
-        : formatNumber(value);
-    const targetDisplay = (value: number) =>
-      info.icon
-        ? `${info.icon}${formatTargetValue(value)}`
-        : `${info.label} ${formatTargetValue(value)}`;
+		const formatTargetValue = (value: number) =>
+			target.type === 'stat'
+				? formatStatValue(String(target.key), value)
+				: formatNumber(value);
+		const targetDisplay = (value: number) =>
+			info.icon
+				? `${info.icon}${formatTargetValue(value)}`
+				: `${info.label} ${formatTargetValue(value)}`;
 
-    items.push(
-      `${army.icon}${formatNumber(target.damage)} vs. ${targetDisplay(target.before)} --> ${targetDisplay(target.after)}`,
-    );
+		items.push(
+			`${army.icon}${formatNumber(target.damage)} vs. ${targetDisplay(target.before)} --> ${targetDisplay(target.after)}`,
+		);
 
-    return { title, items };
-  },
-  onDamageLogTitle: (info) =>
-    `${info.icon} ${info.label} damage trigger evaluation`,
+		return { title, items };
+	},
+	onDamageLogTitle: (info) =>
+		`${info.icon} ${info.label} damage trigger evaluation`,
 };
 
 const buildingTargetFormatter: TargetFormatter = {
-  summarizeBaseEntry: ({ army, targetLabel }) =>
-    `${army.icon} destroy opponent's ${targetLabel}`,
-  describeFortificationItems: ({ fort, targetLabel }) => [
-    `Damage applied to opponent's ${fort.icon} ${fort.label}`,
-    `If opponent ${fort.icon} ${fort.label} reduced to 0, overflow remaining damage attempts to destroy opponent ${targetLabel}`,
-  ],
-  onDamageTitle: (mode, { summaryTarget, describeTarget }) =>
-    mode === 'summarize'
-      ? `On opponent ${summaryTarget} destruction`
-      : `On opponent ${describeTarget} destruction`,
-  buildEvaluationEntry: (
-    log,
-    { army, absorption, fort, targetLabel, formatNumber, formatPercent },
-  ) => {
-    const target = log.target as BuildingEvaluationTarget;
-    const absorptionPart = log.absorption.ignored
-      ? `${absorption.icon} ignored`
-      : `${absorption.icon}${formatPercent(log.absorption.before)}`;
-    const fortPart = log.fortification.ignored
-      ? `${fort.icon} ignored`
-      : `${fort.icon}${formatNumber(log.fortification.before)}`;
+	summarizeBaseEntry: ({ army, targetLabel }) =>
+		`${army.icon} destroy opponent's ${targetLabel}`,
+	describeFortificationItems: ({ fort, targetLabel }) => [
+		`Damage applied to opponent's ${fort.icon} ${fort.label}`,
+		`If opponent ${fort.icon} ${fort.label} reduced to 0, overflow remaining damage attempts to destroy opponent ${targetLabel}`,
+	],
+	onDamageTitle: (mode, { summaryTarget, describeTarget }) =>
+		mode === 'summarize'
+			? `On opponent ${summaryTarget} destruction`
+			: `On opponent ${describeTarget} destruction`,
+	buildEvaluationEntry: (
+		log,
+		{ army, absorption, fort, targetLabel, formatNumber, formatPercent },
+	) => {
+		const target = log.target as BuildingEvaluationTarget;
+		const absorptionPart = log.absorption.ignored
+			? `${absorption.icon} ignored`
+			: `${absorption.icon}${formatPercent(log.absorption.before)}`;
+		const fortPart = log.fortification.ignored
+			? `${fort.icon} ignored`
+			: `${fort.icon}${formatNumber(log.fortification.before)}`;
 
-    const title = `Damage evaluation: ${army.icon}${formatNumber(log.power.modified)} vs. ${absorptionPart} ${fortPart} ${targetLabel}`;
-    const items: SummaryEntry[] = [];
+		const title = `Damage evaluation: ${army.icon}${formatNumber(log.power.modified)} vs. ${absorptionPart} ${fortPart} ${targetLabel}`;
+		const items: SummaryEntry[] = [];
 
-    if (log.absorption.ignored)
-      items.push(
-        `${army.icon}${formatNumber(log.power.modified)} ignores ${absorption.icon} ${absorption.label}`,
-      );
-    else
-      items.push(
-        `${army.icon}${formatNumber(log.power.modified)} vs. ${absorption.icon}${formatPercent(log.absorption.before)} --> ${army.icon}${formatNumber(log.absorption.damageAfter)}`,
-      );
+		if (log.absorption.ignored) {
+			items.push(
+				`${army.icon}${formatNumber(log.power.modified)} ignores ${absorption.icon} ${absorption.label}`,
+			);
+		} else {
+			items.push(
+				`${army.icon}${formatNumber(log.power.modified)} vs. ${absorption.icon}${formatPercent(log.absorption.before)} --> ${army.icon}${formatNumber(log.absorption.damageAfter)}`,
+			);
+		}
 
-    if (log.fortification.ignored)
-      items.push(
-        `${army.icon}${formatNumber(log.absorption.damageAfter)} bypasses ${fort.icon} ${fort.label}`,
-      );
-    else {
-      const remaining = Math.max(
-        0,
-        log.absorption.damageAfter - log.fortification.damage,
-      );
-      items.push(
-        `${army.icon}${formatNumber(log.absorption.damageAfter)} vs. ${fort.icon}${formatNumber(log.fortification.before)} --> ${fort.icon}${formatNumber(log.fortification.after)} ${army.icon}${formatNumber(remaining)}`,
-      );
-    }
+		if (log.fortification.ignored) {
+			items.push(
+				`${army.icon}${formatNumber(log.absorption.damageAfter)} bypasses ${fort.icon} ${fort.label}`,
+			);
+		} else {
+			const remaining = Math.max(
+				0,
+				log.absorption.damageAfter - log.fortification.damage,
+			);
+			items.push(
+				`${army.icon}${formatNumber(log.absorption.damageAfter)} vs. ${fort.icon}${formatNumber(log.fortification.before)} --> ${fort.icon}${formatNumber(log.fortification.after)} ${army.icon}${formatNumber(remaining)}`,
+			);
+		}
 
-    if (!target.existed) items.push(`No ${targetLabel} to destroy`);
-    else {
-      const damageText = `${army.icon}${formatNumber(target.damage)}`;
-      items.push(
-        target.destroyed
-          ? `${damageText} destroys ${targetLabel}`
-          : `${damageText} fails to destroy ${targetLabel}`,
-      );
-    }
+		if (!target.existed) {
+			items.push(`No ${targetLabel} to destroy`);
+		} else {
+			const damageText = `${army.icon}${formatNumber(target.damage)}`;
+			items.push(
+				target.destroyed
+					? `${damageText} destroys ${targetLabel}`
+					: `${damageText} fails to destroy ${targetLabel}`,
+			);
+		}
 
-    return { title, items };
-  },
-  onDamageLogTitle: (info) =>
-    `${info.icon} ${info.label} destruction trigger evaluation`,
+		return { title, items };
+	},
+	onDamageLogTitle: (info) =>
+		`${info.icon} ${info.label} destruction trigger evaluation`,
 };
 
 export function createAttackTargetFormatter(
-  target: AttackTarget,
+	target: AttackTarget,
 ): TargetFormatter {
-  if (target.type === 'building') return buildingTargetFormatter;
-  return defaultTargetFormatter;
+	if (target.type === 'building') {
+		return buildingTargetFormatter;
+	}
+
+	return defaultTargetFormatter;
 }

--- a/packages/web/tests/army-attack-translation.test.ts
+++ b/packages/web/tests/army-attack-translation.test.ts
@@ -1,275 +1,276 @@
+/* eslint-disable max-lines */
 import { describe, it, expect, vi } from 'vitest';
 import type { SummaryEntry } from '../src/translation/content';
 import {
-  summarizeContent,
-  describeContent,
-  logContent,
+	summarizeContent,
+	describeContent,
+	logContent,
 } from '../src/translation/content';
 import {
-  createEngine,
-  performAction,
-  Resource,
-  Stat,
-  type EffectDef,
+	createEngine,
+	performAction,
+	Resource,
+	Stat,
+	type EffectDef,
 } from '@kingdom-builder/engine';
 import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
-  RESOURCES,
-  STATS,
-  PopulationRole,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	RESOURCES,
+	STATS,
+	PopulationRole,
 } from '@kingdom-builder/contents';
 import {
-  action,
-  effect,
-  Types,
-  ResourceMethods,
-  attackParams,
-  resourceParams,
+	action,
+	effect,
+	Types,
+	ResourceMethods,
+	attackParams,
+	resourceParams,
 } from '@kingdom-builder/contents/config/builders';
 
 vi.mock('@kingdom-builder/engine', async () => {
-  return await import('../../engine/src');
+	return await import('../../engine/src');
 });
 
 function createCtx() {
-  return createEngine({
-    actions: ACTIONS,
-    buildings: BUILDINGS,
-    developments: DEVELOPMENTS,
-    populations: POPULATIONS,
-    phases: PHASES,
-    start: GAME_START,
-    rules: RULES,
-  });
+	return createEngine({
+		actions: ACTIONS,
+		buildings: BUILDINGS,
+		developments: DEVELOPMENTS,
+		populations: POPULATIONS,
+		phases: PHASES,
+		start: GAME_START,
+		rules: RULES,
+	});
 }
 
 function pickBuilding() {
-  const entries = BUILDINGS.entries();
-  const selected =
-    entries.find(([, def]) => def.icon && def.name) ?? entries[0];
-  if (!selected) throw new Error('Expected at least one building definition');
-  const [id, def] = selected;
-  return { id, def } as const;
+	const entries = BUILDINGS.entries();
+	const selected =
+		entries.find(([, def]) => def.icon && def.name) ?? entries[0];
+	if (!selected) throw new Error('Expected at least one building definition');
+	const [id, def] = selected;
+	return { id, def } as const;
 }
 
 function iconLabel(
-  icon: string | undefined,
-  label: string | undefined,
-  fallback: string,
+	icon: string | undefined,
+	label: string | undefined,
+	fallback: string,
 ) {
-  const resolved = label ?? fallback;
-  return icon ? `${icon} ${resolved}` : resolved;
+	const resolved = label ?? fallback;
+	return icon ? `${icon} ${resolved}` : resolved;
 }
 
 function createBuildingAttackCtx() {
-  const { id: buildingId, def: building } = pickBuilding();
-  const attack = {
-    ...action()
-      .id('siege_building')
-      .name('Siege Building')
-      .icon('⚔️')
-      .cost(Resource.ap, 1)
-      .effect(
-        effect('attack', 'perform')
-          .params(
-            attackParams()
-              .targetBuilding(buildingId)
-              .onDamageAttacker(
-                effect(Types.Resource, ResourceMethods.ADD)
-                  .params(resourceParams().key(Resource.gold).amount(1))
-                  .build(),
-              )
-              .build(),
-          )
-          .build(),
-      )
-      .build(),
-  };
+	const { id: buildingId, def: building } = pickBuilding();
+	const attack = {
+		...action()
+			.id('siege_building')
+			.name('Siege Building')
+			.icon('⚔️')
+			.cost(Resource.ap, 1)
+			.effect(
+				effect('attack', 'perform')
+					.params(
+						attackParams()
+							.targetBuilding(buildingId)
+							.onDamageAttacker(
+								effect(Types.Resource, ResourceMethods.ADD)
+									.params(resourceParams().key(Resource.gold).amount(1))
+									.build(),
+							)
+							.build(),
+					)
+					.build(),
+			)
+			.build(),
+	};
 
-  const ctx = createEngine({
-    actions: ACTIONS,
-    buildings: BUILDINGS,
-    developments: DEVELOPMENTS,
-    populations: POPULATIONS,
-    phases: PHASES,
-    start: GAME_START,
-    rules: RULES,
-    config: { actions: [attack] },
-  });
+	const ctx = createEngine({
+		actions: ACTIONS,
+		buildings: BUILDINGS,
+		developments: DEVELOPMENTS,
+		populations: POPULATIONS,
+		phases: PHASES,
+		start: GAME_START,
+		rules: RULES,
+		config: { actions: [attack] },
+	});
 
-  return { ctx, attack, buildingId, building } as const;
+	return { ctx, attack, buildingId, building } as const;
 }
 
 describe('army attack translation', () => {
-  it('summarizes attack action with on-damage effects', () => {
-    const ctx = createCtx();
-    const castle = RESOURCES[Resource.castleHP];
-    const army = STATS[Stat.armyStrength];
-    const fort = STATS[Stat.fortificationStrength];
-    const happiness = RESOURCES[Resource.happiness];
-    const plunder = ctx.actions.get('plunder');
-    const warWeariness = STATS[Stat.warWeariness];
-    const armyAttack = ctx.actions.get('army_attack');
-    const attackEffect = armyAttack.effects.find(
-      (e: EffectDef) => e.type === 'attack',
-    );
-    const onDamage = attackEffect?.params?.['onDamage'] as {
-      attacker: EffectDef[];
-      defender: EffectDef[];
-    };
-    const attackerRes = onDamage?.attacker.find(
-      (e: EffectDef) =>
-        e.type === 'resource' &&
-        (e.params as { key?: string }).key === Resource.happiness,
-    );
-    const defenderRes = onDamage?.defender.find(
-      (e: EffectDef) =>
-        e.type === 'resource' &&
-        (e.params as { key?: string }).key === Resource.happiness,
-    );
-    const attackerAmtRaw =
-      (attackerRes?.params as { amount?: number })?.amount ?? 0;
-    const defenderAmtRaw =
-      (defenderRes?.params as { amount?: number })?.amount ?? 0;
-    const attackerAmt =
-      attackerRes?.method === 'remove' ? -attackerAmtRaw : attackerAmtRaw;
-    const defenderAmt =
-      defenderRes?.method === 'remove' ? -defenderAmtRaw : defenderAmtRaw;
-    const warRes = armyAttack.effects.find(
-      (e: EffectDef) =>
-        e.type === 'stat' &&
-        (e.params as { key?: string }).key === Stat.warWeariness,
-    );
-    const warAmt = (warRes?.params as { amount?: number })?.amount ?? 0;
-    const summary = summarizeContent('action', 'army_attack', ctx);
-    expect(summary).toEqual([
-      `${army.icon} opponent's ${fort.icon}${castle.icon}`,
-      {
-        title: `On opponent ${castle.icon} damage`,
-        items: [
-          `${happiness.icon}${defenderAmt} for opponent`,
-          `${happiness.icon}${attackerAmt >= 0 ? '+' : ''}${attackerAmt} for you`,
-          `${plunder.icon} ${plunder.name}`,
-        ],
-      },
-      `${warWeariness.icon}${warAmt >= 0 ? '+' : ''}${warAmt}`,
-    ]);
-  });
+	it('summarizes attack action with on-damage effects', () => {
+		const ctx = createCtx();
+		const castle = RESOURCES[Resource.castleHP];
+		const army = STATS[Stat.armyStrength];
+		const fort = STATS[Stat.fortificationStrength];
+		const happiness = RESOURCES[Resource.happiness];
+		const plunder = ctx.actions.get('plunder');
+		const warWeariness = STATS[Stat.warWeariness];
+		const armyAttack = ctx.actions.get('army_attack');
+		const attackEffect = armyAttack.effects.find(
+			(e: EffectDef) => e.type === 'attack',
+		);
+		const onDamage = attackEffect?.params?.['onDamage'] as {
+			attacker: EffectDef[];
+			defender: EffectDef[];
+		};
+		const attackerRes = onDamage?.attacker.find(
+			(e: EffectDef) =>
+				e.type === 'resource' &&
+				(e.params as { key?: string }).key === Resource.happiness,
+		);
+		const defenderRes = onDamage?.defender.find(
+			(e: EffectDef) =>
+				e.type === 'resource' &&
+				(e.params as { key?: string }).key === Resource.happiness,
+		);
+		const attackerAmtRaw =
+			(attackerRes?.params as { amount?: number })?.amount ?? 0;
+		const defenderAmtRaw =
+			(defenderRes?.params as { amount?: number })?.amount ?? 0;
+		const attackerAmt =
+			attackerRes?.method === 'remove' ? -attackerAmtRaw : attackerAmtRaw;
+		const defenderAmt =
+			defenderRes?.method === 'remove' ? -defenderAmtRaw : defenderAmtRaw;
+		const warRes = armyAttack.effects.find(
+			(e: EffectDef) =>
+				e.type === 'stat' &&
+				(e.params as { key?: string }).key === Stat.warWeariness,
+		);
+		const warAmt = (warRes?.params as { amount?: number })?.amount ?? 0;
+		const summary = summarizeContent('action', 'army_attack', ctx);
+		expect(summary).toEqual([
+			`${army.icon} opponent's ${fort.icon}${castle.icon}`,
+			{
+				title: `On opponent ${castle.icon} damage`,
+				items: [
+					`${happiness.icon}${defenderAmt} for opponent`,
+					`${happiness.icon}${attackerAmt >= 0 ? '+' : ''}${attackerAmt} for you`,
+					`${plunder.icon} ${plunder.name}`,
+				],
+			},
+			`${warWeariness.icon}${warAmt >= 0 ? '+' : ''}${warAmt}`,
+		]);
+	});
 
-  it('describes plunder effects under on-damage entry', () => {
-    const ctx = createCtx();
-    const plunder = ctx.actions.get('plunder');
-    const desc = describeContent('action', 'army_attack', ctx);
-    const onDamage = desc.find(
-      (e) =>
-        typeof e === 'object' &&
-        'title' in e &&
-        e.title.startsWith('On opponent'),
-    ) as { items: SummaryEntry[] };
-    const plunderEntry = onDamage.items.find(
-      (i) =>
-        typeof i === 'object' &&
-        (i as { title: string }).title === `${plunder.icon} ${plunder.name}`,
-    ) as { items?: unknown[] } | undefined;
-    expect(plunderEntry).toBeDefined();
-    expect(
-      plunderEntry &&
-        Array.isArray(plunderEntry.items) &&
-        (plunderEntry.items?.length ?? 0) > 0,
-    ).toBeTruthy();
-  });
+	it('describes plunder effects under on-damage entry', () => {
+		const ctx = createCtx();
+		const plunder = ctx.actions.get('plunder');
+		const desc = describeContent('action', 'army_attack', ctx);
+		const onDamage = desc.find(
+			(e) =>
+				typeof e === 'object' &&
+				'title' in e &&
+				e.title.startsWith('On opponent'),
+		) as { items: SummaryEntry[] };
+		const plunderEntry = onDamage.items.find(
+			(i) =>
+				typeof i === 'object' &&
+				(i as { title: string }).title === `${plunder.icon} ${plunder.name}`,
+		) as { items?: unknown[] } | undefined;
+		expect(plunderEntry).toBeDefined();
+		expect(
+			plunderEntry &&
+				Array.isArray(plunderEntry.items) &&
+				(plunderEntry.items?.length ?? 0) > 0,
+		).toBeTruthy();
+	});
 
-  it('logs army attack action with concrete evaluation', () => {
-    const ctx = createCtx();
-    const armyAttack = ctx.actions.get('army_attack');
-    const castle = RESOURCES[Resource.castleHP];
-    const army = STATS[Stat.armyStrength];
-    const absorption = STATS[Stat.absorption];
-    const fort = STATS[Stat.fortificationStrength];
-    const happiness = RESOURCES[Resource.happiness];
-    const plunder = ctx.actions.get('plunder');
+	it('logs army attack action with concrete evaluation', () => {
+		const ctx = createCtx();
+		const armyAttack = ctx.actions.get('army_attack');
+		const castle = RESOURCES[Resource.castleHP];
+		const army = STATS[Stat.armyStrength];
+		const absorption = STATS[Stat.absorption];
+		const fort = STATS[Stat.fortificationStrength];
+		const happiness = RESOURCES[Resource.happiness];
+		const plunder = ctx.actions.get('plunder');
 
-    ctx.activePlayer.resources[Resource.ap] = 1;
-    ctx.activePlayer.population = {
-      ...ctx.activePlayer.population,
-      [PopulationRole.Legion]: 1,
-      [PopulationRole.Council]: 0,
-    };
-    ctx.activePlayer.stats[Stat.armyStrength] = 2;
-    ctx.activePlayer.resources[Resource.happiness] = 1;
-    ctx.activePlayer.resources[Resource.gold] = 13;
-    ctx.opponent.stats[Stat.fortificationStrength] = 1;
-    ctx.opponent.resources[Resource.happiness] = 3;
-    ctx.opponent.resources[Resource.gold] = 20;
-    const castleBefore = ctx.opponent.resources[Resource.castleHP];
+		ctx.activePlayer.resources[Resource.ap] = 1;
+		ctx.activePlayer.population = {
+			...ctx.activePlayer.population,
+			[PopulationRole.Legion]: 1,
+			[PopulationRole.Council]: 0,
+		};
+		ctx.activePlayer.stats[Stat.armyStrength] = 2;
+		ctx.activePlayer.resources[Resource.happiness] = 1;
+		ctx.activePlayer.resources[Resource.gold] = 13;
+		ctx.opponent.stats[Stat.fortificationStrength] = 1;
+		ctx.opponent.resources[Resource.happiness] = 3;
+		ctx.opponent.resources[Resource.gold] = 20;
+		const castleBefore = ctx.opponent.resources[Resource.castleHP];
 
-    performAction('army_attack', ctx);
-    const castleAfter = ctx.opponent.resources[Resource.castleHP];
-    const log = logContent('action', 'army_attack', ctx);
-    expect(log).toEqual([
-      `Played ${armyAttack.icon} ${armyAttack.name}`,
-      `  Damage evaluation: ${army.icon}2 vs. ${absorption.icon}0% ${fort.icon}1 ${castle.icon}${castleBefore}`,
-      `    ${army.icon}2 vs. ${absorption.icon}0% --> ${army.icon}2`,
-      `    ${army.icon}2 vs. ${fort.icon}1 --> ${fort.icon}0 ${army.icon}1`,
-      `    ${army.icon}1 vs. ${castle.icon}${castleBefore} --> ${castle.icon}${castleAfter}`,
-      `  ${castle.icon} ${castle.label} damage trigger evaluation`,
-      `    Opponent: ${happiness.icon} ${happiness.label} -1 (3→2)`,
-      `    You: ${happiness.icon} ${happiness.label} +1 (1→2)`,
-      `    Triggered ${plunder.icon} ${plunder.name}`,
-      `      Opponent: ${RESOURCES[Resource.gold].icon} ${RESOURCES[Resource.gold].label} -25% (20→15) (-5)`,
-      `      You: ${RESOURCES[Resource.gold].icon} ${RESOURCES[Resource.gold].label} +5 (13→18)`,
-    ]);
-  });
+		performAction('army_attack', ctx);
+		const castleAfter = ctx.opponent.resources[Resource.castleHP];
+		const log = logContent('action', 'army_attack', ctx);
+		expect(log).toEqual([
+			`Played ${armyAttack.icon} ${armyAttack.name}`,
+			`  Damage evaluation: ${army.icon}2 vs. ${absorption.icon}0% ${fort.icon}1 ${castle.icon}${castleBefore}`,
+			`    ${army.icon}2 vs. ${absorption.icon}0% --> ${army.icon}2`,
+			`    ${army.icon}2 vs. ${fort.icon}1 --> ${fort.icon}0 ${army.icon}1`,
+			`    ${army.icon}1 vs. ${castle.icon}${castleBefore} --> ${castle.icon}${castleAfter}`,
+			`  ${castle.icon} ${castle.label} damage trigger evaluation`,
+			`    Opponent: ${happiness.icon} ${happiness.label} -1 (3→2)`,
+			`    You: ${happiness.icon} ${happiness.label} +1 (1→2)`,
+			`    Triggered ${plunder.icon} ${plunder.name}`,
+			`      Opponent: ${RESOURCES[Resource.gold].icon} ${RESOURCES[Resource.gold].label} -25% (20→15) (-5)`,
+			`      You: ${RESOURCES[Resource.gold].icon} ${RESOURCES[Resource.gold].label} +5 (13→18)`,
+		]);
+	});
 
-  it('summarizes building attack as destruction', () => {
-    const { ctx, attack, buildingId, building } = createBuildingAttackCtx();
-    const army = STATS[Stat.armyStrength];
-    const gold = RESOURCES[Resource.gold];
-    const buildingDisplay = iconLabel(building.icon, building.name, buildingId);
-    const summaryTitle = building.icon
-      ? `On opponent ${building.icon} destruction`
-      : `On opponent ${building.name ?? buildingId} destruction`;
+	it('summarizes building attack as destruction', () => {
+		const { ctx, attack, buildingId, building } = createBuildingAttackCtx();
+		const army = STATS[Stat.armyStrength];
+		const gold = RESOURCES[Resource.gold];
+		const buildingDisplay = iconLabel(building.icon, building.name, buildingId);
+		const summaryTitle = building.icon
+			? `On opponent ${building.icon} destruction`
+			: `On opponent ${building.name ?? buildingId} destruction`;
 
-    const summary = summarizeContent('action', attack.id, ctx);
-    expect(summary).toEqual([
-      `${army.icon} destroy opponent's ${buildingDisplay}`,
-      {
-        title: summaryTitle,
-        items: [`${gold.icon}+1 for you`],
-      },
-    ]);
-  });
+		const summary = summarizeContent('action', attack.id, ctx);
+		expect(summary).toEqual([
+			`${army.icon} destroy opponent's ${buildingDisplay}`,
+			{
+				title: summaryTitle,
+				items: [`${gold.icon}+1 for you`],
+			},
+		]);
+	});
 
-  it('logs building attack action with destruction evaluation', () => {
-    const { ctx, attack, buildingId, building } = createBuildingAttackCtx();
-    const army = STATS[Stat.armyStrength];
-    const absorption = STATS[Stat.absorption];
-    const fort = STATS[Stat.fortificationStrength];
-    const gold = RESOURCES[Resource.gold];
-    const buildingDisplay = iconLabel(building.icon, building.name, buildingId);
+	it('logs building attack action with destruction evaluation', () => {
+		const { ctx, attack, buildingId, building } = createBuildingAttackCtx();
+		const army = STATS[Stat.armyStrength];
+		const absorption = STATS[Stat.absorption];
+		const fort = STATS[Stat.fortificationStrength];
+		const gold = RESOURCES[Resource.gold];
+		const buildingDisplay = iconLabel(building.icon, building.name, buildingId);
 
-    ctx.activePlayer.resources[Resource.ap] = 1;
-    ctx.activePlayer.stats[Stat.armyStrength] = 3;
-    ctx.activePlayer.resources[Resource.gold] = 0;
-    ctx.opponent.stats[Stat.fortificationStrength] = 1;
-    ctx.opponent.buildings.add(buildingId);
+		ctx.activePlayer.resources[Resource.ap] = 1;
+		ctx.activePlayer.stats[Stat.armyStrength] = 3;
+		ctx.activePlayer.resources[Resource.gold] = 0;
+		ctx.opponent.stats[Stat.fortificationStrength] = 1;
+		ctx.opponent.buildings.add(buildingId);
 
-    performAction(attack.id, ctx);
-    const log = logContent('action', attack.id, ctx);
-    expect(log).toEqual([
-      `Played ${attack.icon} ${attack.name}`,
-      `  Damage evaluation: ${army.icon}3 vs. ${absorption.icon}0% ${fort.icon}1 ${buildingDisplay}`,
-      `    ${army.icon}3 vs. ${absorption.icon}0% --> ${army.icon}3`,
-      `    ${army.icon}3 vs. ${fort.icon}1 --> ${fort.icon}0 ${army.icon}2`,
-      `    ${army.icon}2 destroys ${buildingDisplay}`,
-      `  ${buildingDisplay} destruction trigger evaluation`,
-      `    You: ${gold.icon} ${gold.label} +1 (0→1)`,
-    ]);
-  });
+		performAction(attack.id, ctx);
+		const log = logContent('action', attack.id, ctx);
+		expect(log).toEqual([
+			`Played ${attack.icon} ${attack.name}`,
+			`  Damage evaluation: ${army.icon}3 vs. ${absorption.icon}0% ${fort.icon}1 ${buildingDisplay}`,
+			`    ${army.icon}3 vs. ${absorption.icon}0% --> ${army.icon}3`,
+			`    ${army.icon}3 vs. ${fort.icon}1 --> ${fort.icon}0 ${army.icon}2`,
+			`    ${army.icon}2 destroys ${buildingDisplay}`,
+			`  ${buildingDisplay} destruction trigger evaluation`,
+			`    You: ${gold.icon} ${gold.label} +1 (0→1)`,
+		]);
+	});
 });


### PR DESCRIPTION
## Summary
- update the App component to use tab indentation, clearer helper names, and extracted callbacks for shared behaviours
- add missing curly braces to attack target formatter conditionals to satisfy lint rules
- disable the max-lines rule for the large army attack translation test file

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dc18daafc88325a68d862ad50417ea