### PR TITLE
Restyle game interface to match landing page

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -9,93 +9,110 @@ import Button from './components/common/Button';
 import TimeControl from './components/common/TimeControl';
 
 function GameLayout() {
-  const { ctx, onExit, darkMode, onToggleDark } = useGameEngine();
-  return (
-    <div className="p-4 w-full bg-slate-100 text-gray-900 dark:bg-slate-900 dark:text-gray-100 min-h-screen">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-center flex-1">
-          Kingdom Builder
-        </h1>
-        {onExit && (
-          <div className="flex items-center gap-3 ml-4">
-            <TimeControl />
-            <Button onClick={onToggleDark} variant="secondary">
-              {darkMode ? 'Light Mode' : 'Dark Mode'}
-            </Button>
-            <Button onClick={onExit} variant="danger">
-              Quit
-            </Button>
-          </div>
-        )}
-      </div>
+	const { ctx, onExit, darkMode, onToggleDark } = useGameEngine();
+	return (
+		<div className="relative min-h-screen w-full overflow-hidden bg-gradient-to-br from-amber-100 via-rose-100 to-sky-100 text-slate-900 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 dark:text-slate-100">
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-amber-300/30 blur-3xl dark:bg-amber-500/20" />
+				<div className="absolute -bottom-28 -left-16 h-80 w-80 rounded-full bg-sky-300/30 blur-3xl dark:bg-sky-500/20" />
+				<div className="absolute top-1/4 right-0 h-72 w-72 translate-x-1/3 rounded-full bg-rose-300/30 blur-3xl dark:bg-rose-500/20" />
+				<div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.55),_rgba(255,255,255,0)_55%)] dark:bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.6),_rgba(15,23,42,0)_60%)]" />
+			</div>
 
-      <div className="grid gap-x-4 gap-y-6 grid-cols-1 sm:grid-cols-1 lg:grid-cols-[minmax(0,1fr)_30rem]">
-        <section className="border rounded bg-white dark:bg-gray-800 shadow flex min-h-[275px]">
-          <div className="flex flex-1 items-stretch rounded overflow-hidden divide-x divide-black/10 dark:divide-white/10">
-            {ctx.game.players.map((p, i) => {
-              const isActive = p.id === ctx.activePlayer.id;
-              const sideClass = i === 0 ? 'pr-6' : 'pl-6';
-              const colorClass =
-                i === 0
-                  ? isActive
-                    ? 'player-bg-blue-active'
-                    : 'player-bg-blue'
-                  : isActive
-                    ? 'player-bg-red-active'
-                    : 'player-bg-red';
-              const bgClass = [
-                'player-bg',
-                sideClass,
-                colorClass,
-                isActive ? 'player-bg-animated' : null,
-              ]
-                .filter(Boolean)
-                .join(' ');
-              return (
-                <PlayerPanel
-                  key={p.id}
-                  player={p}
-                  className={`flex-1 p-4 ${bgClass}`}
-                  isActive={isActive}
-                />
-              );
-            })}
-          </div>
-        </section>
-        <div className="w-full lg:col-start-2">
-          <PhasePanel />
-        </div>
-        <div className="lg:col-start-1 lg:row-start-2">
-          <ActionsPanel />
-        </div>
-        <div className="w-full flex flex-col gap-6 lg:col-start-2 lg:row-start-2">
-          <LogPanel />
-          <HoverCard />
-        </div>
-      </div>
-    </div>
-  );
+			<div className="relative z-10 flex min-h-screen flex-col gap-8 px-4 py-8 sm:px-8 lg:px-12">
+				<div className="mb-4 flex items-center justify-between rounded-3xl border border-white/50 bg-white/70 px-6 py-4 shadow-xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/40">
+					<h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+						Kingdom Builder
+					</h1>
+					{onExit && (
+						<div className="ml-4 flex items-center gap-3">
+							<TimeControl />
+							<Button
+								onClick={onToggleDark}
+								variant="secondary"
+								className="rounded-full px-4 py-2 text-sm font-semibold shadow-lg shadow-slate-900/10 dark:shadow-black/30"
+							>
+								{darkMode ? 'Light Mode' : 'Dark Mode'}
+							</Button>
+							<Button
+								onClick={onExit}
+								variant="danger"
+								className="rounded-full px-4 py-2 text-sm font-semibold shadow-lg shadow-rose-500/30"
+							>
+								Quit
+							</Button>
+						</div>
+					)}
+				</div>
+
+				<div className="grid grid-cols-1 gap-y-6 gap-x-6 lg:grid-cols-[minmax(0,1fr)_30rem]">
+					<section className="relative flex min-h-[275px] items-stretch rounded-3xl border border-white/60 bg-white/70 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/50">
+						<div className="flex flex-1 items-stretch overflow-hidden rounded-3xl divide-x divide-white/50 dark:divide-white/10">
+							{ctx.game.players.map((p, i) => {
+								const isActive = p.id === ctx.activePlayer.id;
+								const sideClass = i === 0 ? 'pr-6' : 'pl-6';
+								const colorClass =
+									i === 0
+										? isActive
+											? 'player-bg-blue-active'
+											: 'player-bg-blue'
+										: isActive
+											? 'player-bg-red-active'
+											: 'player-bg-red';
+								const bgClass = [
+									'player-bg',
+									sideClass,
+									colorClass,
+									isActive ? 'player-bg-animated' : null,
+								]
+									.filter(Boolean)
+									.join(' ');
+								return (
+									<PlayerPanel
+										key={p.id}
+										player={p}
+										className={`flex-1 p-4 ${bgClass}`}
+										isActive={isActive}
+									/>
+								);
+							})}
+						</div>
+					</section>
+					<div className="w-full lg:col-start-2">
+						<PhasePanel />
+					</div>
+					<div className="lg:col-start-1 lg:row-start-2">
+						<ActionsPanel />
+					</div>
+					<div className="flex w-full flex-col gap-6 lg:col-start-2 lg:row-start-2">
+						<LogPanel />
+						<HoverCard />
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }
 
 export default function Game({
-  onExit,
-  darkMode = true,
-  onToggleDark = () => {},
-  devMode = false,
+	onExit,
+	darkMode = true,
+	onToggleDark = () => {},
+	devMode = false,
 }: {
-  onExit?: () => void;
-  darkMode?: boolean;
-  onToggleDark?: () => void;
-  devMode?: boolean;
+	onExit?: () => void;
+	darkMode?: boolean;
+	onToggleDark?: () => void;
+	devMode?: boolean;
 }) {
-  return (
-    <GameProvider
-      {...(onExit ? { onExit } : {})}
-      darkMode={darkMode}
-      onToggleDark={onToggleDark}
-      devMode={devMode}
-    >
-      <GameLayout />
-    </GameProvider>
-  );
+	return (
+		<GameProvider
+			{...(onExit ? { onExit } : {})}
+			darkMode={darkMode}
+			onToggleDark={onToggleDark}
+			devMode={devMode}
+		>
+			<GameLayout />
+		</GameProvider>
+	);
 }

--- a/packages/web/src/components/HoverCard.tsx
+++ b/packages/web/src/components/HoverCard.tsx
@@ -3,71 +3,87 @@ import { renderSummary, renderCosts } from '../translation/render';
 import { useGameEngine } from '../state/GameContext';
 
 export default function HoverCard() {
-  const {
-    hoverCard: data,
-    clearHoverCard,
-    ctx,
-    actionCostResource,
-  } = useGameEngine();
-  if (!data) return null;
-  return (
-    <div
-      className={`border rounded p-4 shadow relative pointer-events-none w-full ${
-        data.bgClass || 'bg-white dark:bg-gray-800'
-      }`}
-      onMouseLeave={clearHoverCard}
-    >
-      <div className="font-semibold mb-2">
-        {data.title}
-        <div className="absolute top-2 right-2">
-          {renderCosts(
-            data.costs,
-            ctx.activePlayer.resources,
-            actionCostResource,
-            data.upkeep,
-          )}
-        </div>
-      </div>
-      {data.effects.length > 0 && (
-        <div className="mb-2">
-          <div className="font-semibold">{data.effectsTitle ?? 'Effects'}</div>
-          <ul className="list-disc pl-4 text-sm">
-            {renderSummary(data.effects)}
-          </ul>
-        </div>
-      )}
-      {(() => {
-        const desc = data.description;
-        const hasDescription =
-          typeof desc === 'string'
-            ? desc.trim().length > 0
-            : Array.isArray(desc) && desc.length > 0;
-        if (!hasDescription) return null;
-        return (
-          <div className="mt-2">
-            <div className={`font-semibold ${data.descriptionClass ?? ''}`}>
-              {data.descriptionTitle ?? 'Description'}
-            </div>
-            {typeof desc === 'string' ? (
-              <div className={`text-sm ${data.descriptionClass ?? ''}`}>
-                {desc}
-              </div>
-            ) : (
-              <ul className="list-disc pl-4 text-sm">{renderSummary(desc)}</ul>
-            )}
-          </div>
-        );
-      })()}
-      {data.requirements.length > 0 && (
-        <div className="text-sm text-red-600 mt-2">
-          <div className="font-semibold text-red-600">Requirements</div>
-          <ul className="list-disc pl-4">
-            {data.requirements.map((r, i) => (
-              <li key={i}>{r}</li>
-            ))}
-          </ul>
-        </div>
-      )}
-    </div>
-  );
+	const {
+		hoverCard: data,
+		clearHoverCard,
+		ctx,
+		actionCostResource,
+	} = useGameEngine();
+	if (!data) return null;
+	return (
+		<div
+			className={`pointer-events-none w-full rounded-3xl border border-white/60 bg-white/80 p-6 shadow-2xl shadow-amber-500/10 backdrop-blur-xl transition dark:border-white/10 dark:bg-slate-900/80 dark:shadow-slate-900/60 ${
+				data.bgClass ?? ''
+			}`}
+			onMouseLeave={clearHoverCard}
+		>
+			<div className="mb-3 flex items-start justify-between gap-4">
+				<div className="text-lg font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+					{data.title}
+				</div>
+				<div className="text-right text-sm text-slate-600 dark:text-slate-300">
+					{renderCosts(
+						data.costs,
+						ctx.activePlayer.resources,
+						actionCostResource,
+						data.upkeep,
+					)}
+				</div>
+			</div>
+			{data.effects.length > 0 && (
+				<div className="mb-2">
+					<div className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-300">
+						{data.effectsTitle ?? 'Effects'}
+					</div>
+					<ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-slate-700 dark:text-slate-200">
+						{renderSummary(data.effects)}
+					</ul>
+				</div>
+			)}
+			{(() => {
+				const desc = data.description;
+				const hasDescription =
+					typeof desc === 'string'
+						? desc.trim().length > 0
+						: Array.isArray(desc) && desc.length > 0;
+				if (!hasDescription) return null;
+				return (
+					<div className="mt-2">
+						<div
+							className={`text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-300 ${
+								data.descriptionClass ?? ''
+							}`}
+						>
+							{data.descriptionTitle ?? 'Description'}
+						</div>
+						{typeof desc === 'string' ? (
+							<div
+								className={`mt-1 text-sm text-slate-700 dark:text-slate-200 ${
+									data.descriptionClass ?? ''
+								}`}
+							>
+								{desc}
+							</div>
+						) : (
+							<ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-slate-700 dark:text-slate-200">
+								{renderSummary(desc)}
+							</ul>
+						)}
+					</div>
+				);
+			})()}
+			{data.requirements.length > 0 && (
+				<div className="mt-2 text-sm text-rose-600 dark:text-rose-300">
+					<div className="text-xs font-semibold uppercase tracking-[0.3em]">
+						Requirements
+					</div>
+					<ul className="mt-1 list-disc space-y-1 pl-5">
+						{data.requirements.map((r, i) => (
+							<li key={i}>{r}</li>
+						))}
+					</ul>
+				</div>
+			)}
+		</div>
+	);
 }

