### PR TITLE
Refine engine context utilities

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,32 +1,32 @@
 import {
-  Resource,
-  Phase,
-  PopulationRole,
-  Stat,
-  GameState,
-  Land,
-  setResourceKeys,
-  setStatKeys,
-  setPhaseKeys,
-  setPopulationRoleKeys,
+	Resource,
+	Phase,
+	PopulationRole,
+	Stat,
+	GameState,
+	Land,
+	setResourceKeys,
+	setStatKeys,
+	setPhaseKeys,
+	setPopulationRoleKeys,
 } from './state';
 import type {
-  ResourceKey,
-  PlayerState,
-  StatKey,
-  PopulationRoleId,
-  StatSourceMeta,
-  StatSourceContribution,
-  StatSourceLink,
+	ResourceKey,
+	PlayerState,
+	StatKey,
+	PopulationRoleId,
+	StatSourceMeta,
+	StatSourceContribution,
+	StatSourceLink,
 } from './state';
 import { Services, PassiveManager } from './services';
 import type { CostBag, RuleSet } from './services';
 import { EngineContext } from './context';
 import {
-  runEffects,
-  EFFECTS,
-  EFFECT_COST_COLLECTORS,
-  registerCoreEffects,
+	runEffects,
+	EFFECTS,
+	EFFECT_COST_COLLECTORS,
+	registerCoreEffects,
 } from './effects';
 import type { EffectDef } from './effects';
 import { collectTriggerEffects } from './triggers';
@@ -37,444 +37,444 @@ import { applyParamsToEffects } from './utils';
 import { createAISystem, createTaxCollectorController } from './ai';
 import { applyStatDelta, withStatSourceFrames } from './stat_sources';
 import {
-  validateGameConfig,
-  type GameConfig,
-  actionSchema,
-  buildingSchema,
-  developmentSchema,
-  populationSchema,
-  type PlayerStartConfig,
-  type ActionConfig as ActionDef,
-  type BuildingConfig as BuildingDef,
-  type DevelopmentConfig as DevelopmentDef,
-  type PopulationConfig as PopulationDef,
-  type StartConfig,
+	validateGameConfig,
+	type GameConfig,
+	actionSchema,
+	buildingSchema,
+	developmentSchema,
+	populationSchema,
+	type PlayerStartConfig,
+	type ActionConfig as ActionDef,
+	type BuildingConfig as BuildingDef,
+	type DevelopmentConfig as DevelopmentDef,
+	type PopulationConfig as PopulationDef,
+	type StartConfig,
 } from './config/schema';
 import type { PhaseDef } from './phases';
 export { snapshotPlayer } from './log';
 export type { PlayerSnapshot, ActionTrace } from './log';
 export type {
-  AttackLog,
-  AttackEvaluationLog,
-  AttackOnDamageLogEntry,
-  AttackPlayerDiff,
-  AttackPowerLog,
+	AttackLog,
+	AttackEvaluationLog,
+	AttackOnDamageLogEntry,
+	AttackPlayerDiff,
+	AttackPowerLog,
 } from './effects/attack';
 
 function isStatKey(key: string): key is StatKey {
-  return key in Stat;
+	return key in Stat;
 }
 
 const START_STAT_SOURCE_META: StatSourceMeta = {
-  key: 'start:setup',
-  longevity: 'permanent',
-  kind: 'start',
-  detail: 'Initial setup',
+	key: 'start:setup',
+	longevity: 'permanent',
+	kind: 'start',
+	detail: 'Initial setup',
 };
 
 function applyCostsWithPassives(
-  actionId: string,
-  base: CostBag,
-  ctx: EngineContext,
+	actionId: string,
+	base: CostBag,
+	ctx: EngineContext,
 ): CostBag {
-  const withDefault = { ...base };
-  const definition = ctx.actions.get(actionId);
-  const key = ctx.actionCostResource;
-  if (key && withDefault[key] === undefined)
-    withDefault[key] = definition.system
-      ? 0
-      : ctx.services.rules.defaultActionAPCost;
-  return ctx.passives.applyCostMods(actionId, withDefault, ctx);
+	const withDefault = { ...base };
+	const definition = ctx.actions.get(actionId);
+	const key = ctx.actionCostResource;
+	if (key && withDefault[key] === undefined)
+		withDefault[key] = definition.system
+			? 0
+			: ctx.services.rules.defaultActionAPCost;
+	return ctx.passives.applyCostMods(actionId, withDefault, ctx);
 }
 
 export function getActionCosts<T extends string>(
-  actionId: T,
-  ctx: EngineContext,
-  params?: ActionParams<T>,
+	actionId: T,
+	ctx: EngineContext,
+	params?: ActionParams<T>,
 ): CostBag {
-  const actionDefinition = ctx.actions.get(actionId);
-  const base = { ...(actionDefinition.baseCosts || {}) };
-  const resolved = applyParamsToEffects(actionDefinition.effects, params || {});
-  for (const effect of resolved) {
-    if (!effect.type || !effect.method) continue;
-    const key = `${effect.type}:${effect.method}`;
-    if (EFFECT_COST_COLLECTORS.has(key))
-      EFFECT_COST_COLLECTORS.get(key)(effect, base, ctx);
-  }
-  return applyCostsWithPassives(actionDefinition.id, base, ctx);
+	const actionDefinition = ctx.actions.get(actionId);
+	const base = { ...(actionDefinition.baseCosts || {}) };
+	const resolved = applyParamsToEffects(actionDefinition.effects, params || {});
+	for (const effect of resolved) {
+		if (!effect.type || !effect.method) continue;
+		const key = `${effect.type}:${effect.method}`;
+		if (EFFECT_COST_COLLECTORS.has(key))
+			EFFECT_COST_COLLECTORS.get(key)(effect, base, ctx);
+	}
+	return applyCostsWithPassives(actionDefinition.id, base, ctx);
 }
 
 export function getActionRequirements<T extends string>(
-  actionId: T,
-  ctx: EngineContext,
-  _params?: ActionParams<T>,
+	actionId: T,
+	ctx: EngineContext,
+	_params?: ActionParams<T>,
 ): string[] {
-  const actionDefinition = ctx.actions.get(actionId);
-  const failures: string[] = [];
-  for (const requirement of actionDefinition.requirements || []) {
-    const ok = runRequirement(requirement, ctx);
-    if (ok !== true) failures.push(String(ok));
-  }
-  return failures;
+	const actionDefinition = ctx.actions.get(actionId);
+	const failures: string[] = [];
+	for (const requirement of actionDefinition.requirements || []) {
+		const ok = runRequirement(requirement, ctx);
+		if (ok !== true) failures.push(String(ok));
+	}
+	return failures;
 }
 
 function canPay(costs: CostBag, player: PlayerState): true | string {
-  for (const key of Object.keys(costs)) {
-    const need = costs[key] ?? 0;
-    const available = player.resources[key] ?? 0;
-    if (available < need) {
-      return `Insufficient ${key}: need ${need}, have ${available}`;
-    }
-  }
-  return true;
+	for (const key of Object.keys(costs)) {
+		const need = costs[key] ?? 0;
+		const available = player.resources[key] ?? 0;
+		if (available < need) {
+			return `Insufficient ${key}: need ${need}, have ${available}`;
+		}
+	}
+	return true;
 }
 
 function pay(costs: CostBag, player: PlayerState) {
-  for (const key of Object.keys(costs)) {
-    const amount = costs[key] ?? 0;
-    player.resources[key] = (player.resources[key] || 0) - amount;
-  }
+	for (const key of Object.keys(costs)) {
+		const amount = costs[key] ?? 0;
+		player.resources[key] = (player.resources[key] || 0) - amount;
+	}
 }
 
 type ActionParamMap = {
-  develop: { id: string; landId: string };
-  build: { id: string };
-  demolish: { id: string };
-  raise_pop: { role: PopulationRoleId };
-  [key: string]: Record<string, unknown>;
+	develop: { id: string; landId: string };
+	build: { id: string };
+	demolish: { id: string };
+	raise_pop: { role: PopulationRoleId };
+	[key: string]: Record<string, unknown>;
 };
 
 export type ActionParams<T extends string> = T extends keyof ActionParamMap
