### PR TITLE
Refactor engine entrypoint into modular components

### DIFF
--- a/packages/engine/src/actions/action_execution.ts
+++ b/packages/engine/src/actions/action_execution.ts
@@ -1,0 +1,122 @@
+import { runEffects } from '../effects';
+import { applyParamsToEffects } from '../utils';
+import { withStatSourceFrames } from '../stat_sources';
+import { runRequirement } from '../requirements';
+import type { EngineContext } from '../context';
+import type { EffectDef } from '../effects';
+import type { ActionParameters } from './action_parameters';
+import {
+	applyCostsWithPassives,
+	applyEffectCostCollectors,
+	deductCostsFromPlayer,
+	verifyCostAffordability,
+} from './costs';
+
+function assertSystemActionUnlocked(
+	actionId: string,
+	engineContext: EngineContext,
+): void {
+	const actionDefinition = engineContext.actions.get(actionId);
+	if (!actionDefinition.system) {
+		return;
+	}
+	const isUnlocked = engineContext.activePlayer.actions.has(actionId);
+	if (isUnlocked) {
+		return;
+	}
+	throw new Error(`Action ${actionId} is locked`);
+}
+
+function evaluateRequirements(
+	actionId: string,
+	engineContext: EngineContext,
+): void {
+	const actionDefinition = engineContext.actions.get(actionId);
+	for (const requirement of actionDefinition.requirements || []) {
+		const requirementResult = runRequirement(requirement, engineContext);
+		if (requirementResult === true) {
+			continue;
+		}
+		throw new Error(String(requirementResult));
+	}
+}
+
+function collectPendingBuildingAdds(resolvedEffects: EffectDef[]): string[] {
+	const pendingBuildingIds: string[] = [];
+	for (const effectDefinition of resolvedEffects) {
+		if (effectDefinition.type !== 'building') {
+			continue;
+		}
+		if (effectDefinition.method !== 'add') {
+			continue;
+		}
+		const buildingId = effectDefinition.params?.['id'];
+		if (typeof buildingId !== 'string') {
+			continue;
+		}
+		pendingBuildingIds.push(buildingId);
+	}
+	return pendingBuildingIds;
+}
+
+function assertBuildingsNotYetConstructed(
+	buildingIds: string[],
+	engineContext: EngineContext,
+): void {
+	for (const buildingId of buildingIds) {
+		if (!engineContext.activePlayer.buildings.has(buildingId)) {
+			continue;
+		}
+		throw new Error(`Building ${buildingId} already built`);
+	}
+}
+
+export function performAction<T extends string>(
+	actionId: T,
+	engineContext: EngineContext,
+	params?: ActionParameters<T>,
+) {
+	engineContext.actionTraces = [];
+	const actionDefinition = engineContext.actions.get(actionId);
+	assertSystemActionUnlocked(actionId, engineContext);
+	evaluateRequirements(actionId, engineContext);
+	const baseCosts = { ...(actionDefinition.baseCosts || {}) };
+	const resolvedEffects = applyParamsToEffects(
+		actionDefinition.effects,
+		params || {},
+	);
+	const pendingBuildingIds = collectPendingBuildingAdds(resolvedEffects);
+	assertBuildingsNotYetConstructed(pendingBuildingIds, engineContext);
+	applyEffectCostCollectors(resolvedEffects, baseCosts, engineContext);
+	const finalCosts = applyCostsWithPassives(
+		actionDefinition.id,
+		baseCosts,
+		engineContext,
+	);
+	const affordability = verifyCostAffordability(
+		finalCosts,
+		engineContext.activePlayer,
+	);
+	if (affordability !== true) {
+		throw new Error(affordability);
+	}
+	deductCostsFromPlayer(finalCosts, engineContext.activePlayer);
+	const passiveManager = engineContext.passives;
+	withStatSourceFrames(
+		engineContext,
+		(_effect, _context, statKey) => ({
+			key: `action:${actionDefinition.id}:${statKey}`,
+			kind: 'action',
+			id: actionDefinition.id,
+			detail: 'Resolution',
+			longevity: 'permanent',
+		}),
+		() => {
+			runEffects(resolvedEffects, engineContext);
+			passiveManager.runResultMods(actionDefinition.id, engineContext);
+		},
+	);
+	const actionTraces = engineContext.actionTraces;
+	engineContext.actionTraces = [];
+	return actionTraces;
+}

--- a/packages/engine/src/actions/action_parameters.ts
+++ b/packages/engine/src/actions/action_parameters.ts
@@ -1,0 +1,14 @@
+import type { PopulationRoleId } from '../state';
+
+type ActionParameterMap = {
+	develop: { id: string; landId: string };
+	build: { id: string };
+	demolish: { id: string };
+	raise_pop: { role: PopulationRoleId };
+	[key: string]: Record<string, unknown>;
+};
+
+export type ActionParameters<T extends string> =
+	T extends keyof ActionParameterMap
+		? ActionParameterMap[T]
+		: Record<string, unknown>;

