### PR TITLE
Refine requirement icon guard handling

### DIFF
--- a/packages/web/src/utils/getRequirementIcons.ts
+++ b/packages/web/src/utils/getRequirementIcons.ts
@@ -1,62 +1,66 @@
 import type { EngineContext } from '@kingdom-builder/engine';
 import {
-  STATS,
-  POPULATION_ROLES,
-  type StatKey,
-  type PopulationRoleId,
+	STATS,
+	POPULATION_ROLES,
+	type StatKey,
+	type PopulationRoleId,
 } from '@kingdom-builder/contents';
 
 interface EvalConfig {
-  type: string;
-  params?: Record<string, unknown>;
+	type: string;
+	params?: Record<string, unknown>;
 }
 
 export type EvaluatorIconGetter = (
-  params?: Record<string, unknown>,
+	params?: Record<string, unknown>,
 ) => string[];
 
 export const EVALUATOR_ICON_MAP: Record<string, EvaluatorIconGetter> = {
-  stat: (params) => {
-    const key = params?.['key'] as StatKey | undefined;
-    return key ? [STATS[key]?.icon || ''] : [];
-  },
-  population: (params) => {
-    const role = params?.['role'] as PopulationRoleId | undefined;
-    return role ? [POPULATION_ROLES[role]?.icon || ''] : [];
-  },
+	stat: (params) => {
+		const key = params?.['key'] as StatKey | undefined;
+		return key ? [STATS[key]?.icon || ''] : [];
+	},
+	population: (params) => {
+		const role = params?.['role'] as PopulationRoleId | undefined;
+		return role ? [POPULATION_ROLES[role]?.icon || ''] : [];
+	},
 };
 
 function collectEvaluatorIcons(evaluator?: EvalConfig): string[] {
-  if (!evaluator) return [];
-  return EVALUATOR_ICON_MAP[evaluator.type]?.(evaluator.params) ?? [];
+	if (!evaluator) {
+		return [];
+	}
+	return EVALUATOR_ICON_MAP[evaluator.type]?.(evaluator.params) ?? [];
 }
 
 interface RequirementConfig {
-  type: string;
-  method: string;
-  params?: Record<string, unknown>;
+	type: string;
+	method: string;
+	params?: Record<string, unknown>;
 }
 
 export function getRequirementIcons(
-  actionId: string,
-  ctx: EngineContext,
+	actionId: string,
+	engineContext: EngineContext,
 ): string[] {
-  const def = ctx.actions.get(actionId);
-  if (!def?.requirements) return [];
-  const icons: string[] = [];
-  for (const req of def.requirements as RequirementConfig[]) {
-    if (req.type === 'evaluator' && req.method === 'compare') {
-      icons.push(
-        ...collectEvaluatorIcons(
-          req.params?.['left'] as EvalConfig | undefined,
-        ),
-      );
-      icons.push(
-        ...collectEvaluatorIcons(
-          req.params?.['right'] as EvalConfig | undefined,
-        ),
-      );
-    }
-  }
-  return icons.filter(Boolean);
+	const actionDefinition = engineContext.actions.get(actionId);
+	if (!actionDefinition?.requirements) {
+		return [];
+	}
+	const icons: string[] = [];
+	for (const requirement of actionDefinition.requirements as RequirementConfig[]) {
+		if (requirement.type === 'evaluator' && requirement.method === 'compare') {
+			icons.push(
+				...collectEvaluatorIcons(
+					requirement.params?.['left'] as EvalConfig | undefined,
+				),
+			);
+			icons.push(
+				...collectEvaluatorIcons(
+					requirement.params?.['right'] as EvalConfig | undefined,
+				),
+			);
+		}
+	}
+	return icons.filter(Boolean);
 }


### PR DESCRIPTION
## Summary
- wrap the evaluator and requirement guard clauses with explicit blocks
- reindent the requirement icon utility with tabs and descriptive parameter names
- rename abbreviated variables in the requirement icon utility for readability

## Testing
- npm run lint
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dc37da5de48325a408eb731967a6df