### PR TITLE
Improve disabled styling for the Actions panel

### DIFF
--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -844,9 +844,15 @@ export default function ActionsPanel() {
 		: 'Show opponent actions';
 
 	return (
-		<section className="relative rounded-3xl border border-white/60 bg-white/75 p-6 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/50 frosted-surface">
-      {panelDisabled && (
-				<div className="pointer-events-none absolute inset-0 rounded-3xl bg-white/70 dark:bg-slate-950/60 frosted-surface" />
+		<section
+			className="relative rounded-3xl border border-white/60 bg-white/75 p-6 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/50 frosted-surface"
+			aria-disabled={panelDisabled || undefined}
+		>
+			{panelDisabled && (
+				<div
+					aria-hidden
+					className="pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-br from-white/70 via-white/55 to-white/10 ring-1 ring-inset ring-white/60 dark:from-slate-100/15 dark:via-slate-100/10 dark:to-transparent dark:ring-white/10"
+				/>
 			)}
 			<div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 				<h2 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
@@ -880,7 +886,10 @@ export default function ActionsPanel() {
 			</div>
 			<div className="relative">
 				{panelDisabled && (
-					<div className="pointer-events-none absolute inset-0 rounded-3xl bg-white/70 backdrop-blur-sm dark:bg-slate-950/60" />
+					<div
+						aria-hidden
+						className="pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-br from-white/75 via-white/55 to-transparent backdrop-blur-sm ring-1 ring-inset ring-white/50 dark:from-slate-100/15 dark:via-slate-100/10 dark:to-transparent dark:ring-white/10"
+					/>
 				)}
 				<div ref={sectionRef} className="space-y-4">
 					{otherActions.length > 0 && (


### PR DESCRIPTION
## Summary
- soften the disabled overlays for the Actions panel so the section no longer turns dark blue
- mark the panel as aria-disabled when interaction is not allowed

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dc4d9cd3d08325bbcf179e13fe7fb7