--- a/packages/engine/src/actions/costs.ts
+++ b/packages/engine/src/actions/costs.ts
@@ -1,0 +1,113 @@
+import { applyParamsToEffects } from '../utils';
+import { EFFECT_COST_COLLECTORS } from '../effects';
+import { runRequirement } from '../requirements';
+import type { EffectDef } from '../effects';
+import type { EngineContext } from '../context';
+import type { CostBag } from '../services';
+import type { PlayerState } from '../state';
+import type { ActionParameters } from './action_parameters';
+
+function cloneCostBag(costBag: CostBag): CostBag {
+	return { ...costBag };
+}
+
+export function applyCostsWithPassives(
+	actionId: string,
+	baseCosts: CostBag,
+	engineContext: EngineContext,
+): CostBag {
+	const defaultedCosts = cloneCostBag(baseCosts);
+	const actionDefinition = engineContext.actions.get(actionId);
+	const primaryCostKey = engineContext.actionCostResource;
+	if (primaryCostKey && defaultedCosts[primaryCostKey] === undefined) {
+		defaultedCosts[primaryCostKey] = actionDefinition.system
+			? 0
+			: engineContext.services.rules.defaultActionAPCost;
+	}
+	return engineContext.passives.applyCostMods(
+		actionDefinition.id,
+		defaultedCosts,
+		engineContext,
+	);
+}
+
+export function applyEffectCostCollectors(
+	resolvedEffects: EffectDef[],
+	baseCosts: CostBag,
+	engineContext: EngineContext,
+): void {
+	for (const effectDefinition of resolvedEffects) {
+		if (!effectDefinition.type || !effectDefinition.method) {
+			continue;
+		}
+		const collectorKey = `${effectDefinition.type}:${effectDefinition.method}`;
+		if (!EFFECT_COST_COLLECTORS.has(collectorKey)) {
+			continue;
+		}
+		const collector = EFFECT_COST_COLLECTORS.get(collectorKey);
+		collector(effectDefinition, baseCosts, engineContext);
+	}
+}
+
+export function getActionCosts<T extends string>(
+	actionId: T,
+	engineContext: EngineContext,
+	params?: ActionParameters<T>,
+): CostBag {
+	const actionDefinition = engineContext.actions.get(actionId);
+	const baseCosts = cloneCostBag(actionDefinition.baseCosts || {});
+	const resolvedEffects = applyParamsToEffects(
+		actionDefinition.effects,
+		params || {},
+	);
+	applyEffectCostCollectors(resolvedEffects, baseCosts, engineContext);
+	const finalCosts = applyCostsWithPassives(
+		actionDefinition.id,
+		baseCosts,
+		engineContext,
+	);
+	return finalCosts;
+}
+
+export function getActionRequirements<T extends string>(
+	actionId: T,
+	engineContext: EngineContext,
+	_params?: ActionParameters<T>,
+): string[] {
+	const actionDefinition = engineContext.actions.get(actionId);
+	const failures: string[] = [];
+	for (const requirement of actionDefinition.requirements || []) {
+		const requirementResult = runRequirement(requirement, engineContext);
+		if (requirementResult === true) {
+			continue;
+		}
+		failures.push(String(requirementResult));
+	}
+	return failures;
+}
+
+export function verifyCostAffordability(
+	costs: CostBag,
+	playerState: PlayerState,
+): true | string {
+	for (const resourceKey of Object.keys(costs)) {
+		const requiredAmount = costs[resourceKey] ?? 0;
+		const availableAmount = playerState.resources[resourceKey] ?? 0;
+		if (availableAmount < requiredAmount) {
+			const shortageDetail = `Insufficient ${resourceKey}: need ${requiredAmount}`;
+			return `${shortageDetail}, have ${availableAmount}`;
+		}
+	}
+	return true;
+}
+
+export function deductCostsFromPlayer(
+	costs: CostBag,
+	playerState: PlayerState,
+): void {
+	for (const resourceKey of Object.keys(costs)) {
+		const amount = costs[resourceKey] ?? 0;
+		playerState.resources[resourceKey] =
+			(playerState.resources[resourceKey] || 0) - amount;
+	}
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,488 +1,53 @@
-import {
+export {
 	Resource,
 	Phase,
 	PopulationRole,
 	Stat,
-	GameState,
-	Land,
-	setResourceKeys,
-	setStatKeys,
-	setPhaseKeys,
-	setPopulationRoleKeys,
-} from './state';
-import type {
+	createEngine,
+} from './setup/create_engine';
+export type {
+	RuleSet,
 	ResourceKey,
-	PlayerState,
 	StatKey,
 	PopulationRoleId,
 	StatSourceMeta,
 	StatSourceContribution,
 	StatSourceLink,
-} from './state';
-import { Services, PassiveManager } from './services';
-import type { CostBag, RuleSet } from './services';
-import { EngineContext } from './context';
-import {
+} from './setup/create_engine';
+export { getActionCosts, getActionRequirements } from './actions/costs';
+export { performAction } from './actions/action_execution';
+export { advance } from './phases/advance';
+export { EngineContext } from './context';
+export { Services, PassiveManager } from './services';
+export {
+	EFFECTS,
+	EFFECT_COST_COLLECTORS,
 	runEffects,
-	EFFECTS,
-	EFFECT_COST_COLLECTORS,
-	registerCoreEffects,
-} from './effects';
-import type { EffectDef } from './effects';
-import { collectTriggerEffects } from './triggers';
-import { EVALUATORS, registerCoreEvaluators } from './evaluators';
-import { runRequirement, registerCoreRequirements } from './requirements';
-import { Registry } from './registry';
-import { applyParamsToEffects } from './utils';
-import { createAISystem, createTaxCollectorController } from './ai';
-import { applyStatDelta, withStatSourceFrames } from './stat_sources';
-import {
-	validateGameConfig,
-	type GameConfig,
-	actionSchema,
-	buildingSchema,
-	developmentSchema,
-	populationSchema,
-	type PlayerStartConfig,
-	type ActionConfig as ActionDef,
-	type BuildingConfig as BuildingDef,
-	type DevelopmentConfig as DevelopmentDef,
-	type PopulationConfig as PopulationDef,
-	type StartConfig,
-} from './config/schema';
-import type { PhaseDef } from './phases';
-export { snapshotPlayer } from './log';
-export type { PlayerSnapshot, ActionTrace } from './log';
-export type {
-	AttackLog,
-	AttackEvaluationLog,
-	AttackOnDamageLogEntry,
-	AttackPlayerDiff,
-	AttackPowerLog,
-} from './effects/attack';
-
-function isStatKey(key: string): key is StatKey {
-	return key in Stat;
-}
-
-const START_STAT_SOURCE_META: StatSourceMeta = {
-	key: 'start:setup',
-	longevity: 'permanent',
-	kind: 'start',
-	detail: 'Initial setup',
-};
-
-function applyCostsWithPassives(
-	actionId: string,
-	base: CostBag,
-	ctx: EngineContext,
-): CostBag {
-	const withDefault = { ...base };
-	const definition = ctx.actions.get(actionId);
-	const key = ctx.actionCostResource;
-	if (key && withDefault[key] === undefined)
-		withDefault[key] = definition.system
-			? 0
-			: ctx.services.rules.defaultActionAPCost;
-	return ctx.passives.applyCostMods(actionId, withDefault, ctx);
-}
-
-export function getActionCosts<T extends string>(
-	actionId: T,
-	ctx: EngineContext,
-	params?: ActionParams<T>,
-): CostBag {
-	const actionDefinition = ctx.actions.get(actionId);
-	const base = { ...(actionDefinition.baseCosts || {}) };
-	const resolved = applyParamsToEffects(actionDefinition.effects, params || {});
-	for (const effect of resolved) {
-		if (!effect.type || !effect.method) continue;
-		const key = `${effect.type}:${effect.method}`;
-		if (EFFECT_COST_COLLECTORS.has(key))
-			EFFECT_COST_COLLECTORS.get(key)(effect, base, ctx);
-	}
-	return applyCostsWithPassives(actionDefinition.id, base, ctx);
-}
-
-export function getActionRequirements<T extends string>(
-	actionId: T,
-	ctx: EngineContext,
-	_params?: ActionParams<T>,
-): string[] {
-	const actionDefinition = ctx.actions.get(actionId);
-	const failures: string[] = [];
-	for (const requirement of actionDefinition.requirements || []) {
-		const ok = runRequirement(requirement, ctx);
-		if (ok !== true) failures.push(String(ok));
-	}
-	return failures;
-}
-
-function canPay(costs: CostBag, player: PlayerState): true | string {
-	for (const key of Object.keys(costs)) {
-		const need = costs[key] ?? 0;
-		const available = player.resources[key] ?? 0;
-		if (available < need) {
-			return `Insufficient ${key}: need ${need}, have ${available}`;
-		}
-	}
-	return true;
-}
-
-function pay(costs: CostBag, player: PlayerState) {
-	for (const key of Object.keys(costs)) {
-		const amount = costs[key] ?? 0;
-		player.resources[key] = (player.resources[key] || 0) - amount;
-	}
-}
-
-type ActionParamMap = {
-	develop: { id: string; landId: string };
-	build: { id: string };
-	demolish: { id: string };
-	raise_pop: { role: PopulationRoleId };
-	[key: string]: Record<string, unknown>;
-};
-
-export type ActionParams<T extends string> = T extends keyof ActionParamMap
-	? ActionParamMap[T]
-	: Record<string, unknown>;
-
-export function performAction<T extends string>(
-	actionId: T,
-	ctx: EngineContext,
-	params?: ActionParams<T>,
-) {
-	ctx.actionTraces = [];
-	const actionDefinition = ctx.actions.get(actionId);
-	if (actionDefinition.system && !ctx.activePlayer.actions.has(actionId))
-		throw new Error(`Action ${actionId} is locked`);
-	for (const requirement of actionDefinition.requirements || []) {
-		const ok = runRequirement(requirement, ctx);
-		if (ok !== true) throw new Error(String(ok));
-	}
-	const base = { ...(actionDefinition.baseCosts || {}) };
-	const resolved = applyParamsToEffects(actionDefinition.effects, params || {});
-	const attemptedBuildingAdds = resolved
-		.filter((effect) => effect.type === 'building' && effect.method === 'add')
-		.map((effect) => effect.params?.['id'])
-		.filter((id): id is string => typeof id === 'string');
-	for (const id of attemptedBuildingAdds) {
-		if (ctx.activePlayer.buildings.has(id))
-			throw new Error(`Building ${id} already built`);
-	}
-	for (const effect of resolved) {
-		if (!effect.type || !effect.method) continue;
-		const key = `${effect.type}:${effect.method}`;
-		if (EFFECT_COST_COLLECTORS.has(key))
-			EFFECT_COST_COLLECTORS.get(key)(effect, base, ctx);
-	}
-	const costs = applyCostsWithPassives(actionDefinition.id, base, ctx);
-	const ok = canPay(costs, ctx.activePlayer);
-	if (ok !== true) throw new Error(ok);
-	pay(costs, ctx.activePlayer);
-
-	withStatSourceFrames(
-		ctx,
-		(_effect, _ctx, statKey) => ({
-			key: `action:${actionDefinition.id}:${statKey}`,
-			kind: 'action',
-			id: actionDefinition.id,
-			detail: 'Resolution',
-			longevity: 'permanent',
-		}),
-		() => {
-			runEffects(resolved, ctx);
-			ctx.passives.runResultMods(actionDefinition.id, ctx);
-		},
-	);
-	const traces = ctx.actionTraces;
-	ctx.actionTraces = [];
-	return traces;
-}
-
-export interface AdvanceResult {
-	phase: string;
-	step: string;
-	effects: EffectDef[];
-	player: PlayerState;
-}
-
-export function advance(ctx: EngineContext): AdvanceResult {
-	const phase = ctx.phases[ctx.game.phaseIndex]!;
-	const step = phase.steps[ctx.game.stepIndex];
-	const player = ctx.activePlayer;
-	const effects: EffectDef[] = [];
-	const phaseFrame = (
-		_effect: EffectDef,
-		_ctx: EngineContext,
-		statKey: StatKey,
-	) => {
-		const partial = {
-			key: `phase:${phase.id}:${step?.id ?? 'step'}:${statKey}`,
-			kind: 'phase',
-			id: phase.id,
-			longevity: 'permanent' as const,
-		} as const;
-		const stepId = step?.id;
-		return stepId ? { ...partial, detail: stepId } : partial;
-	};
-
-	const triggers = step?.triggers ?? [];
-	if (triggers.length) {
-		withStatSourceFrames(ctx, phaseFrame, () => {
-			for (const trig of triggers) {
-				const bundles = collectTriggerEffects(trig, ctx, player);
-				for (const bundle of bundles) {
-					withStatSourceFrames(ctx, bundle.frames, () =>
-						runEffects(bundle.effects, ctx),
-					);
-					effects.push(...bundle.effects);
-				}
-			}
-		});
-	}
-	if (step?.effects) {
-		const stepEffects = step.effects;
-		withStatSourceFrames(ctx, phaseFrame, () => {
-			runEffects(stepEffects, ctx);
-		});
-		effects.push(...stepEffects);
-	}
-
-	if (step)
-		withStatSourceFrames(ctx, phaseFrame, () =>
-			ctx.passives.runResultMods(step.id, ctx),
-		);
-
-	ctx.game.stepIndex += 1;
-	if (ctx.game.stepIndex >= phase.steps.length) {
-		ctx.game.stepIndex = 0;
-		ctx.game.phaseIndex += 1;
-		if (ctx.game.phaseIndex >= ctx.phases.length) {
-			ctx.game.phaseIndex = 0;
-			if (ctx.game.currentPlayerIndex === ctx.game.players.length - 1) {
-				ctx.game.currentPlayerIndex = 0;
-				ctx.game.turn += 1;
-			} else {
-				ctx.game.currentPlayerIndex += 1;
-			}
-		}
-	}
-
-	const nextPhase = ctx.phases[ctx.game.phaseIndex]!;
-	const nextStep = nextPhase.steps[ctx.game.stepIndex];
-	ctx.game.currentPhase = nextPhase.id;
-	ctx.game.currentStep = nextStep ? nextStep.id : '';
-
-	return { phase: phase.id, step: step?.id || '', effects, player };
-}
-
-function applyPlayerStart(
-	player: PlayerState,
-	config: PlayerStartConfig,
-	rules: RuleSet,
-) {
-	for (const [key, value] of Object.entries(config.resources || {}))
-		player.resources[key] = value ?? 0;
-	for (const [key, value] of Object.entries(config.stats || {})) {
-		if (!isStatKey(key)) continue;
-		const val = value ?? 0;
-		const prev = player.stats[key] ?? 0;
-		player.stats[key] = val;
-		if (val !== 0) player.statsHistory[key] = true;
-		const delta = val - prev;
-		if (delta !== 0) applyStatDelta(player, key, delta, START_STAT_SOURCE_META);
-	}
-	for (const [key, value] of Object.entries(config.population || {}))
-		player.population[key] = value ?? 0;
-	if (config.lands)
-		config.lands.forEach((landCfg, idx) => {
-			const land = new Land(
-				`${player.id}-L${idx + 1}`,
-				landCfg.slotsMax ?? rules.slotsPerNewLand,
-				landCfg.tilled ?? false,
-			);
-			if (landCfg.developments) land.developments.push(...landCfg.developments);
-			land.slotsUsed = landCfg.slotsUsed ?? land.developments.length;
-			if (landCfg.upkeep) land.upkeep = { ...landCfg.upkeep };
-			if (landCfg.onPayUpkeepStep)
-				land.onPayUpkeepStep = landCfg.onPayUpkeepStep.map((e) => ({ ...e }));
-			if (landCfg.onGainIncomeStep)
-				land.onGainIncomeStep = landCfg.onGainIncomeStep.map((e) => ({ ...e }));
-			if (landCfg.onGainAPStep)
-				land.onGainAPStep = landCfg.onGainAPStep.map((e) => ({ ...e }));
-			player.lands.push(land);
-		});
-}
-
-function diffPlayerStart(
-	base: PlayerStartConfig,
-	override: PlayerStartConfig | undefined,
-): PlayerStartConfig {
-	const diff: PlayerStartConfig = {};
-	if (!override) return diff;
-	for (const [key, value] of Object.entries(override.resources || {})) {
-		const baseVal = base.resources?.[key] ?? 0;
-		const delta = (value ?? 0) - baseVal;
-		if (delta !== 0) {
-			diff.resources = diff.resources || {};
-			diff.resources[key] = delta;
-		}
-	}
-	for (const [key, value] of Object.entries(override.stats || {})) {
-		const baseVal = base.stats?.[key] ?? 0;
-		const delta = (value ?? 0) - baseVal;
-		if (delta !== 0) {
-			diff.stats = diff.stats || {};
-			diff.stats[key] = delta;
-		}
-	}
-	return diff;
-}
-
-export function createEngine({
-	actions,
-	buildings,
-	developments,
-	populations,
-	phases,
-	start,
-	rules,
-	config,
-}: {
-	actions: Registry<ActionDef>;
-	buildings: Registry<BuildingDef>;
-	developments: Registry<DevelopmentDef>;
-	populations: Registry<PopulationDef>;
-	phases: PhaseDef[];
-	start: StartConfig;
-	rules: RuleSet;
-	config?: GameConfig;
-}) {
-	registerCoreEffects();
-	registerCoreEvaluators();
-	registerCoreRequirements();
-
-	let startCfg = start;
-	if (config) {
-		const cfg = validateGameConfig(config);
-		if (cfg.actions) {
-			const registry = new Registry<ActionDef>(actionSchema);
-			for (const action of cfg.actions) registry.add(action.id, action);
-			actions = registry;
-		}
-		if (cfg.buildings) {
-			const registry = new Registry<BuildingDef>(buildingSchema);
-			for (const building of cfg.buildings) registry.add(building.id, building);
-			buildings = registry;
-		}
-		if (cfg.developments) {
-			const registry = new Registry<DevelopmentDef>(developmentSchema);
-			for (const development of cfg.developments)
-				registry.add(development.id, development);
-			developments = registry;
-		}
-		if (cfg.populations) {
-			const registry = new Registry<PopulationDef>(populationSchema);
-			for (const population of cfg.populations)
-				registry.add(population.id, population);
-			populations = registry;
-		}
-		if (cfg.start) startCfg = cfg.start;
-	}
-
-	setResourceKeys(Object.keys(startCfg.player.resources || {}));
-	setStatKeys(Object.keys(startCfg.player.stats || {}));
-	setPhaseKeys(phases.map((p) => p.id));
-	setPopulationRoleKeys(Object.keys(startCfg.player.population || {}));
-
-	const services = new Services(rules, developments);
-	const passives = new PassiveManager();
-	const game = new GameState('Player', 'Opponent');
-
-	let actionCostResource: ResourceKey = '' as ResourceKey;
-	let intersect: string[] | null = null;
-	for (const [, action] of actions.entries()) {
-		if (action.system) continue;
-		const keys = Object.keys(action.baseCosts || {});
-		if (!keys.length) continue;
-		intersect = intersect ? intersect.filter((k) => keys.includes(k)) : keys;
-	}
-	if (intersect && intersect.length)
-		actionCostResource = intersect[0] as ResourceKey;
-
-	const compA = diffPlayerStart(startCfg.player, startCfg.players?.['A']);
-	const compB = diffPlayerStart(startCfg.player, startCfg.players?.['B']);
-	const compensations = { A: compA, B: compB } as Record<
-		'A' | 'B',
-		PlayerStartConfig
-	>;
-
-	const ctx = new EngineContext(
-		game,
-		services,
-		actions,
-		buildings,
-		developments,
-		populations,
-		passives,
-		phases,
-		actionCostResource,
-		compensations,
-	);
-	const playerA = ctx.game.players[0]!;
-	const playerB = ctx.game.players[1]!;
-
-	const aiSystem = createAISystem({ performAction, advance });
-	aiSystem.register(playerB.id, createTaxCollectorController(playerB.id));
-	ctx.aiSystem = aiSystem;
-
-	applyPlayerStart(playerA, startCfg.player, rules);
-	applyPlayerStart(playerA, compA, rules);
-	applyPlayerStart(playerB, startCfg.player, rules);
-	applyPlayerStart(playerB, compB, rules);
-	ctx.game.currentPlayerIndex = 0;
-	ctx.game.currentPhase = phases[0]?.id || '';
-	ctx.game.currentStep = phases[0]?.steps[0]?.id || '';
-
-	return ctx;
-}
-
-export {
-	Resource,
-	Phase,
-	PopulationRole,
-	Stat,
-	EFFECTS,
-	EFFECT_COST_COLLECTORS,
-	EVALUATORS,
-	EngineContext,
-	Services,
-	PassiveManager,
-};
-
-export type {
-	RuleSet,
-	ResourceKey,
-	StatKey,
-	StatSourceMeta,
-	StatSourceContribution,
-	StatSourceLink,
-};
-export {
 	registerCoreEffects,
 	EffectRegistry,
-	runEffects,
 	EffectCostRegistry,
 } from './effects';
 export type { EffectHandler, EffectDef, EffectCostCollector } from './effects';
-export { applyParamsToEffects } from './utils';
-export { registerCoreEvaluators, EvaluatorRegistry } from './evaluators';
+export {
+	registerCoreEvaluators,
+	EvaluatorRegistry,
+	EVALUATORS,
+} from './evaluators';
 export type { EvaluatorHandler, EvaluatorDef } from './evaluators';
 export { registerCoreRequirements, RequirementRegistry } from './requirements';
 export type { RequirementHandler, RequirementDef } from './requirements';
 export { validateGameConfig } from './config/schema';
 export type { GameConfig } from './config/schema';
 export { resolveAttack } from './effects/attack';
+export type {
+	AttackLog,
+	AttackEvaluationLog,
+	AttackOnDamageLogEntry,
+	AttackPlayerDiff,
+} from './effects/attack';
 export { collectTriggerEffects } from './triggers';
+export { applyParamsToEffects } from './utils';
+export { snapshotPlayer } from './log';
+export type { PlayerSnapshot, ActionTrace } from './log';
+export type { ActionParameters as ActionParams } from './actions/action_parameters';
+export type { AdvanceResult } from './phases/advance';

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -44,6 +44,7 @@ export type {
 	AttackEvaluationLog,
 	AttackOnDamageLogEntry,
 	AttackPlayerDiff,
+	AttackPowerLog,
 } from './effects/attack';
 export { collectTriggerEffects } from './triggers';
 export { applyParamsToEffects } from './utils';

--- a/packages/engine/src/phases/advance.ts
+++ b/packages/engine/src/phases/advance.ts
@@ -1,0 +1,134 @@
+import { collectTriggerEffects } from '../triggers';
+import { runEffects } from '../effects';
+import { withStatSourceFrames } from '../stat_sources';
+import type { EngineContext } from '../context';
+import type { EffectDef } from '../effects';
+import type { PlayerState, StatKey } from '../state';
+
+export interface AdvanceResult {
+	phase: string;
+	step: string;
+	effects: EffectDef[];
+	player: PlayerState;
+}
+
+function createPhaseStatFrame(
+	phaseId: string,
+	stepId: string | undefined,
+): (
+	effect: EffectDef,
+	context: EngineContext,
+	statKey: StatKey,
+) => {
+	key: string;
+	kind: 'phase';
+	id: string;
+	longevity: 'permanent';
+	detail?: string;
+} {
+	return (_effect, _context, statKey) => {
+		const baseFrame: {
+			key: string;
+			kind: 'phase';
+			id: string;
+			longevity: 'permanent';
+		} = {
+			key: `phase:${phaseId}:${stepId ?? 'step'}:${statKey}`,
+			kind: 'phase',
+			id: phaseId,
+			longevity: 'permanent',
+		};
+		return stepId ? { ...baseFrame, detail: stepId } : baseFrame;
+	};
+}
+
+function runTriggerBundles(
+	triggerIds: string[],
+	engineContext: EngineContext,
+	playerState: PlayerState,
+	statFrame: ReturnType<typeof createPhaseStatFrame>,
+	collectedEffects: EffectDef[],
+): void {
+	withStatSourceFrames(engineContext, statFrame, () => {
+		for (const triggerId of triggerIds) {
+			const bundles = collectTriggerEffects(
+				triggerId,
+				engineContext,
+				playerState,
+			);
+			for (const bundle of bundles) {
+				withStatSourceFrames(engineContext, bundle.frames, () => {
+					runEffects(bundle.effects, engineContext);
+				});
+				collectedEffects.push(...bundle.effects);
+			}
+		}
+	});
+}
+
+export function advance(engineContext: EngineContext): AdvanceResult {
+	const currentPhaseDefinition =
+		engineContext.phases[engineContext.game.phaseIndex]!;
+	const currentStepDefinition =
+		currentPhaseDefinition.steps[engineContext.game.stepIndex];
+	const actingPlayer = engineContext.activePlayer;
+	const appliedEffects: EffectDef[] = [];
+	const phaseFrame = createPhaseStatFrame(
+		currentPhaseDefinition.id,
+		currentStepDefinition?.id,
+	);
+	const triggerIds = currentStepDefinition?.triggers ?? [];
+	if (triggerIds.length > 0) {
+		runTriggerBundles(
+			triggerIds,
+			engineContext,
+			actingPlayer,
+			phaseFrame,
+			appliedEffects,
+		);
+	}
+	const stepEffects = currentStepDefinition?.effects;
+	if (stepEffects) {
+		withStatSourceFrames(engineContext, phaseFrame, () => {
+			runEffects(stepEffects, engineContext);
+		});
+		appliedEffects.push(...stepEffects);
+	}
+	if (currentStepDefinition) {
+		withStatSourceFrames(engineContext, phaseFrame, () => {
+			engineContext.passives.runResultMods(
+				currentStepDefinition.id,
+				engineContext,
+			);
+		});
+	}
+	engineContext.game.stepIndex += 1;
+	if (engineContext.game.stepIndex >= currentPhaseDefinition.steps.length) {
+		engineContext.game.stepIndex = 0;
+		engineContext.game.phaseIndex += 1;
+		if (engineContext.game.phaseIndex >= engineContext.phases.length) {
+			engineContext.game.phaseIndex = 0;
+			const lastPlayerIndex = engineContext.game.players.length - 1;
+			if (engineContext.game.currentPlayerIndex === lastPlayerIndex) {
+				engineContext.game.currentPlayerIndex = 0;
+				engineContext.game.turn += 1;
+			} else {
+				engineContext.game.currentPlayerIndex += 1;
+			}
+		}
+	}
+	const nextPhaseDefinition =
+		engineContext.phases[engineContext.game.phaseIndex]!;
+	const nextStepDefinition =
+		nextPhaseDefinition.steps[engineContext.game.stepIndex];
+	engineContext.game.currentPhase = nextPhaseDefinition.id;
+	engineContext.game.currentStep = nextStepDefinition
+		? nextStepDefinition.id
+		: '';
+	return {
+		phase: currentPhaseDefinition.id,
+		step: currentStepDefinition?.id || '',
+		effects: appliedEffects,
+		player: actingPlayer,
+	};
+}

--- a/packages/engine/src/setup/create_engine.ts
+++ b/packages/engine/src/setup/create_engine.ts
@@ -1,0 +1,204 @@
+import type { ZodType } from 'zod';
+import {
+	Resource,
+	Phase,
+	PopulationRole,
+	Stat,
+	GameState,
+	setResourceKeys,
+	setStatKeys,
+	setPhaseKeys,
+	setPopulationRoleKeys,
+} from '../state';
+import type {
+	ResourceKey,
+	StatKey,
+	PopulationRoleId,
+	StatSourceMeta,
+	StatSourceContribution,
+	StatSourceLink,
+} from '../state';
+import { Services, PassiveManager } from '../services';
+import type { RuleSet } from '../services';
+import { EngineContext } from '../context';
+import { registerCoreEffects } from '../effects';
+import { registerCoreEvaluators } from '../evaluators';
+import { registerCoreRequirements } from '../requirements';
+import { Registry } from '../registry';
+import { createAISystem, createTaxCollectorController } from '../ai';
+import { performAction } from '../actions/action_execution';
+import { advance } from '../phases/advance';
+import {
+	validateGameConfig,
+	type GameConfig,
+	actionSchema,
+	buildingSchema,
+	developmentSchema,
+	populationSchema,
+	type PlayerStartConfig,
+	type ActionConfig as ActionDef,
+	type BuildingConfig as BuildingDef,
+	type DevelopmentConfig as DevelopmentDef,
+	type PopulationConfig as PopulationDef,
+	type StartConfig,
+} from '../config/schema';
+import type { PhaseDef } from '../phases';
+import {
+	applyPlayerStartConfiguration,
+	diffPlayerStartConfiguration,
+	determineCommonActionCostResource,
+} from './player_setup';
+
+export interface EngineCreationOptions {
+	actions: Registry<ActionDef>;
+	buildings: Registry<BuildingDef>;
+	developments: Registry<DevelopmentDef>;
+	populations: Registry<PopulationDef>;
+	phases: PhaseDef[];
+	start: StartConfig;
+	rules: RuleSet;
+	config?: GameConfig;
+}
+
+type ValidatedConfig = ReturnType<typeof validateGameConfig>;
+
+type EngineRegistries = {
+	actions: Registry<ActionDef>;
+	buildings: Registry<BuildingDef>;
+	developments: Registry<DevelopmentDef>;
+	populations: Registry<PopulationDef>;
+};
+
+function buildRegistry<DefinitionType extends { id: string }>(
+	definitions: DefinitionType[] | undefined,
+	schema: ZodType<DefinitionType>,
+): Registry<DefinitionType> | undefined {
+	if (!definitions || definitions.length === 0) {
+		return undefined;
+	}
+	const registry = new Registry<DefinitionType>(schema);
+	for (const definition of definitions) {
+		registry.add(definition.id, definition);
+	}
+	return registry;
+}
+
+function overrideRegistries(
+	validatedConfig: ValidatedConfig,
+	currentRegistries: EngineRegistries,
+): EngineRegistries {
+	const nextRegistries = { ...currentRegistries };
+	const actionRegistry = buildRegistry(validatedConfig.actions, actionSchema);
+	if (actionRegistry) {
+		nextRegistries.actions = actionRegistry;
+	}
+	const buildingRegistry = buildRegistry(
+		validatedConfig.buildings,
+		buildingSchema,
+	);
+	if (buildingRegistry) {
+		nextRegistries.buildings = buildingRegistry;
+	}
+	const developmentRegistry = buildRegistry(
+		validatedConfig.developments,
+		developmentSchema,
+	);
+	if (developmentRegistry) {
+		nextRegistries.developments = developmentRegistry;
+	}
+	const populationRegistry = buildRegistry(
+		validatedConfig.populations,
+		populationSchema,
+	);
+	if (populationRegistry) {
+		nextRegistries.populations = populationRegistry;
+	}
+	return nextRegistries;
+}
+
+export function createEngine({
+	actions,
+	buildings,
+	developments,
+	populations,
+	phases,
+	start,
+	rules,
+	config,
+}: EngineCreationOptions) {
+	registerCoreEffects();
+	registerCoreEvaluators();
+	registerCoreRequirements();
+	let startConfig = start;
+	if (config) {
+		const validatedConfig = validateGameConfig(config);
+		({ actions, buildings, developments, populations } = overrideRegistries(
+			validatedConfig,
+			{
+				actions,
+				buildings,
+				developments,
+				populations,
+			},
+		));
+		if (validatedConfig.start) {
+			startConfig = validatedConfig.start;
+		}
+	}
+	setResourceKeys(Object.keys(startConfig.player.resources || {}));
+	setStatKeys(Object.keys(startConfig.player.stats || {}));
+	setPhaseKeys(phases.map((phaseDefinition) => phaseDefinition.id));
+	setPopulationRoleKeys(Object.keys(startConfig.player.population || {}));
+	const services = new Services(rules, developments);
+	const passiveManager = new PassiveManager();
+	const gameState = new GameState('Player', 'Opponent');
+	const actionCostResource = determineCommonActionCostResource(actions);
+	const playerACompensation = diffPlayerStartConfiguration(
+		startConfig.player,
+		startConfig.players?.['A'],
+	);
+	const playerBCompensation = diffPlayerStartConfiguration(
+		startConfig.player,
+		startConfig.players?.['B'],
+	);
+	const compensationMap = {
+		A: playerACompensation,
+		B: playerBCompensation,
+	} as Record<'A' | 'B', PlayerStartConfig>;
+	const engineContext = new EngineContext(
+		gameState,
+		services,
+		actions,
+		buildings,
+		developments,
+		populations,
+		passiveManager,
+		phases,
+		actionCostResource,
+		compensationMap,
+	);
+	const playerOne = engineContext.game.players[0]!;
+	const playerTwo = engineContext.game.players[1]!;
+	const aiSystem = createAISystem({ performAction, advance });
+	aiSystem.register(playerTwo.id, createTaxCollectorController(playerTwo.id));
+	engineContext.aiSystem = aiSystem;
+	applyPlayerStartConfiguration(playerOne, startConfig.player, rules);
+	applyPlayerStartConfiguration(playerOne, playerACompensation, rules);
+	applyPlayerStartConfiguration(playerTwo, startConfig.player, rules);
+	applyPlayerStartConfiguration(playerTwo, playerBCompensation, rules);
+	engineContext.game.currentPlayerIndex = 0;
+	engineContext.game.currentPhase = phases[0]?.id || '';
+	engineContext.game.currentStep = phases[0]?.steps[0]?.id || '';
+	return engineContext;
+}
+
+export { Resource, Phase, PopulationRole, Stat };
+export type {
+	RuleSet,
+	ResourceKey,
+	StatKey,
+	PopulationRoleId,
+	StatSourceMeta,
+	StatSourceContribution,
+	StatSourceLink,
+};

--- a/packages/engine/src/setup/player_setup.ts
+++ b/packages/engine/src/setup/player_setup.ts
@@ -1,0 +1,131 @@
+import { Land, Stat } from '../state';
+import type { PlayerState, StatKey, ResourceKey } from '../state';
+import type { RuleSet } from '../services';
+import { applyStatDelta } from '../stat_sources';
+import type { Registry } from '../registry';
+import type {
+	ActionConfig as ActionDef,
+	PlayerStartConfig,
+} from '../config/schema';
+import { START_STAT_SOURCE_META } from './stat_source_meta';
+
+function cloneEffectList<EffectType extends object>(
+	effectList: EffectType[] | undefined,
+): EffectType[] {
+	if (!effectList) {
+		return [];
+	}
+	return effectList.map((effect) => ({ ...effect }));
+}
+
+function isStatKey(key: string): key is StatKey {
+	return key in Stat;
+}
+
+export function applyPlayerStartConfiguration(
+	playerState: PlayerState,
+	config: PlayerStartConfig,
+	rules: RuleSet,
+): void {
+	for (const [resourceKey, value] of Object.entries(config.resources || {})) {
+		playerState.resources[resourceKey] = value ?? 0;
+	}
+	for (const [statKey, value] of Object.entries(config.stats || {})) {
+		if (!isStatKey(statKey)) {
+			continue;
+		}
+		const statValue = value ?? 0;
+		const previousValue = playerState.stats[statKey] ?? 0;
+		playerState.stats[statKey] = statValue;
+		if (statValue !== 0) {
+			playerState.statsHistory[statKey] = true;
+		}
+		const delta = statValue - previousValue;
+		if (delta !== 0) {
+			applyStatDelta(playerState, statKey, delta, START_STAT_SOURCE_META);
+		}
+	}
+	for (const [roleId, value] of Object.entries(config.population || {})) {
+		playerState.population[roleId] = value ?? 0;
+	}
+	if (config.lands) {
+		config.lands.forEach((landConfig, index) => {
+			const land = new Land(
+				`${playerState.id}-L${index + 1}`,
+				landConfig.slotsMax ?? rules.slotsPerNewLand,
+				landConfig.tilled ?? false,
+			);
+			if (landConfig.developments) {
+				land.developments.push(...landConfig.developments);
+			}
+			land.slotsUsed = landConfig.slotsUsed ?? land.developments.length;
+			if (landConfig.upkeep) {
+				land.upkeep = { ...landConfig.upkeep };
+			}
+			const payUpkeepSteps = landConfig.onPayUpkeepStep;
+			if (payUpkeepSteps) {
+				land.onPayUpkeepStep = cloneEffectList(payUpkeepSteps);
+			}
+			const gainIncomeSteps = landConfig.onGainIncomeStep;
+			if (gainIncomeSteps) {
+				land.onGainIncomeStep = cloneEffectList(gainIncomeSteps);
+			}
+			const gainActionPointSteps = landConfig.onGainAPStep;
+			if (gainActionPointSteps) {
+				land.onGainAPStep = cloneEffectList(gainActionPointSteps);
+			}
+			playerState.lands.push(land);
+		});
+	}
+}
+
+export function diffPlayerStartConfiguration(
+	baseConfig: PlayerStartConfig,
+	overrideConfig: PlayerStartConfig | undefined,
+): PlayerStartConfig {
+	const diff: PlayerStartConfig = {};
+	if (!overrideConfig) {
+		return diff;
+	}
+	for (const [resourceKey, value] of Object.entries(
+		overrideConfig.resources || {},
+	)) {
+		const baseValue = baseConfig.resources?.[resourceKey] ?? 0;
+		const delta = (value ?? 0) - baseValue;
+		if (delta !== 0) {
+			diff.resources = diff.resources || {};
+			diff.resources[resourceKey] = delta;
+		}
+	}
+	for (const [statKey, value] of Object.entries(overrideConfig.stats || {})) {
+		const baseValue = baseConfig.stats?.[statKey] ?? 0;
+		const delta = (value ?? 0) - baseValue;
+		if (delta !== 0) {
+			diff.stats = diff.stats || {};
+			diff.stats[statKey] = delta;
+		}
+	}
+	return diff;
+}
+
+export function determineCommonActionCostResource(
+	actions: Registry<ActionDef>,
+): ResourceKey {
+	let intersection: string[] | null = null;
+	for (const [, actionDefinition] of actions.entries()) {
+		if (actionDefinition.system) {
+			continue;
+		}
+		const costKeys = Object.keys(actionDefinition.baseCosts || {});
+		if (!costKeys.length) {
+			continue;
+		}
+		intersection = intersection
+			? intersection.filter((key) => costKeys.includes(key))
+			: costKeys;
+	}
+	if (intersection && intersection.length > 0) {
+		return intersection[0] as ResourceKey;
+	}
+	return '' as ResourceKey;
+}

--- a/packages/engine/src/setup/stat_source_meta.ts
+++ b/packages/engine/src/setup/stat_source_meta.ts
@@ -1,0 +1,8 @@
+import type { StatSourceMeta } from '../state';
+
+export const START_STAT_SOURCE_META: StatSourceMeta = {
+	key: 'start:setup',
+	longevity: 'permanent',
+	kind: 'start',
+	detail: 'Initial setup',
+};


### PR DESCRIPTION
## Summary
- reorganize engine setup into a dedicated module that validates optional configs and constructs the engine context
- extract action parameter typing, cost utilities, and execution flow into focused modules and wire them through the public index
- add a phase advancement helper and shared stat source metadata utilities used during player initialization

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dc2c792b048325ad34a841879fd33d