### PR TITLE
Improve log panel expansion and scrolling

### DIFF
--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -152,22 +152,26 @@ export default function LogPanel() {
 					...(isExpanded ? {} : { width: '100%' }),
 				}}
 			>
-				<div className="flex items-start gap-2 pb-2">
+				<div className="flex items-center gap-2 pb-2">
 					<h2 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
 						Log
 					</h2>
-					<button
-						type="button"
-						onClick={handleToggleExpand}
-						aria-label={isExpanded ? 'Collapse log panel' : 'Expand log panel'}
-						className={`sticky ${
-							isExpanded ? 'top-6' : 'top-4'
-						} ml-auto inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/60 bg-white/85 text-lg font-semibold text-slate-700 shadow hover:bg-white/95 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-900/85 dark:text-slate-100 dark:hover:bg-slate-900`}
-					>
-						<span aria-hidden="true" className="text-lg leading-none">
-							{isExpanded ? '⤡' : '⛶'}
-						</span>
-					</button>
+					<div className="ml-auto">
+						<div className={`sticky ${isExpanded ? 'top-6' : 'top-4'}`}>
+							<button
+								type="button"
+								onClick={handleToggleExpand}
+								aria-label={
+									isExpanded ? 'Collapse log panel' : 'Expand log panel'
+								}
+								className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/60 bg-white/85 text-lg font-semibold text-slate-700 shadow hover:bg-white/95 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-900/85 dark:text-slate-100 dark:hover:bg-slate-900"
+							>
+								<span aria-hidden="true" className="text-lg leading-none">
+									{isExpanded ? '⤡' : '⛶'}
+								</span>
+							</button>
+						</div>
+					</div>
 				</div>
 				<ul
 					ref={listRef}