-  ? ActionParamMap[T]
-  : Record<string, unknown>;
+	? ActionParamMap[T]
+	: Record<string, unknown>;
 
 export function performAction<T extends string>(
-  actionId: T,
-  ctx: EngineContext,
-  params?: ActionParams<T>,
+	actionId: T,
+	ctx: EngineContext,
+	params?: ActionParams<T>,
 ) {
-  ctx.actionTraces = [];
-  const actionDefinition = ctx.actions.get(actionId);
-  if (actionDefinition.system && !ctx.activePlayer.actions.has(actionId))
-    throw new Error(`Action ${actionId} is locked`);
-  for (const requirement of actionDefinition.requirements || []) {
-    const ok = runRequirement(requirement, ctx);
-    if (ok !== true) throw new Error(String(ok));
-  }
-  const base = { ...(actionDefinition.baseCosts || {}) };
-  const resolved = applyParamsToEffects(actionDefinition.effects, params || {});
-  const attemptedBuildingAdds = resolved
-    .filter((effect) => effect.type === 'building' && effect.method === 'add')
-    .map((effect) => effect.params?.['id'])
-    .filter((id): id is string => typeof id === 'string');
-  for (const id of attemptedBuildingAdds) {
-    if (ctx.activePlayer.buildings.has(id))
-      throw new Error(`Building ${id} already built`);
-  }
-  for (const effect of resolved) {
-    if (!effect.type || !effect.method) continue;
-    const key = `${effect.type}:${effect.method}`;
-    if (EFFECT_COST_COLLECTORS.has(key))
-      EFFECT_COST_COLLECTORS.get(key)(effect, base, ctx);
-  }
-  const costs = applyCostsWithPassives(actionDefinition.id, base, ctx);
-  const ok = canPay(costs, ctx.activePlayer);
-  if (ok !== true) throw new Error(ok);
-  pay(costs, ctx.activePlayer);
+	ctx.actionTraces = [];
+	const actionDefinition = ctx.actions.get(actionId);
+	if (actionDefinition.system && !ctx.activePlayer.actions.has(actionId))
+		throw new Error(`Action ${actionId} is locked`);
+	for (const requirement of actionDefinition.requirements || []) {
+		const ok = runRequirement(requirement, ctx);
+		if (ok !== true) throw new Error(String(ok));
+	}
+	const base = { ...(actionDefinition.baseCosts || {}) };
+	const resolved = applyParamsToEffects(actionDefinition.effects, params || {});
+	const attemptedBuildingAdds = resolved
+		.filter((effect) => effect.type === 'building' && effect.method === 'add')
+		.map((effect) => effect.params?.['id'])
+		.filter((id): id is string => typeof id === 'string');
+	for (const id of attemptedBuildingAdds) {
+		if (ctx.activePlayer.buildings.has(id))
+			throw new Error(`Building ${id} already built`);
+	}
+	for (const effect of resolved) {
+		if (!effect.type || !effect.method) continue;
+		const key = `${effect.type}:${effect.method}`;
+		if (EFFECT_COST_COLLECTORS.has(key))
+			EFFECT_COST_COLLECTORS.get(key)(effect, base, ctx);
+	}
+	const costs = applyCostsWithPassives(actionDefinition.id, base, ctx);
+	const ok = canPay(costs, ctx.activePlayer);
+	if (ok !== true) throw new Error(ok);
+	pay(costs, ctx.activePlayer);
 
-  withStatSourceFrames(
-    ctx,
-    (_effect, _ctx, statKey) => ({
-      key: `action:${actionDefinition.id}:${statKey}`,
-      kind: 'action',
-      id: actionDefinition.id,
-      detail: 'Resolution',
-      longevity: 'permanent',
-    }),
-    () => {
-      runEffects(resolved, ctx);
-      ctx.passives.runResultMods(actionDefinition.id, ctx);
-    },
-  );
-  const traces = ctx.actionTraces;
-  ctx.actionTraces = [];
-  return traces;
+	withStatSourceFrames(
+		ctx,
+		(_effect, _ctx, statKey) => ({
+			key: `action:${actionDefinition.id}:${statKey}`,
+			kind: 'action',
+			id: actionDefinition.id,
+			detail: 'Resolution',
+			longevity: 'permanent',
+		}),
+		() => {
+			runEffects(resolved, ctx);
+			ctx.passives.runResultMods(actionDefinition.id, ctx);
+		},
+	);
+	const traces = ctx.actionTraces;
+	ctx.actionTraces = [];
+	return traces;
 }
 
 export interface AdvanceResult {
-  phase: string;
-  step: string;
-  effects: EffectDef[];
-  player: PlayerState;
+	phase: string;
+	step: string;
+	effects: EffectDef[];
+	player: PlayerState;
 }
 
 export function advance(ctx: EngineContext): AdvanceResult {
-  const phase = ctx.phases[ctx.game.phaseIndex]!;
-  const step = phase.steps[ctx.game.stepIndex];
-  const player = ctx.activePlayer;
-  const effects: EffectDef[] = [];
-  const phaseFrame = (
-    _effect: EffectDef,
-    _ctx: EngineContext,
-    statKey: StatKey,
-  ) => {
-    const partial = {
-      key: `phase:${phase.id}:${step?.id ?? 'step'}:${statKey}`,
-      kind: 'phase',
-      id: phase.id,
-      longevity: 'permanent' as const,
-    } as const;
-    const stepId = step?.id;
-    return stepId ? { ...partial, detail: stepId } : partial;
-  };
+	const phase = ctx.phases[ctx.game.phaseIndex]!;
+	const step = phase.steps[ctx.game.stepIndex];
+	const player = ctx.activePlayer;
+	const effects: EffectDef[] = [];
+	const phaseFrame = (
+		_effect: EffectDef,
+		_ctx: EngineContext,
+		statKey: StatKey,
+	) => {
+		const partial = {
+			key: `phase:${phase.id}:${step?.id ?? 'step'}:${statKey}`,
+			kind: 'phase',
+			id: phase.id,
+			longevity: 'permanent' as const,
+		} as const;
+		const stepId = step?.id;
+		return stepId ? { ...partial, detail: stepId } : partial;
+	};
 
-  const triggers = step?.triggers ?? [];
-  if (triggers.length) {
-    withStatSourceFrames(ctx, phaseFrame, () => {
-      for (const trig of triggers) {
-        const bundles = collectTriggerEffects(trig, ctx, player);
-        for (const bundle of bundles) {
-          withStatSourceFrames(ctx, bundle.frames, () =>
-            runEffects(bundle.effects, ctx),
-          );
-          effects.push(...bundle.effects);
-        }
-      }
-    });
-  }
-  if (step?.effects) {
-    const stepEffects = step.effects;
-    withStatSourceFrames(ctx, phaseFrame, () => {
-      runEffects(stepEffects, ctx);
-    });
-    effects.push(...stepEffects);
-  }
+	const triggers = step?.triggers ?? [];
+	if (triggers.length) {
+		withStatSourceFrames(ctx, phaseFrame, () => {
+			for (const trig of triggers) {
+				const bundles = collectTriggerEffects(trig, ctx, player);
+				for (const bundle of bundles) {
+					withStatSourceFrames(ctx, bundle.frames, () =>
+						runEffects(bundle.effects, ctx),
+					);
+					effects.push(...bundle.effects);
+				}
+			}
+		});
+	}
+	if (step?.effects) {
+		const stepEffects = step.effects;
+		withStatSourceFrames(ctx, phaseFrame, () => {
+			runEffects(stepEffects, ctx);
+		});
+		effects.push(...stepEffects);
+	}
 
-  if (step)
-    withStatSourceFrames(ctx, phaseFrame, () =>
-      ctx.passives.runResultMods(step.id, ctx),
-    );
+	if (step)
+		withStatSourceFrames(ctx, phaseFrame, () =>
+			ctx.passives.runResultMods(step.id, ctx),
+		);
 
-  ctx.game.stepIndex += 1;
-  if (ctx.game.stepIndex >= phase.steps.length) {
-    ctx.game.stepIndex = 0;
-    ctx.game.phaseIndex += 1;
-    if (ctx.game.phaseIndex >= ctx.phases.length) {
-      ctx.game.phaseIndex = 0;
-      if (ctx.game.currentPlayerIndex === ctx.game.players.length - 1) {
-        ctx.game.currentPlayerIndex = 0;
-        ctx.game.turn += 1;
-      } else {
-        ctx.game.currentPlayerIndex += 1;
-      }
-    }
-  }
+	ctx.game.stepIndex += 1;
+	if (ctx.game.stepIndex >= phase.steps.length) {
+		ctx.game.stepIndex = 0;
+		ctx.game.phaseIndex += 1;
+		if (ctx.game.phaseIndex >= ctx.phases.length) {
+			ctx.game.phaseIndex = 0;
+			if (ctx.game.currentPlayerIndex === ctx.game.players.length - 1) {
+				ctx.game.currentPlayerIndex = 0;
+				ctx.game.turn += 1;
+			} else {
+				ctx.game.currentPlayerIndex += 1;
+			}
+		}
+	}
 
-  const nextPhase = ctx.phases[ctx.game.phaseIndex]!;
-  const nextStep = nextPhase.steps[ctx.game.stepIndex];
-  ctx.game.currentPhase = nextPhase.id;
-  ctx.game.currentStep = nextStep ? nextStep.id : '';
+	const nextPhase = ctx.phases[ctx.game.phaseIndex]!;
+	const nextStep = nextPhase.steps[ctx.game.stepIndex];
+	ctx.game.currentPhase = nextPhase.id;
+	ctx.game.currentStep = nextStep ? nextStep.id : '';
 
-  return { phase: phase.id, step: step?.id || '', effects, player };
+	return { phase: phase.id, step: step?.id || '', effects, player };
 }
 
 function applyPlayerStart(
-  player: PlayerState,
-  config: PlayerStartConfig,
-  rules: RuleSet,
+	player: PlayerState,
+	config: PlayerStartConfig,
+	rules: RuleSet,
 ) {
-  for (const [key, value] of Object.entries(config.resources || {}))
-    player.resources[key] = value ?? 0;
-  for (const [key, value] of Object.entries(config.stats || {})) {
-    if (!isStatKey(key)) continue;
-    const val = value ?? 0;
-    const prev = player.stats[key] ?? 0;
-    player.stats[key] = val;
-    if (val !== 0) player.statsHistory[key] = true;
-    const delta = val - prev;
-    if (delta !== 0) applyStatDelta(player, key, delta, START_STAT_SOURCE_META);
-  }
-  for (const [key, value] of Object.entries(config.population || {}))
-    player.population[key] = value ?? 0;
-  if (config.lands)
-    config.lands.forEach((landCfg, idx) => {
-      const land = new Land(
-        `${player.id}-L${idx + 1}`,
-        landCfg.slotsMax ?? rules.slotsPerNewLand,
-        landCfg.tilled ?? false,
-      );
-      if (landCfg.developments) land.developments.push(...landCfg.developments);
-      land.slotsUsed = landCfg.slotsUsed ?? land.developments.length;
-      if (landCfg.upkeep) land.upkeep = { ...landCfg.upkeep };
-      if (landCfg.onPayUpkeepStep)
-        land.onPayUpkeepStep = landCfg.onPayUpkeepStep.map((e) => ({ ...e }));
-      if (landCfg.onGainIncomeStep)
-        land.onGainIncomeStep = landCfg.onGainIncomeStep.map((e) => ({ ...e }));
-      if (landCfg.onGainAPStep)
-        land.onGainAPStep = landCfg.onGainAPStep.map((e) => ({ ...e }));
-      player.lands.push(land);
-    });
+	for (const [key, value] of Object.entries(config.resources || {}))
+		player.resources[key] = value ?? 0;
+	for (const [key, value] of Object.entries(config.stats || {})) {
+		if (!isStatKey(key)) continue;
+		const val = value ?? 0;
+		const prev = player.stats[key] ?? 0;
+		player.stats[key] = val;
+		if (val !== 0) player.statsHistory[key] = true;
+		const delta = val - prev;
+		if (delta !== 0) applyStatDelta(player, key, delta, START_STAT_SOURCE_META);
+	}
+	for (const [key, value] of Object.entries(config.population || {}))
+		player.population[key] = value ?? 0;
+	if (config.lands)
+		config.lands.forEach((landCfg, idx) => {
+			const land = new Land(
+				`${player.id}-L${idx + 1}`,
+				landCfg.slotsMax ?? rules.slotsPerNewLand,
+				landCfg.tilled ?? false,
+			);
+			if (landCfg.developments) land.developments.push(...landCfg.developments);
+			land.slotsUsed = landCfg.slotsUsed ?? land.developments.length;
+			if (landCfg.upkeep) land.upkeep = { ...landCfg.upkeep };
+			if (landCfg.onPayUpkeepStep)
+				land.onPayUpkeepStep = landCfg.onPayUpkeepStep.map((e) => ({ ...e }));
+			if (landCfg.onGainIncomeStep)
+				land.onGainIncomeStep = landCfg.onGainIncomeStep.map((e) => ({ ...e }));
+			if (landCfg.onGainAPStep)
+				land.onGainAPStep = landCfg.onGainAPStep.map((e) => ({ ...e }));
+			player.lands.push(land);
+		});
 }
 
 function diffPlayerStart(
-  base: PlayerStartConfig,
-  override: PlayerStartConfig | undefined,
+	base: PlayerStartConfig,
+	override: PlayerStartConfig | undefined,
 ): PlayerStartConfig {
-  const diff: PlayerStartConfig = {};
-  if (!override) return diff;
-  for (const [key, value] of Object.entries(override.resources || {})) {
-    const baseVal = base.resources?.[key] ?? 0;
-    const delta = (value ?? 0) - baseVal;
-    if (delta !== 0) {
-      diff.resources = diff.resources || {};
-      diff.resources[key] = delta;
-    }
-  }
-  for (const [key, value] of Object.entries(override.stats || {})) {
-    const baseVal = base.stats?.[key] ?? 0;
-    const delta = (value ?? 0) - baseVal;
-    if (delta !== 0) {
-      diff.stats = diff.stats || {};
-      diff.stats[key] = delta;
-    }
-  }
-  return diff;
+	const diff: PlayerStartConfig = {};
+	if (!override) return diff;
+	for (const [key, value] of Object.entries(override.resources || {})) {
+		const baseVal = base.resources?.[key] ?? 0;
+		const delta = (value ?? 0) - baseVal;
+		if (delta !== 0) {
+			diff.resources = diff.resources || {};
+			diff.resources[key] = delta;
+		}
+	}
+	for (const [key, value] of Object.entries(override.stats || {})) {
+		const baseVal = base.stats?.[key] ?? 0;
+		const delta = (value ?? 0) - baseVal;
+		if (delta !== 0) {
+			diff.stats = diff.stats || {};
+			diff.stats[key] = delta;
+		}
+	}
+	return diff;
 }
 
 export function createEngine({
-  actions,
-  buildings,
-  developments,
-  populations,
-  phases,
-  start,
-  rules,
-  config,
+	actions,
+	buildings,
+	developments,
+	populations,
+	phases,
+	start,
+	rules,
+	config,
 }: {
-  actions: Registry<ActionDef>;
-  buildings: Registry<BuildingDef>;
-  developments: Registry<DevelopmentDef>;
-  populations: Registry<PopulationDef>;
-  phases: PhaseDef[];
-  start: StartConfig;
-  rules: RuleSet;
-  config?: GameConfig;
+	actions: Registry<ActionDef>;
+	buildings: Registry<BuildingDef>;
+	developments: Registry<DevelopmentDef>;
+	populations: Registry<PopulationDef>;
+	phases: PhaseDef[];
+	start: StartConfig;
+	rules: RuleSet;
+	config?: GameConfig;
 }) {
-  registerCoreEffects();
-  registerCoreEvaluators();
-  registerCoreRequirements();
+	registerCoreEffects();
+	registerCoreEvaluators();
+	registerCoreRequirements();
 
-  let startCfg = start;
-  if (config) {
-    const cfg = validateGameConfig(config);
-    if (cfg.actions) {
-      const registry = new Registry<ActionDef>(actionSchema);
-      for (const action of cfg.actions) registry.add(action.id, action);
-      actions = registry;
-    }
-    if (cfg.buildings) {
-      const registry = new Registry<BuildingDef>(buildingSchema);
-      for (const building of cfg.buildings) registry.add(building.id, building);
-      buildings = registry;
-    }
-    if (cfg.developments) {
-      const registry = new Registry<DevelopmentDef>(developmentSchema);
-      for (const development of cfg.developments)
-        registry.add(development.id, development);
-      developments = registry;
-    }
-    if (cfg.populations) {
-      const registry = new Registry<PopulationDef>(populationSchema);
-      for (const population of cfg.populations)
-        registry.add(population.id, population);
-      populations = registry;
-    }
-    if (cfg.start) startCfg = cfg.start;
-  }
+	let startCfg = start;
+	if (config) {
+		const cfg = validateGameConfig(config);
+		if (cfg.actions) {
+			const registry = new Registry<ActionDef>(actionSchema);
+			for (const action of cfg.actions) registry.add(action.id, action);
+			actions = registry;
+		}
+		if (cfg.buildings) {
+			const registry = new Registry<BuildingDef>(buildingSchema);
+			for (const building of cfg.buildings) registry.add(building.id, building);
+			buildings = registry;
+		}
+		if (cfg.developments) {
+			const registry = new Registry<DevelopmentDef>(developmentSchema);
+			for (const development of cfg.developments)
+				registry.add(development.id, development);
+			developments = registry;
+		}
+		if (cfg.populations) {
+			const registry = new Registry<PopulationDef>(populationSchema);
+			for (const population of cfg.populations)
+				registry.add(population.id, population);
+			populations = registry;
+		}
+		if (cfg.start) startCfg = cfg.start;
+	}
 
-  setResourceKeys(Object.keys(startCfg.player.resources || {}));
-  setStatKeys(Object.keys(startCfg.player.stats || {}));
-  setPhaseKeys(phases.map((p) => p.id));
-  setPopulationRoleKeys(Object.keys(startCfg.player.population || {}));
+	setResourceKeys(Object.keys(startCfg.player.resources || {}));
+	setStatKeys(Object.keys(startCfg.player.stats || {}));
+	setPhaseKeys(phases.map((p) => p.id));
+	setPopulationRoleKeys(Object.keys(startCfg.player.population || {}));
 
-  const services = new Services(rules, developments);
-  const passives = new PassiveManager();
-  const game = new GameState('Player', 'Opponent');
+	const services = new Services(rules, developments);
+	const passives = new PassiveManager();
+	const game = new GameState('Player', 'Opponent');
 
-  let actionCostResource: ResourceKey = '' as ResourceKey;
-  let intersect: string[] | null = null;
-  for (const [, action] of actions.entries()) {
-    if (action.system) continue;
-    const keys = Object.keys(action.baseCosts || {});
-    if (!keys.length) continue;
-    intersect = intersect ? intersect.filter((k) => keys.includes(k)) : keys;
-  }
-  if (intersect && intersect.length)
-    actionCostResource = intersect[0] as ResourceKey;
+	let actionCostResource: ResourceKey = '' as ResourceKey;
+	let intersect: string[] | null = null;
+	for (const [, action] of actions.entries()) {
+		if (action.system) continue;
+		const keys = Object.keys(action.baseCosts || {});
+		if (!keys.length) continue;
+		intersect = intersect ? intersect.filter((k) => keys.includes(k)) : keys;
+	}
+	if (intersect && intersect.length)
+		actionCostResource = intersect[0] as ResourceKey;
 
-  const compA = diffPlayerStart(startCfg.player, startCfg.players?.['A']);
-  const compB = diffPlayerStart(startCfg.player, startCfg.players?.['B']);
-  const compensations = { A: compA, B: compB } as Record<
-    'A' | 'B',
-    PlayerStartConfig
-  >;
+	const compA = diffPlayerStart(startCfg.player, startCfg.players?.['A']);
+	const compB = diffPlayerStart(startCfg.player, startCfg.players?.['B']);
+	const compensations = { A: compA, B: compB } as Record<
+		'A' | 'B',
+		PlayerStartConfig
+	>;
 
-  const ctx = new EngineContext(
-    game,
-    services,
-    actions,
-    buildings,
-    developments,
-    populations,
-    passives,
-    phases,
-    actionCostResource,
-    compensations,
-  );
-  const playerA = ctx.game.players[0]!;
-  const playerB = ctx.game.players[1]!;
+	const ctx = new EngineContext(
+		game,
+		services,
+		actions,
+		buildings,
+		developments,
+		populations,
+		passives,
+		phases,
+		actionCostResource,
+		compensations,
+	);
+	const playerA = ctx.game.players[0]!;
+	const playerB = ctx.game.players[1]!;
 
-  const ai = createAISystem({ performAction, advance });
-  ai.register(playerB.id, createTaxCollectorController(playerB.id));
-  ctx.ai = ai;
+	const aiSystem = createAISystem({ performAction, advance });
+	aiSystem.register(playerB.id, createTaxCollectorController(playerB.id));
+	ctx.aiSystem = aiSystem;
 
-  applyPlayerStart(playerA, startCfg.player, rules);
-  applyPlayerStart(playerA, compA, rules);
-  applyPlayerStart(playerB, startCfg.player, rules);
-  applyPlayerStart(playerB, compB, rules);
-  ctx.game.currentPlayerIndex = 0;
-  ctx.game.currentPhase = phases[0]?.id || '';
-  ctx.game.currentStep = phases[0]?.steps[0]?.id || '';
+	applyPlayerStart(playerA, startCfg.player, rules);
+	applyPlayerStart(playerA, compA, rules);
+	applyPlayerStart(playerB, startCfg.player, rules);
+	applyPlayerStart(playerB, compB, rules);
+	ctx.game.currentPlayerIndex = 0;
+	ctx.game.currentPhase = phases[0]?.id || '';
+	ctx.game.currentStep = phases[0]?.steps[0]?.id || '';
 
-  return ctx;
+	return ctx;
 }
 
 export {
-  Resource,
-  Phase,
-  PopulationRole,
-  Stat,
-  EFFECTS,
-  EFFECT_COST_COLLECTORS,
-  EVALUATORS,
-  EngineContext,
-  Services,
-  PassiveManager,
+	Resource,
+	Phase,
+	PopulationRole,
+	Stat,
+	EFFECTS,
+	EFFECT_COST_COLLECTORS,
+	EVALUATORS,
+	EngineContext,
+	Services,
+	PassiveManager,
 };
 
 export type {
-  RuleSet,
-  ResourceKey,
-  StatKey,
-  StatSourceMeta,
-  StatSourceContribution,
-  StatSourceLink,
+	RuleSet,
+	ResourceKey,
+	StatKey,
+	StatSourceMeta,
+	StatSourceContribution,
+	StatSourceLink,
 };
 export {
-  registerCoreEffects,
-  EffectRegistry,
-  runEffects,
-  EffectCostRegistry,
+	registerCoreEffects,
+	EffectRegistry,
+	runEffects,
+	EffectCostRegistry,
 } from './effects';
 export type { EffectHandler, EffectDef, EffectCostCollector } from './effects';
 export { applyParamsToEffects } from './utils';

