### PR TITLE
Align overview screens with showcase layout

### DIFF
--- a/packages/web/src/Menu.tsx
+++ b/packages/web/src/Menu.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
 import Button from './components/common/Button';
+import {
+	ShowcaseBackground,
+	ShowcaseLayout,
+	ShowcaseCard,
+	SHOWCASE_BADGE_CLASS,
+	SHOWCASE_INTRO_CLASS,
+} from './components/layouts/ShowcasePage';
 
 interface MenuProps {
 	onStart: () => void;
@@ -10,39 +17,30 @@ interface MenuProps {
 
 const HIGHLIGHTS = [
 	{
-		icon: '🛡️',
-		title: 'Fortify Your Legacy',
-		description:
-			'Balance resources, population, and strategy to guide your dynasty through prosperity or peril.',
+		icon: '⚔️',
+		title: 'Lead Bold Campaigns',
+		description: [
+			'Chain daring orders and spring ambushes.',
+			'Steal momentum before rivals can react.',
+		].join(' '),
 	},
 	{
-		icon: '🌿',
-		title: 'Shape Living Lands',
-		description:
-			'Cultivate fertile territories, raise developments, and watch each province flourish under your command.',
+		icon: '🌱',
+		title: 'Turbocharge Your Realm',
+		description: [
+			'Spin up booming economies and trigger population perks.',
+			'Let every turn snowball into the next.',
+		].join(' '),
 	},
 	{
-		icon: '📜',
-		title: 'Write Royal Decrees',
-		description:
-			'Unlock new actions and forge alliances as every decision echoes across the realm.',
+		icon: '🧠',
+		title: 'Forge Wild Combos',
+		description: [
+			'Unlock outrageous developments that bend the rules.',
+			'Stitch together synergies that reshape the map.',
+		].join(' '),
 	},
 ];
-
-const HERO_BADGE_CLASS = [
-	'inline-flex items-center gap-2 rounded-full border border-white/40',
-	'bg-white/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em]',
-	'text-amber-700 shadow-sm',
-	'dark:border-white/10 dark:bg-white/10 dark:text-amber-200',
-	'frosted-surface',
-].join(' ');
-
-const CTA_SECTION_CLASS = [
-	'w-full max-w-3xl rounded-3xl border border-white/50 bg-white/70 p-8',
-	'shadow-2xl shadow-amber-900/10 dark:border-white/10 dark:bg-slate-900/70',
-	'dark:shadow-slate-900/40',
-	'frosted-surface',
-].join(' ');
 
 const KNOWLEDGE_CARD_CLASS = [
 	'mt-8 flex flex-col gap-4 rounded-2xl border border-white/60 bg-white/60 p-4',
@@ -64,17 +62,7 @@ const PRIMARY_BUTTON_CLASS = [
 
 const DEV_BUTTON_CLASS = [
 	'w-full rounded-full px-5 py-3 text-base font-semibold shadow-lg',
-	'shadow-slate-900/10 dark:shadow-black/30',
-].join(' ');
-
-const MAIN_LAYOUT_CLASS = [
-	'relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col items-center',
-	'gap-16 px-6 py-16',
-].join(' ');
-
-const INTRO_PARAGRAPH_CLASS = [
-	'mt-4 max-w-2xl text-base text-slate-700',
-	'dark:text-slate-300/90 sm:text-lg',
+	'shadow-purple-600/30 dark:shadow-purple-900/40',
 ].join(' ');
 
 const CTA_CONTENT_LAYOUT_CLASS = [
@@ -87,9 +75,7 @@ const CTA_DESCRIPTION_CLASS = [
 	'dark:text-slate-300/80',
 ].join(' ');
 
-const CTA_BUTTON_COLUMN_CLASS = ['flex w-full flex-col gap-3 sm:w-64'].join(
-	' ',
-);
+const CTA_BUTTON_COLUMN_CLASS = 'flex w-full flex-col gap-3 sm:w-64';
 
 const KNOWLEDGE_HEADER_LAYOUT_CLASS = [
 	'flex flex-col gap-4',
@@ -133,14 +119,14 @@ const KNOWLEDGE_PARAGRAPH_TEXT = [
 function HeroSection() {
 	return (
 		<header className="flex flex-col items-center text-center">
-			<span className={HERO_BADGE_CLASS}>
+			<span className={SHOWCASE_BADGE_CLASS}>
 				<span className="text-lg">🏰</span>
 				<span>Rule Your Realm</span>
 			</span>
 			<h1 className="mt-6 text-4xl font-black tracking-tight sm:text-5xl md:text-6xl">
 				Kingdom Builder
 			</h1>
-			<p className={INTRO_PARAGRAPH_CLASS}>{INTRO_PARAGRAPH_TEXT}</p>
+			<p className={SHOWCASE_INTRO_CLASS}>{INTRO_PARAGRAPH_TEXT}</p>
 		</header>
 	);
 }
@@ -159,18 +145,16 @@ function CallToActionSection({
 	onTutorial,
 }: CallToActionProps) {
 	return (
-		<section className={CTA_SECTION_CLASS}>
+		<ShowcaseCard className="flex flex-col gap-8">
 			<div className={CTA_CONTENT_LAYOUT_CLASS}>
 				<div className="text-left">
 					<h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
 						Begin Your Reign
 					</h2>
 					{/* prettier-ignore */}
-					<p
-className={CTA_DESCRIPTION_CLASS}
->
-{CTA_DESCRIPTION_TEXT}
-</p>
+					<p className={CTA_DESCRIPTION_CLASS}>
+                                        {CTA_DESCRIPTION_TEXT}
+                                </p>
 				</div>
 				<div className={CTA_BUTTON_COLUMN_CLASS}>
 					<Button
@@ -180,7 +164,11 @@ className={CTA_DESCRIPTION_CLASS}
 					>
 						Start New Game
 					</Button>
-					<Button className={DEV_BUTTON_CLASS} onClick={onStartDev}>
+					<Button
+						variant="dev"
+						className={DEV_BUTTON_CLASS}
+						onClick={onStartDev}
+					>
 						Start Dev/Debug Game
 					</Button>
 				</div>
@@ -189,11 +177,9 @@ className={CTA_DESCRIPTION_CLASS}
 			<div className={KNOWLEDGE_CARD_CLASS}>
 				<div className={KNOWLEDGE_HEADER_LAYOUT_CLASS}>
 					{/* prettier-ignore */}
-					<div
-className={KNOWLEDGE_TITLE_CLASS}
->
-Learn The Basics
-</div>
+					<div className={KNOWLEDGE_TITLE_CLASS}>
+                                        Learn The Basics
+                                </div>
 					<div className={KNOWLEDGE_ACTIONS_CLASS}>
 						<Button
 							variant="ghost"
@@ -213,7 +199,7 @@ Learn The Basics
 				</div>
 				<p>{KNOWLEDGE_PARAGRAPH_TEXT}</p>
 			</div>
-		</section>
+		</ShowcaseCard>
 	);
 }
 
@@ -245,15 +231,8 @@ export default function Menu({
 	onTutorial,
 }: MenuProps) {
 	return (
-		<div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-amber-100 via-rose-100 to-sky-100 text-slate-900 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 dark:text-slate-100">
-			<div className="pointer-events-none absolute inset-0">
-				<div className="absolute -top-24 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-amber-300/30 blur-3xl dark:bg-amber-500/20" />
-				<div className="absolute -bottom-20 -left-10 h-72 w-72 rounded-full bg-sky-300/30 blur-3xl dark:bg-sky-500/20" />
-				<div className="absolute top-1/3 right-10 h-64 w-64 rounded-full bg-rose-300/30 blur-3xl dark:bg-rose-500/20" />
-				<div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.6),_rgba(255,255,255,0)_55%)] dark:bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.55),_rgba(15,23,42,0)_60%)]" />
-			</div>
-
-			<div className={MAIN_LAYOUT_CLASS}>
+		<ShowcaseBackground>
+			<ShowcaseLayout>
 				<HeroSection />
 				<CallToActionSection
 					onStart={onStart}
@@ -262,7 +241,7 @@ export default function Menu({
 					onTutorial={onTutorial}
 				/>
 				<HighlightsSection />
-			</div>
-		</div>
+			</ShowcaseLayout>
+		</ShowcaseBackground>
 	);
 }

--- a/packages/web/src/Overview.tsx
+++ b/packages/web/src/Overview.tsx
@@ -1,145 +1,160 @@
 import React from 'react';
 import Button from './components/common/Button';
 import {
-  ACTIONS as actionInfo,
-  LAND_INFO,
-  SLOT_INFO,
-  RESOURCES,
-  Resource,
-  PHASES,
-  POPULATION_ROLES,
-  PopulationRole,
-  STATS,
-  Stat,
+	ACTIONS as actionInfo,
+	LAND_INFO,
+	SLOT_INFO,
+	RESOURCES,
+	Resource,
+	PHASES,
+	POPULATION_ROLES,
+	PopulationRole,
+	STATS,
+	Stat,
 } from '@kingdom-builder/contents';
+import {
+	ShowcaseBackground,
+	ShowcaseLayout,
+	ShowcaseCard,
+	SHOWCASE_BADGE_CLASS,
+	SHOWCASE_INTRO_CLASS,
+} from './components/layouts/ShowcasePage';
+import {
+	OVERVIEW_BACK_BUTTON_CLASS,
+	OVERVIEW_CARD_CLASS,
+	OVERVIEW_GRID_CLASS,
+	ParagraphSection,
+	ListSection,
+	renderTokens,
+} from './components/overview/OverviewLayout';
+import type { OverviewSectionDef } from './components/overview/OverviewLayout';
+import { createOverviewSections } from './components/overview/sectionsData';
+import type { OverviewIconSet } from './components/overview/sectionsData';
 
 interface OverviewProps {
-  onBack: () => void;
+	onBack: () => void;
 }
 
-export default function Overview({ onBack }: OverviewProps) {
-  const icons = {
-    expand: actionInfo.get('expand')?.icon,
-    build: actionInfo.get('build')?.icon,
-    attack: actionInfo.get('army_attack')?.icon,
-    develop: actionInfo.get('develop')?.icon,
-    raisePop: actionInfo.get('raise_pop')?.icon,
-    growth: PHASES.find((p) => p.id === 'growth')?.icon,
-    upkeep: PHASES.find((p) => p.id === 'upkeep')?.icon,
-    main: PHASES.find((p) => p.id === 'main')?.icon,
-    land: LAND_INFO.icon,
-    slot: SLOT_INFO.icon,
-    gold: RESOURCES[Resource.gold].icon,
-    ap: RESOURCES[Resource.ap].icon,
-    happiness: RESOURCES[Resource.happiness].icon,
-    castle: RESOURCES[Resource.castleHP].icon,
-    army: STATS[Stat.armyStrength].icon,
-    fort: STATS[Stat.fortificationStrength].icon,
-  };
+const HERO_INTRO_TEXT = [
+	'Map the rhythms of the realm before you issue your first decree.',
+	'Know where every resource, phase, and population surge will carry you.',
+].join(' ');
 
-  return (
-    <div className="p-6 max-w-2xl mx-auto space-y-4">
-      <h1 className="text-3xl font-bold text-center mb-4">Game Overview</h1>
-      <p>
-        Welcome to <strong>Kingdom Builder</strong>, a brisk duel of wits where
-        {icons.expand} expansion, {icons.build} clever construction and
-        {icons.attack} daring raids decide who rules the realm.
-      </p>
-      <section>
-        <h2 className="text-xl font-semibold mt-4 mb-2">
-          Your Objective {icons.castle}
-        </h2>
-        <p>
-          Keep your {icons.castle} castle standing while plotting your rival's
-          downfall. A game ends when a stronghold crumbles, a ruler can't
-          sustain their realm, or the final round closes with one monarch ahead.
-        </p>
-      </section>
-      <section>
-        <h2 className="text-xl font-semibold mt-4 mb-2">Turn Flow</h2>
-        <p>Each round flows through three phases:</p>
-        <ul className="list-disc list-inside">
-          <li>
-            <strong>{icons.growth} Growth</strong> – your realm produces income,
-            raises {icons.army} Army and {icons.fort} Fortification Strength,
-            and triggered effects fire.
-          </li>
-          <li>
-            <strong>{icons.upkeep} Upkeep</strong> – pay wages and resolve
-            ongoing effects.
-          </li>
-          <li>
-            <strong>{icons.main} Main</strong> – both players secretly queue
-            actions then reveal them.
-          </li>
-        </ul>
-      </section>
-      <section>
-        <h2 className="text-xl font-semibold mt-4 mb-2">Resources</h2>
-        <p className="mb-2">Juggle your economy to stay in power:</p>
-        <ul className="list-disc list-inside">
-          <li>
-            {icons.gold} <strong>Gold</strong> funds {icons.build} buildings and
-            schemes.
-          </li>
-          <li>
-            {icons.ap} <strong>Action Points</strong> fuel every move in the
-            {icons.main} Main phase.
-          </li>
-          <li>
-            {icons.happiness} <strong>Happiness</strong> keeps the populace
-            smiling (or rioting).
-          </li>
-          <li>
-            {icons.castle} <strong>Castle HP</strong> is your lifeline—lose it
-            and the crown is gone.
-          </li>
-        </ul>
-      </section>
-      <section>
-        <h2 className="text-xl font-semibold mt-4 mb-2">
-          Land &amp; Developments
-        </h2>
-        <p>
-          Claim {icons.land} land and fill each {icons.slot} slot with
-          developments. Farms grow {icons.gold} gold while other projects unlock
-          more slots or unique perks.
-        </p>
-      </section>
-      <section>
-        <h2 className="text-xl font-semibold mt-4 mb-2">Population</h2>
-        <p>Raise citizens and train them into specialists:</p>
-        <ul className="list-disc list-inside">
-          <li>
-            {POPULATION_ROLES[PopulationRole.Council].icon} Council – grants
-            extra {icons.ap} AP each round.
-          </li>
-          <li>
-            {POPULATION_ROLES[PopulationRole.Legion].icon} Legion – boosts your
-            army for {icons.attack} raids.
-          </li>
-          <li>
-            {POPULATION_ROLES[PopulationRole.Fortifier].icon} Fortifier –
-            reinforces defenses around your castle.
-          </li>
-          <li>
-            {POPULATION_ROLES[PopulationRole.Citizen].icon} Citizens – future
-            specialists awaiting guidance.
-          </li>
-        </ul>
-      </section>
-      <section>
-        <h2 className="text-xl font-semibold mt-4 mb-2">
-          Actions &amp; Strategy
-        </h2>
-        <p className="mb-4">
-          Spend {icons.ap} AP on plays like {icons.expand} expanding territory,
-          {icons.develop} developing land, {icons.raisePop} raising population,
-          or unleashing {icons.attack} attacks. Mix and match to outwit your
-          foe!
-        </p>
-      </section>
-      <Button onClick={onBack}>Back to Start</Button>
-    </div>
-  );
+const HERO_PARAGRAPH_TEXT = [
+	'Welcome to {game}, a brisk duel of wits where {expand} expansion,',
+	'{build} clever construction, and {attack} daring raids decide who steers the crown.',
+].join(' ');
+
+export default function Overview({ onBack }: OverviewProps) {
+	const icons: OverviewIconSet = {
+		expand: actionInfo.get('expand')?.icon,
+		build: actionInfo.get('build')?.icon,
+		attack: actionInfo.get('army_attack')?.icon,
+		develop: actionInfo.get('develop')?.icon,
+		raisePop: actionInfo.get('raise_pop')?.icon,
+		growth: PHASES.find((p) => p.id === 'growth')?.icon,
+		upkeep: PHASES.find((p) => p.id === 'upkeep')?.icon,
+		main: PHASES.find((p) => p.id === 'main')?.icon,
+		land: LAND_INFO.icon,
+		slot: SLOT_INFO.icon,
+		gold: RESOURCES[Resource.gold].icon,
+		ap: RESOURCES[Resource.ap].icon,
+		happiness: RESOURCES[Resource.happiness].icon,
+		castle: RESOURCES[Resource.castleHP].icon,
+		army: STATS[Stat.armyStrength].icon,
+		fort: STATS[Stat.fortificationStrength].icon,
+		council: POPULATION_ROLES[PopulationRole.Council].icon,
+		legion: POPULATION_ROLES[PopulationRole.Legion].icon,
+		fortifier: POPULATION_ROLES[PopulationRole.Fortifier].icon,
+		citizen: POPULATION_ROLES[PopulationRole.Citizen].icon,
+	};
+
+	const tokens: Record<string, React.ReactNode> = {
+		castle: icons.castle,
+		army: icons.army,
+		fort: icons.fort,
+		ap: icons.ap,
+		expand: icons.expand,
+		develop: icons.develop,
+		raisePop: icons.raisePop,
+		attack: icons.attack,
+		build: icons.build,
+		land: icons.land,
+		slot: icons.slot,
+		gold: icons.gold,
+		main: icons.main,
+	};
+
+	const heroTokens: Record<string, React.ReactNode> = {
+		...tokens,
+		game: <strong>Kingdom Builder</strong>,
+	};
+
+	const sections: OverviewSectionDef[] = createOverviewSections(icons);
+
+	const renderSection = (section: OverviewSectionDef) => {
+		if (section.kind === 'paragraph') {
+			const paragraphs = section.paragraphs.map((text) =>
+				renderTokens(text, tokens),
+			);
+			return (
+				<ParagraphSection
+					key={section.id}
+					icon={section.icon}
+					title={section.title}
+					span={section.span ?? false}
+					paragraphs={paragraphs}
+				/>
+			);
+		}
+		const items = section.items.map((item) => ({
+			icon: item.icon,
+			label: item.label,
+			body: item.body.map((text) => renderTokens(text, tokens)),
+		}));
+		return (
+			<ListSection
+				key={section.id}
+				icon={section.icon}
+				title={section.title}
+				span={section.span ?? false}
+				items={items}
+			/>
+		);
+	};
+
+	return (
+		<ShowcaseBackground>
+			<ShowcaseLayout className="items-center">
+				<header className="flex flex-col items-center text-center">
+					<span className={SHOWCASE_BADGE_CLASS}>
+						<span className="text-lg">📘</span>
+						<span>Know The Realm</span>
+					</span>
+					<h1 className="mt-6 text-4xl font-black tracking-tight sm:text-5xl md:text-6xl">
+						Game Overview
+					</h1>
+					<p className={SHOWCASE_INTRO_CLASS}>{HERO_INTRO_TEXT}</p>
+				</header>
+
+				<ShowcaseCard as="article" className={OVERVIEW_CARD_CLASS}>
+					<p className="text-base leading-relaxed">
+						{renderTokens(HERO_PARAGRAPH_TEXT, heroTokens)}
+					</p>
+
+					<div className={OVERVIEW_GRID_CLASS}>
+						{sections.map(renderSection)}
+					</div>
+				</ShowcaseCard>
+
+				<Button
+					variant="ghost"
+					className={OVERVIEW_BACK_BUTTON_CLASS}
+					onClick={onBack}
+				>
+					Back to Start
+				</Button>
+			</ShowcaseLayout>
+		</ShowcaseBackground>
+	);
 }

--- a/packages/web/src/Tutorial.tsx
+++ b/packages/web/src/Tutorial.tsx
@@ -1,23 +1,136 @@
 import React from 'react';
+import Button from './components/common/Button';
+import {
+	ShowcaseBackground,
+	ShowcaseLayout,
+	ShowcaseCard,
+	SHOWCASE_BADGE_CLASS,
+	SHOWCASE_INTRO_CLASS,
+} from './components/layouts/ShowcasePage';
+import { renderTokens } from './components/overview/OverviewLayout';
 
 interface TutorialProps {
-  onBack: () => void;
+	onBack: () => void;
 }
 
+const QUICK_STEPS = [
+	{
+		icon: '🧭',
+		title: 'Survey the Realm',
+		description: [
+			'Check your lands, population, and upcoming triggers.',
+			'Then plan which engines are primed to fire.',
+		].join(' '),
+	},
+	{
+		icon: '⚙️',
+		title: 'Prime Your Economy',
+		description: [
+			'Queue early actions that grow income or Action Points—momentum',
+			'now pays off all game long.',
+		].join(' '),
+	},
+	{
+		icon: '🎯',
+		title: 'Plan the Gambit',
+		description: [
+			'Line up developments, population swaps, or raids that chain',
+			'together for a show-stopping reveal.',
+		].join(' '),
+	},
+];
+
+const STEP_CARD_CLASS = [
+	'flex flex-col gap-2 rounded-2xl border border-white/60 bg-white/60 p-4',
+	'text-sm text-slate-700 shadow-inner',
+	'dark:border-white/10 dark:bg-white/5 dark:text-slate-300/80',
+].join(' ');
+
+const TUTORIAL_CARD_CLASS = [
+	'max-w-3xl space-y-8 text-left text-slate-700',
+	'dark:text-slate-200',
+].join(' ');
+
+const TUTORIAL_CALLOUT_CLASS = [
+	'rounded-2xl border border-dashed border-white/60 bg-white/40 p-5',
+	'text-sm leading-relaxed text-slate-700 shadow-inner',
+	'dark:border-white/10 dark:bg-white/5 dark:text-slate-300/80',
+].join(' ');
+
+const TUTORIAL_BACK_BUTTON_CLASS = [
+	'w-full rounded-full border border-white/50 bg-white/60 px-6 py-3',
+	'text-sm font-semibold text-slate-700 shadow-md transition',
+	'hover:border-white/70 hover:bg-white/80',
+	'dark:border-white/10 dark:bg-white/5 dark:text-slate-200',
+	'dark:hover:border-white/20 dark:hover:bg-white/10 sm:w-auto frosted-surface',
+].join(' ');
+
+const HERO_INTRO_TEXT = [
+	'Get a lightning-fast primer before the full walkthrough lands.',
+	'Experiment freely and come back soon for narrated turns and guided challenges.',
+].join(' ');
+
+const TUTORIAL_PARAGRAPH_TEXT = [
+	'Learn the rhythm of {game} with quick hits.',
+	'Each tip spotlights a core system so you can improvise while we polish the tour.',
+].join(' ');
+
+const TUTORIAL_CALLOUT_LINES = [
+	'More scripted scenarios, narrated turns, and puzzle drills are on the way.',
+	'Have ideas? Share them so we can fold them into the next update.',
+];
+
 export default function Tutorial({ onBack }: TutorialProps) {
-  return (
-    <div className="p-6 max-w-2xl mx-auto space-y-4">
-      <h1 className="text-3xl font-bold text-center mb-4">Tutorial</h1>
-      <p>
-        Learn the basics of <strong>Kingdom Builder</strong> and explore how to
-        grow your realm. More guided steps will be added soon.
-      </p>
-      <button
-        className="border px-4 py-2 hoverable cursor-pointer"
-        onClick={onBack}
-      >
-        Back to Start
-      </button>
-    </div>
-  );
+	const introTokens: Record<string, React.ReactNode> = {
+		game: <strong>Kingdom Builder</strong>,
+	};
+
+	return (
+		<ShowcaseBackground>
+			<ShowcaseLayout className="items-center">
+				<header className="flex flex-col items-center text-center">
+					<span className={SHOWCASE_BADGE_CLASS}>
+						<span className="text-lg">🎓</span>
+						<span>Learn By Doing</span>
+					</span>
+					<h1 className="mt-6 text-4xl font-black tracking-tight sm:text-5xl md:text-6xl">
+						Tutorial
+					</h1>
+					<p className={SHOWCASE_INTRO_CLASS}>{HERO_INTRO_TEXT}</p>
+				</header>
+
+				<ShowcaseCard as="article" className={TUTORIAL_CARD_CLASS}>
+					<p className="text-base leading-relaxed">
+						{renderTokens(TUTORIAL_PARAGRAPH_TEXT, introTokens)}
+					</p>
+
+					<div className="grid gap-4 sm:grid-cols-3">
+						{QUICK_STEPS.map((step) => (
+							<div key={step.title} className={STEP_CARD_CLASS}>
+								<div className="text-2xl">{step.icon}</div>
+								<h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+									{step.title}
+								</h2>
+								<p>{step.description}</p>
+							</div>
+						))}
+					</div>
+
+					<div className={TUTORIAL_CALLOUT_CLASS}>
+						{TUTORIAL_CALLOUT_LINES.map((line) => (
+							<p key={line}>{line}</p>
+						))}
+					</div>
+				</ShowcaseCard>
+
+				<Button
+					variant="ghost"
+					className={TUTORIAL_BACK_BUTTON_CLASS}
+					onClick={onBack}
+				>
+					Back to Start
+				</Button>
+			</ShowcaseLayout>
+		</ShowcaseBackground>
+	);
 }

--- a/packages/web/src/components/common/Button.tsx
+++ b/packages/web/src/components/common/Button.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-	variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'ghost';
+	variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'ghost' | 'dev';
 };
 
 const VARIANT_CLASSES: Record<string, string> = {
@@ -15,6 +15,7 @@ const VARIANT_CLASSES: Record<string, string> = {
 		'bg-gradient-to-r from-rose-500 to-red-500 text-white shadow-lg shadow-rose-500/40 hover:from-rose-400 hover:to-red-400 focus-visible:ring-rose-200/70',
 	ghost:
 		'bg-transparent text-slate-700 hover:bg-white/60 dark:text-slate-200 dark:hover:bg-white/10 focus-visible:ring-white/40',
+	dev: 'bg-gradient-to-r from-purple-600 to-fuchsia-500 text-white shadow-lg shadow-purple-500/40 hover:from-purple-500 hover:to-fuchsia-400 focus-visible:ring-purple-200/70',
 };
 
 export default function Button({

--- a/packages/web/src/components/layouts/ShowcasePage.tsx
+++ b/packages/web/src/components/layouts/ShowcasePage.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+
+export const SHOWCASE_BACKGROUND_CLASS = [
+	'relative min-h-screen overflow-hidden bg-gradient-to-br',
+	'from-amber-100 via-rose-100 to-sky-100 text-slate-900',
+	'dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 dark:text-slate-100',
+].join(' ');
+
+const BACKDROP_LAYER = [
+	'pointer-events-none absolute inset-0',
+	'bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.6),_rgba(255,255,255,0)_55%)]',
+	'dark:bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.55),_rgba(15,23,42,0)_60%)]',
+].join(' ');
+
+export const SHOWCASE_LAYOUT_CLASS = [
+	'relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col items-center',
+	'gap-16 px-6 py-16',
+].join(' ');
+
+export const SHOWCASE_BADGE_CLASS = [
+	'inline-flex items-center gap-2 rounded-full border border-white/40',
+	'bg-white/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em]',
+	'text-amber-700 shadow-sm',
+	'dark:border-white/10 dark:bg-white/10 dark:text-amber-200',
+	'frosted-surface',
+].join(' ');
+
+const SHOWCASE_CARD_BASE_CLASS = [
+	'w-full max-w-3xl rounded-3xl border border-white/50 bg-white/70 p-8',
+	'shadow-2xl shadow-amber-900/10 dark:border-white/10 dark:bg-slate-900/70',
+	'dark:shadow-slate-900/40',
+	'frosted-surface',
+].join(' ');
+
+export const SHOWCASE_INTRO_CLASS = [
+	'mt-4 max-w-2xl text-base text-slate-700',
+	'dark:text-slate-300/90 sm:text-lg',
+].join(' ');
+
+interface ShowcaseBackgroundProps {
+	children: React.ReactNode;
+	className?: string;
+}
+
+export function ShowcaseBackground({
+	children,
+	className = '',
+}: ShowcaseBackgroundProps) {
+	return (
+		<div className={`${SHOWCASE_BACKGROUND_CLASS} ${className}`}>
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute -top-24 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-amber-300/30 blur-3xl dark:bg-amber-500/20" />
+				<div className="absolute -bottom-20 -left-10 h-72 w-72 rounded-full bg-sky-300/30 blur-3xl dark:bg-sky-500/20" />
+				<div className="absolute top-1/3 right-10 h-64 w-64 rounded-full bg-rose-300/30 blur-3xl dark:bg-rose-500/20" />
+				<div className={BACKDROP_LAYER} />
+			</div>
+			{children}
+		</div>
+	);
+}
+
+interface ShowcaseLayoutProps {
+	children: React.ReactNode;
+	className?: string;
+}
+
+export function ShowcaseLayout({
+	children,
+	className = '',
+}: ShowcaseLayoutProps) {
+	return (
+		<div className={`${SHOWCASE_LAYOUT_CLASS} ${className}`}>{children}</div>
+	);
+}
+
+interface ShowcaseCardProps {
+	children: React.ReactNode;
+	className?: string;
+	as?: keyof JSX.IntrinsicElements;
+}
+
+export function ShowcaseCard({
+	children,
+	className = '',
+	as: Component = 'section',
+}: ShowcaseCardProps) {
+	return (
+		<Component className={`${SHOWCASE_CARD_BASE_CLASS} ${className}`}>
+			{children}
+		</Component>
+	);
+}

--- a/packages/web/src/components/overview/OverviewLayout.tsx
+++ b/packages/web/src/components/overview/OverviewLayout.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+
+export const SECTION_CLASS = [
+	'rounded-2xl border border-white/60 bg-white/55 p-6',
+	'shadow-inner backdrop-blur-sm',
+	'dark:border-white/10 dark:bg-white/5',
+].join(' ');
+
+export const SECTION_TITLE_CLASS = [
+	'flex items-center gap-2 text-base font-semibold',
+	'text-slate-900 dark:text-slate-100',
+].join(' ');
+
+export const PARAGRAPH_CLASS = [
+	'mt-3 text-sm leading-relaxed text-slate-700',
+	'dark:text-slate-300/80',
+].join(' ');
+
+export const LIST_CLASS = 'mt-3 space-y-3';
+export const LIST_ITEM_CLASS = 'space-y-1';
+export const LIST_HEADING_CLASS = 'flex items-center gap-2';
+
+export const SECTION_EMPHASIS_CLASS = [
+	'font-semibold text-slate-900',
+	'dark:text-slate-100',
+].join(' ');
+
+export const LIST_TEXT_CLASS = [
+	'text-sm leading-relaxed text-slate-700',
+	'dark:text-slate-300/80',
+].join(' ');
+
+export const OVERVIEW_CARD_CLASS = [
+	'max-w-4xl space-y-8 text-left text-slate-700',
+	'dark:text-slate-200',
+].join(' ');
+
+export const OVERVIEW_GRID_CLASS = 'grid gap-6 md:grid-cols-2';
+
+export const OVERVIEW_BACK_BUTTON_CLASS = [
+	'w-full rounded-full border border-white/50 bg-white/60 px-6 py-3',
+	'text-sm font-semibold text-slate-700 shadow-md transition',
+	'hover:border-white/70 hover:bg-white/80',
+	'dark:border-white/10 dark:bg-white/5 dark:text-slate-200',
+	'dark:hover:border-white/20 dark:hover:bg-white/10 sm:w-auto frosted-surface',
+].join(' ');
+
+export type OverviewParagraphDef = {
+	kind: 'paragraph';
+	id: string;
+	icon: React.ReactNode;
+	title: string;
+	span?: boolean;
+	paragraphs: string[];
+};
+
+export type OverviewListItemDef = {
+	icon?: React.ReactNode;
+	label: string;
+	body: string[];
+};
+
+export type OverviewListDef = {
+	kind: 'list';
+	id: string;
+	icon: React.ReactNode;
+	title: string;
+	span?: boolean;
+	items: OverviewListItemDef[];
+};
+
+export type OverviewSectionDef = OverviewParagraphDef | OverviewListDef;
+
+export type ParagraphSectionProps = {
+	icon: React.ReactNode;
+	title: string;
+	span?: boolean;
+	paragraphs: React.ReactNode[];
+};
+
+type RenderedListItem = {
+	icon?: React.ReactNode;
+	label: React.ReactNode;
+	body: React.ReactNode[];
+};
+
+export type ListSectionProps = {
+	icon: React.ReactNode;
+	title: string;
+	span?: boolean;
+	items: RenderedListItem[];
+};
+
+export function sectionClass(span?: boolean) {
+	return [SECTION_CLASS, span ? 'md:col-span-2' : ''].filter(Boolean).join(' ');
+}
+
+export function renderTokens<TTokens extends Record<string, React.ReactNode>>(
+	text: string,
+	tokens: TTokens,
+): React.ReactNode {
+	const parts = text.split(/(\{[a-zA-Z]+\})/g);
+	return (
+		<>
+			{parts.map((part, index) => {
+				const match = part.match(/^\{([a-zA-Z]+)\}$/);
+				if (match) {
+					const tokenKey = match[1] as keyof TTokens;
+					const hasToken = Object.prototype.hasOwnProperty.call(
+						tokens,
+						tokenKey,
+					);
+					if (hasToken) {
+						return (
+							<React.Fragment key={index}>
+								{tokens[tokenKey] ?? match[0]}
+							</React.Fragment>
+						);
+					}
+					/* prettier-ignore */
+					return (
+					<React.Fragment key={index}>
+{match[0]}
+</React.Fragment>
+);
+				}
+				/* prettier-ignore */
+				return (
+					<React.Fragment key={index}>
+				{part}
+			</React.Fragment>
+		);
+			})}
+		</>
+	);
+}
+
+export function ParagraphSection({
+	icon,
+	title,
+	paragraphs,
+	span,
+}: ParagraphSectionProps) {
+	return (
+		<section className={sectionClass(span)}>
+			<h2 className={SECTION_TITLE_CLASS}>
+				<span>{icon}</span>
+				<span>{title}</span>
+			</h2>
+			{paragraphs.map((content, index) => (
+				<p key={index} className={PARAGRAPH_CLASS}>
+					{content}
+				</p>
+			))}
+		</section>
+	);
+}
+
+export function ListSection({ icon, title, items, span }: ListSectionProps) {
+	return (
+		<section className={sectionClass(span)}>
+			<h2 className={SECTION_TITLE_CLASS}>
+				<span>{icon}</span>
+				<span>{title}</span>
+			</h2>
+			<ul className={LIST_CLASS}>
+				{items.map((item, index) => (
+					<li key={index} className={LIST_ITEM_CLASS}>
+						<div className={LIST_HEADING_CLASS}>
+							{item.icon ? <span>{item.icon}</span> : null}
+							{/* prettier-ignore */}
+							<span className={SECTION_EMPHASIS_CLASS}>
+                                                                {item.label}
+                                                        </span>
+						</div>
+						{item.body.map((content, bodyIndex) => (
+							<p key={bodyIndex} className={LIST_TEXT_CLASS}>
+								{content}
+							</p>
+						))}
+					</li>
+				))}
+			</ul>
+		</section>
+	);
+}

--- a/packages/web/src/components/overview/sectionsData.ts
+++ b/packages/web/src/components/overview/sectionsData.ts
@@ -1,0 +1,157 @@
+import type { ReactNode } from 'react';
+import type { OverviewSectionDef } from './OverviewLayout';
+
+export interface OverviewIconSet {
+	expand?: ReactNode;
+	build?: ReactNode;
+	attack?: ReactNode;
+	develop?: ReactNode;
+	raisePop?: ReactNode;
+	growth?: ReactNode;
+	upkeep?: ReactNode;
+	main?: ReactNode;
+	land?: ReactNode;
+	slot?: ReactNode;
+	gold?: ReactNode;
+	ap?: ReactNode;
+	happiness?: ReactNode;
+	castle?: ReactNode;
+	army?: ReactNode;
+	fort?: ReactNode;
+	council?: ReactNode;
+	legion?: ReactNode;
+	fortifier?: ReactNode;
+	citizen?: ReactNode;
+}
+
+export function createOverviewSections(
+	icons: OverviewIconSet,
+): OverviewSectionDef[] {
+	return [
+		{
+			kind: 'paragraph',
+			id: 'objective',
+			icon: icons.castle,
+			title: 'Your Objective',
+			span: true,
+			paragraphs: [
+				'Keep your {castle} castle standing through every assault.',
+				"Plot daring turns that unravel your rival's engine.",
+				'Victory strikes when a stronghold falls or a ruler stalls out.',
+				'The final round crowns the monarch with the healthiest realm.',
+			],
+		},
+		{
+			kind: 'list',
+			id: 'turn-flow',
+			icon: icons.growth,
+			title: 'Turn Flow',
+			span: true,
+			items: [
+				{
+					icon: icons.growth,
+					label: 'Growth',
+					body: [
+						'Kickstarts your engine with income and {army} Army strength.',
+						'Stacks {fort} Fortification bonuses and triggers automatic boons.',
+					],
+				},
+				{
+					icon: icons.upkeep,
+					label: 'Upkeep',
+					body: [
+						'Settles wages, ongoing effects, and any debts your realm has racked up.',
+					],
+				},
+				{
+					icon: icons.main,
+					label: 'Main Phase',
+					body: [
+						'Both players secretly queue actions.',
+						'Reveal them in a flurry of {ap} AP-powered maneuvers.',
+					],
+				},
+			],
+		},
+		{
+			kind: 'list',
+			id: 'resources',
+			icon: icons.gold,
+			title: 'Resources',
+			items: [
+				{
+					icon: icons.gold,
+					label: 'Gold',
+					body: ['Fuels {build} buildings, diplomacy, and daring plays.'],
+				},
+				{
+					icon: icons.ap,
+					label: 'Action Points',
+					body: ['Are the energy for every turn in the {main} Main phase.'],
+				},
+				{
+					icon: icons.happiness,
+					label: 'Happiness',
+					body: ['Keeps the populace cheering instead of rioting.'],
+				},
+				{
+					icon: icons.castle,
+					label: 'Castle HP',
+					body: ['Is your lifeline—lose it and the dynasty topples.'],
+				},
+			],
+		},
+		{
+			kind: 'paragraph',
+			id: 'land',
+			icon: icons.land,
+			title: 'Land & Developments',
+			paragraphs: [
+				'Claim {land} land and slot in {slot} developments to unlock perks.',
+				'Farms pump {gold} gold while signature projects open slots or unleash passives.',
+			],
+		},
+		{
+			kind: 'list',
+			id: 'population',
+			icon: icons.council,
+			title: 'Population Roles',
+			span: true,
+			items: [
+				{
+					icon: icons.council,
+					label: 'Council',
+					body: ['Rallies extra {ap} Action Points each round.'],
+				},
+				{
+					icon: icons.legion,
+					label: 'Legion',
+					body: [
+						'Reinforces {army} Army strength for devastating {attack} raids.',
+					],
+				},
+				{
+					icon: icons.fortifier,
+					label: 'Fortifier',
+					body: ['Cements your defenses with persistent buffs.'],
+				},
+				{
+					icon: icons.citizen,
+					label: 'Citizens',
+					body: ['Wait in the wings, ready to specialize as needed.'],
+				},
+			],
+		},
+		{
+			kind: 'paragraph',
+			id: 'actions',
+			icon: icons.develop,
+			title: 'Actions & Strategy',
+			span: true,
+			paragraphs: [
+				'Spend {ap} AP to {expand} grow territory or {develop} upgrade key lands.',
+				'Field {raisePop} specialists or launch {attack} attacks to snowball momentum.',
+			],
+		},
+	];
+}


### PR DESCRIPTION
## Summary
- add a shared showcase-style layout and overview helpers reused by menu, overview, and tutorial pages
- refresh the menu CTA, highlights, and developer button copy to match the updated styling
- rewrite overview and tutorial content using tokenized sections with livelier copy and consistent formatting

## Testing
- npm run lint
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dc3a637fdc832582b426ef2ae8eaf3