--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -3,214 +3,214 @@ import { useGameEngine } from '../state/GameContext';
 import { useAnimate } from '../utils/useAutoAnimate';
 
 export default function LogPanel() {
-  const { log: entries, ctx } = useGameEngine();
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const listRef = useAnimate<HTMLUListElement>();
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [isOverlay, setIsOverlay] = useState(false);
-  const [collapsedSize, setCollapsedSize] = useState<{
-    width: number;
-    height: number;
-  } | null>(null);
-  const [expandedBase, setExpandedBase] = useState<{
-    width: number;
-    height: number;
-  } | null>(null);
-  const [overlayOffsets, setOverlayOffsets] = useState<{
-    top: number;
-    right: number;
-  } | null>(null);
-  const [viewport, setViewport] = useState(() => ({
-    width: typeof window === 'undefined' ? 0 : window.innerWidth,
-    height: typeof window === 'undefined' ? 0 : window.innerHeight,
-  }));
+	const { log: entries, ctx } = useGameEngine();
+	const wrapperRef = useRef<HTMLDivElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const listRef = useAnimate<HTMLUListElement>();
+	const [isExpanded, setIsExpanded] = useState(false);
+	const [isOverlay, setIsOverlay] = useState(false);
+	const [collapsedSize, setCollapsedSize] = useState<{
+		width: number;
+		height: number;
+	} | null>(null);
+	const [expandedBase, setExpandedBase] = useState<{
+		width: number;
+		height: number;
+	} | null>(null);
+	const [overlayOffsets, setOverlayOffsets] = useState<{
+		top: number;
+		right: number;
+	} | null>(null);
+	const [viewport, setViewport] = useState(() => ({
+		width: typeof window === 'undefined' ? 0 : window.innerWidth,
+		height: typeof window === 'undefined' ? 0 : window.innerHeight,
+	}));
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const handleResize = () => {
-      setViewport({ width: window.innerWidth, height: window.innerHeight });
-    };
-    window.addEventListener('resize', handleResize);
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
+	useEffect(() => {
+		if (typeof window === 'undefined') return;
+		const handleResize = () => {
+			setViewport({ width: window.innerWidth, height: window.innerHeight });
+		};
+		window.addEventListener('resize', handleResize);
+		return () => {
+			window.removeEventListener('resize', handleResize);
+		};
+	}, []);
 
-  useEffect(() => {
-    if (isExpanded) return;
-    const node = containerRef.current;
-    const wrapper = wrapperRef.current;
-    if (!node || !wrapper) return;
-    const rect = node.getBoundingClientRect();
-    const wrapperRect = wrapper.getBoundingClientRect();
-    setCollapsedSize({ width: rect.width, height: rect.height });
-    setOverlayOffsets({
-      top: rect.top - wrapperRect.top,
-      right: wrapperRect.right - rect.right,
-    });
-  }, [entries, isExpanded, viewport.height, viewport.width]);
+	useEffect(() => {
+		if (isExpanded) return;
+		const node = containerRef.current;
+		const wrapper = wrapperRef.current;
+		if (!node || !wrapper) return;
+		const rect = node.getBoundingClientRect();
+		const wrapperRect = wrapper.getBoundingClientRect();
+		setCollapsedSize({ width: rect.width, height: rect.height });
+		setOverlayOffsets({
+			top: rect.top - wrapperRect.top,
+			right: wrapperRect.right - rect.right,
+		});
+	}, [entries, isExpanded, viewport.height, viewport.width]);
 
-  const clampDimension = (target: number, viewportLimit: number) => {
-    if (viewportLimit <= 0) return target;
-    return Math.min(target, viewportLimit);
-  };
+	const clampDimension = (target: number, viewportLimit: number) => {
+		if (viewportLimit <= 0) return target;
+		return Math.min(target, viewportLimit);
+	};
 
-  const expandedStyle =
-    isExpanded && expandedBase
-      ? {
-          width: `${clampDimension(
-            expandedBase.width,
-            viewport.width > 32 ? viewport.width - 32 : viewport.width,
-          )}px`,
-          height: `${clampDimension(
-            expandedBase.height,
-            viewport.height > 32 ? viewport.height - 32 : viewport.height,
-          )}px`,
-        }
-      : undefined;
+	const expandedStyle =
+		isExpanded && expandedBase
+			? {
+					width: `${clampDimension(
+						expandedBase.width,
+						viewport.width > 32 ? viewport.width - 32 : viewport.width,
+					)}px`,
+					height: `${clampDimension(
+						expandedBase.height,
+						viewport.height > 32 ? viewport.height - 32 : viewport.height,
+					)}px`,
+				}
+			: undefined;
 
-  const handleToggleExpand = () => {
-    const node = containerRef.current;
-    const wrapper = wrapperRef.current;
-    if (!node || !wrapper) return;
+	const handleToggleExpand = () => {
+		const node = containerRef.current;
+		const wrapper = wrapperRef.current;
+		if (!node || !wrapper) return;
 
-    if (!isExpanded) {
-      const rect = node.getBoundingClientRect();
-      const wrapperRect = wrapper.getBoundingClientRect();
-      setCollapsedSize({ width: rect.width, height: rect.height });
-      setOverlayOffsets({
-        top: rect.top - wrapperRect.top,
-        right: wrapperRect.right - rect.right,
-      });
-      setExpandedBase({ width: rect.width * 2, height: rect.height * 4 });
-      setIsOverlay(true);
-      setIsExpanded(true);
-      return;
-    }
+		if (!isExpanded) {
+			const rect = node.getBoundingClientRect();
+			const wrapperRect = wrapper.getBoundingClientRect();
+			setCollapsedSize({ width: rect.width, height: rect.height });
+			setOverlayOffsets({
+				top: rect.top - wrapperRect.top,
+				right: wrapperRect.right - rect.right,
+			});
+			setExpandedBase({ width: rect.width * 2, height: rect.height * 4 });
+			setIsOverlay(true);
+			setIsExpanded(true);
+			return;
+		}
 
-    setIsExpanded(false);
-    setExpandedBase(null);
-  };
+		setIsExpanded(false);
+		setExpandedBase(null);
+	};
 
-  useEffect(() => {
-    if (!isExpanded) return;
-    setIsOverlay(true);
-  }, [isExpanded]);
+	useEffect(() => {
+		if (!isExpanded) return;
+		setIsOverlay(true);
+	}, [isExpanded]);
 
-  const handleTransitionEnd = (event: React.TransitionEvent<HTMLDivElement>) => {
-    if (event.target !== event.currentTarget) return;
-    if (isExpanded || !isOverlay) return;
-    setIsOverlay(false);
-    setOverlayOffsets(null);
-  };
+	const handleTransitionEnd = (
+		event: React.TransitionEvent<HTMLDivElement>,
+	) => {
+		if (event.target !== event.currentTarget) return;
+		if (isExpanded || !isOverlay) return;
+		setIsOverlay(false);
+		setOverlayOffsets(null);
+	};
 
-  useEffect(() => {
-    const container = containerRef.current;
-    const list = listRef.current;
-    if (!container || !list) return;
+	useEffect(() => {
+		const container = containerRef.current;
+		const list = listRef.current;
+		if (!container || !list) return;
 
-    const scrollToBottom = (behavior: ScrollBehavior) => {
-      if (container.scrollHeight > container.clientHeight)
-        container.scrollTo({ top: container.scrollHeight, behavior });
-    };
+		const scrollToBottom = (behavior: ScrollBehavior) => {
+			if (container.scrollHeight > container.clientHeight)
+				container.scrollTo({ top: container.scrollHeight, behavior });
+		};
 
-    const animations =
-      typeof list.getAnimations === 'function' ? list.getAnimations() : [];
-    if (animations.length === 0) {
-      scrollToBottom('smooth');
-      return;
-    }
+		const animations =
+			typeof list.getAnimations === 'function' ? list.getAnimations() : [];
+		if (animations.length === 0) {
+			scrollToBottom('smooth');
+			return;
+		}
 
-    let cancelled = false;
-    const finished = animations.map((animation) =>
-      animation.finished.catch(() => undefined),
-    );
+		let cancelled = false;
+		const finished = animations.map((animation) =>
+			animation.finished.catch(() => undefined),
+		);
 
-    void Promise.all(finished).then(() => {
-      if (!cancelled) scrollToBottom('smooth');
-    });
+		void Promise.all(finished).then(() => {
+			if (!cancelled) scrollToBottom('smooth');
+		});
 
-    return () => {
-      cancelled = true;
-    };
-  }, [entries]);
+		return () => {
+			cancelled = true;
+		};
+	}, [entries]);
 
-  return (
-    <div
-      ref={wrapperRef}
-      className={`relative ${isExpanded || isOverlay ? 'z-50' : ''}`}
-      style={
-        collapsedSize && collapsedSize.height
-          ? { minHeight: `${collapsedSize.height}px` }
-          : undefined
-      }
-    >
-      <div
-        ref={containerRef}
-        className={`border rounded bg-white dark:bg-gray-800 shadow transition-all duration-300 ease-in-out ${
-          isOverlay ? 'absolute left-auto' : 'w-full'
-        } ${
-          isExpanded
-            ? 'overflow-auto p-6 shadow-2xl'
-            : 'p-4 overflow-y-auto max-h-80'
-        }`}
-        style={{
-          ...(expandedStyle ?? {}),
-          ...(!isExpanded && isOverlay && collapsedSize
-            ? {
-                width: `${collapsedSize.width}px`,
-                height: `${collapsedSize.height}px`,
-              }
-            : {}),
-          ...(isOverlay && overlayOffsets
-            ? {
-                top: `${overlayOffsets.top}px`,
-                right: `${overlayOffsets.right}px`,
-              }
-            : {}),
-        }}
-        onTransitionEnd={handleTransitionEnd}
-      >
-        <div className="flex items-center justify-between gap-2">
-          <h2 className="text-xl font-semibold">Log</h2>
-          <button
-            type="button"
-            onClick={handleToggleExpand}
-            aria-label={isExpanded ? 'Collapse log panel' : 'Expand log panel'}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent bg-slate-200 text-slate-700 hover:bg-slate-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-indigo-500 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:focus-visible:ring-offset-gray-800"
-          >
-            <span aria-hidden="true" className="text-lg leading-none">
-              {isExpanded ? '⤡' : '⛶'}
-            </span>
-          </button>
-        </div>
-        <ul
-          ref={listRef}
-          className={`mt-2 ${isExpanded ? 'space-y-2' : 'space-y-1'}`}
-        >
-          {entries.map((entry, idx) => {
-            const aId = ctx.game.players[0]?.id;
-            const bId = ctx.game.players[1]?.id;
-            const colorClass =
-              entry.playerId === aId
-                ? 'log-entry-a'
-                : entry.playerId === bId
-                  ? 'log-entry-b'
-                  : '';
-            return (
-              <li
-                key={idx}
-                className={`${
-                  isExpanded ? 'text-sm leading-relaxed' : 'text-xs'
-                } font-mono whitespace-pre-wrap ${colorClass}`}
-              >
-                [{entry.time}] {entry.text}
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-    </div>
-  );
+	return (
+		<div
+			ref={wrapperRef}
+			className={`relative ${isExpanded || isOverlay ? 'z-50' : ''}`}
+			style={
+				collapsedSize && collapsedSize.height
+					? { minHeight: `${collapsedSize.height}px` }
+					: undefined
+			}
+		>
+			<div
+				ref={containerRef}
+				className={`relative rounded-3xl border border-white/60 bg-white/75 shadow-2xl shadow-amber-500/10 backdrop-blur-xl transition-all duration-300 ease-in-out dark:border-white/10 dark:bg-slate-900/75 dark:shadow-slate-900/50 ${
+					isOverlay ? 'absolute left-auto' : 'w-full'
+				} ${isExpanded ? 'overflow-auto p-6' : 'max-h-80 overflow-y-auto p-4'}`}
+				style={{
+					...(expandedStyle ?? {}),
+					...(!isExpanded && isOverlay && collapsedSize
+						? {
+								width: `${collapsedSize.width}px`,
+								height: `${collapsedSize.height}px`,
+							}
+						: {}),
+					...(isOverlay && overlayOffsets
+						? {
+								top: `${overlayOffsets.top}px`,
+								right: `${overlayOffsets.right}px`,
+							}
+						: {}),
+				}}
+				onTransitionEnd={handleTransitionEnd}
+			>
+				<div className="flex items-center justify-between gap-2">
+					<h2 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+						Log
+					</h2>
+					<button
+						type="button"
+						onClick={handleToggleExpand}
+						aria-label={isExpanded ? 'Collapse log panel' : 'Expand log panel'}
+						className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/60 bg-white/80 text-lg font-semibold text-slate-700 shadow hover:bg-white/90 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-100 dark:hover:bg-slate-900"
+					>
+						<span aria-hidden="true" className="text-lg leading-none">
+							{isExpanded ? '⤡' : '⛶'}
+						</span>
+					</button>
+				</div>
+				<ul
+					ref={listRef}
+					className={`mt-3 ${isExpanded ? 'space-y-3 text-sm' : 'space-y-2 text-xs'} text-slate-700 dark:text-slate-200`}
+				>
+					{entries.map((entry, idx) => {
+						const aId = ctx.game.players[0]?.id;
+						const bId = ctx.game.players[1]?.id;
+						const colorClass =
+							entry.playerId === aId
+								? 'log-entry-a'
+								: entry.playerId === bId
+									? 'log-entry-b'
+									: '';
+						return (
+							<li
+								key={idx}
+								className={`${
+									isExpanded ? 'text-sm leading-relaxed' : 'text-xs'
+								} font-mono whitespace-pre-wrap ${colorClass}`}
+							>
+								[{entry.time}] {entry.text}
+							</li>
+						);
+					})}
+				</ul>
+			</div>
+		</div>
+	);
 }

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -4,115 +4,117 @@ import { renderSummary, renderCosts } from '../../translation/render';
 import type { Focus } from '@kingdom-builder/contents';
 
 function stripSummary(
-  summary: Summary | undefined,
-  requirements: readonly string[],
+	summary: Summary | undefined,
+	requirements: readonly string[],
 ): Summary | undefined {
-  const first = summary?.[0];
-  const baseSummary = !first
-    ? summary
-    : typeof first === 'string'
-      ? summary
-      : first.items;
-  if (!baseSummary) return baseSummary;
-  if (requirements.length === 0) return baseSummary;
-  const requirementSet = new Set(
-    requirements.map((req) => req.trim()).filter((req) => req.length > 0),
-  );
-  const filterEntries = (entries: Summary): Summary => {
-    const filtered: Summary = [];
-    for (const entry of entries) {
-      if (typeof entry === 'string') {
-        if (requirementSet.has(entry.trim())) continue;
-        filtered.push(entry);
-      } else {
-        const nested = filterEntries(entry.items);
-        if (nested.length > 0) {
-          filtered.push({ ...entry, items: nested });
-        }
-      }
-    }
-    return filtered;
-  };
-  const filtered = filterEntries(baseSummary);
-  return filtered.length > 0 ? filtered : undefined;
+	const first = summary?.[0];
+	const baseSummary = !first
+		? summary
+		: typeof first === 'string'
+			? summary
+			: first.items;
+	if (!baseSummary) return baseSummary;
+	if (requirements.length === 0) return baseSummary;
+	const requirementSet = new Set(
+		requirements.map((req) => req.trim()).filter((req) => req.length > 0),
+	);
+	const filterEntries = (entries: Summary): Summary => {
+		const filtered: Summary = [];
+		for (const entry of entries) {
+			if (typeof entry === 'string') {
+				if (requirementSet.has(entry.trim())) continue;
+				filtered.push(entry);
+			} else {
+				const nested = filterEntries(entry.items);
+				if (nested.length > 0) {
+					filtered.push({ ...entry, items: nested });
+				}
+			}
+		}
+		return filtered;
+	};
+	const filtered = filterEntries(baseSummary);
+	return filtered.length > 0 ? filtered : undefined;
 }
 
 export type ActionCardProps = {
-  title: React.ReactNode;
-  costs: Record<string, number>;
-  playerResources: Record<string, number>;
-  actionCostResource: string;
-  upkeep?: Record<string, number> | undefined;
-  summary?: Summary | undefined;
-  implemented?: boolean;
-  enabled: boolean;
-  tooltip?: string | undefined;
-  requirements?: string[];
-  requirementIcons?: string[];
-  onClick?: () => void;
-  onMouseEnter?: () => void;
-  onMouseLeave?: () => void;
-  focus?: Focus | undefined;
+	title: React.ReactNode;
+	costs: Record<string, number>;
+	playerResources: Record<string, number>;
+	actionCostResource: string;
+	upkeep?: Record<string, number> | undefined;
+	summary?: Summary | undefined;
+	implemented?: boolean;
+	enabled: boolean;
+	tooltip?: string | undefined;
+	requirements?: string[];
+	requirementIcons?: string[];
+	onClick?: () => void;
+	onMouseEnter?: () => void;
+	onMouseLeave?: () => void;
+	focus?: Focus | undefined;
 };
 
 export default function ActionCard({
-  title,
-  costs,
-  playerResources,
-  actionCostResource,
-  upkeep,
-  summary,
-  implemented = true,
-  enabled,
-  tooltip,
-  requirements = [],
-  requirementIcons = [],
-  onClick,
-  onMouseEnter,
-  onMouseLeave,
-  focus,
+	title,
+	costs,
+	playerResources,
+	actionCostResource,
+	upkeep,
+	summary,
+	implemented = true,
+	enabled,
+	tooltip,
+	requirements = [],
+	requirementIcons = [],
+	onClick,
+	onMouseEnter,
+	onMouseLeave,
+	focus,
 }: ActionCardProps) {
-  const focusClass = (() => {
-    switch (focus) {
-      case 'economy':
-        return 'bg-green-100 dark:bg-green-900/40 hover:bg-green-200 dark:hover:bg-green-900/60';
-      case 'aggressive':
-        return 'bg-orange-100 dark:bg-orange-900/40 hover:bg-orange-200 dark:hover:bg-orange-900/60';
-      case 'defense':
-        return 'bg-blue-100 dark:bg-blue-900/40 hover:bg-blue-200 dark:hover:bg-blue-900/60';
-      default:
-        return 'bg-yellow-100 dark:bg-yellow-900/40 hover:bg-yellow-200 dark:hover:bg-yellow-900/60';
-    }
-  })();
-  return (
-    <button
-      className={`relative panel-card border border-black/10 dark:border-white/10 p-2 flex flex-col items-start gap-1 h-full shadow-sm ${
-        enabled ? 'hoverable cursor-pointer' : 'opacity-50 cursor-not-allowed'
-      } ${focusClass}`}
-      title={tooltip}
-      onClick={enabled ? onClick : undefined}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-    >
-      <span className="text-base font-medium">{title}</span>
-      <div className="absolute top-2 right-2 flex flex-col items-end gap-1 text-right">
-        {renderCosts(costs, playerResources, actionCostResource, upkeep)}
-        {requirements.length > 0 && (
-          <div className="flex flex-col items-end gap-0.5 text-xs text-red-600">
-            <div className="whitespace-nowrap">
-              Req
-              {requirementIcons.length > 0 && ` ${requirementIcons.join('')}`}
-            </div>
-          </div>
-        )}
-      </div>
-      <ul className="text-sm list-disc pl-4 text-left">
-        {implemented ? (
-          renderSummary(stripSummary(summary, requirements))
-        ) : (
-          <li className="italic text-red-600">Not implemented yet</li>
-        )}
-      </ul>
-    </button>
-  );
+	const focusClass = (() => {
+		switch (focus) {
+			case 'economy':
+				return 'from-emerald-200/70 to-emerald-100/40 dark:from-emerald-900/40 dark:to-emerald-800/20';
+			case 'aggressive':
+				return 'from-amber-200/70 to-orange-100/40 dark:from-amber-900/40 dark:to-orange-900/20';
+			case 'defense':
+				return 'from-blue-200/70 to-sky-100/40 dark:from-blue-900/40 dark:to-sky-900/20';
+			default:
+				return 'from-rose-200/70 to-rose-100/40 dark:from-rose-900/40 dark:to-rose-800/20';
+		}
+	})();
+	return (
+		<button
+			className={`relative panel-card flex h-full flex-col items-start gap-2 border border-white/40 bg-gradient-to-br p-4 text-left shadow-lg shadow-amber-500/10 transition ${
+				enabled ? 'hoverable cursor-pointer' : 'cursor-not-allowed opacity-50'
+			} ${focusClass}`}
+			title={tooltip}
+			onClick={enabled ? onClick : undefined}
+			onMouseEnter={onMouseEnter}
+			onMouseLeave={onMouseLeave}
+		>
+			<span className="text-base font-medium">{title}</span>
+			<div className="absolute top-2 right-2 flex flex-col items-end gap-1 text-right">
+				{renderCosts(costs, playerResources, actionCostResource, upkeep)}
+				{requirements.length > 0 && (
+					<div className="flex flex-col items-end gap-0.5 text-xs text-rose-500 dark:text-rose-300">
+						<div className="whitespace-nowrap">
+							Req
+							{requirementIcons.length > 0 && ` ${requirementIcons.join('')}`}
+						</div>
+					</div>
+				)}
+			</div>
+			<ul className="text-sm list-disc pl-4 text-left">
+				{implemented ? (
+					renderSummary(stripSummary(summary, requirements))
+				) : (
+					<li className="italic text-rose-500 dark:text-rose-300">
+						Not implemented yet
+					</li>
+				)}
+			</ul>
+		</button>
+	);
 }

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -1,19 +1,19 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { getActionCosts, getActionRequirements } from '@kingdom-builder/engine';
 import {
-  RESOURCES,
-  POPULATION_ROLES,
-  PopulationRole,
-  SLOT_INFO,
-  LAND_INFO,
-  type Focus,
-  type ResourceKey,
+	RESOURCES,
+	POPULATION_ROLES,
+	PopulationRole,
+	SLOT_INFO,
+	LAND_INFO,
+	type Focus,
+	type ResourceKey,
 } from '@kingdom-builder/contents';
 import {
-  describeContent,
-  summarizeContent,
-  splitSummary,
-  type Summary,
+	describeContent,
+	summarizeContent,
+	splitSummary,
+	type Summary,
 } from '../../translation';
 import ActionCard from './ActionCard';
 import { useGameEngine } from '../../state/GameContext';
@@ -22,902 +22,909 @@ import { getRequirementIcons } from '../../utils/getRequirementIcons';
 import { useAnimate } from '../../utils/useAutoAnimate';
 
 interface Action {
-  id: string;
-  name: string;
-  system?: boolean;
-  order?: number;
-  category?: string;
-  focus?: Focus;
+	id: string;
+	name: string;
+	system?: boolean;
+	order?: number;
+	category?: string;
+	focus?: Focus;
 }
 interface Development {
-  id: string;
-  name: string;
-  system?: boolean;
-  order?: number;
-  focus?: Focus;
+	id: string;
+	name: string;
+	system?: boolean;
+	order?: number;
+	focus?: Focus;
 }
 interface Building {
-  id: string;
-  name: string;
-  icon?: string;
-  focus?: Focus;
+	id: string;
+	name: string;
+	icon?: string;
+	focus?: Focus;
 }
 
 type DisplayPlayer = ReturnType<typeof useGameEngine>['ctx']['activePlayer'];
 
 function isResourceKey(key: string): key is ResourceKey {
-  return key in RESOURCES;
+	return key in RESOURCES;
 }
 
 function formatMissingResources(
-  costs: Record<string, number>,
-  playerResources: Record<string, number | undefined>,
+	costs: Record<string, number>,
+	playerResources: Record<string, number | undefined>,
 ) {
-  const missing: string[] = [];
-  for (const [key, required] of Object.entries(costs)) {
-    const available = playerResources[key] ?? 0;
-    const shortage = required - available;
-    if (shortage <= 0) continue;
-    if (isResourceKey(key)) {
-      missing.push(
-        `${shortage} ${RESOURCES[key].icon} ${RESOURCES[key].label}`,
-      );
-    } else {
-      missing.push(`${shortage} ${key}`);
-    }
-  }
+	const missing: string[] = [];
+	for (const [key, required] of Object.entries(costs)) {
+		const available = playerResources[key] ?? 0;
+		const shortage = required - available;
+		if (shortage <= 0) continue;
+		if (isResourceKey(key)) {
+			missing.push(
+				`${shortage} ${RESOURCES[key].icon} ${RESOURCES[key].label}`,
+			);
+		} else {
+			missing.push(`${shortage} ${key}`);
+		}
+	}
 
-  if (missing.length === 0) return undefined;
+	if (missing.length === 0) return undefined;
 
-  return `Need ${missing.join(', ')}`;
+	return `Need ${missing.join(', ')}`;
 }
 
 function GenericActions({
-  actions,
-  summaries,
-  player,
-  canInteract,
+	actions,
+	summaries,
+	player,
+	canInteract,
 }: {
-  actions: Action[];
-  summaries: Map<string, Summary>;
-  player: DisplayPlayer;
-  canInteract: boolean;
+	actions: Action[];
+	summaries: Map<string, Summary>;
+	player: DisplayPlayer;
+	canInteract: boolean;
 }) {
-  const {
-    ctx,
-    handlePerform,
-    handleHoverCard,
-    clearHoverCard,
-    actionCostResource,
-  } = useGameEngine();
-  const formatRequirement = (req: string) => req;
-  const entries = useMemo(() => {
-    return actions
-      .map((action) => {
-        const costsBag = getActionCosts(action.id, ctx);
-        const costs: Record<string, number> = {};
-        for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
-        const total = Object.entries(costs).reduce(
-          (sum, [k, v]) => (k === actionCostResource ? sum : sum + (v ?? 0)),
-          0,
-        );
-        return { action, costs, total };
-      })
-      .sort((a, b) => a.total - b.total);
-  }, [actions, ctx, actionCostResource]);
-  return (
-    <>
-      {entries.map(({ action, costs }) => {
-        const requirements = getActionRequirements(action.id, ctx).map(
-          formatRequirement,
-        );
-        const requirementIcons = getRequirementIcons(action.id, ctx);
-        const canPay = Object.entries(costs).every(
-          ([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
-        );
-        const meetsReq = requirements.length === 0;
-        const summary = summaries.get(action.id);
-        const implemented = (summary?.length ?? 0) > 0; // TODO: implement action effects
-        const enabled = canPay && meetsReq && canInteract && implemented;
-        const insufficientTooltip = formatMissingResources(
-          costs,
-          player.resources,
-        );
-        const title = !implemented
-          ? 'Not implemented yet'
-          : !meetsReq
-            ? requirements.join(', ')
-            : !canPay
-              ? (insufficientTooltip ?? 'Cannot pay costs')
-              : undefined;
-        return (
-          <ActionCard
-            key={action.id}
-            title={
-              <>
-                {ctx.actions.get(action.id)?.icon || ''} {action.name}
-              </>
-            }
-            costs={costs}
-            playerResources={player.resources}
-            actionCostResource={actionCostResource}
-            requirements={requirements}
-            requirementIcons={requirementIcons}
-            summary={summary}
-            implemented={implemented}
-            enabled={enabled}
-            tooltip={title}
-            focus={(ctx.actions.get(action.id) as Action | undefined)?.focus}
-            onClick={() => {
-              if (!canInteract) return;
-              void handlePerform(action);
-            }}
-            onMouseEnter={() => {
-              const full = describeContent('action', action.id, ctx);
-              const { effects, description } = splitSummary(full);
-              handleHoverCard({
-                title: `${ctx.actions.get(action.id)?.icon || ''} ${action.name}`,
-                effects,
-                requirements,
-                costs,
-                ...(description && { description }),
-                ...(!implemented && {
-                  description: 'Not implemented yet',
-                  descriptionClass: 'italic text-red-600',
-                }),
-                bgClass: 'bg-gray-100 dark:bg-gray-700',
-              });
-            }}
-            onMouseLeave={clearHoverCard}
-          />
-        );
-      })}
-    </>
-  );
+	const {
+		ctx,
+		handlePerform,
+		handleHoverCard,
+		clearHoverCard,
+		actionCostResource,
+	} = useGameEngine();
+	const formatRequirement = (req: string) => req;
+	const entries = useMemo(() => {
+		return actions
+			.map((action) => {
+				const costsBag = getActionCosts(action.id, ctx);
+				const costs: Record<string, number> = {};
+				for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
+				const total = Object.entries(costs).reduce(
+					(sum, [k, v]) => (k === actionCostResource ? sum : sum + (v ?? 0)),
+					0,
+				);
+				return { action, costs, total };
+			})
+			.sort((a, b) => a.total - b.total);
+	}, [actions, ctx, actionCostResource]);
+	return (
+		<>
+			{entries.map(({ action, costs }) => {
+				const requirements = getActionRequirements(action.id, ctx).map(
+					formatRequirement,
+				);
+				const requirementIcons = getRequirementIcons(action.id, ctx);
+				const canPay = Object.entries(costs).every(
+					([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
+				);
+				const meetsReq = requirements.length === 0;
+				const summary = summaries.get(action.id);
+				const implemented = (summary?.length ?? 0) > 0; // TODO: implement action effects
+				const enabled = canPay && meetsReq && canInteract && implemented;
+				const insufficientTooltip = formatMissingResources(
+					costs,
+					player.resources,
+				);
+				const title = !implemented
+					? 'Not implemented yet'
+					: !meetsReq
+						? requirements.join(', ')
+						: !canPay
+							? (insufficientTooltip ?? 'Cannot pay costs')
+							: undefined;
+				return (
+					<ActionCard
+						key={action.id}
+						title={
+							<>
+								{ctx.actions.get(action.id)?.icon || ''} {action.name}
+							</>
+						}
+						costs={costs}
+						playerResources={player.resources}
+						actionCostResource={actionCostResource}
+						requirements={requirements}
+						requirementIcons={requirementIcons}
+						summary={summary}
+						implemented={implemented}
+						enabled={enabled}
+						tooltip={title}
+						focus={(ctx.actions.get(action.id) as Action | undefined)?.focus}
+						onClick={() => {
+							if (!canInteract) return;
+							void handlePerform(action);
+						}}
+						onMouseEnter={() => {
+							const full = describeContent('action', action.id, ctx);
+							const { effects, description } = splitSummary(full);
+							handleHoverCard({
+								title: `${ctx.actions.get(action.id)?.icon || ''} ${action.name}`,
+								effects,
+								requirements,
+								costs,
+								...(description && { description }),
+								...(!implemented && {
+									description: 'Not implemented yet',
+									descriptionClass: 'italic text-red-600',
+								}),
+								bgClass:
+									'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+							});
+						}}
+						onMouseLeave={clearHoverCard}
+					/>
+				);
+			})}
+		</>
+	);
 }
 
 function RaisePopOptions({
-  action,
-  player,
-  canInteract,
+	action,
+	player,
+	canInteract,
 }: {
-  action: Action;
-  player: DisplayPlayer;
-  canInteract: boolean;
+	action: Action;
+	player: DisplayPlayer;
+	canInteract: boolean;
 }) {
-  const {
-    ctx,
-    handlePerform,
-    handleHoverCard,
-    clearHoverCard,
-    actionCostResource,
-  } = useGameEngine();
-  const formatRequirement = (req: string) => req;
-  const requirementIcons = getRequirementIcons(action.id, ctx);
-  return (
-    <>
-      {[
-        PopulationRole.Council,
-        PopulationRole.Legion,
-        PopulationRole.Fortifier,
-      ].map((role) => {
-        const costsBag = getActionCosts(action.id, ctx);
-        const costs: Record<string, number> = {};
-        for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
-        const upkeep = ctx.populations.get(role)?.upkeep;
-        const requirements = getActionRequirements(action.id, ctx).map(
-          formatRequirement,
-        );
-        const canPay = Object.entries(costs).every(
-          ([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
-        );
-        const meetsReq = requirements.length === 0;
-        const enabled = canPay && meetsReq && canInteract;
-        const insufficientTooltip = formatMissingResources(
-          costs,
-          player.resources,
-        );
-        const title = !meetsReq
-          ? requirements.join(', ')
-          : !canPay
-            ? (insufficientTooltip ?? 'Cannot pay costs')
-            : undefined;
-        const summary = describeContent('action', action.id, ctx, { role });
-        const shortSummary = summarizeContent('action', action.id, ctx, {
-          role,
-        });
-        return (
-          <ActionCard
-            key={role}
-            title={
-              <>
-                {ctx.actions.get(action.id).icon || ''}
-                {POPULATION_ROLES[role]?.icon} {ctx.actions.get(action.id).name}
-                : {POPULATION_ROLES[role]?.label}
-              </>
-            }
-            costs={costs}
-            upkeep={upkeep}
-            playerResources={player.resources}
-            actionCostResource={actionCostResource}
-            requirements={requirements}
-            requirementIcons={requirementIcons}
-            summary={shortSummary}
-            enabled={enabled}
-            tooltip={title}
-            focus={(ctx.actions.get(action.id) as Action | undefined)?.focus}
-            onClick={() => {
-              if (!canInteract) return;
-              void handlePerform(action, { role });
-            }}
-            onMouseEnter={() => {
-              const { effects, description } = splitSummary(summary);
-              handleHoverCard({
-                title: `${ctx.actions.get(action.id).icon || ''}${
-                  POPULATION_ROLES[role]?.icon
-                } ${ctx.actions.get(action.id).name}: ${
-                  POPULATION_ROLES[role]?.label || ''
-                }`,
-                effects,
-                requirements,
-                costs,
-                upkeep,
-                ...(description && { description }),
-                bgClass: 'bg-gray-100 dark:bg-gray-700',
-              });
-            }}
-            onMouseLeave={clearHoverCard}
-          />
-        );
-      })}
-    </>
-  );
+	const {
+		ctx,
+		handlePerform,
+		handleHoverCard,
+		clearHoverCard,
+		actionCostResource,
+	} = useGameEngine();
+	const formatRequirement = (req: string) => req;
+	const requirementIcons = getRequirementIcons(action.id, ctx);
+	return (
+		<>
+			{[
+				PopulationRole.Council,
+				PopulationRole.Legion,
+				PopulationRole.Fortifier,
+			].map((role) => {
+				const costsBag = getActionCosts(action.id, ctx);
+				const costs: Record<string, number> = {};
+				for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
+				const upkeep = ctx.populations.get(role)?.upkeep;
+				const requirements = getActionRequirements(action.id, ctx).map(
+					formatRequirement,
+				);
+				const canPay = Object.entries(costs).every(
+					([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
+				);
+				const meetsReq = requirements.length === 0;
+				const enabled = canPay && meetsReq && canInteract;
+				const insufficientTooltip = formatMissingResources(
+					costs,
+					player.resources,
+				);
+				const title = !meetsReq
+					? requirements.join(', ')
+					: !canPay
+						? (insufficientTooltip ?? 'Cannot pay costs')
+						: undefined;
+				const summary = describeContent('action', action.id, ctx, { role });
+				const shortSummary = summarizeContent('action', action.id, ctx, {
+					role,
+				});
+				return (
+					<ActionCard
+						key={role}
+						title={
+							<>
+								{ctx.actions.get(action.id).icon || ''}
+								{POPULATION_ROLES[role]?.icon} {ctx.actions.get(action.id).name}
+								: {POPULATION_ROLES[role]?.label}
+							</>
+						}
+						costs={costs}
+						upkeep={upkeep}
+						playerResources={player.resources}
+						actionCostResource={actionCostResource}
+						requirements={requirements}
+						requirementIcons={requirementIcons}
+						summary={shortSummary}
+						enabled={enabled}
+						tooltip={title}
+						focus={(ctx.actions.get(action.id) as Action | undefined)?.focus}
+						onClick={() => {
+							if (!canInteract) return;
+							void handlePerform(action, { role });
+						}}
+						onMouseEnter={() => {
+							const { effects, description } = splitSummary(summary);
+							handleHoverCard({
+								title: `${ctx.actions.get(action.id).icon || ''}${
+									POPULATION_ROLES[role]?.icon
+								} ${ctx.actions.get(action.id).name}: ${
+									POPULATION_ROLES[role]?.label || ''
+								}`,
+								effects,
+								requirements,
+								costs,
+								upkeep,
+								...(description && { description }),
+								bgClass:
+									'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+							});
+						}}
+						onMouseLeave={clearHoverCard}
+					/>
+				);
+			})}
+		</>
+	);
 }
 
 function BasicOptions({
-  actions,
-  summaries,
-  player,
-  canInteract,
+	actions,
+	summaries,
+	player,
+	canInteract,
 }: {
-  actions: Action[];
-  summaries: Map<string, Summary>;
-  player: DisplayPlayer;
-  canInteract: boolean;
+	actions: Action[];
+	summaries: Map<string, Summary>;
+	player: DisplayPlayer;
+	canInteract: boolean;
 }) {
-  const listRef = useAnimate<HTMLDivElement>();
-  return (
-    <div>
-      <h3 className="font-medium">
-        Basic{' '}
-        <span className="italic text-sm font-normal">
-          (Effects take place immediately, unless stated otherwise)
-        </span>
-      </h3>
-      <div
-        ref={listRef}
-        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
-      >
-        <GenericActions
-          actions={actions}
-          summaries={summaries}
-          player={player}
-          canInteract={canInteract}
-        />
-      </div>
-    </div>
-  );
+	const listRef = useAnimate<HTMLDivElement>();
+	return (
+		<div>
+			<h3 className="font-medium">
+				Basic{' '}
+				<span className="italic text-sm font-normal">
+					(Effects take place immediately, unless stated otherwise)
+				</span>
+			</h3>
+			<div
+				ref={listRef}
+				className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+			>
+				<GenericActions
+					actions={actions}
+					summaries={summaries}
+					player={player}
+					canInteract={canInteract}
+				/>
+			</div>
+		</div>
+	);
 }
 
 function HireOptions({
-  action,
-  player,
-  canInteract,
+	action,
+	player,
+	canInteract,
 }: {
-  action: Action;
-  player: DisplayPlayer;
-  canInteract: boolean;
+	action: Action;
+	player: DisplayPlayer;
+	canInteract: boolean;
 }) {
-  const listRef = useAnimate<HTMLDivElement>();
-  return (
-    <div>
-      <h3 className="font-medium">
-        Hire{' '}
-        <span className="italic text-sm font-normal">
-          (Recruit population instantly; upkeep and role effects apply while
-          they remain)
-        </span>
-      </h3>
-      <div
-        ref={listRef}
-        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
-      >
-        <RaisePopOptions
-          action={action}
-          player={player}
-          canInteract={canInteract}
-        />
-      </div>
-    </div>
-  );
+	const listRef = useAnimate<HTMLDivElement>();
+	return (
+		<div>
+			<h3 className="font-medium">
+				Hire{' '}
+				<span className="italic text-sm font-normal">
+					(Recruit population instantly; upkeep and role effects apply while
+					they remain)
+				</span>
+			</h3>
+			<div
+				ref={listRef}
+				className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+			>
+				<RaisePopOptions
+					action={action}
+					player={player}
+					canInteract={canInteract}
+				/>
+			</div>
+		</div>
+	);
 }
 
 function DevelopOptions({
-  action,
-  isActionPhase,
-  developments,
-  summaries,
-  hasDevelopLand,
-  player,
-  canInteract,
+	action,
+	isActionPhase,
+	developments,
+	summaries,
+	hasDevelopLand,
+	player,
+	canInteract,
 }: {
-  action: Action;
-  isActionPhase: boolean;
-  developments: Development[];
-  summaries: Map<string, Summary>;
-  hasDevelopLand: boolean;
-  player: DisplayPlayer;
-  canInteract: boolean;
+	action: Action;
+	isActionPhase: boolean;
+	developments: Development[];
+	summaries: Map<string, Summary>;
+	hasDevelopLand: boolean;
+	player: DisplayPlayer;
+	canInteract: boolean;
 }) {
-  const listRef = useAnimate<HTMLDivElement>();
-  const {
-    ctx,
-    handlePerform,
-    handleHoverCard,
-    clearHoverCard,
-    actionCostResource,
-  } = useGameEngine();
-  const landIdForCost = player.lands[0]?.id as string;
-  const entries = useMemo(() => {
-    return developments
-      .map((d) => {
-        const costsBag = getActionCosts(action.id, ctx, {
-          id: d.id,
-          landId: landIdForCost,
-        });
-        const costs: Record<string, number> = {};
-        for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
-        const total = Object.entries(costs).reduce(
-          (sum, [k, v]) => (k === actionCostResource ? sum : sum + (v ?? 0)),
-          0,
-        );
-        return { d, costs, total };
-      })
-      .sort((a, b) => a.total - b.total);
-  }, [developments, ctx, action.id, landIdForCost, actionCostResource]);
-  return (
-    <div>
-      <h3 className="font-medium">
-        {ctx.actions.get(action.id)?.icon || ''}{' '}
-        {ctx.actions.get(action.id)?.name}{' '}
-        <span className="italic text-sm font-normal">
-          (Effects take place on build and last until development is removed)
-        </span>
-      </h3>
-      <div
-        ref={listRef}
-        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
-      >
-        {entries.map(({ d, costs }) => {
-          const upkeep = ctx.developments.get(d.id)?.upkeep;
-          const requirements = hasDevelopLand
-            ? []
-            : [
-                `Requires ${LAND_INFO.icon} ${LAND_INFO.label} with free ${SLOT_INFO.icon} ${SLOT_INFO.label}`,
-              ];
-          const canPay =
-            hasDevelopLand &&
-            Object.entries(costs).every(
-              ([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
-            );
-          const summary = summaries.get(d.id);
-          const implemented = (summary?.length ?? 0) > 0; // TODO: implement development effects
-          const enabled = canPay && isActionPhase && canInteract && implemented;
-          const insufficientTooltip = formatMissingResources(
-            costs,
-            player.resources,
-          );
-          const title = !implemented
-            ? 'Not implemented yet'
-            : !hasDevelopLand
-              ? `No ${LAND_INFO.icon} ${LAND_INFO.label} with free ${SLOT_INFO.icon} ${SLOT_INFO.label}`
-              : !canPay
-                ? (insufficientTooltip ?? 'Cannot pay costs')
-                : undefined;
-          return (
-            <ActionCard
-              key={d.id}
-              title={
-                <>
-                  {ctx.developments.get(d.id)?.icon} {d.name}
-                </>
-              }
-              costs={costs}
-              upkeep={upkeep}
-              playerResources={player.resources}
-              actionCostResource={actionCostResource}
-              requirements={requirements}
-              requirementIcons={[SLOT_INFO.icon]}
-              summary={summary}
-              implemented={implemented}
-              enabled={enabled}
-              tooltip={title}
-              focus={
-                (ctx.developments.get(d.id) as Development | undefined)?.focus
-              }
-              onClick={() => {
-                if (!canInteract) return;
-                const landId = player.lands.find((l) => l.slotsFree > 0)?.id;
-                void handlePerform(action, { id: d.id, landId });
-              }}
-              onMouseEnter={() => {
-                const full = describeContent('development', d.id, ctx);
-                const { effects, description } = splitSummary(full);
-                handleHoverCard({
-                  title: `${ctx.actions.get(action.id)?.icon || ''} ${
-                    ctx.actions.get(action.id)?.name
-                  } - ${ctx.developments.get(d.id)?.icon || ''} ${d.name}`,
-                  effects,
-                  requirements,
-                  costs,
-                  upkeep,
-                  ...(description && { description }),
-                  ...(!implemented && {
-                    description: 'Not implemented yet',
-                    descriptionClass: 'italic text-red-600',
-                  }),
-                  bgClass: 'bg-gray-100 dark:bg-gray-700',
-                });
-              }}
-              onMouseLeave={clearHoverCard}
-            />
-          );
-        })}
-      </div>
-    </div>
-  );
+	const listRef = useAnimate<HTMLDivElement>();
+	const {
+		ctx,
+		handlePerform,
+		handleHoverCard,
+		clearHoverCard,
+		actionCostResource,
+	} = useGameEngine();
+	const landIdForCost = player.lands[0]?.id as string;
+	const entries = useMemo(() => {
+		return developments
+			.map((d) => {
+				const costsBag = getActionCosts(action.id, ctx, {
+					id: d.id,
+					landId: landIdForCost,
+				});
+				const costs: Record<string, number> = {};
+				for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
+				const total = Object.entries(costs).reduce(
+					(sum, [k, v]) => (k === actionCostResource ? sum : sum + (v ?? 0)),
+					0,
+				);
+				return { d, costs, total };
+			})
+			.sort((a, b) => a.total - b.total);
+	}, [developments, ctx, action.id, landIdForCost, actionCostResource]);
+	return (
+		<div>
+			<h3 className="font-medium">
+				{ctx.actions.get(action.id)?.icon || ''}{' '}
+				{ctx.actions.get(action.id)?.name}{' '}
+				<span className="italic text-sm font-normal">
+					(Effects take place on build and last until development is removed)
+				</span>
+			</h3>
+			<div
+				ref={listRef}
+				className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+			>
+				{entries.map(({ d, costs }) => {
+					const upkeep = ctx.developments.get(d.id)?.upkeep;
+					const requirements = hasDevelopLand
+						? []
+						: [
+								`Requires ${LAND_INFO.icon} ${LAND_INFO.label} with free ${SLOT_INFO.icon} ${SLOT_INFO.label}`,
+							];
+					const canPay =
+						hasDevelopLand &&
+						Object.entries(costs).every(
+							([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
+						);
+					const summary = summaries.get(d.id);
+					const implemented = (summary?.length ?? 0) > 0; // TODO: implement development effects
+					const enabled = canPay && isActionPhase && canInteract && implemented;
+					const insufficientTooltip = formatMissingResources(
+						costs,
+						player.resources,
+					);
+					const title = !implemented
+						? 'Not implemented yet'
+						: !hasDevelopLand
+							? `No ${LAND_INFO.icon} ${LAND_INFO.label} with free ${SLOT_INFO.icon} ${SLOT_INFO.label}`
+							: !canPay
+								? (insufficientTooltip ?? 'Cannot pay costs')
+								: undefined;
+					return (
+						<ActionCard
+							key={d.id}
+							title={
+								<>
+									{ctx.developments.get(d.id)?.icon} {d.name}
+								</>
+							}
+							costs={costs}
+							upkeep={upkeep}
+							playerResources={player.resources}
+							actionCostResource={actionCostResource}
+							requirements={requirements}
+							requirementIcons={[SLOT_INFO.icon]}
+							summary={summary}
+							implemented={implemented}
+							enabled={enabled}
+							tooltip={title}
+							focus={
+								(ctx.developments.get(d.id) as Development | undefined)?.focus
+							}
+							onClick={() => {
+								if (!canInteract) return;
+								const landId = player.lands.find((l) => l.slotsFree > 0)?.id;
+								void handlePerform(action, { id: d.id, landId });
+							}}
+							onMouseEnter={() => {
+								const full = describeContent('development', d.id, ctx);
+								const { effects, description } = splitSummary(full);
+								handleHoverCard({
+									title: `${ctx.actions.get(action.id)?.icon || ''} ${
+										ctx.actions.get(action.id)?.name
+									} - ${ctx.developments.get(d.id)?.icon || ''} ${d.name}`,
+									effects,
+									requirements,
+									costs,
+									upkeep,
+									...(description && { description }),
+									...(!implemented && {
+										description: 'Not implemented yet',
+										descriptionClass: 'italic text-red-600',
+									}),
+									bgClass:
+										'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+								});
+							}}
+							onMouseLeave={clearHoverCard}
+						/>
+					);
+				})}
+			</div>
+		</div>
+	);
 }
 
 function BuildOptions({
-  action,
-  isActionPhase,
-  buildings,
-  summaries,
-  descriptions,
-  player,
-  canInteract,
+	action,
+	isActionPhase,
+	buildings,
+	summaries,
+	descriptions,
+	player,
+	canInteract,
 }: {
-  action: Action;
-  isActionPhase: boolean;
-  buildings: Building[];
-  summaries: Map<string, Summary>;
-  descriptions: Map<string, Summary>;
-  player: DisplayPlayer;
-  canInteract: boolean;
+	action: Action;
+	isActionPhase: boolean;
+	buildings: Building[];
+	summaries: Map<string, Summary>;
+	descriptions: Map<string, Summary>;
+	player: DisplayPlayer;
+	canInteract: boolean;
 }) {
-  const listRef = useAnimate<HTMLDivElement>();
-  const {
-    ctx,
-    handlePerform,
-    handleHoverCard,
-    clearHoverCard,
-    actionCostResource,
-  } = useGameEngine();
-  const entries = useMemo(() => {
-    const owned = player.buildings;
-    return buildings
-      .filter((b) => !owned.has(b.id))
-      .map((b) => {
-        const costsBag = getActionCosts(action.id, ctx, { id: b.id });
-        const costs: Record<string, number> = {};
-        for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
-        const total = Object.entries(costs).reduce(
-          (sum, [k, v]) => (k === actionCostResource ? sum : sum + (v ?? 0)),
-          0,
-        );
-        return { b, costs, total };
-      })
-      .sort((a, b) => a.total - b.total);
-  }, [buildings, ctx, action.id, actionCostResource, player.buildings.size]);
-  return (
-    <div>
-      <h3 className="font-medium">
-        {ctx.actions.get(action.id)?.icon || ''}{' '}
-        {ctx.actions.get(action.id)?.name}{' '}
-        <span className="italic text-sm font-normal">
-          (Effects take place on build and last until building is removed)
-        </span>
-      </h3>
-      <div
-        ref={listRef}
-        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
-      >
-        {entries.map(({ b, costs }) => {
-          const requirements: string[] = [];
-          const canPay = Object.entries(costs).every(
-            ([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
-          );
-          const summary = summaries.get(b.id);
-          const implemented = (summary?.length ?? 0) > 0; // TODO: implement building effects
-          const enabled = canPay && isActionPhase && canInteract && implemented;
-          const insufficientTooltip = formatMissingResources(
-            costs,
-            player.resources,
-          );
-          const title = !implemented
-            ? 'Not implemented yet'
-            : !canPay
-              ? (insufficientTooltip ?? 'Cannot pay costs')
-              : undefined;
-          const upkeep = ctx.buildings.get(b.id)?.upkeep;
-          return (
-            <ActionCard
-              key={b.id}
-              title={
-                <>
-                  {ctx.buildings.get(b.id)?.icon || ''} {b.name}
-                </>
-              }
-              costs={costs}
-              upkeep={upkeep}
-              playerResources={player.resources}
-              actionCostResource={actionCostResource}
-              requirements={requirements}
-              requirementIcons={[
-                POPULATION_ROLES[PopulationRole.Citizen]?.icon ?? '',
-              ]}
-              summary={summary}
-              implemented={implemented}
-              enabled={enabled}
-              tooltip={title}
-              focus={(ctx.buildings.get(b.id) as Building | undefined)?.focus}
-              onClick={() => {
-                if (!canInteract) return;
-                void handlePerform(action, { id: b.id });
-              }}
-              onMouseEnter={() => {
-                const full = descriptions.get(b.id) ?? [];
-                const { effects, description } = splitSummary(full);
-                handleHoverCard({
-                  title: `${ctx.actions.get(action.id)?.icon || ''} ${
-                    ctx.actions.get(action.id)?.name
-                  } - ${ctx.buildings.get(b.id)?.icon || ''} ${b.name}`,
-                  effects,
-                  requirements,
-                  costs,
-                  upkeep,
-                  ...(description && { description }),
-                  ...(!implemented && {
-                    description: 'Not implemented yet',
-                    descriptionClass: 'italic text-red-600',
-                  }),
-                  bgClass: 'bg-gray-100 dark:bg-gray-700',
-                });
-              }}
-              onMouseLeave={clearHoverCard}
-            />
-          );
-        })}
-      </div>
-    </div>
-  );
+	const listRef = useAnimate<HTMLDivElement>();
+	const {
+		ctx,
+		handlePerform,
+		handleHoverCard,
+		clearHoverCard,
+		actionCostResource,
+	} = useGameEngine();
+	const entries = useMemo(() => {
+		const owned = player.buildings;
+		return buildings
+			.filter((b) => !owned.has(b.id))
+			.map((b) => {
+				const costsBag = getActionCosts(action.id, ctx, { id: b.id });
+				const costs: Record<string, number> = {};
+				for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
+				const total = Object.entries(costs).reduce(
+					(sum, [k, v]) => (k === actionCostResource ? sum : sum + (v ?? 0)),
+					0,
+				);
+				return { b, costs, total };
+			})
+			.sort((a, b) => a.total - b.total);
+	}, [buildings, ctx, action.id, actionCostResource, player.buildings.size]);
+	return (
+		<div>
+			<h3 className="font-medium">
+				{ctx.actions.get(action.id)?.icon || ''}{' '}
+				{ctx.actions.get(action.id)?.name}{' '}
+				<span className="italic text-sm font-normal">
+					(Effects take place on build and last until building is removed)
+				</span>
+			</h3>
+			<div
+				ref={listRef}
+				className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+			>
+				{entries.map(({ b, costs }) => {
+					const requirements: string[] = [];
+					const canPay = Object.entries(costs).every(
+						([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
+					);
+					const summary = summaries.get(b.id);
+					const implemented = (summary?.length ?? 0) > 0; // TODO: implement building effects
+					const enabled = canPay && isActionPhase && canInteract && implemented;
+					const insufficientTooltip = formatMissingResources(
+						costs,
+						player.resources,
+					);
+					const title = !implemented
+						? 'Not implemented yet'
+						: !canPay
+							? (insufficientTooltip ?? 'Cannot pay costs')
+							: undefined;
+					const upkeep = ctx.buildings.get(b.id)?.upkeep;
+					return (
+						<ActionCard
+							key={b.id}
+							title={
+								<>
+									{ctx.buildings.get(b.id)?.icon || ''} {b.name}
+								</>
+							}
+							costs={costs}
+							upkeep={upkeep}
+							playerResources={player.resources}
+							actionCostResource={actionCostResource}
+							requirements={requirements}
+							requirementIcons={[
+								POPULATION_ROLES[PopulationRole.Citizen]?.icon ?? '',
+							]}
+							summary={summary}
+							implemented={implemented}
+							enabled={enabled}
+							tooltip={title}
+							focus={(ctx.buildings.get(b.id) as Building | undefined)?.focus}
+							onClick={() => {
+								if (!canInteract) return;
+								void handlePerform(action, { id: b.id });
+							}}
+							onMouseEnter={() => {
+								const full = descriptions.get(b.id) ?? [];
+								const { effects, description } = splitSummary(full);
+								handleHoverCard({
+									title: `${ctx.actions.get(action.id)?.icon || ''} ${
+										ctx.actions.get(action.id)?.name
+									} - ${ctx.buildings.get(b.id)?.icon || ''} ${b.name}`,
+									effects,
+									requirements,
+									costs,
+									upkeep,
+									...(description && { description }),
+									...(!implemented && {
+										description: 'Not implemented yet',
+										descriptionClass: 'italic text-red-600',
+									}),
+									bgClass:
+										'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+								});
+							}}
+							onMouseLeave={clearHoverCard}
+						/>
+					);
+				})}
+			</div>
+		</div>
+	);
 }
 
 function DemolishOptions({
-  action,
-  isActionPhase,
-  player,
-  canInteract,
+	action,
+	isActionPhase,
+	player,
+	canInteract,
 }: {
-  action: Action;
-  isActionPhase: boolean;
-  player: DisplayPlayer;
-  canInteract: boolean;
+	action: Action;
+	isActionPhase: boolean;
+	player: DisplayPlayer;
+	canInteract: boolean;
 }) {
-  const listRef = useAnimate<HTMLDivElement>();
-  const {
-    ctx,
-    handlePerform,
-    handleHoverCard,
-    clearHoverCard,
-    actionCostResource,
-  } = useGameEngine();
-  const entries = useMemo(() => {
-    return Array.from(player.buildings)
-      .map((id) => {
-        const building = ctx.buildings.get(id) as Building | undefined;
-        if (!building) return null;
-        const costsBag = getActionCosts(action.id, ctx, { id });
-        const costs: Record<string, number> = {};
-        for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
-        const total = Object.entries(costs).reduce(
-          (sum, [k, v]) => (k === actionCostResource ? sum : sum + (v ?? 0)),
-          0,
-        );
-        return { id, building, costs, total };
-      })
-      .filter(
-        (
-          entry,
-        ): entry is {
-          id: string;
-          building: Building;
-          costs: Record<string, number>;
-          total: number;
-        } => entry !== null,
-      )
-      .sort((a, b) => {
-        if (a.total !== b.total) return a.total - b.total;
-        return a.building.name.localeCompare(b.building.name);
-      });
-  }, [ctx, action.id, actionCostResource, player.buildings.size]);
+	const listRef = useAnimate<HTMLDivElement>();
+	const {
+		ctx,
+		handlePerform,
+		handleHoverCard,
+		clearHoverCard,
+		actionCostResource,
+	} = useGameEngine();
+	const entries = useMemo(() => {
+		return Array.from(player.buildings)
+			.map((id) => {
+				const building = ctx.buildings.get(id) as Building | undefined;
+				if (!building) return null;
+				const costsBag = getActionCosts(action.id, ctx, { id });
+				const costs: Record<string, number> = {};
+				for (const [k, v] of Object.entries(costsBag)) costs[k] = v ?? 0;
+				const total = Object.entries(costs).reduce(
+					(sum, [k, v]) => (k === actionCostResource ? sum : sum + (v ?? 0)),
+					0,
+				);
+				return { id, building, costs, total };
+			})
+			.filter(
+				(
+					entry,
+				): entry is {
+					id: string;
+					building: Building;
+					costs: Record<string, number>;
+					total: number;
+				} => entry !== null,
+			)
+			.sort((a, b) => {
+				if (a.total !== b.total) return a.total - b.total;
+				return a.building.name.localeCompare(b.building.name);
+			});
+	}, [ctx, action.id, actionCostResource, player.buildings.size]);
 
-  if (entries.length === 0) return null;
+	if (entries.length === 0) return null;
 
-  return (
-    <div>
-      <h3 className="font-medium">
-        {ctx.actions.get(action.id)?.icon || ''}{' '}
-        {ctx.actions.get(action.id)?.name}{' '}
-        <span className="italic text-sm font-normal">
-          (Removes a structure and its ongoing benefits)
-        </span>
-      </h3>
-      <div
-        ref={listRef}
-        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
-      >
-        {entries.map(({ id, building, costs }) => {
-          const requirements: string[] = [];
-          const canPay = Object.entries(costs).every(
-            ([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
-          );
-          const summary = summarizeContent('building', id, ctx, {
-            installed: true,
-          });
-          const implemented = (summary?.length ?? 0) > 0;
-          const enabled = canPay && isActionPhase && canInteract && implemented;
-          const insufficientTooltip = formatMissingResources(
-            costs,
-            player.resources,
-          );
-          const title = !implemented
-            ? 'Not implemented yet'
-            : !canPay
-              ? (insufficientTooltip ?? 'Cannot pay costs')
-              : undefined;
-          const upkeep = ctx.buildings.get(id)?.upkeep;
-          return (
-            <ActionCard
-              key={id}
-              title={
-                <>
-                  {ctx.buildings.get(id)?.icon || ''} {building.name}
-                </>
-              }
-              costs={costs}
-              upkeep={upkeep}
-              playerResources={player.resources}
-              actionCostResource={actionCostResource}
-              requirements={requirements}
-              requirementIcons={[]}
-              summary={summary}
-              implemented={implemented}
-              enabled={enabled}
-              tooltip={title}
-              focus={(ctx.buildings.get(id) as Building | undefined)?.focus}
-              onClick={() => {
-                if (!canInteract) return;
-                void handlePerform(action, { id });
-              }}
-              onMouseEnter={() => {
-                const full = describeContent('building', id, ctx, {
-                  installed: true,
-                });
-                const { effects, description } = splitSummary(full);
-                handleHoverCard({
-                  title: `${ctx.actions.get(action.id)?.icon || ''} ${
-                    ctx.actions.get(action.id)?.name
-                  } - ${ctx.buildings.get(id)?.icon || ''} ${building.name}`,
-                  effects,
-                  requirements,
-                  costs,
-                  upkeep,
-                  ...(description && { description }),
-                  ...(!implemented && {
-                    description: 'Not implemented yet',
-                    descriptionClass: 'italic text-red-600',
-                  }),
-                  bgClass: 'bg-gray-100 dark:bg-gray-700',
-                });
-              }}
-              onMouseLeave={clearHoverCard}
-            />
-          );
-        })}
-      </div>
-    </div>
-  );
+	return (
+		<div>
+			<h3 className="font-medium">
+				{ctx.actions.get(action.id)?.icon || ''}{' '}
+				{ctx.actions.get(action.id)?.name}{' '}
+				<span className="italic text-sm font-normal">
+					(Removes a structure and its ongoing benefits)
+				</span>
+			</h3>
+			<div
+				ref={listRef}
+				className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+			>
+				{entries.map(({ id, building, costs }) => {
+					const requirements: string[] = [];
+					const canPay = Object.entries(costs).every(
+						([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
+					);
+					const summary = summarizeContent('building', id, ctx, {
+						installed: true,
+					});
+					const implemented = (summary?.length ?? 0) > 0;
+					const enabled = canPay && isActionPhase && canInteract && implemented;
+					const insufficientTooltip = formatMissingResources(
+						costs,
+						player.resources,
+					);
+					const title = !implemented
+						? 'Not implemented yet'
+						: !canPay
+							? (insufficientTooltip ?? 'Cannot pay costs')
+							: undefined;
+					const upkeep = ctx.buildings.get(id)?.upkeep;
+					return (
+						<ActionCard
+							key={id}
+							title={
+								<>
+									{ctx.buildings.get(id)?.icon || ''} {building.name}
+								</>
+							}
+							costs={costs}
+							upkeep={upkeep}
+							playerResources={player.resources}
+							actionCostResource={actionCostResource}
+							requirements={requirements}
+							requirementIcons={[]}
+							summary={summary}
+							implemented={implemented}
+							enabled={enabled}
+							tooltip={title}
+							focus={(ctx.buildings.get(id) as Building | undefined)?.focus}
+							onClick={() => {
+								if (!canInteract) return;
+								void handlePerform(action, { id });
+							}}
+							onMouseEnter={() => {
+								const full = describeContent('building', id, ctx, {
+									installed: true,
+								});
+								const { effects, description } = splitSummary(full);
+								handleHoverCard({
+									title: `${ctx.actions.get(action.id)?.icon || ''} ${
+										ctx.actions.get(action.id)?.name
+									} - ${ctx.buildings.get(id)?.icon || ''} ${building.name}`,
+									effects,
+									requirements,
+									costs,
+									upkeep,
+									...(description && { description }),
+									...(!implemented && {
+										description: 'Not implemented yet',
+										descriptionClass: 'italic text-red-600',
+									}),
+									bgClass:
+										'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+								});
+							}}
+							onMouseLeave={clearHoverCard}
+						/>
+					);
+				})}
+			</div>
+		</div>
+	);
 }
 
 export default function ActionsPanel() {
-  const { ctx, tabsEnabled, actionCostResource } = useGameEngine();
-  const sectionRef = useAnimate<HTMLDivElement>();
-  const player = ctx.game.players[0]!;
-  const opponent = ctx.game.players[1]!;
-  const [viewingOpponent, setViewingOpponent] = useState(false);
+	const { ctx, tabsEnabled, actionCostResource } = useGameEngine();
+	const sectionRef = useAnimate<HTMLDivElement>();
+	const player = ctx.game.players[0]!;
+	const opponent = ctx.game.players[1]!;
+	const [viewingOpponent, setViewingOpponent] = useState(false);
 
-  const actionPhaseId = useMemo(
-    () => ctx.phases.find((p) => p.action)?.id,
-    [ctx],
-  );
-  const isActionPhase = isActionPhaseActive(
-    ctx.game.currentPhase,
-    actionPhaseId,
-    tabsEnabled,
-  );
-  const isLocalTurn = ctx.activePlayer.id === player.id;
+	const actionPhaseId = useMemo(
+		() => ctx.phases.find((p) => p.action)?.id,
+		[ctx],
+	);
+	const isActionPhase = isActionPhaseActive(
+		ctx.game.currentPhase,
+		actionPhaseId,
+		tabsEnabled,
+	);
+	const isLocalTurn = ctx.activePlayer.id === player.id;
 
-  useEffect(() => {
-    if (!isLocalTurn && viewingOpponent) setViewingOpponent(false);
-  }, [isLocalTurn, viewingOpponent]);
+	useEffect(() => {
+		if (!isLocalTurn && viewingOpponent) setViewingOpponent(false);
+	}, [isLocalTurn, viewingOpponent]);
 
-  const selectedPlayer = viewingOpponent ? opponent : player;
-  const canInteract = isLocalTurn && isActionPhase && !viewingOpponent;
-  const panelDisabled = !canInteract;
+	const selectedPlayer = viewingOpponent ? opponent : player;
+	const canInteract = isLocalTurn && isActionPhase && !viewingOpponent;
+	const panelDisabled = !canInteract;
 
-  const actions = useMemo<Action[]>(
-    () =>
-      Array.from(
-        (ctx.actions as unknown as { map: Map<string, Action> }).map.values(),
-      )
-        .filter((a) => !a.system || selectedPlayer.actions.has(a.id))
-        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
-    [ctx, selectedPlayer.actions.size, selectedPlayer.id],
-  );
-  const developmentOptions = useMemo<Development[]>(
-    () =>
-      Array.from(
-        (
-          ctx.developments as unknown as { map: Map<string, Development> }
-        ).map.values(),
-      )
-        .filter((d) => !d.system)
-        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
-    [ctx],
-  );
-  const buildingOptions = useMemo<Building[]>(
-    () =>
-      Array.from(
-        (
-          ctx.buildings as unknown as { map: Map<string, Building> }
-        ).map.values(),
-      ),
-    [ctx],
-  );
+	const actions = useMemo<Action[]>(
+		() =>
+			Array.from(
+				(ctx.actions as unknown as { map: Map<string, Action> }).map.values(),
+			)
+				.filter((a) => !a.system || selectedPlayer.actions.has(a.id))
+				.sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+		[ctx, selectedPlayer.actions.size, selectedPlayer.id],
+	);
+	const developmentOptions = useMemo<Development[]>(
+		() =>
+			Array.from(
+				(
+					ctx.developments as unknown as { map: Map<string, Development> }
+				).map.values(),
+			)
+				.filter((d) => !d.system)
+				.sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+		[ctx],
+	);
+	const buildingOptions = useMemo<Building[]>(
+		() =>
+			Array.from(
+				(
+					ctx.buildings as unknown as { map: Map<string, Building> }
+				).map.values(),
+			),
+		[ctx],
+	);
 
-  const actionSummaries = useMemo(() => {
-    const map = new Map<string, Summary>();
-    actions.forEach((a) =>
-      map.set(a.id, summarizeContent('action', a.id, ctx)),
-    );
-    return map;
-  }, [actions, ctx]);
-  const developmentSummaries = useMemo(() => {
-    const map = new Map<string, Summary>();
-    developmentOptions.forEach((d) =>
-      map.set(d.id, summarizeContent('development', d.id, ctx)),
-    );
-    return map;
-  }, [developmentOptions, ctx]);
-  const buildingSummaries = useMemo(() => {
-    const map = new Map<string, Summary>();
-    buildingOptions.forEach((b) =>
-      map.set(b.id, summarizeContent('building', b.id, ctx)),
-    );
-    return map;
-  }, [buildingOptions, ctx]);
-  const buildingDescriptions = useMemo(() => {
-    const map = new Map<string, Summary>();
-    buildingOptions.forEach((b) =>
-      map.set(b.id, describeContent('building', b.id, ctx)),
-    );
-    return map;
-  }, [buildingOptions, ctx]);
+	const actionSummaries = useMemo(() => {
+		const map = new Map<string, Summary>();
+		actions.forEach((a) =>
+			map.set(a.id, summarizeContent('action', a.id, ctx)),
+		);
+		return map;
+	}, [actions, ctx]);
+	const developmentSummaries = useMemo(() => {
+		const map = new Map<string, Summary>();
+		developmentOptions.forEach((d) =>
+			map.set(d.id, summarizeContent('development', d.id, ctx)),
+		);
+		return map;
+	}, [developmentOptions, ctx]);
+	const buildingSummaries = useMemo(() => {
+		const map = new Map<string, Summary>();
+		buildingOptions.forEach((b) =>
+			map.set(b.id, summarizeContent('building', b.id, ctx)),
+		);
+		return map;
+	}, [buildingOptions, ctx]);
+	const buildingDescriptions = useMemo(() => {
+		const map = new Map<string, Summary>();
+		buildingOptions.forEach((b) =>
+			map.set(b.id, describeContent('building', b.id, ctx)),
+		);
+		return map;
+	}, [buildingOptions, ctx]);
 
-  const hasDevelopLand = selectedPlayer.lands.some((l) => l.slotsFree > 0);
-  const developAction = actions.find((a) => a.category === 'development');
-  const buildAction = actions.find((a) => a.category === 'building');
-  const demolishAction = actions.find((a) => a.category === 'building_remove');
-  const raisePopAction = actions.find((a) => a.category === 'population');
-  const otherActions = actions.filter(
-    (a) => (a.category ?? 'basic') === 'basic',
-  );
+	const hasDevelopLand = selectedPlayer.lands.some((l) => l.slotsFree > 0);
+	const developAction = actions.find((a) => a.category === 'development');
+	const buildAction = actions.find((a) => a.category === 'building');
+	const demolishAction = actions.find((a) => a.category === 'building_remove');
+	const raisePopAction = actions.find((a) => a.category === 'population');
+	const otherActions = actions.filter(
+		(a) => (a.category ?? 'basic') === 'basic',
+	);
 
-  const toggleLabel = viewingOpponent
-    ? 'Show player actions'
-    : 'Show opponent actions';
+	const toggleLabel = viewingOpponent
+		? 'Show player actions'
+		: 'Show opponent actions';
 
-  return (
-    <section className="border rounded p-4 bg-white dark:bg-gray-800 shadow relative">
-      {panelDisabled && (
-        <div className="absolute inset-0 bg-gray-200/60 dark:bg-gray-900/60 rounded pointer-events-none" />
-      )}
-      <div className="flex items-center justify-between mb-2">
-        <h2 className="text-xl font-semibold">
-          {viewingOpponent ? `${opponent.name} Actions` : 'Actions'} (1{' '}
-          {RESOURCES[actionCostResource].icon} each)
-        </h2>
-        <div className="flex items-center gap-2">
-          {viewingOpponent && (
-            <span className="text-sm text-gray-600 dark:text-gray-300">
-              Viewing Opponent
-            </span>
-          )}
-          {!isActionPhase && (
-            <span className="text-sm text-gray-600 dark:text-gray-300">
-              Not in Main phase
-            </span>
-          )}
-          {isLocalTurn && (
-            <button
-              type="button"
-              className="text-lg leading-none px-2 py-1 border rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition"
-              onClick={() => setViewingOpponent((prev) => !prev)}
-              aria-label={toggleLabel}
-            >
-              {viewingOpponent ? '←' : '→'}
-            </button>
-          )}
-        </div>
-      </div>
-      <div ref={sectionRef} className="space-y-3">
-        {otherActions.length > 0 && (
-          <BasicOptions
-            actions={otherActions}
-            summaries={actionSummaries}
-            player={selectedPlayer}
-            canInteract={canInteract}
-          />
-        )}
-        {raisePopAction && (
-          <HireOptions
-            action={raisePopAction}
-            player={selectedPlayer}
-            canInteract={canInteract}
-          />
-        )}
-        {developAction && (
-          <DevelopOptions
-            action={developAction}
-            isActionPhase={isActionPhase}
-            developments={developmentOptions}
-            summaries={developmentSummaries}
-            hasDevelopLand={hasDevelopLand}
-            player={selectedPlayer}
-            canInteract={canInteract}
-          />
-        )}
-        {buildAction && (
-          <BuildOptions
-            action={buildAction}
-            isActionPhase={isActionPhase}
-            buildings={buildingOptions}
-            summaries={buildingSummaries}
-            descriptions={buildingDescriptions}
-            player={selectedPlayer}
-            canInteract={canInteract}
-          />
-        )}
-        {demolishAction && (
-          <DemolishOptions
-            action={demolishAction}
-            isActionPhase={isActionPhase}
-            player={selectedPlayer}
-            canInteract={canInteract}
-          />
-        )}
-      </div>
-    </section>
-  );
+	return (
+		<section className="relative rounded-3xl border border-white/60 bg-white/75 p-6 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/50">
+			{panelDisabled && (
+				<div className="pointer-events-none absolute inset-0 rounded-3xl bg-white/70 backdrop-blur-sm dark:bg-slate-950/60" />
+			)}
+			<div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+				<h2 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+					{viewingOpponent ? `${opponent.name} Actions` : 'Actions'}{' '}
+					<span className="text-base font-normal text-slate-500 dark:text-slate-300">
+						(1 {RESOURCES[actionCostResource].icon} each)
+					</span>
+				</h2>
+				<div className="flex flex-wrap items-center gap-2">
+					{viewingOpponent && (
+						<span className="rounded-full border border-white/60 bg-white/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/10 dark:text-slate-200">
+							Viewing Opponent
+						</span>
+					)}
+					{!isActionPhase && (
+						<span className="rounded-full border border-white/60 bg-white/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/10 dark:text-slate-200">
+							Not In Main Phase
+						</span>
+					)}
+					{isLocalTurn && (
+						<button
+							type="button"
+							className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/60 bg-white/70 text-lg font-semibold text-slate-700 shadow-md transition hover:bg-white/90 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-100 dark:hover:bg-slate-900"
+							onClick={() => setViewingOpponent((prev) => !prev)}
+							aria-label={toggleLabel}
+						>
+							{viewingOpponent ? '←' : '→'}
+						</button>
+					)}
+				</div>
+			</div>
+			<div ref={sectionRef} className="space-y-4">
+				{otherActions.length > 0 && (
+					<BasicOptions
+						actions={otherActions}
+						summaries={actionSummaries}
+						player={selectedPlayer}
+						canInteract={canInteract}
+					/>
+				)}
+				{raisePopAction && (
+					<HireOptions
+						action={raisePopAction}
+						player={selectedPlayer}
+						canInteract={canInteract}
+					/>
+				)}
+				{developAction && (
+					<DevelopOptions
+						action={developAction}
+						isActionPhase={isActionPhase}
+						developments={developmentOptions}
+						summaries={developmentSummaries}
+						hasDevelopLand={hasDevelopLand}
+						player={selectedPlayer}
+						canInteract={canInteract}
+					/>
+				)}
+				{buildAction && (
+					<BuildOptions
+						action={buildAction}
+						isActionPhase={isActionPhase}
+						buildings={buildingOptions}
+						summaries={buildingSummaries}
+						descriptions={buildingDescriptions}
+						player={selectedPlayer}
+						canInteract={canInteract}
+					/>
+				)}
+				{demolishAction && (
+					<DemolishOptions
+						action={demolishAction}
+						isActionPhase={isActionPhase}
+						player={selectedPlayer}
+						canInteract={canInteract}
+					/>
+				)}
+			</div>
+		</section>
+	);
 }

--- a/packages/web/src/components/common/Button.tsx
+++ b/packages/web/src/components/common/Button.tsx
@@ -1,31 +1,38 @@
 import React from 'react';
 
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'ghost';
+	variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'ghost';
 };
 
 const VARIANT_CLASSES: Record<string, string> = {
-  primary: 'bg-blue-600 text-white hover:bg-blue-700',
-  secondary: 'bg-gray-600 text-white hover:bg-gray-700',
-  success: 'bg-green-600 text-white hover:bg-green-700',
-  danger: 'bg-red-600 text-white hover:bg-red-700',
-  ghost: '',
+	primary:
+		'bg-gradient-to-r from-blue-600 to-indigo-500 text-white shadow-lg shadow-blue-500/30 hover:from-blue-500 hover:to-indigo-400 focus-visible:ring-blue-200/80',
+	secondary:
+		'bg-slate-900/80 text-white shadow-lg shadow-slate-900/30 hover:bg-slate-900/70 dark:bg-white/15 dark:text-slate-100 dark:hover:bg-white/20 focus-visible:ring-slate-200/60',
+	success:
+		'bg-gradient-to-r from-emerald-500 to-teal-500 text-white shadow-lg shadow-emerald-500/30 hover:from-emerald-400 hover:to-teal-400 focus-visible:ring-emerald-200/70',
+	danger:
+		'bg-gradient-to-r from-rose-500 to-red-500 text-white shadow-lg shadow-rose-500/40 hover:from-rose-400 hover:to-red-400 focus-visible:ring-rose-200/70',
+	ghost:
+		'bg-transparent text-slate-700 hover:bg-white/60 dark:text-slate-200 dark:hover:bg-white/10 focus-visible:ring-white/40',
 };
 
 export default function Button({
-  variant = 'secondary',
-  disabled,
-  className = '',
-  type = 'button',
-  ...rest
+	variant = 'secondary',
+	disabled,
+	className = '',
+	type = 'button',
+	...rest
 }: ButtonProps) {
-  const variantClass = VARIANT_CLASSES[variant] ?? VARIANT_CLASSES.secondary;
-  return (
-    <button
-      type={type}
-      disabled={disabled}
-      className={`px-3 py-1 rounded disabled:opacity-50 disabled:cursor-not-allowed ${disabled ? '' : 'hoverable'} ${variantClass} ${className}`}
-      {...rest}
-    />
-  );
+	const variantClass = VARIANT_CLASSES[variant] ?? VARIANT_CLASSES.secondary;
+	return (
+		<button
+			type={type}
+			disabled={disabled}
+			className={`inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${
+				disabled ? '' : 'hoverable'
+			} ${variantClass} focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-0 ${className}`}
+			{...rest}
+		/>
+	);
 }

--- a/packages/web/src/components/common/TimeControl.tsx
+++ b/packages/web/src/components/common/TimeControl.tsx
@@ -2,50 +2,51 @@ import React from 'react';
 import { useGameEngine, TIME_SCALE_OPTIONS } from '../../state/GameContext';
 
 export default function TimeControl() {
-  const { ctx, timeScale, setTimeScale } = useGameEngine();
-  const devMode = ctx.game.devMode;
+	const { ctx, timeScale, setTimeScale } = useGameEngine();
+	const devMode = ctx.game.devMode;
 
-  return (
-    <div className="flex items-center gap-2" aria-label="Time control">
-      {devMode && (
-        <span
-          className="rounded bg-purple-600 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-white shadow"
-          title="Developer mode enabled"
-        >
-          Dev
-        </span>
-      )}
-      <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-        Speed
-      </span>
-      <div
-        className="flex overflow-hidden rounded-md border border-gray-300 dark:border-gray-600"
-        role="group"
-        aria-label="Game speed"
-      >
-        {TIME_SCALE_OPTIONS.map((option, index) => {
-          const active = option === timeScale;
-          return (
-            <button
-              key={option}
-              type="button"
-              className={`px-2 py-1 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 ${
-                active
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-white text-gray-700 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
-              } ${
-                index > 0 ? 'border-l border-gray-300 dark:border-gray-600' : ''
-              }`}
-              aria-pressed={active}
-              onClick={() => {
-                if (!active) setTimeScale(option);
-              }}
-            >
-              x{option}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
+	return (
+		<div
+			className="flex items-center gap-2 rounded-full border border-white/50 bg-white/60 px-3 py-1.5 text-sm font-medium shadow-inner backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
+			aria-label="Time control"
+		>
+			{devMode && (
+				<span
+					className="rounded-full bg-gradient-to-r from-purple-600 to-fuchsia-500 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white shadow-md"
+					title="Developer mode enabled"
+				>
+					Dev
+				</span>
+			)}
+			<span className="text-xs uppercase tracking-[0.3em] text-slate-600 dark:text-slate-300">
+				Speed
+			</span>
+			<div
+				className="flex overflow-hidden rounded-full border border-white/50 bg-white/40 shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/50"
+				role="group"
+				aria-label="Game speed"
+			>
+				{TIME_SCALE_OPTIONS.map((option, index) => {
+					const active = option === timeScale;
+					return (
+						<button
+							key={option}
+							type="button"
+							className={`px-3 py-1 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-0 ${
+								active
+									? 'bg-gradient-to-r from-blue-600 to-indigo-500 text-white shadow-inner'
+									: 'text-slate-700 hover:bg-white/60 dark:text-slate-200 dark:hover:bg-slate-800/80'
+							} ${index > 0 ? 'border-l border-white/40 dark:border-white/10' : ''}`}
+							aria-pressed={active}
+							onClick={() => {
+								if (!active) setTimeScale(option);
+							}}
+						>
+							x{option}
+						</button>
+					);
+				})}
+			</div>
+		</div>
+	);
 }

--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -6,121 +6,121 @@ import { useAnimate } from '../../utils/useAutoAnimate';
 import Button from '../common/Button';
 
 const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
-  const {
-    ctx,
-    phaseSteps,
-    setPhaseSteps,
-    phaseTimer,
-    phasePaused,
-    displayPhase,
-    setDisplayPhase,
-    phaseHistories,
-    tabsEnabled,
-    handleEndTurn,
-  } = useGameEngine();
+	const {
+		ctx,
+		phaseSteps,
+		setPhaseSteps,
+		phaseTimer,
+		phasePaused,
+		displayPhase,
+		setDisplayPhase,
+		phaseHistories,
+		tabsEnabled,
+		handleEndTurn,
+	} = useGameEngine();
 
-  const actionPhaseId = useMemo(
-    () => ctx.phases.find((p) => p.action)?.id,
-    [ctx],
-  );
-  const isActionPhase = isActionPhaseActive(
-    ctx.game.currentPhase,
-    actionPhaseId,
-    tabsEnabled,
-  );
+	const actionPhaseId = useMemo(
+		() => ctx.phases.find((p) => p.action)?.id,
+		[ctx],
+	);
+	const isActionPhase = isActionPhaseActive(
+		ctx.game.currentPhase,
+		actionPhaseId,
+		tabsEnabled,
+	);
 
-  const phaseStepsRef = useAnimate<HTMLUListElement>();
+	const phaseStepsRef = useAnimate<HTMLUListElement>();
 
-  useEffect(() => {
-    const el = phaseStepsRef.current;
-    if (!el) return;
-    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
-  }, [phaseSteps]);
+	useEffect(() => {
+		const el = phaseStepsRef.current;
+		if (!el) return;
+		el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+	}, [phaseSteps]);
 
-  return (
-    <section
-      ref={ref}
-      className="border rounded p-4 bg-white dark:bg-gray-800 shadow relative w-full flex flex-col h-full min-h-[275px]"
-    >
-      <div className="absolute -top-6 left-0 font-semibold">
-        Turn {ctx.game.turn} - {ctx.activePlayer.name}
-      </div>
-      <div className="flex mb-2 border-b border-gray-200 dark:border-gray-700">
-        {ctx.phases.map((p) => {
-          const isSelected = displayPhase === p.id;
-          const tabClasses = [
-            'text-sm relative flex items-center gap-1 rounded-none px-3 py-1 transition-shadow hover:scale-100',
-            isSelected
-              ? 'font-semibold text-gray-900 dark:text-gray-100 shadow-[inset_0_-2px_0_rgba(59,130,246,0.95)] dark:shadow-[inset_0_-2px_0_rgba(96,165,250,0.9)]'
-              : 'text-gray-500 shadow-[inset_0_-2px_0_rgba(0,0,0,0)] dark:shadow-[inset_0_-2px_0_rgba(0,0,0,0)]',
-            tabsEnabled ? 'hover:text-gray-800 dark:hover:text-gray-200' : '',
-            !isSelected && tabsEnabled
-              ? 'hover:shadow-[inset_0_-2px_0_rgba(96,165,250,0.75)] dark:hover:shadow-[inset_0_-2px_0_rgba(147,197,253,0.75)]'
-              : '',
-          ]
-            .filter(Boolean)
-            .join(' ');
-          return (
-            <Button
-              key={p.id}
-              type="button"
-              disabled={!tabsEnabled}
-              onClick={() => {
-                if (!tabsEnabled) return;
-                setDisplayPhase(p.id);
-                setPhaseSteps(phaseHistories[p.id] ?? []);
-              }}
-              variant="ghost"
-              className={tabClasses}
-            >
-              {p.icon} {p.label}
-            </Button>
-          );
-        })}
-      </div>
-      <ul
-        ref={phaseStepsRef}
-        className="text-sm text-left space-y-1 overflow-hidden flex-1"
-      >
-        {phaseSteps.map((s, i) => (
-          <li key={i} className={s.active ? 'font-semibold' : ''}>
-            <div>{s.title}</div>
-            <ul className="pl-4 list-disc list-inside">
-              {s.items.length > 0 ? (
-                s.items.map((it, j) => (
-                  <li key={j} className={it.italic ? 'italic' : ''}>
-                    {it.text}
-                    {it.done && <span className="text-green-600 ml-1">✔️</span>}
-                  </li>
-                ))
-              ) : (
-                <li>...</li>
-              )}
-            </ul>
-          </li>
-        ))}
-      </ul>
-      {(!isActionPhase || phaseTimer > 0) && (
-        <div className="absolute top-2 right-2">
-          <TimerCircle progress={phaseTimer} paused={phasePaused} />
-        </div>
-      )}
-      {isActionPhase && (
-        <div className="mt-2 text-right">
-          <Button
-            variant="primary"
-            disabled={Boolean(
-              actionPhaseId &&
-                phaseHistories[actionPhaseId]?.some((s) => s.active),
-            )}
-            onClick={() => void handleEndTurn()}
-          >
-            Next Turn
-          </Button>
-        </div>
-      )}
-    </section>
-  );
+	return (
+		<section
+			ref={ref}
+			className="relative flex h-full min-h-[275px] w-full flex-col gap-3 rounded-3xl border border-white/60 bg-white/75 px-6 py-6 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/50"
+		>
+			<div className="absolute -top-6 left-4 rounded-full border border-white/60 bg-white/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-700 shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-200">
+				Turn {ctx.game.turn} · {ctx.activePlayer.name}
+			</div>
+			<div className="flex flex-wrap gap-2 border-b border-white/40 pb-2 dark:border-white/10">
+				{ctx.phases.map((p) => {
+					const isSelected = displayPhase === p.id;
+					const tabClasses = [
+						'relative flex items-center gap-2 rounded-full px-4 py-2 text-sm transition-all',
+						isSelected
+							? 'bg-gradient-to-r from-blue-500/90 to-indigo-500/90 text-white shadow-lg shadow-blue-500/30'
+							: 'text-slate-600 hover:bg-white/60 hover:text-slate-800 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-slate-100',
+						tabsEnabled ? '' : 'opacity-60',
+					]
+						.filter(Boolean)
+						.join(' ');
+					return (
+						<Button
+							key={p.id}
+							type="button"
+							disabled={!tabsEnabled}
+							onClick={() => {
+								if (!tabsEnabled) return;
+								setDisplayPhase(p.id);
+								setPhaseSteps(phaseHistories[p.id] ?? []);
+							}}
+							variant="ghost"
+							className={tabClasses}
+						>
+							<span className="text-lg leading-none">{p.icon}</span>
+							<span className="text-xs font-semibold uppercase tracking-[0.2em]">
+								{p.label}
+							</span>
+						</Button>
+					);
+				})}
+			</div>
+			<ul
+				ref={phaseStepsRef}
+				className="flex-1 space-y-2 overflow-hidden text-left text-sm"
+			>
+				{phaseSteps.map((s, i) => (
+					<li key={i} className={s.active ? 'font-semibold' : ''}>
+						<div>{s.title}</div>
+						<ul className="pl-4 list-disc list-inside">
+							{s.items.length > 0 ? (
+								s.items.map((it, j) => (
+									<li key={j} className={it.italic ? 'italic' : ''}>
+										{it.text}
+										{it.done && <span className="text-green-600 ml-1">✔️</span>}
+									</li>
+								))
+							) : (
+								<li>...</li>
+							)}
+						</ul>
+					</li>
+				))}
+			</ul>
+			{(!isActionPhase || phaseTimer > 0) && (
+				<div className="absolute top-2 right-2">
+					<TimerCircle progress={phaseTimer} paused={phasePaused} />
+				</div>
+			)}
+			{isActionPhase && (
+				<div className="mt-2 text-right">
+					<Button
+						variant="primary"
+						disabled={Boolean(
+							actionPhaseId &&
+								phaseHistories[actionPhaseId]?.some((s) => s.active),
+						)}
+						onClick={() => void handleEndTurn()}
+					>
+						Next Turn
+					</Button>
+				</div>
+			)}
+		</section>
+	);
 });
 
 export default PhasePanel;

--- a/packages/web/src/components/player/BuildingDisplay.tsx
+++ b/packages/web/src/components/player/BuildingDisplay.tsx
@@ -5,48 +5,49 @@ import { useGameEngine } from '../../state/GameContext';
 import { useAnimate } from '../../utils/useAutoAnimate';
 
 interface BuildingDisplayProps {
-  player: EngineContext['activePlayer'];
+	player: EngineContext['activePlayer'];
 }
 
 const BuildingDisplay: React.FC<BuildingDisplayProps> = ({ player }) => {
-  const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
-  if (player.buildings.size === 0) return null;
-  const animateBuildings = useAnimate<HTMLDivElement>();
-  return (
-    <div ref={animateBuildings} className="flex flex-wrap gap-2 mt-2 w-fit">
-      {Array.from(player.buildings).map((b) => {
-        const name = ctx.buildings.get(b)?.name || b;
-        const icon = ctx.buildings.get(b)?.icon || '';
-        const upkeep = ctx.buildings.get(b)?.upkeep;
-        const title = `${icon} ${name}`;
-        return (
-          <div
-            key={b}
-            className="panel-card p-2 text-center hoverable cursor-help"
-            onMouseEnter={() => {
-              const full = describeContent('building', b, ctx, {
-                installed: true,
-              });
-              const { effects, description } = splitSummary(full);
-              handleHoverCard({
-                title,
-                effects,
-                requirements: [],
-                upkeep,
-                ...(description && { description }),
-                bgClass: 'bg-gray-100 dark:bg-gray-700',
-              });
-            }}
-            onMouseLeave={clearHoverCard}
-          >
-            <span className="font-medium">
-              {icon} {name}
-            </span>
-          </div>
-        );
-      })}
-    </div>
-  );
+	const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
+	if (player.buildings.size === 0) return null;
+	const animateBuildings = useAnimate<HTMLDivElement>();
+	return (
+		<div ref={animateBuildings} className="mt-3 flex w-full flex-wrap gap-3">
+			{Array.from(player.buildings).map((b) => {
+				const name = ctx.buildings.get(b)?.name || b;
+				const icon = ctx.buildings.get(b)?.icon || '';
+				const upkeep = ctx.buildings.get(b)?.upkeep;
+				const title = `${icon} ${name}`;
+				return (
+					<div
+						key={b}
+						className="panel-card flex min-w-[9rem] flex-col items-center gap-1 px-4 py-3 text-center text-sm font-semibold text-slate-700 hoverable dark:text-slate-100"
+						onMouseEnter={() => {
+							const full = describeContent('building', b, ctx, {
+								installed: true,
+							});
+							const { effects, description } = splitSummary(full);
+							handleHoverCard({
+								title,
+								effects,
+								requirements: [],
+								upkeep,
+								...(description && { description }),
+								bgClass:
+									'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+							});
+						}}
+						onMouseLeave={clearHoverCard}
+					>
+						<span className="font-medium">
+							{icon} {name}
+						</span>
+					</div>
+				);
+			})}
+		</div>
+	);
 };
 
 export default BuildingDisplay;

--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
 import {
-  LAND_INFO,
-  SLOT_INFO,
-  DEVELOPMENTS_INFO,
+	LAND_INFO,
+	SLOT_INFO,
+	DEVELOPMENTS_INFO,
 } from '@kingdom-builder/contents';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { describeContent, splitSummary } from '../../translation';
@@ -10,145 +10,148 @@ import { useGameEngine } from '../../state/GameContext';
 import { useAnimate } from '../../utils/useAutoAnimate';
 
 interface LandDisplayProps {
-  player: EngineContext['activePlayer'];
+	player: EngineContext['activePlayer'];
 }
 
 const LandTile: React.FC<{
-  land: EngineContext['activePlayer']['lands'][number];
-  ctx: ReturnType<typeof useGameEngine>['ctx'];
-  handleHoverCard: ReturnType<typeof useGameEngine>['handleHoverCard'];
-  clearHoverCard: ReturnType<typeof useGameEngine>['clearHoverCard'];
-  developAction?: { icon?: string; name: string } | undefined;
+	land: EngineContext['activePlayer']['lands'][number];
+	ctx: ReturnType<typeof useGameEngine>['ctx'];
+	handleHoverCard: ReturnType<typeof useGameEngine>['handleHoverCard'];
+	clearHoverCard: ReturnType<typeof useGameEngine>['clearHoverCard'];
+	developAction?: { icon?: string; name: string } | undefined;
 }> = ({ land, ctx, handleHoverCard, clearHoverCard, developAction }) => {
-  const showLandCard = () => {
-    const full = describeContent('land', land, ctx);
-    const { effects, description } = splitSummary(full);
-    handleHoverCard({
-      title: `${LAND_INFO.icon} ${LAND_INFO.label}`,
-      effects,
-      requirements: [],
-      effectsTitle: DEVELOPMENTS_INFO.label,
-      ...(description && { description }),
-      bgClass: 'bg-gray-100 dark:bg-gray-700',
-    });
-  };
-  const animateSlots = useAnimate<HTMLDivElement>();
-  return (
-    <div
-      className="land-tile"
-      onMouseEnter={showLandCard}
-      onMouseLeave={clearHoverCard}
-    >
-      <span className="font-medium">
-        {LAND_INFO.icon} {LAND_INFO.label}
-      </span>
-      <div
-        ref={animateSlots}
-        className="mt-1 flex flex-wrap justify-center gap-1"
-      >
-        {Array.from({ length: land.slotsMax }).map((_, i) => {
-          const devId = land.developments[i];
-          if (devId) {
-            const name = ctx.developments.get(devId)?.name || devId;
-            const title = `${ctx.developments.get(devId)?.icon || ''} ${name}`;
-            const handleLeave = () => showLandCard();
-            return (
-              <span
-                key={i}
-                className="land-slot"
-                aria-label={name}
-                onMouseEnter={(e) => {
-                  e.stopPropagation();
-                  const full = describeContent('development', devId, ctx, {
-                    installed: true,
-                  });
-                  const { effects, description } = splitSummary(full);
-                  handleHoverCard({
-                    title,
-                    effects,
-                    requirements: [],
-                    ...(description && { description }),
-                    bgClass: 'bg-gray-100 dark:bg-gray-700',
-                  });
-                }}
-                onMouseLeave={(e) => {
-                  e.stopPropagation();
-                  handleLeave();
-                }}
-              >
-                <span aria-hidden="true">
-                  {ctx.developments.get(devId)?.icon}
-                </span>
-              </span>
-            );
-          }
-          const handleLeave = () => showLandCard();
-          return (
-            <span
-              key={i}
-              className="land-slot italic"
-              aria-label={`${SLOT_INFO.label} (empty)`}
-              onMouseEnter={(e) => {
-                e.stopPropagation();
-                handleHoverCard({
-                  title: `${SLOT_INFO.icon} ${SLOT_INFO.label} (empty)`,
-                  effects: [],
-                  ...(developAction && {
-                    description: `Use ${developAction.icon || ''} ${developAction.name} to build here`,
-                  }),
-                  requirements: [],
-                  bgClass: 'bg-gray-100 dark:bg-gray-700',
-                });
-              }}
-              onMouseLeave={(e) => {
-                e.stopPropagation();
-                handleLeave();
-              }}
-            >
-              <span aria-hidden="true">{SLOT_INFO.icon}</span>
-            </span>
-          );
-        })}
-      </div>
-    </div>
-  );
+	const showLandCard = () => {
+		const full = describeContent('land', land, ctx);
+		const { effects, description } = splitSummary(full);
+		handleHoverCard({
+			title: `${LAND_INFO.icon} ${LAND_INFO.label}`,
+			effects,
+			requirements: [],
+			effectsTitle: DEVELOPMENTS_INFO.label,
+			...(description && { description }),
+			bgClass:
+				'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+		});
+	};
+	const animateSlots = useAnimate<HTMLDivElement>();
+	return (
+		<div
+			className="land-tile"
+			onMouseEnter={showLandCard}
+			onMouseLeave={clearHoverCard}
+		>
+			<span className="font-medium">
+				{LAND_INFO.icon} {LAND_INFO.label}
+			</span>
+			<div
+				ref={animateSlots}
+				className="mt-1 flex flex-wrap justify-center gap-1"
+			>
+				{Array.from({ length: land.slotsMax }).map((_, i) => {
+					const devId = land.developments[i];
+					if (devId) {
+						const name = ctx.developments.get(devId)?.name || devId;
+						const title = `${ctx.developments.get(devId)?.icon || ''} ${name}`;
+						const handleLeave = () => showLandCard();
+						return (
+							<span
+								key={i}
+								className="land-slot"
+								aria-label={name}
+								onMouseEnter={(e) => {
+									e.stopPropagation();
+									const full = describeContent('development', devId, ctx, {
+										installed: true,
+									});
+									const { effects, description } = splitSummary(full);
+									handleHoverCard({
+										title,
+										effects,
+										requirements: [],
+										...(description && { description }),
+										bgClass:
+											'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+									});
+								}}
+								onMouseLeave={(e) => {
+									e.stopPropagation();
+									handleLeave();
+								}}
+							>
+								<span aria-hidden="true">
+									{ctx.developments.get(devId)?.icon}
+								</span>
+							</span>
+						);
+					}
+					const handleLeave = () => showLandCard();
+					return (
+						<span
+							key={i}
+							className="land-slot italic"
+							aria-label={`${SLOT_INFO.label} (empty)`}
+							onMouseEnter={(e) => {
+								e.stopPropagation();
+								handleHoverCard({
+									title: `${SLOT_INFO.icon} ${SLOT_INFO.label} (empty)`,
+									effects: [],
+									...(developAction && {
+										description: `Use ${developAction.icon || ''} ${developAction.name} to build here`,
+									}),
+									requirements: [],
+									bgClass:
+										'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+								});
+							}}
+							onMouseLeave={(e) => {
+								e.stopPropagation();
+								handleLeave();
+							}}
+						>
+							<span aria-hidden="true">{SLOT_INFO.icon}</span>
+						</span>
+					);
+				})}
+			</div>
+		</div>
+	);
 };
 
 const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
-  const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
-  const developAction = useMemo(() => {
-    const entry = Array.from(
-      (
-        ctx.actions as unknown as {
-          map: Map<string, { category?: string; icon?: string; name: string }>;
-        }
-      ).map.entries(),
-    ).find(([, a]) => a.category === 'development');
-    if (!entry) return undefined;
-    const [, info] = entry;
-    return info.icon
-      ? { icon: info.icon, name: info.name }
-      : { name: info.name };
-  }, [ctx]);
-  if (player.lands.length === 0) return null;
-  const animateLands = useAnimate<HTMLDivElement>();
-  return (
-    <div
-      ref={animateLands}
-      className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2 mt-2 w-full"
-    >
-      {player.lands.map((land) => (
-        <LandTile
-          key={land.id}
-          land={land}
-          ctx={ctx}
-          handleHoverCard={handleHoverCard}
-          clearHoverCard={clearHoverCard}
-          developAction={developAction}
-        />
-      ))}
-    </div>
-  );
+	const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
+	const developAction = useMemo(() => {
+		const entry = Array.from(
+			(
+				ctx.actions as unknown as {
+					map: Map<string, { category?: string; icon?: string; name: string }>;
+				}
+			).map.entries(),
+		).find(([, a]) => a.category === 'development');
+		if (!entry) return undefined;
+		const [, info] = entry;
+		return info.icon
+			? { icon: info.icon, name: info.name }
+			: { name: info.name };
+	}, [ctx]);
+	if (player.lands.length === 0) return null;
+	const animateLands = useAnimate<HTMLDivElement>();
+	return (
+		<div
+			ref={animateLands}
+			className="mt-3 grid w-full grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+		>
+			{player.lands.map((land) => (
+				<LandTile
+					key={land.id}
+					land={land}
+					ctx={ctx}
+					handleHoverCard={handleHoverCard}
+					clearHoverCard={clearHoverCard}
+					developAction={developAction}
+				/>
+			))}
+		</div>
+	);
 };
 
 export default LandDisplay;

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -1,95 +1,96 @@
 import React from 'react';
 import { useGameEngine } from '../../state/GameContext';
 import {
-  MODIFIER_INFO as modifierInfo,
-  PHASES,
-  PASSIVE_INFO,
-  POPULATIONS,
+	MODIFIER_INFO as modifierInfo,
+	PHASES,
+	PASSIVE_INFO,
+	POPULATIONS,
 } from '@kingdom-builder/contents';
 import { describeEffects, splitSummary } from '../../translation';
 import type { EffectDef } from '@kingdom-builder/engine';
 import { useAnimate } from '../../utils/useAutoAnimate';
 
 export const ICON_MAP: Record<string, string> = {
-  cost_mod: modifierInfo.cost.icon,
-  result_mod: modifierInfo.result.icon,
+	cost_mod: modifierInfo.cost.icon,
+	result_mod: modifierInfo.result.icon,
 };
 
 const POPULATION_PASSIVE_PREFIXES = new Set(
-  POPULATIONS.keys().map((id) => `${id}_`),
+	POPULATIONS.keys().map((id) => `${id}_`),
 );
 
 export default function PassiveDisplay({
-  player,
+	player,
 }: {
-  player: ReturnType<typeof useGameEngine>['ctx']['activePlayer'];
+	player: ReturnType<typeof useGameEngine>['ctx']['activePlayer'];
 }) {
-  const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
-  const ids = ctx.passives.list(player.id);
-  const defs = ctx.passives.values(player.id) as {
-    effects?: EffectDef[];
-    onUpkeepPhase?: EffectDef[];
-  }[];
-  const map = new Map<
-    string,
-    { effects?: EffectDef[]; onUpkeepPhase?: EffectDef[] }
-  >(ids.map((id, i) => [id, defs[i]!]));
+	const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
+	const ids = ctx.passives.list(player.id);
+	const defs = ctx.passives.values(player.id) as {
+		effects?: EffectDef[];
+		onUpkeepPhase?: EffectDef[];
+	}[];
+	const map = new Map<
+		string,
+		{ effects?: EffectDef[]; onUpkeepPhase?: EffectDef[] }
+	>(ids.map((id, i) => [id, defs[i]!]));
 
-  const buildingIds = Array.from(player.buildings);
-  const buildingIdSet = new Set(buildingIds);
-  const buildingPrefixes = buildingIds.map((id) => `${id}_`);
-  const developmentIds = new Set(
-    player.lands.flatMap((l) => l.developments.map((d) => `${d}_${l.id}`)),
-  );
+	const buildingIds = Array.from(player.buildings);
+	const buildingIdSet = new Set(buildingIds);
+	const buildingPrefixes = buildingIds.map((id) => `${id}_`);
+	const developmentIds = new Set(
+		player.lands.flatMap((l) => l.developments.map((d) => `${d}_${l.id}`)),
+	);
 
-  const entries = Array.from(map.entries()).filter(([id]) => {
-    if (buildingIdSet.has(id) || developmentIds.has(id)) return false;
-    if (buildingPrefixes.some((prefix) => id.startsWith(prefix))) return false;
-    for (const prefix of POPULATION_PASSIVE_PREFIXES)
-      if (id.startsWith(prefix)) return false;
-    return true;
-  });
-  if (entries.length === 0) return null;
+	const entries = Array.from(map.entries()).filter(([id]) => {
+		if (buildingIdSet.has(id) || developmentIds.has(id)) return false;
+		if (buildingPrefixes.some((prefix) => id.startsWith(prefix))) return false;
+		for (const prefix of POPULATION_PASSIVE_PREFIXES)
+			if (id.startsWith(prefix)) return false;
+		return true;
+	});
+	if (entries.length === 0) return null;
 
-  const getIcon = (effects: EffectDef[] | undefined) => {
-    const first = effects?.[0];
-    return ICON_MAP[first?.type as keyof typeof ICON_MAP] ?? PASSIVE_INFO.icon;
-  };
+	const getIcon = (effects: EffectDef[] | undefined) => {
+		const first = effects?.[0];
+		return ICON_MAP[first?.type as keyof typeof ICON_MAP] ?? PASSIVE_INFO.icon;
+	};
 
-  const animatePassives = useAnimate<HTMLDivElement>();
-  return (
-    <div
-      ref={animatePassives}
-      className="panel-card flex items-center gap-1 px-3 py-2 w-fit"
-    >
-      {entries.map(([id, def]) => {
-        const icon = getIcon(def.effects);
-        const items = describeEffects(def.effects || [], ctx);
-        const upkeepLabel =
-          PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
-        const summary = def.onUpkeepPhase
-          ? [{ title: `Until your next ${upkeepLabel} Phase`, items }]
-          : items;
-        return (
-          <span
-            key={id}
-            className="hoverable cursor-pointer"
-            onMouseEnter={() => {
-              const { effects, description } = splitSummary(summary);
-              handleHoverCard({
-                title: `${icon} ${PASSIVE_INFO.label}`,
-                effects,
-                requirements: [],
-                ...(description && { description }),
-                bgClass: 'bg-gray-100 dark:bg-gray-700',
-              });
-            }}
-            onMouseLeave={clearHoverCard}
-          >
-            {icon}
-          </span>
-        );
-      })}
-    </div>
-  );
+	const animatePassives = useAnimate<HTMLDivElement>();
+	return (
+		<div
+			ref={animatePassives}
+			className="panel-card flex w-fit items-center gap-3 px-4 py-3 text-lg"
+		>
+			{entries.map(([id, def]) => {
+				const icon = getIcon(def.effects);
+				const items = describeEffects(def.effects || [], ctx);
+				const upkeepLabel =
+					PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
+				const summary = def.onUpkeepPhase
+					? [{ title: `Until your next ${upkeepLabel} Phase`, items }]
+					: items;
+				return (
+					<span
+						key={id}
+						className="hoverable cursor-pointer"
+						onMouseEnter={() => {
+							const { effects, description } = splitSummary(summary);
+							handleHoverCard({
+								title: `${icon} ${PASSIVE_INFO.label}`,
+								effects,
+								requirements: [],
+								...(description && { description }),
+								bgClass:
+									'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+							});
+						}}
+						onMouseLeave={clearHoverCard}
+					>
+						{icon}
+					</span>
+				);
+			})}
+		</div>
+	);
 }

--- a/packages/web/src/components/player/PlayerPanel.tsx
+++ b/packages/web/src/components/player/PlayerPanel.tsx
@@ -8,42 +8,44 @@ import PassiveDisplay from './PassiveDisplay';
 import { useAnimate } from '../../utils/useAutoAnimate';
 
 interface PlayerPanelProps {
-  player: EngineContext['activePlayer'];
-  className?: string;
-  isActive?: boolean;
+	player: EngineContext['activePlayer'];
+	className?: string;
+	isActive?: boolean;
 }
 
 const PlayerPanel: React.FC<PlayerPanelProps> = ({
-  player,
-  className = '',
-  isActive = false,
+	player,
+	className = '',
+	isActive = false,
 }) => {
-  const animateBar = useAnimate<HTMLDivElement>();
-  const animateSections = useAnimate<HTMLDivElement>();
-  return (
-    <div className={`player-panel h-full flex flex-col space-y-1 ${className}`}>
-      <h3 className="font-semibold">
-        {isActive && (
-          <span role="img" aria-label="active player" className="mr-1">
-            👑
-          </span>
-        )}
-        {player.name}
-      </h3>
-      <div
-        ref={animateBar}
-        className="panel-card flex flex-wrap items-center gap-2 px-3 py-2 w-fit"
-      >
-        <ResourceBar player={player} />
-        <PopulationInfo player={player} />
-      </div>
-      <div ref={animateSections} className="flex flex-col space-y-1">
-        <LandDisplay player={player} />
-        <BuildingDisplay player={player} />
-        <PassiveDisplay player={player} />
-      </div>
-    </div>
-  );
+	const animateBar = useAnimate<HTMLDivElement>();
+	const animateSections = useAnimate<HTMLDivElement>();
+	return (
+		<div
+			className={`player-panel flex h-full flex-col gap-2 text-slate-800 dark:text-slate-100 ${className}`}
+		>
+			<h3 className="text-lg font-semibold tracking-tight">
+				{isActive && (
+					<span role="img" aria-label="active player" className="mr-1">
+						👑
+					</span>
+				)}
+				{player.name}
+			</h3>
+			<div
+				ref={animateBar}
+				className="panel-card flex w-fit flex-wrap items-center gap-3 px-4 py-3"
+			>
+				<ResourceBar player={player} />
+				<PopulationInfo player={player} />
+			</div>
+			<div ref={animateSections} className="flex flex-col gap-2">
+				<LandDisplay player={player} />
+				<BuildingDisplay player={player} />
+				<PassiveDisplay player={player} />
+			</div>
+		</div>
+	);
 };
 
 export default PlayerPanel;

--- a/packages/web/src/components/player/PopulationInfo.tsx
+++ b/packages/web/src/components/player/PopulationInfo.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {
-  POPULATION_ROLES,
-  STATS,
-  POPULATION_INFO,
-  POPULATION_ARCHETYPE_INFO,
+	POPULATION_ROLES,
+	STATS,
+	POPULATION_INFO,
+	POPULATION_ARCHETYPE_INFO,
 } from '@kingdom-builder/contents';
 import { formatStatValue, getStatBreakdownSummary } from '../../utils/stats';
 import type { EngineContext } from '@kingdom-builder/engine';
@@ -11,188 +11,193 @@ import { useGameEngine } from '../../state/GameContext';
 import { useValueChangeIndicators } from '../../utils/useValueChangeIndicators';
 
 interface StatButtonProps {
-  statKey: keyof typeof STATS;
-  value: number;
-  onShow: () => void;
-  onHide: () => void;
+	statKey: keyof typeof STATS;
+	value: number;
+	onShow: () => void;
+	onHide: () => void;
 }
 
 const formatStatDelta = (statKey: keyof typeof STATS, delta: number) => {
-  const formatted = formatStatValue(statKey, Math.abs(delta));
-  return `${delta > 0 ? '+' : '-'}${formatted}`;
+	const formatted = formatStatValue(statKey, Math.abs(delta));
+	return `${delta > 0 ? '+' : '-'}${formatted}`;
 };
 
 const StatButton: React.FC<StatButtonProps> = ({
-  statKey,
-  value,
-  onShow,
-  onHide,
+	statKey,
+	value,
+	onShow,
+	onHide,
 }) => {
-  const info = STATS[statKey];
-  const changes = useValueChangeIndicators(value);
+	const info = STATS[statKey];
+	const changes = useValueChangeIndicators(value);
 
-  return (
-    <button
-      type="button"
-      className="bar-item hoverable cursor-help rounded px-1 relative overflow-visible"
-      onMouseEnter={onShow}
-      onMouseLeave={onHide}
-      onFocus={onShow}
-      onBlur={onHide}
-      onClick={onShow}
-    >
-      {info.icon}
-      {formatStatValue(statKey, value)}
-      {changes.map((change) => (
-        <span
-          key={change.id}
-          className={`value-change-indicator ${
-            change.direction === 'gain'
-              ? 'value-change-indicator--gain text-emerald-300'
-              : 'value-change-indicator--loss text-rose-300'
-          }`}
-          aria-hidden="true"
-        >
-          {formatStatDelta(statKey, change.delta)}
-        </span>
-      ))}
-    </button>
-  );
+	return (
+		<button
+			type="button"
+			className="bar-item hoverable cursor-help relative overflow-visible"
+			onMouseEnter={onShow}
+			onMouseLeave={onHide}
+			onFocus={onShow}
+			onBlur={onHide}
+			onClick={onShow}
+		>
+			{info.icon}
+			{formatStatValue(statKey, value)}
+			{changes.map((change) => (
+				<span
+					key={change.id}
+					className={`value-change-indicator ${
+						change.direction === 'gain'
+							? 'value-change-indicator--gain text-emerald-300'
+							: 'value-change-indicator--loss text-rose-300'
+					}`}
+					aria-hidden="true"
+				>
+					{formatStatDelta(statKey, change.delta)}
+				</span>
+			))}
+		</button>
+	);
 };
 
 interface PopulationInfoProps {
-  player: EngineContext['activePlayer'];
+	player: EngineContext['activePlayer'];
 }
 
 const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
-  const { handleHoverCard, clearHoverCard, ctx } = useGameEngine();
-  const popEntries = Object.entries(player.population).filter(([, v]) => v > 0);
-  const currentPop = popEntries.reduce((sum, [, v]) => sum + v, 0);
-  const popDetails = popEntries.map(([role, count]) => ({ role, count }));
+	const { handleHoverCard, clearHoverCard, ctx } = useGameEngine();
+	const popEntries = Object.entries(player.population).filter(([, v]) => v > 0);
+	const currentPop = popEntries.reduce((sum, [, v]) => sum + v, 0);
+	const popDetails = popEntries.map(([role, count]) => ({ role, count }));
 
-  const showPopulationCard = () =>
-    handleHoverCard({
-      title: `${POPULATION_INFO.icon} ${POPULATION_INFO.label}`,
-      effects: Object.values(POPULATION_ROLES).map(
-        (r) => `${r.icon} ${r.label} - ${r.description}`,
-      ),
-      effectsTitle: POPULATION_ARCHETYPE_INFO.label,
-      requirements: [],
-      description: POPULATION_INFO.description,
-      bgClass: 'bg-gray-100 dark:bg-gray-700',
-    });
+	const showPopulationCard = () =>
+		handleHoverCard({
+			title: `${POPULATION_INFO.icon} ${POPULATION_INFO.label}`,
+			effects: Object.values(POPULATION_ROLES).map(
+				(r) => `${r.icon} ${r.label} - ${r.description}`,
+			),
+			effectsTitle: POPULATION_ARCHETYPE_INFO.label,
+			requirements: [],
+			description: POPULATION_INFO.description,
+			bgClass:
+				'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+		});
 
-  const showStatCard = (statKey: string) => {
-    const info = STATS[statKey as keyof typeof STATS];
-    if (!info) return;
-    const breakdown = getStatBreakdownSummary(statKey, player, ctx);
-    handleHoverCard({
-      title: `${info.icon} ${info.label}`,
-      effects: breakdown,
-      effectsTitle: 'Breakdown',
-      requirements: [],
-      description: info.description,
-      bgClass: 'bg-gray-100 dark:bg-gray-700',
-    });
-  };
+	const showStatCard = (statKey: string) => {
+		const info = STATS[statKey as keyof typeof STATS];
+		if (!info) return;
+		const breakdown = getStatBreakdownSummary(statKey, player, ctx);
+		handleHoverCard({
+			title: `${info.icon} ${info.label}`,
+			effects: breakdown,
+			effectsTitle: 'Breakdown',
+			requirements: [],
+			description: info.description,
+			bgClass:
+				'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+		});
+	};
 
-  return (
-    <>
-      <div className="h-4 border-l border-black/10 dark:border-white/10" />
-      <div
-        role="button"
-        tabIndex={0}
-        className="bar-item hoverable cursor-help rounded px-1"
-        onMouseEnter={showPopulationCard}
-        onMouseLeave={clearHoverCard}
-        onFocus={showPopulationCard}
-        onBlur={clearHoverCard}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            showPopulationCard();
-          }
-        }}
-      >
-        {POPULATION_INFO.icon}
-        {currentPop}/{player.maxPopulation}
-        {popDetails.length > 0 && (
-          <>
-            {' ('}
-            {popDetails.map(({ role, count }, i) => {
-              const info =
-                POPULATION_ROLES[role as keyof typeof POPULATION_ROLES];
-              return (
-                <React.Fragment key={role}>
-                  {i > 0 && ','}
-                  <button
-                    type="button"
-                    className="cursor-help hoverable rounded px-1"
-                    onMouseEnter={(e) => {
-                      e.stopPropagation();
-                      handleHoverCard({
-                        title: `${info.icon} ${info.label}`,
-                        effects: [],
-                        requirements: [],
-                        description: info.description,
-                        bgClass: 'bg-gray-100 dark:bg-gray-700',
-                      });
-                    }}
-                    onMouseLeave={(e) => {
-                      e.stopPropagation();
-                      showPopulationCard();
-                    }}
-                    onFocus={(e) => {
-                      e.stopPropagation();
-                      handleHoverCard({
-                        title: `${info.icon} ${info.label}`,
-                        effects: [],
-                        requirements: [],
-                        description: info.description,
-                        bgClass: 'bg-gray-100 dark:bg-gray-700',
-                      });
-                    }}
-                    onBlur={(e) => {
-                      e.stopPropagation();
-                      showPopulationCard();
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleHoverCard({
-                        title: `${info.icon} ${info.label}`,
-                        effects: [],
-                        requirements: [],
-                        description: info.description,
-                        bgClass: 'bg-gray-100 dark:bg-gray-700',
-                      });
-                    }}
-                  >
-                    {info.icon}
-                    {count}
-                  </button>
-                </React.Fragment>
-              );
-            })}
-            {')'}
-          </>
-        )}
-      </div>
-      {Object.entries(player.stats)
-        .filter(([k, v]) => {
-          const info = STATS[k as keyof typeof STATS];
-          return !info.capacity && (v !== 0 || player.statsHistory?.[k]);
-        })
-        .map(([k, v]) => (
-          <StatButton
-            key={k}
-            statKey={k as keyof typeof STATS}
-            value={v}
-            onShow={() => showStatCard(k)}
-            onHide={clearHoverCard}
-          />
-        ))}
-    </>
-  );
+	return (
+		<>
+			<div className="h-6 border-l border-white/40 dark:border-white/10" />
+			<div
+				role="button"
+				tabIndex={0}
+				className="bar-item hoverable cursor-help"
+				onMouseEnter={showPopulationCard}
+				onMouseLeave={clearHoverCard}
+				onFocus={showPopulationCard}
+				onBlur={clearHoverCard}
+				onKeyDown={(e) => {
+					if (e.key === 'Enter' || e.key === ' ') {
+						e.preventDefault();
+						showPopulationCard();
+					}
+				}}
+			>
+				{POPULATION_INFO.icon}
+				{currentPop}/{player.maxPopulation}
+				{popDetails.length > 0 && (
+					<>
+						{' ('}
+						{popDetails.map(({ role, count }, i) => {
+							const info =
+								POPULATION_ROLES[role as keyof typeof POPULATION_ROLES];
+							return (
+								<React.Fragment key={role}>
+									{i > 0 && ','}
+									<button
+										type="button"
+										className="cursor-help rounded-full border border-white/40 bg-white/40 px-2 py-1 text-xs font-semibold text-slate-700 hoverable dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100"
+										onMouseEnter={(e) => {
+											e.stopPropagation();
+											handleHoverCard({
+												title: `${info.icon} ${info.label}`,
+												effects: [],
+												requirements: [],
+												description: info.description,
+												bgClass:
+													'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+											});
+										}}
+										onMouseLeave={(e) => {
+											e.stopPropagation();
+											showPopulationCard();
+										}}
+										onFocus={(e) => {
+											e.stopPropagation();
+											handleHoverCard({
+												title: `${info.icon} ${info.label}`,
+												effects: [],
+												requirements: [],
+												description: info.description,
+												bgClass:
+													'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+											});
+										}}
+										onBlur={(e) => {
+											e.stopPropagation();
+											showPopulationCard();
+										}}
+										onClick={(e) => {
+											e.stopPropagation();
+											handleHoverCard({
+												title: `${info.icon} ${info.label}`,
+												effects: [],
+												requirements: [],
+												description: info.description,
+												bgClass:
+													'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+											});
+										}}
+									>
+										{info.icon}
+										{count}
+									</button>
+								</React.Fragment>
+							);
+						})}
+						{')'}
+					</>
+				)}
+			</div>
+			{Object.entries(player.stats)
+				.filter(([k, v]) => {
+					const info = STATS[k as keyof typeof STATS];
+					return !info.capacity && (v !== 0 || player.statsHistory?.[k]);
+				})
+				.map(([k, v]) => (
+					<StatButton
+						key={k}
+						statKey={k as keyof typeof STATS}
+						value={v}
+						onShow={() => showStatCard(k)}
+						onHide={clearHoverCard}
+					/>
+				))}
+		</>
+	);
 };
 
 export default PopulationInfo;

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -5,93 +5,94 @@ import { useGameEngine } from '../../state/GameContext';
 import { useValueChangeIndicators } from '../../utils/useValueChangeIndicators';
 
 interface ResourceButtonProps {
-  resourceKey: keyof typeof RESOURCES;
-  value: number;
-  onShow: () => void;
-  onHide: () => void;
+	resourceKey: keyof typeof RESOURCES;
+	value: number;
+	onShow: () => void;
+	onHide: () => void;
 }
 
 const formatDelta = (delta: number) => {
-  const absolute = Math.abs(delta);
-  const formatted = Number.isInteger(absolute)
-    ? absolute.toString()
-    : absolute.toLocaleString(undefined, {
-        maximumFractionDigits: 2,
-        minimumFractionDigits: 0,
-      });
-  return `${delta > 0 ? '+' : '-'}${formatted}`;
+	const absolute = Math.abs(delta);
+	const formatted = Number.isInteger(absolute)
+		? absolute.toString()
+		: absolute.toLocaleString(undefined, {
+				maximumFractionDigits: 2,
+				minimumFractionDigits: 0,
+			});
+	return `${delta > 0 ? '+' : '-'}${formatted}`;
 };
 
 const ResourceButton: React.FC<ResourceButtonProps> = ({
-  resourceKey,
-  value,
-  onShow,
-  onHide,
+	resourceKey,
+	value,
+	onShow,
+	onHide,
 }) => {
-  const info = RESOURCES[resourceKey];
-  const changes = useValueChangeIndicators(value);
+	const info = RESOURCES[resourceKey];
+	const changes = useValueChangeIndicators(value);
 
-  return (
-    <button
-      type="button"
-      className="bar-item hoverable cursor-help rounded px-1 relative overflow-visible"
-      onMouseEnter={onShow}
-      onMouseLeave={onHide}
-      onFocus={onShow}
-      onBlur={onHide}
-      onClick={onShow}
-      aria-label={`${info.label}: ${value}`}
-    >
-      {info.icon}
-      {value}
-      {changes.map((change) => (
-        <span
-          key={change.id}
-          className={`value-change-indicator ${
-            change.direction === 'gain'
-              ? 'value-change-indicator--gain text-emerald-300'
-              : 'value-change-indicator--loss text-rose-300'
-          }`}
-          aria-hidden="true"
-        >
-          {formatDelta(change.delta)}
-        </span>
-      ))}
-    </button>
-  );
+	return (
+		<button
+			type="button"
+			className="bar-item hoverable cursor-help relative overflow-visible"
+			onMouseEnter={onShow}
+			onMouseLeave={onHide}
+			onFocus={onShow}
+			onBlur={onHide}
+			onClick={onShow}
+			aria-label={`${info.label}: ${value}`}
+		>
+			{info.icon}
+			{value}
+			{changes.map((change) => (
+				<span
+					key={change.id}
+					className={`value-change-indicator ${
+						change.direction === 'gain'
+							? 'value-change-indicator--gain text-emerald-300'
+							: 'value-change-indicator--loss text-rose-300'
+					}`}
+					aria-hidden="true"
+				>
+					{formatDelta(change.delta)}
+				</span>
+			))}
+		</button>
+	);
 };
 
 interface ResourceBarProps {
-  player: EngineContext['activePlayer'];
+	player: EngineContext['activePlayer'];
 }
 
 const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
-  const { handleHoverCard, clearHoverCard } = useGameEngine();
-  return (
-    <>
-      {(Object.keys(RESOURCES) as (keyof typeof RESOURCES)[]).map((k) => {
-        const info = RESOURCES[k];
-        const v = player.resources[k] ?? 0;
-        const showResourceCard = () =>
-          handleHoverCard({
-            title: `${info.icon} ${info.label}`,
-            effects: [],
-            requirements: [],
-            description: info.description,
-            bgClass: 'bg-gray-100 dark:bg-gray-700',
-          });
-        return (
-          <ResourceButton
-            key={k}
-            resourceKey={k}
-            value={v}
-            onShow={showResourceCard}
-            onHide={clearHoverCard}
-          />
-        );
-      })}
-    </>
-  );
+	const { handleHoverCard, clearHoverCard } = useGameEngine();
+	return (
+		<>
+			{(Object.keys(RESOURCES) as (keyof typeof RESOURCES)[]).map((k) => {
+				const info = RESOURCES[k];
+				const v = player.resources[k] ?? 0;
+				const showResourceCard = () =>
+					handleHoverCard({
+						title: `${info.icon} ${info.label}`,
+						effects: [],
+						requirements: [],
+						description: info.description,
+						bgClass:
+							'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+					});
+				return (
+					<ResourceButton
+						key={k}
+						resourceKey={k}
+						value={v}
+						onShow={showResourceCard}
+						onHide={clearHoverCard}
+					/>
+				);
+			})}
+		</>
+	);
 };
 
 export default ResourceBar;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -44,16 +44,16 @@
 
 @layer components {
   .bar-item {
-    @apply flex items-center gap-1 tabular-nums whitespace-nowrap appearance-none bg-transparent border-0 p-0;
+    @apply flex items-center gap-1 whitespace-nowrap rounded-full border border-white/40 bg-white/50 px-3 py-1 text-sm font-semibold tabular-nums text-slate-700 shadow-sm shadow-white/30 transition appearance-none dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100;
   }
   .hoverable {
-    @apply transition-colors transition-transform duration-150 hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-105;
+    @apply transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/60 hover:shadow-lg hover:shadow-amber-500/10 dark:hover:bg-white/10 dark:hover:shadow-black/30;
   }
   .panel-card {
-    @apply rounded-md bg-black/5 dark:bg-white/10;
+    @apply rounded-2xl border border-white/50 bg-white/70 shadow-lg shadow-amber-500/10 backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-black/50;
   }
   .player-panel .panel-card {
-    @apply bg-gray-50/40 dark:bg-gray-700/40;
+    @apply border-white/40 bg-white/80 dark:border-white/10 dark:bg-slate-900/60;
   }
   .value-change-indicator {
     @apply pointer-events-none font-black tracking-wide text-sm sm:text-base;
@@ -76,18 +76,18 @@
     filter: drop-shadow(0 0 6px rgba(248, 113, 113, 0.4));
   }
   .land-tile {
-    @apply relative panel-card border border-black/10 dark:border-white/10 p-2 text-center hoverable cursor-help;
+    @apply relative panel-card border border-white/50 p-3 text-center hoverable cursor-help shadow-lg shadow-amber-500/10 dark:border-white/10;
   }
   .land-slot {
-    @apply panel-card border border-black/10 dark:border-white/10 p-1 text-lg leading-none hoverable cursor-help flex items-center justify-center gap-1 shrink-0 min-w-8 min-h-8;
+    @apply panel-card border border-white/40 p-1.5 text-lg leading-none hoverable cursor-help flex items-center justify-center gap-1 shrink-0 min-w-8 min-h-8 dark:border-white/10;
   }
   .player-bg {
-    @apply relative overflow-hidden text-gray-900 dark:text-white;
-    --stripe-color: rgba(0, 0, 0, 0.04);
+    @apply relative overflow-hidden rounded-3xl text-slate-900 shadow-xl shadow-slate-900/10 backdrop-blur-xl dark:text-slate-100 dark:shadow-black/40;
+    --stripe-color: rgba(255, 255, 255, 0.45);
     background-color: var(--player-color);
   }
   .dark .player-bg {
-    --stripe-color: rgba(255, 255, 255, 0.04);
+    --stripe-color: rgba(15, 23, 42, 0.45);
   }
   .player-bg::before {
     content: '';
@@ -107,7 +107,7 @@
     background-size: 32px 32px;
     background-position: 0 0;
     background-repeat: repeat;
-    opacity: 0.9;
+    opacity: 0.65;
     will-change: background-position;
     transition: opacity 150ms ease-in-out;
   }
@@ -123,39 +123,39 @@
     animation: player-bg-slide 2s linear infinite;
   }
   .player-bg-blue {
-    --player-color: rgba(219, 234, 254, 0.5);
+    --player-color: rgba(191, 219, 254, 0.75);
   }
   .player-bg-blue-active {
-    --player-color: rgba(191, 219, 254, 0.7);
+    --player-color: rgba(147, 197, 253, 0.85);
   }
   .player-bg-red {
-    --player-color: rgba(254, 226, 226, 0.5);
+    --player-color: rgba(254, 205, 211, 0.75);
   }
   .player-bg-red-active {
-    --player-color: rgba(254, 202, 202, 0.7);
+    --player-color: rgba(251, 182, 206, 0.85);
   }
   .dark .player-bg-blue {
-    --player-color: rgba(30, 58, 138, 0.3);
+    --player-color: rgba(37, 99, 235, 0.35);
   }
   .dark .player-bg-blue-active {
-    --player-color: rgba(59, 130, 246, 0.4);
+    --player-color: rgba(96, 165, 250, 0.5);
   }
   .dark .player-bg-red {
-    --player-color: rgba(127, 29, 29, 0.3);
+    --player-color: rgba(190, 18, 60, 0.35);
   }
   .dark .player-bg-red-active {
-    --player-color: rgba(220, 38, 38, 0.4);
+    --player-color: rgba(244, 63, 94, 0.5);
   }
   .log-entry-a {
-    color: rgb(30, 58, 138);
+    color: rgb(37, 99, 235);
   }
   .log-entry-b {
-    color: rgb(127, 29, 29);
+    color: rgb(190, 18, 60);
   }
   .dark .log-entry-a {
-    color: rgb(219, 234, 254);
+    color: rgb(191, 219, 254);
   }
   .dark .log-entry-b {
-    color: rgb(254, 226, 226);
+    color: rgb(251, 207, 232);
   }
 }

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -6,98 +6,102 @@ import React from 'react';
 import ActionsPanel from '../src/components/actions/ActionsPanel';
 import { createEngine, PopulationRole, Stat } from '@kingdom-builder/engine';
 import {
-  RESOURCES,
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
-  POPULATION_ROLES,
-  STATS,
-  SLOT_INFO,
-  LAND_INFO,
+	RESOURCES,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	POPULATION_ROLES,
+	STATS,
+	SLOT_INFO,
+	LAND_INFO,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
-  return await import('../../engine/src');
+	return await import('../../engine/src');
 });
 
 const ctx = createEngine({
-  actions: ACTIONS,
-  buildings: BUILDINGS,
-  developments: DEVELOPMENTS,
-  populations: POPULATIONS,
-  phases: PHASES,
-  start: GAME_START,
-  rules: RULES,
+	actions: ACTIONS,
+	buildings: BUILDINGS,
+	developments: DEVELOPMENTS,
+	populations: POPULATIONS,
+	phases: PHASES,
+	start: GAME_START,
+	rules: RULES,
 });
 const actionCostResource = ctx.actionCostResource;
 const mockGame = {
-  ctx,
-  log: [],
-  hoverCard: null,
-  handleHoverCard: vi.fn(),
-  clearHoverCard: vi.fn(),
-  phaseSteps: [],
-  setPhaseSteps: vi.fn(),
-  phaseTimer: 0,
-  phasePaused: false,
-  setPaused: vi.fn(),
-  mainApStart: 0,
-  displayPhase: ctx.game.currentPhase,
-  setDisplayPhase: vi.fn(),
-  phaseHistories: {},
-  tabsEnabled: true,
-  actionCostResource,
-  handlePerform: vi.fn().mockResolvedValue(undefined),
-  runUntilActionPhase: vi.fn(),
-  handleEndTurn: vi.fn().mockResolvedValue(undefined),
-  updateMainPhaseStep: vi.fn(),
-  darkMode: false,
-  onToggleDark: vi.fn(),
+	ctx,
+	log: [],
+	hoverCard: null,
+	handleHoverCard: vi.fn(),
+	clearHoverCard: vi.fn(),
+	phaseSteps: [],
+	setPhaseSteps: vi.fn(),
+	phaseTimer: 0,
+	phasePaused: false,
+	setPaused: vi.fn(),
+	mainApStart: 0,
+	displayPhase: ctx.game.currentPhase,
+	setDisplayPhase: vi.fn(),
+	phaseHistories: {},
+	tabsEnabled: true,
+	actionCostResource,
+	handlePerform: vi.fn().mockResolvedValue(undefined),
+	runUntilActionPhase: vi.fn(),
+	handleEndTurn: vi.fn().mockResolvedValue(undefined),
+	updateMainPhaseStep: vi.fn(),
+	darkMode: false,
+	onToggleDark: vi.fn(),
 };
 
 vi.mock('../src/state/GameContext', () => ({
-  useGameEngine: () => mockGame,
+	useGameEngine: () => mockGame,
 }));
 
 describe('<ActionsPanel />', () => {
-  it('lists available actions with proper icons', () => {
-    render(<ActionsPanel />);
-    const apIcon = RESOURCES[actionCostResource].icon;
-    expect(screen.getByText(`Actions (1 ${apIcon} each)`)).toBeInTheDocument();
-    const action = ctx.actions.entries()[0][1];
-    const label = `${action.icon} ${action.name}`;
-    expect(screen.getByText(label)).toBeInTheDocument();
-  });
+	it('lists available actions with proper icons', () => {
+		render(<ActionsPanel />);
+		const apIcon = RESOURCES[actionCostResource].icon;
+		expect(
+			screen.getByRole('heading', {
+				name: new RegExp(`Actions\\s*\\(1\\s*${apIcon}\\s*each\\)`),
+			}),
+		).toBeInTheDocument();
+		const action = ctx.actions.entries()[0][1];
+		const label = `${action.icon} ${action.name}`;
+		expect(screen.getByText(label)).toBeInTheDocument();
+	});
 
-  it('shows short requirement indicator when unmet', () => {
-    render(<ActionsPanel />);
-    const popIcon = STATS[Stat.maxPopulation].icon;
-    expect(screen.getAllByText(`Req ${popIcon}`)[0]).toBeInTheDocument();
-  });
+	it('shows short requirement indicator when unmet', () => {
+		render(<ActionsPanel />);
+		const popIcon = STATS[Stat.maxPopulation].icon;
+		expect(screen.getAllByText(`Req ${popIcon}`)[0]).toBeInTheDocument();
+	});
 
-  it('shows development slot requirement indicator when no slots are free', () => {
-    const originalSlots = ctx.activePlayer.lands.map((l) => l.slotsUsed);
-    ctx.activePlayer.lands.forEach((l) => (l.slotsUsed = l.slotsMax));
-    render(<ActionsPanel />);
-    expect(screen.getAllByText(`Req ${SLOT_INFO.icon}`)[0]).toBeInTheDocument();
-    expect(
-      screen.getAllByTitle(
-        `No ${LAND_INFO.icon} ${LAND_INFO.label} with free ${SLOT_INFO.icon} ${SLOT_INFO.label}`,
-      )[0],
-    ).toBeInTheDocument();
-    ctx.activePlayer.lands.forEach((l, i) => (l.slotsUsed = originalSlots[i]));
-  });
+	it('shows development slot requirement indicator when no slots are free', () => {
+		const originalSlots = ctx.activePlayer.lands.map((l) => l.slotsUsed);
+		ctx.activePlayer.lands.forEach((l) => (l.slotsUsed = l.slotsMax));
+		render(<ActionsPanel />);
+		expect(screen.getAllByText(`Req ${SLOT_INFO.icon}`)[0]).toBeInTheDocument();
+		expect(
+			screen.getAllByTitle(
+				`No ${LAND_INFO.icon} ${LAND_INFO.label} with free ${SLOT_INFO.icon} ${SLOT_INFO.label}`,
+			)[0],
+		).toBeInTheDocument();
+		ctx.activePlayer.lands.forEach((l, i) => (l.slotsUsed = originalSlots[i]));
+	});
 
-  it('shows war weariness vs legion requirement icons when unmet', () => {
-    render(<ActionsPanel />);
-    const wwIcon = STATS[Stat.warWeariness].icon;
-    const legIcon = POPULATION_ROLES[PopulationRole.Legion].icon;
-    expect(
-      screen.getAllByText(`Req ${wwIcon}${legIcon}`)[0],
-    ).toBeInTheDocument();
-  });
+	it('shows war weariness vs legion requirement icons when unmet', () => {
+		render(<ActionsPanel />);
+		const wwIcon = STATS[Stat.warWeariness].icon;
+		const legIcon = POPULATION_ROLES[PopulationRole.Legion].icon;
+		expect(
+			screen.getAllByText(`Req ${wwIcon}${legIcon}`)[0],
+		).toBeInTheDocument();
+	});
 });

--- a/packages/web/tests/PhasePanel.test.tsx
+++ b/packages/web/tests/PhasePanel.test.tsx
@@ -6,75 +6,82 @@ import React from 'react';
 import PhasePanel from '../src/components/phases/PhasePanel';
 import { createEngine } from '@kingdom-builder/engine';
 import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
-  return await import('../../engine/src');
+	return await import('../../engine/src');
 });
 
 const ctx = createEngine({
-  actions: ACTIONS,
-  buildings: BUILDINGS,
-  developments: DEVELOPMENTS,
-  populations: POPULATIONS,
-  phases: PHASES,
-  start: GAME_START,
-  rules: RULES,
+	actions: ACTIONS,
+	buildings: BUILDINGS,
+	developments: DEVELOPMENTS,
+	populations: POPULATIONS,
+	phases: PHASES,
+	start: GAME_START,
+	rules: RULES,
 });
 const actionCostResource = ctx.actionCostResource;
 const mockGame = {
-  ctx,
-  log: [],
-  hoverCard: null,
-  handleHoverCard: vi.fn(),
-  clearHoverCard: vi.fn(),
-  phaseSteps: [],
-  setPhaseSteps: vi.fn(),
-  phaseTimer: 0,
-  phasePaused: false,
-  setPaused: vi.fn(),
-  mainApStart: 0,
-  displayPhase: ctx.game.currentPhase,
-  setDisplayPhase: vi.fn(),
-  phaseHistories: {},
-  tabsEnabled: true,
-  actionCostResource,
-  handlePerform: vi.fn().mockResolvedValue(undefined),
-  runUntilActionPhase: vi.fn(),
-  handleEndTurn: vi.fn().mockResolvedValue(undefined),
-  updateMainPhaseStep: vi.fn(),
-  darkMode: false,
-  onToggleDark: vi.fn(),
+	ctx,
+	log: [],
+	hoverCard: null,
+	handleHoverCard: vi.fn(),
+	clearHoverCard: vi.fn(),
+	phaseSteps: [],
+	setPhaseSteps: vi.fn(),
+	phaseTimer: 0,
+	phasePaused: false,
+	setPaused: vi.fn(),
+	mainApStart: 0,
+	displayPhase: ctx.game.currentPhase,
+	setDisplayPhase: vi.fn(),
+	phaseHistories: {},
+	tabsEnabled: true,
+	actionCostResource,
+	handlePerform: vi.fn().mockResolvedValue(undefined),
+	runUntilActionPhase: vi.fn(),
+	handleEndTurn: vi.fn().mockResolvedValue(undefined),
+	updateMainPhaseStep: vi.fn(),
+	darkMode: false,
+	onToggleDark: vi.fn(),
 };
 
 vi.mock('../src/state/GameContext', () => ({
-  useGameEngine: () => mockGame,
+	useGameEngine: () => mockGame,
 }));
 
 beforeAll(() => {
-  Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
-    value: vi.fn(),
-    writable: true,
-  });
+	Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+		value: vi.fn(),
+		writable: true,
+	});
 });
 
 describe('<PhasePanel />', () => {
-  it('displays current turn and phases', () => {
-    render(<PhasePanel />);
-    expect(
-      screen.getByText(`Turn ${ctx.game.turn} - ${ctx.activePlayer.name}`),
-    ).toBeInTheDocument();
-    const firstPhase = ctx.phases[0];
-    const phaseLabel = `${firstPhase.icon} ${firstPhase.label}`;
-    expect(
-      screen.getByRole('button', { name: phaseLabel }),
-    ).toBeInTheDocument();
-  });
+	it('displays current turn and phases', () => {
+		render(<PhasePanel />);
+		expect(
+			screen.getByText((content) => {
+				const turnText = `Turn ${ctx.game.turn}`;
+				return (
+					typeof content === 'string' &&
+					content.includes(turnText) &&
+					content.includes(ctx.activePlayer.name)
+				);
+			}),
+		).toBeInTheDocument();
+		const firstPhase = ctx.phases[0];
+		const phaseLabel = `${firstPhase.icon} ${firstPhase.label}`;
+		expect(
+			screen.getByRole('button', { name: phaseLabel }),
+		).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
## Summary
- align the in-game layout and panels with the landing page glassmorphism styling, including gradient backdrops and refreshed headers
- update shared UI elements such as buttons, hover cards, time control, and player displays to use the new visual language
- adjust existing tests to accommodate the updated typography and layout structure

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dc214417208325a5c58a3291a4b928