### PR TITLE
Limit log history in UI log panel

### DIFF
--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -3,7 +3,7 @@ import { useGameEngine } from '../state/GameContext';
 import { useAnimate } from '../utils/useAutoAnimate';
 
 export default function LogPanel() {
-	const { log: entries, ctx } = useGameEngine();
+	const { log: entries, logOverflowed, ctx } = useGameEngine();
 	const containerRef = useRef<HTMLDivElement>(null);
 	const listRef = useAnimate<HTMLUListElement>();
 	const [isExpanded, setIsExpanded] = useState(false);
@@ -173,6 +173,11 @@ export default function LogPanel() {
 						</div>
 					</div>
 				</div>
+				{logOverflowed ? (
+					<p className="mt-2 text-xs italic text-amber-700 dark:text-amber-300">
+						Older log entries were trimmed.
+					</p>
+				) : null}
 				<ul
 					ref={listRef}
 					className={`mt-3 ${isExpanded ? 'space-y-3 text-sm' : 'space-y-2 text-xs'} text-slate-700 dark:text-slate-200`}

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -83,6 +83,7 @@ type PhaseStep = {
 interface GameEngineContextValue {
 	ctx: EngineContext;
 	log: LogEntry[];
+	logOverflowed: boolean;
 	hoverCard: HoverCard | null;
 	handleHoverCard: (data: HoverCard) => void;
 	clearHoverCard: () => void;
@@ -142,7 +143,9 @@ export function GameProvider({
 	const [, setTick] = useState(0);
 	const refresh = () => setTick((t) => t + 1);
 
+	const MAX_LOG_ENTRIES = 250;
 	const [log, setLog] = useState<LogEntry[]>([]);
+	const [logOverflowed, setLogOverflowed] = useState(false);
 	const [hoverCard, setHoverCard] = useState<HoverCard | null>(null);
 	const hoverTimeout = useRef<number>();
 
@@ -201,7 +204,12 @@ export function GameProvider({
 				text: `[${p.name}] ${text}`,
 				playerId: p.id,
 			}));
-			return [...prev, ...items];
+			const combined = [...prev, ...items];
+			if (combined.length > MAX_LOG_ENTRIES) {
+				setLogOverflowed(true);
+				return combined.slice(-MAX_LOG_ENTRIES);
+			}
+			return combined;
 		});
 	};
 
@@ -572,6 +580,7 @@ export function GameProvider({
 	const value: GameEngineContextValue = {
 		ctx,
 		log,
+		logOverflowed,
 		hoverCard,
 		handleHoverCard,
 		clearHoverCard,


### PR DESCRIPTION
## Summary
- cap the stored game log to 250 entries and expose an overflow flag in the game context
- surface a message in the log panel UI when older log entries are trimmed

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc486be50c8325b3769ec5b352273b