### PR TITLE
feat(engine): support stacked percent modifiers

### DIFF
--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -663,6 +663,7 @@ class CostModParamsBuilder extends ParamsBuilder<{
 	actionId?: string;
 	key?: ResourceKey;
 	amount?: number;
+	percent?: number;
 }> {
 	id(id: string) {
 		return this.set('id', id);
@@ -675,6 +676,9 @@ class CostModParamsBuilder extends ParamsBuilder<{
 	}
 	amount(amount: number) {
 		return this.set('amount', amount);
+	}
+	percent(percent: number) {
+		return this.set('percent', percent);
 	}
 }
 
@@ -705,6 +709,7 @@ class ResultModParamsBuilder extends ParamsBuilder<{
 	evaluation?: { type: string; id?: string };
 	amount?: number;
 	adjust?: number;
+	percent?: number;
 }> {
 	id(id: string) {
 		return this.set('id', id);
@@ -723,6 +728,9 @@ class ResultModParamsBuilder extends ParamsBuilder<{
 	}
 	adjust(amount: number) {
 		return this.set('adjust', amount);
+	}
+	percent(percent: number) {
+		return this.set('percent', percent);
 	}
 }
 

--- a/packages/engine/src/effects/cost_mod.ts
+++ b/packages/engine/src/effects/cost_mod.ts
@@ -2,35 +2,52 @@ import type { EffectHandler } from '.';
 import type { ResourceKey } from '../state';
 
 interface CostModParams {
-  id: string;
-  actionId?: string;
-  key: ResourceKey;
-  amount: number;
-  [key: string]: unknown;
+	id: string;
+	actionId?: string;
+	key: ResourceKey;
+	amount?: number;
+	percent?: number;
+	[key: string]: unknown;
 }
 
 export const costMod: EffectHandler<CostModParams> = (effect, ctx) => {
-  const { id, actionId, key, amount } = effect.params || ({} as CostModParams);
-  if (!id || !key || amount === undefined) {
-    throw new Error('cost_mod requires id, key, amount');
-  }
-  const ownerId = ctx.activePlayer.id;
-  const modId = `${id}_${ownerId}`;
-  if (effect.method === 'add') {
-    ctx.passives.registerCostModifier(
-      modId,
-      (targetActionId, costs, innerCtx) => {
-        if (
-          innerCtx.activePlayer.id === ownerId &&
-          (!actionId || targetActionId === actionId)
-        ) {
-          const current = costs[key] || 0;
-          return { ...costs, [key]: current + amount };
-        }
-        return costs;
-      },
-    );
-  } else if (effect.method === 'remove') {
-    ctx.passives.unregisterCostModifier(modId);
-  }
+	const params = effect.params || ({} as CostModParams);
+	const { id, actionId, key } = params;
+	const rawAmount = params['amount'];
+	const amount = typeof rawAmount === 'number' ? rawAmount : undefined;
+	const rawPercent = params['percent'];
+	const percent = typeof rawPercent === 'number' ? rawPercent : undefined;
+	if (!id || !key || (amount === undefined && percent === undefined)) {
+		throw new Error(
+			'cost_mod requires id, key, and at least amount or percent',
+		);
+	}
+	const ownerId = ctx.activePlayer.id;
+	const modId = `${id}_${ownerId}`;
+	if (effect.method === 'add') {
+		ctx.passives.registerCostModifier(
+			modId,
+			(targetActionId, costs, innerCtx) => {
+				if (
+					innerCtx.activePlayer.id !== ownerId ||
+					(actionId && targetActionId !== actionId)
+				)
+					return;
+				let flat: Record<string, number> | undefined;
+				if (amount !== undefined) flat = { [key]: amount };
+				let percentMap: Record<string, number> | undefined;
+				if (percent !== undefined) percentMap = { [key]: percent };
+				if (!flat && !percentMap) return;
+				const result: {
+					flat?: Record<string, number>;
+					percent?: Record<string, number>;
+				} = {};
+				if (flat) result.flat = flat;
+				if (percentMap) result.percent = percentMap;
+				return result;
+			},
+		);
+	} else if (effect.method === 'remove') {
+		ctx.passives.unregisterCostModifier(modId);
+	}
 };

--- a/packages/engine/src/effects/result_mod.ts
+++ b/packages/engine/src/effects/result_mod.ts
@@ -2,65 +2,76 @@ import type { EffectHandler } from '.';
 import { runEffects } from '.';
 
 interface ResultModParams {
-  id: string;
-  actionId?: string;
-  evaluation?: { type: string; id: string };
-  amount?: number;
-  adjust?: number;
-  [key: string]: unknown;
+	id: string;
+	actionId?: string;
+	evaluation?: { type: string; id: string };
+	amount?: number;
+	adjust?: number;
+	percent?: number;
+	[key: string]: unknown;
 }
 
 export const resultMod: EffectHandler<ResultModParams> = (effect, ctx) => {
-  const { id, actionId, evaluation } = effect.params || ({} as ResultModParams);
-  if (!id || (!actionId && !evaluation))
-    throw new Error('result_mod requires id and actionId or evaluation');
-  const ownerId = ctx.activePlayer.id;
-  const modId = `${id}_${ownerId}`;
-  if (effect.method === 'add') {
-    const effects = effect.effects || [];
-    if (actionId)
-      ctx.passives.registerResultModifier(
-        modId,
-        (executedActionId, innerContext) => {
-          if (
-            executedActionId === actionId &&
-            innerContext.activePlayer.id === ownerId
-          ) {
-            runEffects(effects, innerContext);
-          }
-        },
-      );
-    else if (evaluation) {
-      const target = `${evaluation.type}:${evaluation.id}`;
-      const rawAmount = effect.params?.['amount'];
-      const amount = typeof rawAmount === 'number' ? rawAmount : undefined;
-      const rawAdjust = effect.params?.['adjust'];
-      const adjust = typeof rawAdjust === 'number' ? rawAdjust : undefined;
-      ctx.passives.registerEvaluationModifier(
-        modId,
-        target,
-        (innerContext, gains) => {
-          if (innerContext.activePlayer.id !== ownerId) return;
-          if (effects.length) runEffects(effects, innerContext);
-          if (adjust !== undefined) for (const g of gains) g.amount += adjust;
-          if (amount !== undefined)
-            for (const g of gains)
-              if (g.amount > 0)
-                runEffects(
-                  [
-                    {
-                      type: 'resource',
-                      method: 'add',
-                      params: { key: g.key, amount },
-                    },
-                  ],
-                  innerContext,
-                );
-        },
-      );
-    }
-  } else if (effect.method === 'remove') {
-    if (actionId) ctx.passives.unregisterResultModifier(modId);
-    else if (evaluation) ctx.passives.unregisterEvaluationModifier(modId);
-  }
+	const params = effect.params || ({} as ResultModParams);
+	const { id, actionId, evaluation } = params;
+	if (!id || (!actionId && !evaluation))
+		throw new Error('result_mod requires id and actionId or evaluation');
+	const ownerId = ctx.activePlayer.id;
+	const modId = `${id}_${ownerId}`;
+	if (effect.method === 'add') {
+		const effects = effect.effects || [];
+		if (actionId)
+			ctx.passives.registerResultModifier(
+				modId,
+				(executedActionId, innerContext) => {
+					if (
+						executedActionId === actionId &&
+						innerContext.activePlayer.id === ownerId
+					) {
+						runEffects(effects, innerContext);
+					}
+				},
+			);
+		else if (evaluation) {
+			const target = `${evaluation.type}:${evaluation.id}`;
+			const rawAmount = params['amount'];
+			const amount = typeof rawAmount === 'number' ? rawAmount : undefined;
+			const rawAdjust = params['adjust'];
+			const adjust = typeof rawAdjust === 'number' ? rawAdjust : undefined;
+			const rawPercent = params['percent'];
+			const percent = typeof rawPercent === 'number' ? rawPercent : undefined;
+			ctx.passives.registerEvaluationModifier(
+				modId,
+				target,
+				(innerContext, gains) => {
+					if (innerContext.activePlayer.id !== ownerId) return;
+					if (effects.length) runEffects(effects, innerContext);
+					if (adjust !== undefined) {
+						for (const g of gains) g.amount += adjust;
+					}
+					if (amount !== undefined) {
+						for (const g of gains) {
+							if (g.amount > 0)
+								runEffects(
+									[
+										{
+											type: 'resource',
+											method: 'add',
+											params: { key: g.key, amount },
+										},
+									],
+									innerContext,
+								);
+						}
+					}
+					if (percent !== undefined) {
+						return { percent };
+					}
+				},
+			);
+		}
+	} else if (effect.method === 'remove') {
+		if (actionId) ctx.passives.unregisterResultModifier(modId);
+		else if (evaluation) ctx.passives.unregisterEvaluationModifier(modId);
+	}
 };

--- a/packages/engine/tests/effects/cost_mod.test.ts
+++ b/packages/engine/tests/effects/cost_mod.test.ts
@@ -5,45 +5,93 @@ import { createContentFactory } from '../factories/content';
 import { Resource as CResource } from '@kingdom-builder/contents';
 
 describe('cost_mod effects', () => {
-  it('adds and removes cost modifiers', () => {
-    const content = createContentFactory();
-    const target = content.action({ baseCosts: { [CResource.gold]: 2 } });
-    const addMod = content.action({
-      effects: [
-        {
-          type: 'cost_mod',
-          method: 'add',
-          params: {
-            id: 'm',
-            actionId: target.id,
-            key: CResource.gold,
-            amount: 1,
-          },
-        },
-      ],
-    });
-    const remMod = content.action({
-      system: true,
-      effects: [
-        {
-          type: 'cost_mod',
-          method: 'remove',
-          params: { id: 'm', key: CResource.gold, amount: 0 },
-        },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    const before = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
-    const cost = getActionCosts(addMod.id, ctx);
-    ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
-    ctx.activePlayer.gold = cost[CResource.gold] ?? 0;
-    performAction(addMod.id, ctx);
-    const increased = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
-    ctx.activePlayer.actions.add(remMod.id);
-    performAction(remMod.id, ctx);
-    const after = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
-    expect(increased).toBe(before + 1);
-    expect(after).toBe(before);
-  });
+	it('adds and removes cost modifiers', () => {
+		const content = createContentFactory();
+		const target = content.action({ baseCosts: { [CResource.gold]: 2 } });
+		const addMod = content.action({
+			effects: [
+				{
+					type: 'cost_mod',
+					method: 'add',
+					params: {
+						id: 'm',
+						actionId: target.id,
+						key: CResource.gold,
+						amount: 1,
+					},
+				},
+			],
+		});
+		const remMod = content.action({
+			system: true,
+			effects: [
+				{
+					type: 'cost_mod',
+					method: 'remove',
+					params: { id: 'm', key: CResource.gold, amount: 0 },
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') advance(ctx);
+		const before = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
+		const cost = getActionCosts(addMod.id, ctx);
+		ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
+		ctx.activePlayer.gold = cost[CResource.gold] ?? 0;
+		performAction(addMod.id, ctx);
+		const increased = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
+		ctx.activePlayer.actions.add(remMod.id);
+		performAction(remMod.id, ctx);
+		const after = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
+		expect(increased).toBe(before + 1);
+		expect(after).toBe(before);
+	});
+
+	it('supports stacked percentage modifiers after flat adjustments', () => {
+		const content = createContentFactory();
+		const target = content.action({ baseCosts: { [CResource.gold]: 3 } });
+		const addMods = content.action({
+			system: true,
+			effects: [
+				{
+					type: 'cost_mod',
+					method: 'add',
+					params: {
+						id: 'flat',
+						actionId: target.id,
+						key: CResource.gold,
+						amount: 4,
+					},
+				},
+				{
+					type: 'cost_mod',
+					method: 'add',
+					params: {
+						id: 'pctA',
+						actionId: target.id,
+						key: CResource.gold,
+						percent: 0.2,
+					},
+				},
+				{
+					type: 'cost_mod',
+					method: 'add',
+					params: {
+						id: 'pctB',
+						actionId: target.id,
+						key: CResource.gold,
+						percent: -0.1,
+					},
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') advance(ctx);
+		ctx.activePlayer.actions.add(addMods.id);
+		const before = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
+		performAction(addMods.id, ctx);
+		const after = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
+		const expectedBase = before + 4;
+		expect(after).toBeCloseTo(expectedBase * (1 + 0.2 - 0.1));
+	});
 });


### PR DESCRIPTION
## Summary
- allow cost_mod effects and PassiveManager to collect flat and percent cost adjustments and apply percent stacking after flat changes
- extend result_mod evaluation hooks to accept percent adjustments and multiply gains while preserving existing flat behaviour
- add builder helpers and engine tests covering stacked percent modifiers on costs and evaluations

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dc3f4a8f848325902a19d8a0bdbaaa