--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -138,8 +138,10 @@ export default function LogPanel() {
 		>
 			<div
 				ref={containerRef}
-				className={`relative rounded-3xl border border-white/60 bg-white/75 shadow-2xl shadow-amber-500/10 transition-all duration-300 ease-in-out dark:border-white/10 dark:bg-slate-900/75 dark:shadow-slate-900/50 frosted-surface ${
-					isExpanded ? 'p-6' : 'max-h-80 p-4'
+				className={`relative rounded-3xl border border-white/60 shadow-2xl shadow-amber-500/10 transition-all duration-300 ease-in-out dark:border-white/10 dark:shadow-slate-900/50 frosted-surface ${
+					isExpanded
+						? 'bg-white/90 p-6 dark:bg-slate-900/90'
+						: 'max-h-80 bg-white/75 p-4 dark:bg-slate-900/75'
 				} ${
 					isExpanded
 						? 'overflow-y-auto custom-scrollbar'
@@ -150,20 +152,26 @@ export default function LogPanel() {
 					...(isExpanded ? {} : { width: '100%' }),
 				}}
 			>
-				<div className="sticky top-0 z-10 flex items-center justify-between gap-2 rounded-2xl bg-white/70 pb-2 pt-1 backdrop-blur-sm dark:bg-slate-900/70">
+				<div className="flex items-center gap-2 pb-2">
 					<h2 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
 						Log
 					</h2>
-					<button
-						type="button"
-						onClick={handleToggleExpand}
-						aria-label={isExpanded ? 'Collapse log panel' : 'Expand log panel'}
-						className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/60 bg-white/80 text-lg font-semibold text-slate-700 shadow hover:bg-white/90 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-100 dark:hover:bg-slate-900"
-					>
-						<span aria-hidden="true" className="text-lg leading-none">
-							{isExpanded ? '⤡' : '⛶'}
-						</span>
-					</button>
+					<div className="ml-auto">
+						<div className={`sticky ${isExpanded ? 'top-6' : 'top-4'}`}>
+							<button
+								type="button"
+								onClick={handleToggleExpand}
+								aria-label={
+									isExpanded ? 'Collapse log panel' : 'Expand log panel'
+								}
+								className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/60 bg-white/85 text-lg font-semibold text-slate-700 shadow hover:bg-white/95 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-900/85 dark:text-slate-100 dark:hover:bg-slate-900"
+							>
+								<span aria-hidden="true" className="text-lg leading-none">
+									{isExpanded ? '⤡' : '⛶'}
+								</span>
+							</button>
+						</div>
+					</div>
 				</div>
 				<ul
 					ref={listRef}

--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -152,26 +152,22 @@ export default function LogPanel() {
 					...(isExpanded ? {} : { width: '100%' }),
 				}}
 			>
-				<div className="flex items-center gap-2 pb-2">
+				<div className="flex items-start gap-2 pb-2">
 					<h2 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
 						Log
 					</h2>
-					<div className="ml-auto">
-						<div className={`sticky ${isExpanded ? 'top-6' : 'top-4'}`}>
-							<button
-								type="button"
-								onClick={handleToggleExpand}
-								aria-label={
-									isExpanded ? 'Collapse log panel' : 'Expand log panel'
-								}
-								className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/60 bg-white/85 text-lg font-semibold text-slate-700 shadow hover:bg-white/95 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-900/85 dark:text-slate-100 dark:hover:bg-slate-900"
-							>
-								<span aria-hidden="true" className="text-lg leading-none">
-									{isExpanded ? '⤡' : '⛶'}
-								</span>
-							</button>
-						</div>
-					</div>
+					<button
+						type="button"
+						onClick={handleToggleExpand}
+						aria-label={isExpanded ? 'Collapse log panel' : 'Expand log panel'}
+						className={`sticky ${
+							isExpanded ? 'top-6' : 'top-4'
+						} ml-auto inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/60 bg-white/85 text-lg font-semibold text-slate-700 shadow hover:bg-white/95 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-900/85 dark:text-slate-100 dark:hover:bg-slate-900`}
+					>
+						<span aria-hidden="true" className="text-lg leading-none">
+							{isExpanded ? '⤡' : '⛶'}
+						</span>
+					</button>
 				</div>
 				<ul
 					ref={listRef}

--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -1,23 +1,15 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useGameEngine } from '../state/GameContext';
 import { useAnimate } from '../utils/useAutoAnimate';
 
 export default function LogPanel() {
 	const { log: entries, ctx } = useGameEngine();
-	const wrapperRef = useRef<HTMLDivElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const listRef = useAnimate<HTMLUListElement>();
 	const [isExpanded, setIsExpanded] = useState(false);
-	const [isOverlay, setIsOverlay] = useState(false);
 	const [collapsedSize, setCollapsedSize] = useState<{
 		width: number;
 		height: number;
-	} | null>(null);
-	const [expandedBase, setExpandedBase] = useState<{
-		width: number;
-		height: number;
-	} | null>(null);
-	const [overlayOffsets, setOverlayOffsets] = useState<{
 		top: number;
 		right: number;
 	} | null>(null);
@@ -25,6 +17,7 @@ export default function LogPanel() {
 		width: typeof window === 'undefined' ? 0 : window.innerWidth,
 		height: typeof window === 'undefined' ? 0 : window.innerHeight,
 	}));
+	const pendingScrollRef = useRef(false);
 
 	useEffect(() => {
 		if (typeof window === 'undefined') return;
@@ -37,111 +30,106 @@ export default function LogPanel() {
 		};
 	}, []);
 
