### PR TITLE
Refine population removal effect formatting

### DIFF
--- a/packages/engine/src/effects/population_remove.ts
+++ b/packages/engine/src/effects/population_remove.ts
@@ -4,42 +4,52 @@ import { applyParamsToEffects } from '../utils';
 import { withStatSourceFrames } from '../stat_sources';
 import type { PopulationRoleId } from '../state';
 
-export const populationRemove: EffectHandler = (effect, ctx, mult = 1) => {
-  const role = effect.params?.['role'] as PopulationRoleId;
-  if (!role) throw new Error('population:remove requires role');
-  for (let i = 0; i < Math.floor(mult); i++) {
-    const player = ctx.activePlayer;
-    const current = player.population[role] || 0;
-    if (current <= 0) return;
-    const def = ctx.populations.get(role);
-    const index = current;
-    if (def.onUnassigned) {
-      const effects = applyParamsToEffects(def.onUnassigned, {
-        index,
-        player: player.id,
-        role,
-      });
-      const frames = [
-        () => ({
-          kind: 'population',
-          id: role,
-          longevity: 'ongoing' as const,
-          dependsOn: [
-            {
-              type: 'population',
-              id: role,
-              detail: 'assigned',
-            },
-          ],
-          removal: {
-            type: 'population',
-            id: role,
-            detail: 'unassigned',
-          },
-        }),
-      ];
-      withStatSourceFrames(ctx, frames, () => runEffects(effects, ctx));
-    }
-    player.population[role] = current - 1;
-  }
+export const populationRemove: EffectHandler = (
+	effect,
+	engineContext,
+	mult = 1,
+) => {
+	const role = effect.params?.['role'] as PopulationRoleId;
+	if (!role) {
+		throw new Error('population:remove requires role');
+	}
+	for (let i = 0; i < Math.floor(mult); i++) {
+		const player = engineContext.activePlayer;
+		const current = player.population[role] || 0;
+		if (current <= 0) {
+			return;
+		}
+		const roleDefinition = engineContext.populations.get(role);
+		const index = current;
+		if (roleDefinition.onUnassigned) {
+			const effects = applyParamsToEffects(roleDefinition.onUnassigned, {
+				index,
+				player: player.id,
+				role,
+			});
+			const frames = [
+				() => ({
+					kind: 'population',
+					id: role,
+					longevity: 'ongoing' as const,
+					dependsOn: [
+						{
+							type: 'population',
+							id: role,
+							detail: 'assigned',
+						},
+					],
+					removal: {
+						type: 'population',
+						id: role,
+						detail: 'unassigned',
+					},
+				}),
+			];
+			withStatSourceFrames(engineContext, frames, () =>
+				runEffects(effects, engineContext),
+			);
+		}
+		player.population[role] = current - 1;
+	}
 };


### PR DESCRIPTION
## Summary
- wrap the population removal role and zero-count guards in braces for clarity
- rename context variables to clearer identifiers and convert the handler to tab indentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc37dba45c83259700e43689572efe