### PR TITLE
Fix phase panel transition timing for upkeep steps

### DIFF
--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -549,12 +549,12 @@ export function GameProvider({
 
 	// Update main phase steps once action phase becomes active
 	useEffect(() => {
-		if (ctx.phases[ctx.game.phaseIndex]?.action) {
-			const start = ctx.activePlayer.resources[actionCostResource] as number;
-			setMainApStart(start);
-			updateMainPhaseStep(start);
-		}
-	}, [ctx.game.phaseIndex]);
+		if (!tabsEnabled) return;
+		if (!ctx.phases[ctx.game.phaseIndex]?.action) return;
+		const start = ctx.activePlayer.resources[actionCostResource] as number;
+		setMainApStart(start);
+		updateMainPhaseStep(start);
+	}, [ctx.game.phaseIndex, tabsEnabled]);
 
 	useEffect(() => {
 		void runUntilActionPhase();


### PR DESCRIPTION
## Summary
- prevent the main phase step tracker from updating while the UI tabs are disabled so upkeep steps can complete before the phase switches

## Testing
- npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68dc4d73eda483258a35bc279f96da80