-	useEffect(() => {
-		if (isExpanded) return;
-		const node = containerRef.current;
-		const wrapper = wrapperRef.current;
-		if (!node || !wrapper) return;
-		const rect = node.getBoundingClientRect();
-		const wrapperRect = wrapper.getBoundingClientRect();
-		setCollapsedSize({ width: rect.width, height: rect.height });
-		setOverlayOffsets({
-			top: rect.top - wrapperRect.top,
-			right: wrapperRect.right - rect.right,
-		});
-	}, [entries, isExpanded, viewport.height, viewport.width]);
-
-	const clampDimension = (target: number, viewportLimit: number) => {
-		if (viewportLimit <= 0) return target;
-		return Math.min(target, viewportLimit);
-	};
-
-	const expandedStyle =
-		isExpanded && expandedBase
-			? {
-					width: `${clampDimension(
-						expandedBase.width,
-						viewport.width > 32 ? viewport.width - 32 : viewport.width,
-					)}px`,
-					height: `${clampDimension(
-						expandedBase.height,
-						viewport.height > 32 ? viewport.height - 32 : viewport.height,
-					)}px`,
-				}
-			: undefined;
+	const expandedStyle = useMemo(() => {
+		if (!isExpanded || !collapsedSize) return undefined;
+		const horizontalPadding = viewport.width > 32 ? 32 : 16;
+		const verticalPadding = viewport.height > 32 ? 32 : 16;
+		const maxWidth = Math.max(0, viewport.width - horizontalPadding);
+		const maxHeight = Math.max(0, viewport.height - verticalPadding);
+		const targetWidth = Math.min(collapsedSize.width * 2, maxWidth);
+		const targetHeight = Math.min(collapsedSize.height * 4, maxHeight);
+		const desiredRight = Math.max(16, collapsedSize.right);
+		const maxRight = Math.max(16, viewport.width - targetWidth - 16);
+		const availableRight = Math.min(desiredRight, maxRight);
+		const availableTop = Math.max(
+			16,
+			Math.min(collapsedSize.top, viewport.height - targetHeight - 16),
+		);
+		return {
+			position: 'fixed' as const,
+			width: `${targetWidth}px`,
+			height: `${targetHeight}px`,
+			top: `${availableTop}px`,
+			right: `${availableRight}px`,
+		};
+	}, [collapsedSize, isExpanded, viewport.height, viewport.width]);
 
 	const handleToggleExpand = () => {
 		const node = containerRef.current;
-		const wrapper = wrapperRef.current;
-		if (!node || !wrapper) return;
+		if (!node) return;
 
 		if (!isExpanded) {
 			const rect = node.getBoundingClientRect();
-			const wrapperRect = wrapper.getBoundingClientRect();
-			setCollapsedSize({ width: rect.width, height: rect.height });
-			setOverlayOffsets({
-				top: rect.top - wrapperRect.top,
-				right: wrapperRect.right - rect.right,
+			setCollapsedSize({
+				width: rect.width,
+				height: rect.height,
+				top: rect.top,
+				right: viewport.width - rect.right,
 			});
-			setExpandedBase({ width: rect.width * 2, height: rect.height * 4 });
-			setIsOverlay(true);
 			setIsExpanded(true);
 			return;
 		}
 
 		setIsExpanded(false);
-		setExpandedBase(null);
+		pendingScrollRef.current = true;
 	};
 
 	useEffect(() => {
 		if (!isExpanded) return;
-		setIsOverlay(true);
+		const container = containerRef.current;
+		if (!container) return;
+		container.scrollTo({ top: container.scrollHeight, behavior: 'auto' });
 	}, [isExpanded]);
-
-	const handleTransitionEnd = (
-		event: React.TransitionEvent<HTMLDivElement>,
-	) => {
-		if (event.target !== event.currentTarget) return;
-		if (isExpanded || !isOverlay) return;
-		setIsOverlay(false);
-		setOverlayOffsets(null);
-	};
 
 	useEffect(() => {
 		const container = containerRef.current;
 		const list = listRef.current;
 		if (!container || !list) return;
 
-		const scrollToBottom = (behavior: ScrollBehavior) => {
-			if (container.scrollHeight > container.clientHeight)
-				container.scrollTo({ top: container.scrollHeight, behavior });
-		};
+		pendingScrollRef.current = true;
 
-		const animations =
-			typeof list.getAnimations === 'function' ? list.getAnimations() : [];
-		if (animations.length === 0) {
-			scrollToBottom('smooth');
+		if (typeof ResizeObserver === 'undefined') {
+			container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
 			return;
 		}
 
-		let cancelled = false;
-		const finished = animations.map((animation) =>
-			animation.finished.catch(() => undefined),
-		);
-
-		void Promise.all(finished).then(() => {
-			if (!cancelled) scrollToBottom('smooth');
+		let raf = 0;
+		const observer = new ResizeObserver(() => {
+			if (!pendingScrollRef.current) return;
+			pendingScrollRef.current = false;
+			raf = window.requestAnimationFrame(() => {
+				container.scrollTo({
+					top: container.scrollHeight,
+					behavior: 'smooth',
+				});
+			});
 		});
 
+		observer.observe(list);
+
 		return () => {
-			cancelled = true;
+			pendingScrollRef.current = false;
+			observer.disconnect();
+			if (raf) window.cancelAnimationFrame(raf);
 		};
-	}, [entries]);
+	}, [entries, isExpanded, listRef]);
+
+	useEffect(() => {
+		if (isExpanded) return;
+		const node = containerRef.current;
+		if (!node) return;
+		const rect = node.getBoundingClientRect();
+		setCollapsedSize({
+			width: rect.width,
+			height: rect.height,
+			top: rect.top,
+			right: viewport.width - rect.right,
+		});
+	}, [entries, isExpanded, viewport.width, viewport.height]);
 
 	return (
 		<div
-			ref={wrapperRef}
-			className={`relative ${isExpanded || isOverlay ? 'z-50' : ''}`}
+			className={`relative ${isExpanded ? 'z-50' : ''}`}
 			style={
 				collapsedSize && collapsedSize.height
 					? { minHeight: `${collapsedSize.height}px` }
@@ -151,26 +139,18 @@ export default function LogPanel() {
 			<div
 				ref={containerRef}
 				className={`relative rounded-3xl border border-white/60 bg-white/75 shadow-2xl shadow-amber-500/10 transition-all duration-300 ease-in-out dark:border-white/10 dark:bg-slate-900/75 dark:shadow-slate-900/50 frosted-surface ${
-					isOverlay ? 'absolute left-auto' : 'w-full'
-				} ${isExpanded ? 'overflow-auto p-6' : 'max-h-80 overflow-y-auto p-4'}`}
+					isExpanded ? 'p-6' : 'max-h-80 p-4'
+				} ${
+					isExpanded
+						? 'overflow-y-auto custom-scrollbar'
+						: 'overflow-y-auto no-scrollbar'
+				}`}
 				style={{
 					...(expandedStyle ?? {}),
-					...(!isExpanded && isOverlay && collapsedSize
-						? {
-								width: `${collapsedSize.width}px`,
-								height: `${collapsedSize.height}px`,
-							}
-						: {}),
-					...(isOverlay && overlayOffsets
-						? {
-								top: `${overlayOffsets.top}px`,
-								right: `${overlayOffsets.right}px`,
-							}
-						: {}),
+					...(isExpanded ? {} : { width: '100%' }),
 				}}
-				onTransitionEnd={handleTransitionEnd}
 			>
-				<div className="flex items-center justify-between gap-2">
+				<div className="sticky top-0 z-10 flex items-center justify-between gap-2 rounded-2xl bg-white/70 pb-2 pt-1 backdrop-blur-sm dark:bg-slate-900/70">
 					<h2 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
 						Log
 					</h2>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -215,5 +215,37 @@
 }
 
 .no-scrollbar {
-	scrollbar-width: none;
+  scrollbar-width: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.6) transparent;
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  width: 8px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.6);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+.dark .custom-scrollbar {
+  scrollbar-color: rgba(148, 163, 184, 0.45) transparent;
+}
+
+.dark .custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.45);
 }


### PR DESCRIPTION
## Summary
- replace the animation-based auto-scroll with a ResizeObserver-driven approach so new log entries always slide fully into view
- anchor the expanded log panel to the viewport’s right edge with a sticky header so it grows leftward over the action pane without losing the toggle button
- hide scrollbars in the collapsed view and add themed scrollbar styling for the expanded state to match the rest of the UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc3e45ead083258bf2a5c2cae836d3