### PR TITLE
Fix opponent view toggle overlay in action panel

### DIFF
--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -845,9 +845,6 @@ export default function ActionsPanel() {
 
 	return (
 		<section className="relative rounded-3xl border border-white/60 bg-white/75 p-6 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/50">
-			{panelDisabled && (
-				<div className="pointer-events-none absolute inset-0 rounded-3xl bg-white/70 backdrop-blur-sm dark:bg-slate-950/60" />
-			)}
 			<div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 				<h2 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
 					{viewingOpponent ? `${opponent.name} Actions` : 'Actions'}{' '}
@@ -878,52 +875,57 @@ export default function ActionsPanel() {
 					)}
 				</div>
 			</div>
-			<div ref={sectionRef} className="space-y-4">
-				{otherActions.length > 0 && (
-					<BasicOptions
-						actions={otherActions}
-						summaries={actionSummaries}
-						player={selectedPlayer}
-						canInteract={canInteract}
-					/>
+			<div className="relative">
+				{panelDisabled && (
+					<div className="pointer-events-none absolute inset-0 rounded-3xl bg-white/70 backdrop-blur-sm dark:bg-slate-950/60" />
 				)}
-				{raisePopAction && (
-					<HireOptions
-						action={raisePopAction}
-						player={selectedPlayer}
-						canInteract={canInteract}
-					/>
-				)}
-				{developAction && (
-					<DevelopOptions
-						action={developAction}
-						isActionPhase={isActionPhase}
-						developments={developmentOptions}
-						summaries={developmentSummaries}
-						hasDevelopLand={hasDevelopLand}
-						player={selectedPlayer}
-						canInteract={canInteract}
-					/>
-				)}
-				{buildAction && (
-					<BuildOptions
-						action={buildAction}
-						isActionPhase={isActionPhase}
-						buildings={buildingOptions}
-						summaries={buildingSummaries}
-						descriptions={buildingDescriptions}
-						player={selectedPlayer}
-						canInteract={canInteract}
-					/>
-				)}
-				{demolishAction && (
-					<DemolishOptions
-						action={demolishAction}
-						isActionPhase={isActionPhase}
-						player={selectedPlayer}
-						canInteract={canInteract}
-					/>
-				)}
+				<div ref={sectionRef} className="space-y-4">
+					{otherActions.length > 0 && (
+						<BasicOptions
+							actions={otherActions}
+							summaries={actionSummaries}
+							player={selectedPlayer}
+							canInteract={canInteract}
+						/>
+					)}
+					{raisePopAction && (
+						<HireOptions
+							action={raisePopAction}
+							player={selectedPlayer}
+							canInteract={canInteract}
+						/>
+					)}
+					{developAction && (
+						<DevelopOptions
+							action={developAction}
+							isActionPhase={isActionPhase}
+							developments={developmentOptions}
+							summaries={developmentSummaries}
+							hasDevelopLand={hasDevelopLand}
+							player={selectedPlayer}
+							canInteract={canInteract}
+						/>
+					)}
+					{buildAction && (
+						<BuildOptions
+							action={buildAction}
+							isActionPhase={isActionPhase}
+							buildings={buildingOptions}
+							summaries={buildingSummaries}
+							descriptions={buildingDescriptions}
+							player={selectedPlayer}
+							canInteract={canInteract}
+						/>
+					)}
+					{demolishAction && (
+						<DemolishOptions
+							action={demolishAction}
+							isActionPhase={isActionPhase}
+							player={selectedPlayer}
+							canInteract={canInteract}
+						/>
+					)}
+				</div>
 			</div>
 		</section>
 	);


### PR DESCRIPTION
## Summary
- keep the "view opponent" toggle button outside the disabled overlay so it stays crisp when the action pane is locked
- continue shading the actionable area by moving the overlay inside the action list container

## Testing
- npm run lint
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dc2bd377d483258a29dcf81b1fac4d