--- a/packages/engine/src/stat_sources.ts
+++ b/packages/engine/src/stat_sources.ts
@@ -1,0 +1,1 @@
+export * from './stat_sources/index';

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -1,36 +1,36 @@
 import React, {
-  createContext,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-  useEffect,
+	createContext,
+	useContext,
+	useMemo,
+	useRef,
+	useState,
+	useEffect,
 } from 'react';
 import {
-  createEngine,
-  performAction,
-  advance,
-  getActionCosts,
-  type EngineContext,
-  type ActionParams,
+	createEngine,
+	performAction,
+	advance,
+	getActionCosts,
+	type EngineContext,
+	type ActionParams,
 } from '@kingdom-builder/engine';
 import {
-  RESOURCES,
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
-  type ResourceKey,
-  type StepDef,
+	RESOURCES,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	type ResourceKey,
+	type StepDef,
 } from '@kingdom-builder/contents';
 import {
-  snapshotPlayer,
-  diffStepSnapshots,
-  logContent,
-  type Summary,
+	snapshotPlayer,
+	diffStepSnapshots,
+	logContent,
+	type Summary,
 } from '../translation';
 
 const RESOURCE_KEYS = Object.keys(RESOURCES) as ResourceKey[];
@@ -40,568 +40,572 @@ const TIME_SCALE_STORAGE_KEY = 'kingdom-builder:time-scale';
 const ACTION_EFFECT_DELAY = 600;
 
 function readStoredTimeScale(): TimeScale | null {
-  if (typeof window === 'undefined') return null;
-  const raw = window.localStorage.getItem(TIME_SCALE_STORAGE_KEY);
-  if (!raw) return null;
-  const parsed = Number(raw);
-  return (TIME_SCALE_OPTIONS as readonly number[]).includes(parsed)
-    ? (parsed as TimeScale)
-    : null;
+	if (typeof window === 'undefined') return null;
+	const raw = window.localStorage.getItem(TIME_SCALE_STORAGE_KEY);
+	if (!raw) return null;
+	const parsed = Number(raw);
+	return (TIME_SCALE_OPTIONS as readonly number[]).includes(parsed)
+		? (parsed as TimeScale)
+		: null;
 }
 
 interface Action {
-  id: string;
-  name: string;
-  system?: boolean;
+	id: string;
+	name: string;
+	system?: boolean;
 }
 
 type LogEntry = {
-  time: string;
-  text: string;
-  playerId: string;
+	time: string;
+	text: string;
+	playerId: string;
 };
 
 interface HoverCard {
-  title: string;
-  effects: Summary;
-  requirements: string[];
-  costs?: Record<string, number>;
-  upkeep?: Record<string, number> | undefined;
-  description?: string | Summary;
-  descriptionTitle?: string;
-  descriptionClass?: string;
-  effectsTitle?: string;
-  bgClass?: string;
+	title: string;
+	effects: Summary;
+	requirements: string[];
+	costs?: Record<string, number>;
+	upkeep?: Record<string, number> | undefined;
+	description?: string | Summary;
+	descriptionTitle?: string;
+	descriptionClass?: string;
+	effectsTitle?: string;
+	bgClass?: string;
 }
 
 type PhaseStep = {
-  title: string;
-  items: { text: string; italic?: boolean; done?: boolean }[];
-  active: boolean;
+	title: string;
+	items: { text: string; italic?: boolean; done?: boolean }[];
+	active: boolean;
 };
 
 interface GameEngineContextValue {
-  ctx: EngineContext;
-  log: LogEntry[];
-  hoverCard: HoverCard | null;
-  handleHoverCard: (data: HoverCard) => void;
-  clearHoverCard: () => void;
-  phaseSteps: PhaseStep[];
-  setPhaseSteps: React.Dispatch<React.SetStateAction<PhaseStep[]>>;
-  phaseTimer: number;
-  phasePaused: boolean;
-  setPaused: (v: boolean) => void;
-  mainApStart: number;
-  displayPhase: string;
-  setDisplayPhase: (id: string) => void;
-  phaseHistories: Record<string, PhaseStep[]>;
-  tabsEnabled: boolean;
-  actionCostResource: ResourceKey;
-  handlePerform: (
-    action: Action,
-    params?: Record<string, unknown>,
-  ) => Promise<void>;
-  runUntilActionPhase: () => Promise<void>;
-  handleEndTurn: () => Promise<void>;
-  updateMainPhaseStep: (apStartOverride?: number) => void;
-  onExit?: () => void;
-  darkMode: boolean;
-  onToggleDark: () => void;
-  timeScale: TimeScale;
-  setTimeScale: (value: TimeScale) => void;
+	ctx: EngineContext;
+	log: LogEntry[];
+	hoverCard: HoverCard | null;
+	handleHoverCard: (data: HoverCard) => void;
+	clearHoverCard: () => void;
+	phaseSteps: PhaseStep[];
+	setPhaseSteps: React.Dispatch<React.SetStateAction<PhaseStep[]>>;
+	phaseTimer: number;
+	phasePaused: boolean;
+	setPaused: (v: boolean) => void;
+	mainApStart: number;
+	displayPhase: string;
+	setDisplayPhase: (id: string) => void;
+	phaseHistories: Record<string, PhaseStep[]>;
+	tabsEnabled: boolean;
+	actionCostResource: ResourceKey;
+	handlePerform: (
+		action: Action,
+		params?: Record<string, unknown>,
+	) => Promise<void>;
+	runUntilActionPhase: () => Promise<void>;
+	handleEndTurn: () => Promise<void>;
+	updateMainPhaseStep: (apStartOverride?: number) => void;
+	onExit?: () => void;
+	darkMode: boolean;
+	onToggleDark: () => void;
+	timeScale: TimeScale;
+	setTimeScale: (value: TimeScale) => void;
 }
 
 const GameEngineContext = createContext<GameEngineContextValue | null>(null);
 
 export function GameProvider({
-  children,
-  onExit,
-  darkMode = true,
-  onToggleDark = () => {},
-  devMode = false,
+	children,
+	onExit,
+	darkMode = true,
+	onToggleDark = () => {},
+	devMode = false,
 }: {
-  children: React.ReactNode;
-  onExit?: () => void;
-  darkMode?: boolean;
-  onToggleDark?: () => void;
-  devMode?: boolean;
+	children: React.ReactNode;
+	onExit?: () => void;
+	darkMode?: boolean;
+	onToggleDark?: () => void;
+	devMode?: boolean;
 }) {
-  const ctx = useMemo<EngineContext>(() => {
-    const engine = createEngine({
-      actions: ACTIONS,
-      buildings: BUILDINGS,
-      developments: DEVELOPMENTS,
-      populations: POPULATIONS,
-      phases: PHASES,
-      start: GAME_START,
-      rules: RULES,
-    });
-    engine.game.devMode = devMode;
-    return engine;
-  }, [devMode]);
-  const [, setTick] = useState(0);
-  const refresh = () => setTick((t) => t + 1);
+	const ctx = useMemo<EngineContext>(() => {
+		const engine = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		engine.game.devMode = devMode;
+		return engine;
+	}, [devMode]);
+	const [, setTick] = useState(0);
+	const refresh = () => setTick((t) => t + 1);
 
-  const [log, setLog] = useState<LogEntry[]>([]);
-  const [hoverCard, setHoverCard] = useState<HoverCard | null>(null);
-  const hoverTimeout = useRef<number>();
+	const [log, setLog] = useState<LogEntry[]>([]);
+	const [hoverCard, setHoverCard] = useState<HoverCard | null>(null);
+	const hoverTimeout = useRef<number>();
 
-  const [phaseSteps, setPhaseSteps] = useState<PhaseStep[]>([]);
-  const [phaseTimer, setPhaseTimer] = useState(0);
-  const [phasePaused, setPhasePaused] = useState(false);
-  const phasePausedRef = useRef(false);
-  const [mainApStart, setMainApStart] = useState(0);
-  const [displayPhase, setDisplayPhase] = useState(ctx.game.currentPhase);
-  const [phaseHistories, setPhaseHistories] = useState<
-    Record<string, PhaseStep[]>
-  >({});
-  const [tabsEnabled, setTabsEnabled] = useState(false);
-  const enqueue = <T,>(task: () => Promise<T> | T) => ctx.enqueue(task);
+	const [phaseSteps, setPhaseSteps] = useState<PhaseStep[]>([]);
+	const [phaseTimer, setPhaseTimer] = useState(0);
+	const [phasePaused, setPhasePaused] = useState(false);
+	const phasePausedRef = useRef(false);
+	const [mainApStart, setMainApStart] = useState(0);
+	const [displayPhase, setDisplayPhase] = useState(ctx.game.currentPhase);
+	const [phaseHistories, setPhaseHistories] = useState<
+		Record<string, PhaseStep[]>
+	>({});
+	const [tabsEnabled, setTabsEnabled] = useState(false);
+	const enqueue = <T,>(task: () => Promise<T> | T) => ctx.enqueue(task);
 
-  const [timeScale, setTimeScaleState] = useState<TimeScale>(() => {
-    if (devMode) return 100;
-    return readStoredTimeScale() ?? 1;
-  });
-  useEffect(() => {
-    if (devMode) {
-      setTimeScaleState(100);
-    } else {
-      setTimeScaleState(readStoredTimeScale() ?? 1);
-    }
-  }, [devMode]);
-  const changeTimeScale = (value: TimeScale) => {
-    setTimeScaleState((prev) => {
-      if (prev === value) return prev;
-      if (typeof window !== 'undefined')
-        window.localStorage.setItem(TIME_SCALE_STORAGE_KEY, String(value));
-      return value;
-    });
-  };
+	const [timeScale, setTimeScaleState] = useState<TimeScale>(() => {
+		if (devMode) return 100;
+		return readStoredTimeScale() ?? 1;
+	});
+	useEffect(() => {
+		if (devMode) {
+			setTimeScaleState(100);
+		} else {
+			setTimeScaleState(readStoredTimeScale() ?? 1);
+		}
+	}, [devMode]);
+	const changeTimeScale = (value: TimeScale) => {
+		setTimeScaleState((prev) => {
+			if (prev === value) return prev;
+			if (typeof window !== 'undefined')
+				window.localStorage.setItem(TIME_SCALE_STORAGE_KEY, String(value));
+			return value;
+		});
+	};
 
-  const actionCostResource = ctx.actionCostResource as ResourceKey;
+	const actionCostResource = ctx.actionCostResource as ResourceKey;
 
-  const actionPhaseId = useMemo(
-    () => ctx.phases.find((p) => p.action)?.id,
-    [ctx],
-  );
+	const actionPhaseId = useMemo(
+		() => ctx.phases.find((p) => p.action)?.id,
+		[ctx],
+	);
 
-  function setPaused(v: boolean) {
-    phasePausedRef.current = v;
-    setPhasePaused(v);
-  }
+	function setPaused(v: boolean) {
+		phasePausedRef.current = v;
+		setPhasePaused(v);
+	}
 
-  const addLog = (
-    entry: string | string[],
-    player?: EngineContext['activePlayer'],
-  ) => {
-    const p = player ?? ctx.activePlayer;
-    setLog((prev) => {
-      const items = (Array.isArray(entry) ? entry : [entry]).map((text) => ({
-        time: new Date().toLocaleTimeString(),
-        text: `[${p.name}] ${text}`,
-        playerId: p.id,
-      }));
-      return [...prev, ...items];
-    });
-  };
+	const addLog = (
+		entry: string | string[],
+		player?: EngineContext['activePlayer'],
+	) => {
+		const p = player ?? ctx.activePlayer;
+		setLog((prev) => {
+			const items = (Array.isArray(entry) ? entry : [entry]).map((text) => ({
+				time: new Date().toLocaleTimeString(),
+				text: `[${p.name}] ${text}`,
+				playerId: p.id,
+			}));
+			return [...prev, ...items];
+		});
+	};
 
-  useEffect(() => {
-    ctx.game.players.forEach((player) => {
-      const comp = ctx.compensations[player.id];
-      if (
-        !comp ||
-        (Object.keys(comp.resources || {}).length === 0 &&
-          Object.keys(comp.stats || {}).length === 0)
-      )
-        return;
-      const after = snapshotPlayer(player, ctx);
-      const before = {
-        ...after,
-        resources: { ...after.resources },
-        stats: { ...after.stats },
-        buildings: [...after.buildings],
-        lands: after.lands.map((l) => ({
-          ...l,
-          developments: [...l.developments],
-        })),
-        passives: [...after.passives],
-      };
-      for (const [k, v] of Object.entries(comp.resources || {}))
-        before.resources[k] = (before.resources[k] || 0) - (v ?? 0);
-      for (const [k, v] of Object.entries(comp.stats || {}))
-        before.stats[k] = (before.stats[k] || 0) - (v ?? 0);
-      const lines = diffStepSnapshots(
-        before,
-        after,
-        undefined,
-        ctx,
-        RESOURCE_KEYS,
-      );
-      if (lines.length)
-        addLog(
-          ['Last-player compensation:', ...lines.map((l: string) => `  ${l}`)],
-          player,
-        );
-    });
-  }, [ctx]);
+	useEffect(() => {
+		ctx.game.players.forEach((player) => {
+			const comp = ctx.compensations[player.id];
+			if (
+				!comp ||
+				(Object.keys(comp.resources || {}).length === 0 &&
+					Object.keys(comp.stats || {}).length === 0)
+			)
+				return;
+			const after = snapshotPlayer(player, ctx);
+			const before = {
+				...after,
+				resources: { ...after.resources },
+				stats: { ...after.stats },
+				buildings: [...after.buildings],
+				lands: after.lands.map((l) => ({
+					...l,
+					developments: [...l.developments],
+				})),
+				passives: [...after.passives],
+			};
+			for (const [k, v] of Object.entries(comp.resources || {}))
+				before.resources[k] = (before.resources[k] || 0) - (v ?? 0);
+			for (const [k, v] of Object.entries(comp.stats || {}))
+				before.stats[k] = (before.stats[k] || 0) - (v ?? 0);
+			const lines = diffStepSnapshots(
+				before,
+				after,
+				undefined,
+				ctx,
+				RESOURCE_KEYS,
+			);
+			if (lines.length)
+				addLog(
+					['Last-player compensation:', ...lines.map((l: string) => `  ${l}`)],
+					player,
+				);
+		});
+	}, [ctx]);
 
-  function handleHoverCard(data: HoverCard) {
-    if (hoverTimeout.current) window.clearTimeout(hoverTimeout.current);
-    hoverTimeout.current = window.setTimeout(() => setHoverCard(data), 300);
-  }
-  function clearHoverCard() {
-    if (hoverTimeout.current) window.clearTimeout(hoverTimeout.current);
-    setHoverCard(null);
-  }
+	function handleHoverCard(data: HoverCard) {
+		if (hoverTimeout.current) window.clearTimeout(hoverTimeout.current);
+		hoverTimeout.current = window.setTimeout(() => setHoverCard(data), 300);
+	}
+	function clearHoverCard() {
+		if (hoverTimeout.current) window.clearTimeout(hoverTimeout.current);
+		setHoverCard(null);
+	}
 
-  function updateMainPhaseStep(apStartOverride?: number) {
-    const total = apStartOverride ?? mainApStart;
-    const remaining = ctx.activePlayer.resources[actionCostResource] ?? 0;
-    const spent = total - remaining;
-    const steps = [
-      {
-        title: `Step 1 - Spend all ${RESOURCES[actionCostResource]?.label ?? ''}`,
-        items: [
-          {
-            text: `${RESOURCES[actionCostResource]?.icon ?? ''} ${spent}/${total} spent`,
-            done: remaining === 0,
-          },
-        ],
-        active: remaining > 0,
-      },
-    ];
-    setPhaseSteps(steps);
-    if (actionPhaseId) {
-      setPhaseHistories((prev) => ({ ...prev, [actionPhaseId]: steps }));
-      setDisplayPhase(actionPhaseId);
-    } else {
-      setDisplayPhase(ctx.game.currentPhase);
-    }
-  }
+	function updateMainPhaseStep(apStartOverride?: number) {
+		const total = apStartOverride ?? mainApStart;
+		const remaining = ctx.activePlayer.resources[actionCostResource] ?? 0;
+		const spent = total - remaining;
+		const steps = [
+			{
+				title: `Step 1 - Spend all ${RESOURCES[actionCostResource]?.label ?? ''}`,
+				items: [
+					{
+						text: `${RESOURCES[actionCostResource]?.icon ?? ''} ${spent}/${total} spent`,
+						done: remaining === 0,
+					},
+				],
+				active: remaining > 0,
+			},
+		];
+		setPhaseSteps(steps);
+		if (actionPhaseId) {
+			setPhaseHistories((prev) => ({ ...prev, [actionPhaseId]: steps }));
+			setDisplayPhase(actionPhaseId);
+		} else {
+			setDisplayPhase(ctx.game.currentPhase);
+		}
+	}
 
-  function runDelay(total: number) {
-    const scale = timeScale || 1;
-    const adjustedTotal = total / scale;
-    if (adjustedTotal <= 0) {
-      setPhaseTimer(0);
-      return Promise.resolve();
-    }
-    const tick = Math.max(16, Math.min(100, adjustedTotal / 10));
-    setPhaseTimer(0);
-    return new Promise<void>((resolve) => {
-      let elapsed = 0;
-      const interval = window.setInterval(() => {
-        if (phasePausedRef.current) return;
-        elapsed += tick;
-        setPhaseTimer(Math.min(1, elapsed / adjustedTotal));
-        if (elapsed >= adjustedTotal) {
-          window.clearInterval(interval);
-          setPhaseTimer(0);
-          resolve();
-        }
-      }, tick);
-    });
-  }
+	function runDelay(total: number) {
+		const scale = timeScale || 1;
+		const adjustedTotal = total / scale;
+		if (adjustedTotal <= 0) {
+			setPhaseTimer(0);
+			return Promise.resolve();
+		}
+		const tick = Math.max(16, Math.min(100, adjustedTotal / 10));
+		setPhaseTimer(0);
+		return new Promise<void>((resolve) => {
+			let elapsed = 0;
+			const interval = window.setInterval(() => {
+				if (phasePausedRef.current) return;
+				elapsed += tick;
+				setPhaseTimer(Math.min(1, elapsed / adjustedTotal));
+				if (elapsed >= adjustedTotal) {
+					window.clearInterval(interval);
+					setPhaseTimer(0);
+					resolve();
+				}
+			}, tick);
+		});
+	}
 
-  function runStepDelay() {
-    return runDelay(1000);
-  }
+	function runStepDelay() {
+		return runDelay(1000);
+	}
 
-  async function runUntilActionPhaseCore() {
-    setTabsEnabled(false);
-    setPhaseSteps([]);
-    setDisplayPhase(ctx.game.currentPhase);
-    setPhaseHistories({});
-    let lastPhase: string | null = null;
-    while (!ctx.phases[ctx.game.phaseIndex]?.action) {
-      const before = snapshotPlayer(ctx.activePlayer, ctx);
-      const { phase, step, player, effects } = advance(ctx);
-      const phaseDef = ctx.phases.find((p) => p.id === phase)!;
-      const stepDef = phaseDef.steps.find((s) => s.id === step);
-      if (phase !== lastPhase) {
-        await runDelay(1500);
-        setPhaseSteps([]);
-        setDisplayPhase(phase);
-        addLog(`${phaseDef.icon} ${phaseDef.label} Phase`, player);
-        lastPhase = phase;
-      }
-      const after = snapshotPlayer(player, ctx);
-      const stepWithEffects: StepDef | undefined = stepDef
-        ? ({ ...(stepDef as StepDef), effects } as StepDef)
-        : undefined;
-      const changes = diffStepSnapshots(
-        before,
-        after,
-        stepWithEffects,
-        ctx,
-        RESOURCE_KEYS,
-      );
-      if (changes.length) {
-        addLog(
-          changes.map((c) => `  ${c}`),
-          player,
-        );
-      }
-      const entry = {
-        title: stepDef?.title || step,
-        items:
-          changes.length > 0
-            ? changes.map((text) => ({ text }))
-            : [{ text: 'No effect', italic: true }],
-        active: false,
-      };
-      setPhaseSteps((prev) => [...prev, entry]);
-      setPhaseHistories((prev) => ({
-        ...prev,
-        [phase]: [...(prev[phase] ?? []), entry],
-      }));
-      await runStepDelay();
-    }
-    await runDelay(1500);
-    const start = ctx.activePlayer.resources[actionCostResource] as number;
-    setMainApStart(start);
-    updateMainPhaseStep(start);
-    setDisplayPhase(ctx.game.currentPhase);
-    setTabsEnabled(true);
-    refresh();
-  }
+	async function runUntilActionPhaseCore() {
+		setTabsEnabled(false);
+		setPhaseSteps([]);
+		setDisplayPhase(ctx.game.currentPhase);
+		setPhaseHistories({});
+		let lastPhase: string | null = null;
+		while (!ctx.phases[ctx.game.phaseIndex]?.action) {
+			const before = snapshotPlayer(ctx.activePlayer, ctx);
+			const { phase, step, player, effects } = advance(ctx);
+			const phaseDef = ctx.phases.find((p) => p.id === phase)!;
+			const stepDef = phaseDef.steps.find((s) => s.id === step);
+			if (phase !== lastPhase) {
+				await runDelay(1500);
+				setPhaseSteps([]);
+				setDisplayPhase(phase);
+				addLog(`${phaseDef.icon} ${phaseDef.label} Phase`, player);
+				lastPhase = phase;
+			}
+			const after = snapshotPlayer(player, ctx);
+			const stepWithEffects: StepDef | undefined = stepDef
+				? ({ ...(stepDef as StepDef), effects } as StepDef)
+				: undefined;
+			const changes = diffStepSnapshots(
+				before,
+				after,
+				stepWithEffects,
+				ctx,
+				RESOURCE_KEYS,
+			);
+			if (changes.length) {
+				addLog(
+					changes.map((c) => `  ${c}`),
+					player,
+				);
+			}
+			const entry = {
+				title: stepDef?.title || step,
+				items:
+					changes.length > 0
+						? changes.map((text) => ({ text }))
+						: [{ text: 'No effect', italic: true }],
+				active: false,
+			};
+			setPhaseSteps((prev) => [...prev, entry]);
+			setPhaseHistories((prev) => ({
+				...prev,
+				[phase]: [...(prev[phase] ?? []), entry],
+			}));
+			await runStepDelay();
+		}
+		await runDelay(1500);
+		const start = ctx.activePlayer.resources[actionCostResource] as number;
+		setMainApStart(start);
+		updateMainPhaseStep(start);
+		setDisplayPhase(ctx.game.currentPhase);
+		setTabsEnabled(true);
+		refresh();
+	}
 
-  const runUntilActionPhase = () => enqueue(runUntilActionPhaseCore);
+	const runUntilActionPhase = () => enqueue(runUntilActionPhaseCore);
 
-  function waitWithScale(base: number) {
-    const scale = timeScale || 1;
-    const duration = base / scale;
-    if (duration <= 0) return Promise.resolve();
-    return new Promise<void>((resolve) => {
-      window.setTimeout(() => resolve(), duration);
-    });
-  }
+	function waitWithScale(base: number) {
+		const scale = timeScale || 1;
+		const duration = base / scale;
+		if (duration <= 0) return Promise.resolve();
+		return new Promise<void>((resolve) => {
+			window.setTimeout(() => resolve(), duration);
+		});
+	}
 
-  async function logWithEffectDelay(
-    lines: string[],
-    player: EngineContext['activePlayer'],
-  ) {
-    if (!lines.length) return;
-    const [first, ...rest] = lines;
-    if (first === undefined) return;
-    addLog(first, player);
-    const delay = ACTION_EFFECT_DELAY;
-    for (const line of rest) {
-      await waitWithScale(delay);
-      addLog(line, player);
-    }
-  }
+	async function logWithEffectDelay(
+		lines: string[],
+		player: EngineContext['activePlayer'],
+	) {
+		if (!lines.length) return;
+		const [first, ...rest] = lines;
+		if (first === undefined) return;
+		addLog(first, player);
+		const delay = ACTION_EFFECT_DELAY;
+		for (const line of rest) {
+			await waitWithScale(delay);
+			addLog(line, player);
+		}
+	}
 
-  async function perform(action: Action, params?: Record<string, unknown>) {
-    const player = ctx.activePlayer;
-    const before = snapshotPlayer(player, ctx);
-    const costs = getActionCosts(
-      action.id,
-      ctx,
-      params as ActionParams<string>,
-    );
-    try {
-      const traces = performAction(
-        action.id,
-        ctx,
-        params as ActionParams<string>,
-      );
+	async function perform(action: Action, params?: Record<string, unknown>) {
+		const player = ctx.activePlayer;
+		const before = snapshotPlayer(player, ctx);
+		const costs = getActionCosts(
+			action.id,
+			ctx,
+			params as ActionParams<string>,
+		);
+		try {
+			const traces = performAction(
+				action.id,
+				ctx,
+				params as ActionParams<string>,
+			);
 
-      const after = snapshotPlayer(player, ctx);
-      const stepDef = ctx.actions.get(action.id);
-      const changes = diffStepSnapshots(
-        before,
-        after,
-        stepDef,
-        ctx,
-        RESOURCE_KEYS,
-      );
-      const messages = logContent('action', action.id, ctx, params);
-      const costLines: string[] = [];
-      for (const key of Object.keys(costs) as (keyof typeof RESOURCES)[]) {
-        const amt = costs[key] ?? 0;
-        if (!amt) continue;
-        const info = RESOURCES[key];
-        const icon = info?.icon ? `${info.icon} ` : '';
-        const label = info?.label ?? key;
-        const b = before.resources[key] ?? 0;
-        const a = b - amt;
-        costLines.push(`    ${icon}${label} -${amt} (${b}→${a})`);
-      }
-      if (costLines.length) {
-        messages.splice(1, 0, '  💲 Action cost', ...costLines);
-      }
+			const after = snapshotPlayer(player, ctx);
+			const stepDef = ctx.actions.get(action.id);
+			const changes = diffStepSnapshots(
+				before,
+				after,
+				stepDef,
+				ctx,
+				RESOURCE_KEYS,
+			);
+			const messages = logContent('action', action.id, ctx, params);
+			const costLines: string[] = [];
+			for (const key of Object.keys(costs) as (keyof typeof RESOURCES)[]) {
+				const amt = costs[key] ?? 0;
+				if (!amt) continue;
+				const info = RESOURCES[key];
+				const icon = info?.icon ? `${info.icon} ` : '';
+				const label = info?.label ?? key;
+				const b = before.resources[key] ?? 0;
+				const a = b - amt;
+				costLines.push(`    ${icon}${label} -${amt} (${b}→${a})`);
+			}
+			if (costLines.length) {
+				messages.splice(1, 0, '  💲 Action cost', ...costLines);
+			}
 
-      const normalize = (line: string) =>
-        (line.split(' (')[0] ?? '').replace(/\s[+-]?\d+$/, '').trim();
+			const normalize = (line: string) =>
+				(line.split(' (')[0] ?? '').replace(/\s[+-]?\d+$/, '').trim();
 
-      const subLines: string[] = [];
-      for (const trace of traces) {
-        const subStep = ctx.actions.get(trace.id);
-        const subChanges = diffStepSnapshots(
-          trace.before,
-          trace.after,
-          subStep,
-          ctx,
-          RESOURCE_KEYS,
-        );
-        if (!subChanges.length) continue;
-        subLines.push(...subChanges);
-        const icon = ctx.actions.get(trace.id)?.icon || '';
-        const name = ctx.actions.get(trace.id).name;
-        const line = `  ${icon} ${name}`;
-        const idx = messages.indexOf(line);
-        if (idx !== -1)
-          messages.splice(idx + 1, 0, ...subChanges.map((c) => `    ${c}`));
-      }
+			const subLines: string[] = [];
+			for (const trace of traces) {
+				const subStep = ctx.actions.get(trace.id);
+				const subChanges = diffStepSnapshots(
+					trace.before,
+					trace.after,
+					subStep,
+					ctx,
+					RESOURCE_KEYS,
+				);
+				if (!subChanges.length) continue;
+				subLines.push(...subChanges);
+				const icon = ctx.actions.get(trace.id)?.icon || '';
+				const name = ctx.actions.get(trace.id).name;
+				const line = `  ${icon} ${name}`;
+				const idx = messages.indexOf(line);
+				if (idx !== -1)
+					messages.splice(idx + 1, 0, ...subChanges.map((c) => `    ${c}`));
+			}
 
-      const subPrefixes = subLines.map(normalize);
+			const subPrefixes = subLines.map(normalize);
 
-      const messagePrefixes = new Set<string>();
-      for (const line of messages) {
-        const trimmed = line.trim();
-        if (!trimmed.startsWith('You:') && !trimmed.startsWith('Opponent:'))
-          continue;
-        const body = trimmed.slice(trimmed.indexOf(':') + 1).trim();
-        const normalized = normalize(body);
-        if (normalized) messagePrefixes.add(normalized);
-      }
+			const messagePrefixes = new Set<string>();
+			for (const line of messages) {
+				const trimmed = line.trim();
+				if (!trimmed.startsWith('You:') && !trimmed.startsWith('Opponent:'))
+					continue;
+				const body = trimmed.slice(trimmed.indexOf(':') + 1).trim();
+				const normalized = normalize(body);
+				if (normalized) messagePrefixes.add(normalized);
+			}
 
-      const costLabels = new Set(
-        Object.keys(costs) as (keyof typeof RESOURCES)[],
-      );
-      const filtered = changes.filter((line) => {
-        const normalizedLine = normalize(line);
-        if (messagePrefixes.has(normalizedLine)) return false;
-        if (subPrefixes.includes(normalizedLine)) return false;
-        for (const key of costLabels) {
-          const info = RESOURCES[key];
-          const prefix = info?.icon ? `${info.icon} ${info.label}` : info.label;
-          if (line.startsWith(prefix)) return false;
-        }
-        return true;
-      });
-      const logLines = [...messages, ...filtered.map((c) => `  ${c}`)];
+			const costLabels = new Set(
+				Object.keys(costs) as (keyof typeof RESOURCES)[],
+			);
+			const filtered = changes.filter((line) => {
+				const normalizedLine = normalize(line);
+				if (messagePrefixes.has(normalizedLine)) return false;
+				if (subPrefixes.includes(normalizedLine)) return false;
+				for (const key of costLabels) {
+					const info = RESOURCES[key];
+					const prefix = info?.icon ? `${info.icon} ${info.label}` : info.label;
+					if (line.startsWith(prefix)) return false;
+				}
+				return true;
+			});
+			const logLines = [...messages, ...filtered.map((c) => `  ${c}`)];
 
-      updateMainPhaseStep();
-      refresh();
+			updateMainPhaseStep();
+			refresh();
 
-      await logWithEffectDelay(logLines, player);
+			await logWithEffectDelay(logLines, player);
 
-      if (
-        ctx.game.devMode &&
-        (ctx.activePlayer.resources[actionCostResource] ?? 0) <= 0
-      ) {
-        await endTurn();
-      }
-    } catch (e) {
-      const icon = ctx.actions.get(action.id)?.icon || '';
-      addLog(
-        `Failed to play ${icon} ${action.name}: ${(e as Error).message}`,
-        player,
-      );
-      return;
-    }
-  }
+			if (
+				ctx.game.devMode &&
+				(ctx.activePlayer.resources[actionCostResource] ?? 0) <= 0
+			) {
+				await endTurn();
+			}
+		} catch (e) {
+			const icon = ctx.actions.get(action.id)?.icon || '';
+			addLog(
+				`Failed to play ${icon} ${action.name}: ${(e as Error).message}`,
+				player,
+			);
+			return;
+		}
+	}
 
-  const handlePerform = (action: Action, params?: Record<string, unknown>) =>
-    enqueue(() => perform(action, params));
+	const handlePerform = (action: Action, params?: Record<string, unknown>) =>
+		enqueue(() => perform(action, params));
 
-  const performRef = useRef<typeof perform>(perform);
-  useEffect(() => {
-    performRef.current = perform;
-  }, [perform]);
+	const performRef = useRef<typeof perform>(perform);
+	useEffect(() => {
+		performRef.current = perform;
+	}, [perform]);
 
-  async function endTurn() {
-    const phaseDef = ctx.phases[ctx.game.phaseIndex];
-    if (!phaseDef?.action) return;
-    if ((ctx.activePlayer.resources[actionCostResource] ?? 0) > 0) return;
-    advance(ctx);
-    setPhaseHistories({});
-    await runUntilActionPhaseCore();
-  }
+	async function endTurn() {
+		const phaseDef = ctx.phases[ctx.game.phaseIndex];
+		if (!phaseDef?.action) return;
+		if ((ctx.activePlayer.resources[actionCostResource] ?? 0) > 0) return;
+		advance(ctx);
+		setPhaseHistories({});
+		await runUntilActionPhaseCore();
+	}
 
-  const handleEndTurn = () => enqueue(endTurn);
+	const handleEndTurn = () => enqueue(endTurn);
 
-  // Update main phase steps once action phase becomes active
-  useEffect(() => {
-    if (ctx.phases[ctx.game.phaseIndex]?.action) {
-      const start = ctx.activePlayer.resources[actionCostResource] as number;
-      setMainApStart(start);
-      updateMainPhaseStep(start);
-    }
-  }, [ctx.game.phaseIndex]);
+	// Update main phase steps once action phase becomes active
+	useEffect(() => {
+		if (ctx.phases[ctx.game.phaseIndex]?.action) {
+			const start = ctx.activePlayer.resources[actionCostResource] as number;
+			setMainApStart(start);
+			updateMainPhaseStep(start);
+		}
+	}, [ctx.game.phaseIndex]);
 
-  useEffect(() => {
-    void runUntilActionPhase();
-  }, []);
+	useEffect(() => {
+		void runUntilActionPhase();
+	}, []);
 
-  useEffect(() => {
-    const phaseDef = ctx.phases[ctx.game.phaseIndex];
-    if (!phaseDef?.action) return;
-    const ai = ctx.ai;
-    const activeId = ctx.activePlayer.id;
-    if (!ai?.has(activeId)) return;
-    void ctx.enqueue(async () => {
-      await ai.run(activeId, ctx, {
-        performAction: async (actionId, engineCtx, params) => {
-          const definition = engineCtx.actions.get(actionId);
-          if (!definition)
-            throw new Error(`Unknown action ${String(actionId)} for AI`);
-          const action: Action = {
-            id: definition.id,
-            name: definition.name,
-          };
-          if (definition.system !== undefined)
-            action.system = definition.system;
-          await performRef.current(action, params as Record<string, unknown>);
-        },
-        advance: (engineCtx) => {
-          advance(engineCtx);
-        },
-      });
-      setPhaseHistories({});
-      await runUntilActionPhaseCore();
-    });
-  }, [ctx.ai, ctx.game.phaseIndex, ctx.activePlayer.id, ctx]);
+	useEffect(() => {
+		const phaseDef = ctx.phases[ctx.game.phaseIndex];
+		if (!phaseDef?.action) return;
+		const aiSystem = ctx.aiSystem;
+		const activeId = ctx.activePlayer.id;
+		if (!aiSystem?.has(activeId)) return;
+		void ctx.enqueue(async () => {
+			await aiSystem.run(activeId, ctx, {
+				performAction: async (
+					actionId: string,
+					engineCtx: EngineContext,
+					params?: ActionParams<string>,
+				) => {
+					const definition = engineCtx.actions.get(actionId);
+					if (!definition)
+						throw new Error(`Unknown action ${String(actionId)} for AI`);
+					const action: Action = {
+						id: definition.id,
+						name: definition.name,
+					};
+					if (definition.system !== undefined)
+						action.system = definition.system;
+					await performRef.current(action, params as Record<string, unknown>);
+				},
+				advance: (engineCtx: EngineContext) => {
+					advance(engineCtx);
+				},
+			});
+			setPhaseHistories({});
+			await runUntilActionPhaseCore();
+		});
+	}, [ctx.aiSystem, ctx.game.phaseIndex, ctx.activePlayer.id, ctx]);
 
-  const value: GameEngineContextValue = {
-    ctx,
-    log,
-    hoverCard,
-    handleHoverCard,
-    clearHoverCard,
-    phaseSteps,
-    setPhaseSteps,
-    phaseTimer,
-    phasePaused,
-    setPaused,
-    mainApStart,
-    displayPhase,
-    setDisplayPhase,
-    phaseHistories,
-    tabsEnabled,
-    actionCostResource,
-    handlePerform,
-    runUntilActionPhase,
-    handleEndTurn,
-    updateMainPhaseStep,
-    darkMode,
-    onToggleDark,
-    timeScale,
-    setTimeScale: changeTimeScale,
-    ...(onExit ? { onExit } : {}),
-  };
+	const value: GameEngineContextValue = {
+		ctx,
+		log,
+		hoverCard,
+		handleHoverCard,
+		clearHoverCard,
+		phaseSteps,
+		setPhaseSteps,
+		phaseTimer,
+		phasePaused,
+		setPaused,
+		mainApStart,
+		displayPhase,
+		setDisplayPhase,
+		phaseHistories,
+		tabsEnabled,
+		actionCostResource,
+		handlePerform,
+		runUntilActionPhase,
+		handleEndTurn,
+		updateMainPhaseStep,
+		darkMode,
+		onToggleDark,
+		timeScale,
+		setTimeScale: changeTimeScale,
+		...(onExit ? { onExit } : {}),
+	};
 
-  return (
-    <GameEngineContext.Provider value={value}>
-      {children}
-    </GameEngineContext.Provider>
-  );
+	return (
+		<GameEngineContext.Provider value={value}>
+			{children}
+		</GameEngineContext.Provider>
+	);
 }
 
 export const useGameEngine = (): GameEngineContextValue => {
-  const value = useContext(GameEngineContext);
-  if (!value) throw new Error('useGameEngine must be used within GameProvider');
-  return value;
+	const value = useContext(GameEngineContext);
+	if (!value) throw new Error('useGameEngine must be used within GameProvider');
+	return value;
 };


### PR DESCRIPTION
## Summary
- Reformat `EngineContext` with tab indentation, clearer queue naming, and braces around conditional bodies. 【F:packages/engine/src/context.ts†L1-L80】
- Rename the engine AI handle to `aiSystem` and update web consumers with explicit parameter types. 【F:packages/engine/src/index.ts†L422-L449】【F:packages/web/src/state/GameContext.tsx†L520-L598】
- Add a compatibility re-export for stat source utilities. 【F:packages/engine/src/stat_sources.ts†L1-L1】

## Testing
- npm run test:coverage 【6ab46f†L1-L62】

------
https://chatgpt.com/codex/tasks/task_e_68dc1c8c1e1c8325ac6e2b1271b4fa6a