### PR TITLE
Fix log panel background overflow

### DIFF
--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -4,7 +4,8 @@ import { useAnimate } from '../utils/useAutoAnimate';
 
 export default function LogPanel() {
 	const { log: entries, logOverflowed, ctx } = useGameEngine();
-	const containerRef = useRef<HTMLDivElement>(null);
+	const outerRef = useRef<HTMLDivElement>(null);
+	const scrollRef = useRef<HTMLDivElement>(null);
 	const listRef = useAnimate<HTMLUListElement>();
 	const [isExpanded, setIsExpanded] = useState(false);
 	const [collapsedSize, setCollapsedSize] = useState<{
@@ -55,7 +56,7 @@ export default function LogPanel() {
 	}, [collapsedSize, isExpanded, viewport.height, viewport.width]);
 
 	const handleToggleExpand = () => {
-		const node = containerRef.current;
+		const node = outerRef.current;
 		if (!node) return;
 
 		if (!isExpanded) {
@@ -76,13 +77,13 @@ export default function LogPanel() {
 
 	useEffect(() => {
 		if (!isExpanded) return;
-		const container = containerRef.current;
+		const container = scrollRef.current;
 		if (!container) return;
 		container.scrollTo({ top: container.scrollHeight, behavior: 'auto' });
 	}, [isExpanded]);
 
 	useEffect(() => {
-		const container = containerRef.current;
+		const container = scrollRef.current;
 		const list = listRef.current;
 		if (!container || !list) return;
 
@@ -116,7 +117,7 @@ export default function LogPanel() {
 
 	useEffect(() => {
 		if (isExpanded) return;
-		const node = containerRef.current;
+		const node = outerRef.current;
 		if (!node) return;
 		const rect = node.getBoundingClientRect();
 		setCollapsedSize({
@@ -137,72 +138,77 @@ export default function LogPanel() {
 			}
 		>
 			<div
-				ref={containerRef}
+				ref={outerRef}
 				className={`relative rounded-3xl border border-white/60 shadow-2xl shadow-amber-500/10 transition-all duration-300 ease-in-out dark:border-white/10 dark:shadow-slate-900/50 frosted-surface ${
 					isExpanded
-						? 'bg-white/90 p-6 dark:bg-slate-900/90'
-						: 'max-h-80 bg-white/75 p-4 dark:bg-slate-900/75'
-				} ${
-					isExpanded
-						? 'overflow-y-auto custom-scrollbar'
-						: 'overflow-y-auto no-scrollbar'
+						? 'bg-white/90 dark:bg-slate-900/90'
+						: 'bg-white/75 dark:bg-slate-900/75'
 				}`}
 				style={{
 					...(expandedStyle ?? {}),
 					...(isExpanded ? {} : { width: '100%' }),
 				}}
 			>
-				<div className="flex items-center gap-2 pb-2">
-					<h2 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
-						Log
-					</h2>
-					<div className="ml-auto">
-						<div className={`sticky ${isExpanded ? 'top-6' : 'top-4'}`}>
-							<button
-								type="button"
-								onClick={handleToggleExpand}
-								aria-label={
-									isExpanded ? 'Collapse log panel' : 'Expand log panel'
-								}
-								className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/60 bg-white/85 text-lg font-semibold text-slate-700 shadow hover:bg-white/95 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-900/85 dark:text-slate-100 dark:hover:bg-slate-900"
-							>
-								<span aria-hidden="true" className="text-lg leading-none">
-									{isExpanded ? '⤡' : '⛶'}
-								</span>
-							</button>
+				<div
+					ref={scrollRef}
+					className={`relative flex flex-col ${
+						isExpanded
+							? 'h-full overflow-y-auto p-6 custom-scrollbar'
+							: 'max-h-80 overflow-y-auto p-4 no-scrollbar'
+					}`}
+				>
+					<div className="flex items-center gap-2 pb-2">
+						<h2 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+							Log
+						</h2>
+						<div className="ml-auto">
+							<div className={`sticky ${isExpanded ? 'top-6' : 'top-4'}`}>
+								<button
+									type="button"
+									onClick={handleToggleExpand}
+									aria-label={
+										isExpanded ? 'Collapse log panel' : 'Expand log panel'
+									}
+									className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/60 bg-white/85 text-lg font-semibold text-slate-700 shadow hover:bg-white/95 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-900/85 dark:text-slate-100 dark:hover:bg-slate-900"
+								>
+									<span aria-hidden="true" className="text-lg leading-none">
+										{isExpanded ? '⤡' : '⛶'}
+									</span>
+								</button>
+							</div>
 						</div>
 					</div>
+					{logOverflowed ? (
+						<p className="mt-2 text-xs italic text-amber-700 dark:text-amber-300">
+							Older log entries were trimmed.
+						</p>
+					) : null}
+					<ul
+						ref={listRef}
+						className={`mt-3 ${isExpanded ? 'space-y-3 text-sm' : 'space-y-2 text-xs'} text-slate-700 dark:text-slate-200`}
+					>
+						{entries.map((entry, idx) => {
+							const aId = ctx.game.players[0]?.id;
+							const bId = ctx.game.players[1]?.id;
+							const colorClass =
+								entry.playerId === aId
+									? 'log-entry-a'
+									: entry.playerId === bId
+										? 'log-entry-b'
+										: '';
+							return (
+								<li
+									key={idx}
+									className={`${
+										isExpanded ? 'text-sm leading-relaxed' : 'text-xs'
+									} font-mono whitespace-pre-wrap ${colorClass}`}
+								>
+									[{entry.time}] {entry.text}
+								</li>
+							);
+						})}
+					</ul>
 				</div>
-				{logOverflowed ? (
-					<p className="mt-2 text-xs italic text-amber-700 dark:text-amber-300">
-						Older log entries were trimmed.
-					</p>
-				) : null}
-				<ul
-					ref={listRef}
-					className={`mt-3 ${isExpanded ? 'space-y-3 text-sm' : 'space-y-2 text-xs'} text-slate-700 dark:text-slate-200`}
-				>
-					{entries.map((entry, idx) => {
-						const aId = ctx.game.players[0]?.id;
-						const bId = ctx.game.players[1]?.id;
-						const colorClass =
-							entry.playerId === aId
-								? 'log-entry-a'
-								: entry.playerId === bId
-									? 'log-entry-b'
-									: '';
-						return (
-							<li
-								key={idx}
-								className={`${
-									isExpanded ? 'text-sm leading-relaxed' : 'text-xs'
-								} font-mono whitespace-pre-wrap ${colorClass}`}
-							>
-								[{entry.time}] {entry.text}
-							</li>
-						);
-					})}
-				</ul>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- split the log panel so the frosted background lives on the outer container while the inner element handles scrolling
- keep expand/collapse measurements accurate by introducing separate refs for the outer shell and scroll area

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc49d8cf948325b56d1e7d77630b39