### PR TITLE
Implement Royal Decree action choice flow

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -3,411 +3,446 @@ import { Resource } from './resources';
 import { Stat, STATS } from './stats';
 import { PopulationRole, POPULATION_ROLES } from './populationRoles';
 import {
-  actionSchema,
-  type ActionConfig,
+	actionSchema,
+	type ActionConfig,
 } from '@kingdom-builder/engine/config/schema';
 import {
-  action,
-  effect,
-  requirement,
-  Types,
-  LandMethods,
-  ResourceMethods,
-  DevelopmentMethods,
-  PopulationMethods,
-  ActionMethods,
-  PassiveMethods,
-  CostModMethods,
-  ResultModMethods,
-  BuildingMethods,
-  StatMethods,
-  resourceParams,
-  statParams,
-  developmentParams,
-  resultModParams,
-  passiveParams,
-  costModParams,
-  developmentEvaluator,
-  populationEvaluator,
-  statEvaluator,
-  attackParams,
-  transferParams,
+	action,
+	effect,
+	requirement,
+	Types,
+	LandMethods,
+	ResourceMethods,
+	DevelopmentMethods,
+	PopulationMethods,
+	ActionMethods,
+	PassiveMethods,
+	CostModMethods,
+	ResultModMethods,
+	BuildingMethods,
+	StatMethods,
+	resourceParams,
+	statParams,
+	developmentParams,
+	resultModParams,
+	passiveParams,
+	costModParams,
+	developmentEvaluator,
+	populationEvaluator,
+	statEvaluator,
+	attackParams,
+	transferParams,
 } from './config/builders';
 import type { Focus } from './defs';
 
+export interface ActionChoice {
+	type: 'development';
+	options: string[];
+}
+
 export interface ActionDef extends ActionConfig {
-  category?: string;
-  order?: number;
-  focus?: Focus;
+	category?: string;
+	order?: number;
+	focus?: Focus;
+	choice?: ActionChoice;
 }
 
 export function createActionRegistry() {
-  const registry = new Registry<ActionDef>(actionSchema.passthrough());
+	const registry = new Registry<ActionDef>(actionSchema.passthrough());
 
-  registry.add('expand', {
-    ...action()
-      .id('expand')
-      .name('Expand')
-      .icon('🌱')
-      .cost(Resource.ap, 1)
-      .cost(Resource.gold, 2)
-      .effect(effect(Types.Land, LandMethods.ADD).param('count', 1).build())
-      .effect(
-        effect(Types.Resource, ResourceMethods.ADD)
-          .params(resourceParams().key(Resource.happiness).amount(1))
-          .build(),
-      )
-      .build(),
-    category: 'basic',
-    order: 1,
-    focus: 'economy',
-  });
+	registry.add('expand', {
+		...action()
+			.id('expand')
+			.name('Expand')
+			.icon('🌱')
+			.cost(Resource.ap, 1)
+			.cost(Resource.gold, 2)
+			.effect(effect(Types.Land, LandMethods.ADD).param('count', 1).build())
+			.effect(
+				effect(Types.Resource, ResourceMethods.ADD)
+					.params(resourceParams().key(Resource.happiness).amount(1))
+					.build(),
+			)
+			.build(),
+		category: 'basic',
+		order: 1,
+		focus: 'economy',
+	});
 
-  registry.add('overwork', {
-    ...action()
-      .id('overwork')
-      .name('Overwork')
-      .icon('🛠️')
-      .cost(Resource.ap, 1)
-      .effect(
-        effect()
-          .evaluator(developmentEvaluator().id('farm'))
-          .effect(
-            effect(Types.Resource, ResourceMethods.ADD)
-              .round('down')
-              .params(resourceParams().key(Resource.gold).amount(2))
-              .build(),
-          )
-          .effect({
-            type: Types.Resource,
-            method: ResourceMethods.REMOVE,
-            round: 'up',
-            params: resourceParams()
-              .key(Resource.happiness)
-              .amount(0.5)
-              .build(),
-            meta: { allowShortfall: true },
-          })
-          .build(),
-      )
-      .build(),
-    category: 'basic',
-    order: 2,
-    focus: 'economy',
-  });
+	registry.add('overwork', {
+		...action()
+			.id('overwork')
+			.name('Overwork')
+			.icon('🛠️')
+			.cost(Resource.ap, 1)
+			.effect(
+				effect()
+					.evaluator(developmentEvaluator().id('farm'))
+					.effect(
+						effect(Types.Resource, ResourceMethods.ADD)
+							.round('down')
+							.params(resourceParams().key(Resource.gold).amount(2))
+							.build(),
+					)
+					.effect({
+						type: Types.Resource,
+						method: ResourceMethods.REMOVE,
+						round: 'up',
+						params: resourceParams()
+							.key(Resource.happiness)
+							.amount(0.5)
+							.build(),
+						meta: { allowShortfall: true },
+					})
+					.build(),
+			)
+			.build(),
+		category: 'basic',
+		order: 2,
+		focus: 'economy',
+	});
 
-  registry.add('develop', {
-    ...action()
-      .id('develop')
-      .name('Develop')
-      .icon('🏗️')
-      .cost(Resource.ap, 1)
-      .cost(Resource.gold, 3)
-      .effect(
-        effect(Types.Development, DevelopmentMethods.ADD)
-          .params(developmentParams().id('$id').landId('$landId'))
-          .build(),
-      )
-      .build(),
-    category: 'development',
-    order: 1,
-    focus: 'economy',
-  });
+	registry.add('develop', {
+		...action()
+			.id('develop')
+			.name('Develop')
+			.icon('🏗️')
+			.cost(Resource.ap, 1)
+			.cost(Resource.gold, 3)
+			.effect(
+				effect(Types.Development, DevelopmentMethods.ADD)
+					.params(developmentParams().id('$id').landId('$landId'))
+					.build(),
+			)
+			.build(),
+		category: 'development',
+		order: 1,
+		focus: 'economy',
+	});
 
-  registry.add('tax', {
-    ...action()
-      .id('tax')
-      .name('Tax')
-      .icon('💰')
-      .cost(Resource.ap, 1)
-      .effect(
-        effect()
-          .evaluator(populationEvaluator().param('id', 'tax'))
-          .effect(
-            effect(Types.Resource, ResourceMethods.ADD)
-              .params(resourceParams().key(Resource.gold).amount(4))
-              .build(),
-          )
-          .effect({
-            type: Types.Resource,
-            method: ResourceMethods.REMOVE,
-            round: 'up',
-            params: resourceParams()
-              .key(Resource.happiness)
-              .amount(0.5)
-              .build(),
-            meta: { allowShortfall: true },
-          })
-          .build(),
-      )
-      .build(),
-    category: 'basic',
-    order: 3,
-    focus: 'economy',
-  });
+	registry.add('tax', {
+		...action()
+			.id('tax')
+			.name('Tax')
+			.icon('💰')
+			.cost(Resource.ap, 1)
+			.effect(
+				effect()
+					.evaluator(populationEvaluator().param('id', 'tax'))
+					.effect(
+						effect(Types.Resource, ResourceMethods.ADD)
+							.params(resourceParams().key(Resource.gold).amount(4))
+							.build(),
+					)
+					.effect({
+						type: Types.Resource,
+						method: ResourceMethods.REMOVE,
+						round: 'up',
+						params: resourceParams()
+							.key(Resource.happiness)
+							.amount(0.5)
+							.build(),
+						meta: { allowShortfall: true },
+					})
+					.build(),
+			)
+			.build(),
+		category: 'basic',
+		order: 3,
+		focus: 'economy',
+	});
 
-  registry.add('reallocate', {
-    ...action()
-      .id('reallocate')
-      .name('Reallocate')
-      .icon('🔄')
-      .cost(Resource.ap, 1)
-      .cost(Resource.gold, 5)
-      .build(),
-    category: 'basic',
-    order: 4,
-    focus: 'economy',
-  });
+	registry.add('reallocate', {
+		...action()
+			.id('reallocate')
+			.name('Reallocate')
+			.icon('🔄')
+			.cost(Resource.ap, 1)
+			.cost(Resource.gold, 5)
+			.build(),
+		category: 'basic',
+		order: 4,
+		focus: 'economy',
+	});
 
-  registry.add('raise_pop', {
-    ...action()
-      .id('raise_pop')
-      .name('Hire')
-      .icon('👶')
-      .cost(Resource.ap, 1)
-      .cost(Resource.gold, 5)
-      .requirement(
-        requirement('evaluator', 'compare')
-          .param('left', populationEvaluator().build())
-          .param('operator', 'lt')
-          .param('right', statEvaluator().key(Stat.maxPopulation).build())
-          .message('Free space for 👥')
-          .build(),
-      )
-      .effect(
-        effect(Types.Population, PopulationMethods.ADD)
-          .param('role', '$role')
-          .build(),
-      )
-      .effect(
-        effect(Types.Resource, ResourceMethods.ADD)
-          .params(resourceParams().key(Resource.happiness).amount(1))
-          .build(),
-      )
-      .build(),
-    category: 'population',
-    order: 1,
-    focus: 'economy',
-  });
+	registry.add('raise_pop', {
+		...action()
+			.id('raise_pop')
+			.name('Hire')
+			.icon('👶')
+			.cost(Resource.ap, 1)
+			.cost(Resource.gold, 5)
+			.requirement(
+				requirement('evaluator', 'compare')
+					.param('left', populationEvaluator().build())
+					.param('operator', 'lt')
+					.param('right', statEvaluator().key(Stat.maxPopulation).build())
+					.message('Free space for 👥')
+					.build(),
+			)
+			.effect(
+				effect(Types.Population, PopulationMethods.ADD)
+					.param('role', '$role')
+					.build(),
+			)
+			.effect(
+				effect(Types.Resource, ResourceMethods.ADD)
+					.params(resourceParams().key(Resource.happiness).amount(1))
+					.build(),
+			)
+			.build(),
+		category: 'population',
+		order: 1,
+		focus: 'economy',
+	});
 
-  registry.add('royal_decree', {
-    ...action()
-      .id('royal_decree')
-      .name('Royal Decree')
-      .icon('📜')
-      .cost(Resource.ap, 1)
-      .cost(Resource.gold, 12)
-      .build(),
-    category: 'basic',
-    order: 5,
-    focus: 'other',
-  });
+	registry.add('royal_decree', {
+		...action()
+			.id('royal_decree')
+			.name('Royal Decree')
+			.icon('📜')
+			.cost(Resource.ap, 1)
+			.cost(Resource.gold, 12)
+			.effect(
+				effect(Types.Action, ActionMethods.PERFORM)
+					.param('id', 'expand')
+					.build(),
+			)
+			.effect(
+				effect(Types.Action, ActionMethods.PERFORM)
+					.param('id', 'till')
+					.param('params', { landId: '$landId' })
+					.build(),
+			)
+			.effect(
+				effect(Types.Action, ActionMethods.PERFORM)
+					.param('id', 'develop')
+					.param('params', { id: '$developmentId', landId: '$landId' })
+					.build(),
+			)
+			.effect({
+				type: Types.Resource,
+				method: ResourceMethods.REMOVE,
+				params: resourceParams().key(Resource.happiness).amount(3).build(),
+				meta: { allowShortfall: true },
+			})
+			.build(),
+		category: 'basic',
+		order: 5,
+		focus: 'other',
+		choice: {
+			type: 'development',
+			options: ['farm', 'house', 'outpost', 'watchtower'],
+		},
+	});
 
-  registry.add('army_attack', {
-    ...action()
-      .id('army_attack')
-      .name('Army Attack')
-      .icon('🗡️')
-      .cost(Resource.ap, 1)
-      .requirement(
-        requirement('evaluator', 'compare')
-          .param('left', statEvaluator().key(Stat.warWeariness).build())
-          .param('operator', 'lt')
-          .param(
-            'right',
-            populationEvaluator().role(PopulationRole.Legion).build(),
-          )
-          .message(
-            `${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be lower than ${POPULATION_ROLES[PopulationRole.Legion].icon} ${POPULATION_ROLES[PopulationRole.Legion].label}`,
-          )
-          .build(),
-      )
-      .effect(
-        effect('attack', 'perform')
-          .params(
-            attackParams()
-              .targetResource(Resource.castleHP)
-              .onDamageAttacker(
-                effect(Types.Resource, ResourceMethods.ADD)
-                  .params(resourceParams().key(Resource.happiness).amount(1))
-                  .build(),
-                effect(Types.Action, ActionMethods.PERFORM)
-                  .param('id', 'plunder')
-                  .build(),
-              )
-              .onDamageDefender({
-                type: Types.Resource,
-                method: ResourceMethods.REMOVE,
-                params: resourceParams()
-                  .key(Resource.happiness)
-                  .amount(1)
-                  .build(),
-                meta: { allowShortfall: true },
-              }),
-          )
-          .build(),
-      )
-      .effect(
-        effect(Types.Stat, StatMethods.ADD)
-          .params(statParams().key(Stat.warWeariness).amount(1))
-          .build(),
-      )
-      .build(),
-    category: 'basic',
-    order: 6,
-    focus: 'aggressive',
-  });
+	registry.add('army_attack', {
+		...action()
+			.id('army_attack')
+			.name('Army Attack')
+			.icon('🗡️')
+			.cost(Resource.ap, 1)
+			.requirement(
+				requirement('evaluator', 'compare')
+					.param('left', statEvaluator().key(Stat.warWeariness).build())
+					.param('operator', 'lt')
+					.param(
+						'right',
+						populationEvaluator().role(PopulationRole.Legion).build(),
+					)
+					.message(
+						`${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be lower than ${POPULATION_ROLES[PopulationRole.Legion].icon} ${POPULATION_ROLES[PopulationRole.Legion].label}`,
+					)
+					.build(),
+			)
+			.effect(
+				effect('attack', 'perform')
+					.params(
+						attackParams()
+							.targetResource(Resource.castleHP)
+							.onDamageAttacker(
+								effect(Types.Resource, ResourceMethods.ADD)
+									.params(resourceParams().key(Resource.happiness).amount(1))
+									.build(),
+								effect(Types.Action, ActionMethods.PERFORM)
+									.param('id', 'plunder')
+									.build(),
+							)
+							.onDamageDefender({
+								type: Types.Resource,
+								method: ResourceMethods.REMOVE,
+								params: resourceParams()
+									.key(Resource.happiness)
+									.amount(1)
+									.build(),
+								meta: { allowShortfall: true },
+							}),
+					)
+					.build(),
+			)
+			.effect(
+				effect(Types.Stat, StatMethods.ADD)
+					.params(statParams().key(Stat.warWeariness).amount(1))
+					.build(),
+			)
+			.build(),
+		category: 'basic',
+		order: 6,
+		focus: 'aggressive',
+	});
 
-  registry.add('hold_festival', {
-    ...action()
-      .id('hold_festival')
-      .name('Hold Festival')
-      .icon('🎉')
-      .cost(Resource.ap, 1)
-      .cost(Resource.gold, 3)
-      .requirement(
-        requirement('evaluator', 'compare')
-          .param('left', statEvaluator().key(Stat.warWeariness).build())
-          .param('operator', 'eq')
-          .param('right', 0)
-          .message(
-            `${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be 0`,
-          )
-          .build(),
-      )
-      .effect(
-        effect(Types.Resource, ResourceMethods.ADD)
-          .params(resourceParams().key(Resource.happiness).amount(3))
-          .build(),
-      )
-      .effect(
-        effect(Types.Stat, StatMethods.REMOVE)
-          .params(statParams().key(Stat.fortificationStrength).amount(3))
-          .build(),
-      )
-      .effect(
-        effect(Types.Passive, PassiveMethods.ADD)
-          .params(
-            passiveParams()
-              .id('hold_festival_penalty')
-              .onUpkeepPhase(
-                effect(Types.Passive, PassiveMethods.REMOVE)
-                  .param('id', 'hold_festival_penalty')
-                  .build(),
-              ),
-          )
-          .effect(
-            effect(Types.ResultMod, ResultModMethods.ADD)
-              .params(
-                resultModParams()
-                  .id('hold_festival_attack_happiness_penalty')
-                  .actionId('army_attack'),
-              )
-              .effect({
-                type: Types.Resource,
-                method: ResourceMethods.REMOVE,
-                params: resourceParams()
-                  .key(Resource.happiness)
-                  .amount(3)
-                  .build(),
-                meta: { allowShortfall: true },
-              })
-              .build(),
-          )
-          .build(),
-      )
-      .build(),
-    category: 'basic',
-    order: 7,
-    focus: 'economy',
-  });
+	registry.add('hold_festival', {
+		...action()
+			.id('hold_festival')
+			.name('Hold Festival')
+			.icon('🎉')
+			.cost(Resource.ap, 1)
+			.cost(Resource.gold, 3)
+			.requirement(
+				requirement('evaluator', 'compare')
+					.param('left', statEvaluator().key(Stat.warWeariness).build())
+					.param('operator', 'eq')
+					.param('right', 0)
+					.message(
+						`${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be 0`,
+					)
+					.build(),
+			)
+			.effect(
+				effect(Types.Resource, ResourceMethods.ADD)
+					.params(resourceParams().key(Resource.happiness).amount(3))
+					.build(),
+			)
+			.effect(
+				effect(Types.Stat, StatMethods.REMOVE)
+					.params(statParams().key(Stat.fortificationStrength).amount(3))
+					.build(),
+			)
+			.effect(
+				effect(Types.Passive, PassiveMethods.ADD)
+					.params(
+						passiveParams()
+							.id('hold_festival_penalty')
+							.onUpkeepPhase(
+								effect(Types.Passive, PassiveMethods.REMOVE)
+									.param('id', 'hold_festival_penalty')
+									.build(),
+							),
+					)
+					.effect(
+						effect(Types.ResultMod, ResultModMethods.ADD)
+							.params(
+								resultModParams()
+									.id('hold_festival_attack_happiness_penalty')
+									.actionId('army_attack'),
+							)
+							.effect({
+								type: Types.Resource,
+								method: ResourceMethods.REMOVE,
+								params: resourceParams()
+									.key(Resource.happiness)
+									.amount(3)
+									.build(),
+								meta: { allowShortfall: true },
+							})
+							.build(),
+					)
+					.build(),
+			)
+			.build(),
+		category: 'basic',
+		order: 7,
+		focus: 'economy',
+	});
 
-  registry.add(
-    'plunder',
-    action()
-      .id('plunder')
-      .name('Plunder')
-      .icon('🏴\u200d☠️')
-      .system()
-      // Base 25% transfer; modifiers may adjust via result_mod targeting
-      // evaluation { type: 'transfer_pct', id: 'percent' } with an `adjust` value.
-      .effect(
-        effect(Types.Resource, ResourceMethods.TRANSFER)
-          .params(transferParams().key(Resource.gold).percent(25))
-          .build(),
-      )
-      .build(),
-  );
+	registry.add(
+		'plunder',
+		action()
+			.id('plunder')
+			.name('Plunder')
+			.icon('🏴\u200d☠️')
+			.system()
+			// Base 25% transfer; modifiers may adjust via result_mod targeting
+			// evaluation { type: 'transfer_pct', id: 'percent' } with an `adjust` value.
+			.effect(
+				effect(Types.Resource, ResourceMethods.TRANSFER)
+					.params(transferParams().key(Resource.gold).percent(25))
+					.build(),
+			)
+			.build(),
+	);
 
-  registry.add(
-    'plow',
-    action()
-      .id('plow')
-      .name('Plow')
-      .icon('🚜')
-      .system()
-      .cost(Resource.ap, 1)
-      .cost(Resource.gold, 6)
-      .effect(
-        effect(Types.Action, ActionMethods.PERFORM)
-          .param('id', 'expand')
-          .build(),
-      )
-      .effect(
-        effect(Types.Action, ActionMethods.PERFORM).param('id', 'till').build(),
-      )
-      .effect(
-        effect(Types.Passive, PassiveMethods.ADD)
-          .params(
-            passiveParams()
-              .id('plow_cost_mod')
-              .onUpkeepPhase(
-                effect(Types.Passive, PassiveMethods.REMOVE)
-                  .param('id', 'plow_cost_mod')
-                  .build(),
-              ),
-          )
-          .effect(
-            effect(Types.CostMod, CostModMethods.ADD)
-              .params(
-                costModParams()
-                  .id('plow_cost_all')
-                  .key(Resource.gold)
-                  .amount(2),
-              )
-              .build(),
-          )
-          .build(),
-      )
-      .build(),
-  );
+	registry.add(
+		'plow',
+		action()
+			.id('plow')
+			.name('Plow')
+			.icon('🚜')
+			.system()
+			.cost(Resource.ap, 1)
+			.cost(Resource.gold, 6)
+			.effect(
+				effect(Types.Action, ActionMethods.PERFORM)
+					.param('id', 'expand')
+					.build(),
+			)
+			.effect(
+				effect(Types.Action, ActionMethods.PERFORM).param('id', 'till').build(),
+			)
+			.effect(
+				effect(Types.Passive, PassiveMethods.ADD)
+					.params(
+						passiveParams()
+							.id('plow_cost_mod')
+							.onUpkeepPhase(
+								effect(Types.Passive, PassiveMethods.REMOVE)
+									.param('id', 'plow_cost_mod')
+									.build(),
+							),
+					)
+					.effect(
+						effect(Types.CostMod, CostModMethods.ADD)
+							.params(
+								costModParams()
+									.id('plow_cost_all')
+									.key(Resource.gold)
+									.amount(2),
+							)
+							.build(),
+					)
+					.build(),
+			)
+			.build(),
+	);
 
-  registry.add(
-    'till',
-    action()
-      .id('till')
-      .name('Till')
-      .icon('🧑‍🌾')
-      .system()
-      .effect(effect(Types.Land, LandMethods.TILL).build())
-      .build(),
-  );
+	registry.add(
+		'till',
+		action()
+			.id('till')
+			.name('Till')
+			.icon('🧑‍🌾')
+			.system()
+			.effect(
+				effect(Types.Land, LandMethods.TILL).param('landId', '$landId').build(),
+			)
+			.build(),
+	);
 
-  registry.add('build', {
-    ...action()
-      .id('build')
-      .name('Build')
-      .icon('🏛️')
-      .effect(
-        effect(Types.Building, BuildingMethods.ADD).param('id', '$id').build(),
-      )
-      .build(),
-    category: 'building',
-    order: 1,
-    focus: 'other',
-  });
+	registry.add('build', {
+		...action()
+			.id('build')
+			.name('Build')
+			.icon('🏛️')
+			.effect(
+				effect(Types.Building, BuildingMethods.ADD).param('id', '$id').build(),
+			)
+			.build(),
+		category: 'building',
+		order: 1,
+		focus: 'other',
+	});
 
-  return registry;
+	return registry;
 }
 
 export const ACTIONS = createActionRegistry();

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -5,9 +5,9 @@ export { POPULATIONS, createPopulationRegistry } from './populations';
 export { PHASES } from './phases';
 export type { PhaseDef, StepDef } from './config/builders';
 export {
-  POPULATION_ROLES,
-  PopulationRole,
-  type PopulationRoleId,
+	POPULATION_ROLES,
+	PopulationRole,
+	type PopulationRoleId,
 } from './populationRoles';
 export { Resource, type ResourceKey, RESOURCES } from './resources';
 export { Stat, type StatKey, STATS } from './stats';
@@ -18,14 +18,14 @@ export { PASSIVE_INFO } from './passive';
 export { MODIFIER_INFO } from './modifiers';
 export { GAME_START } from './game';
 export { RULES } from './rules';
-export type { ActionDef } from './actions';
+export type { ActionDef, ActionChoice } from './actions';
 export type { BuildingDef } from './buildings';
 export type { DevelopmentDef } from './developments';
 export type { PopulationDef, TriggerKey, Focus } from './defs';
 export {
-  ON_PAY_UPKEEP_STEP,
-  ON_GAIN_INCOME_STEP,
-  ON_GAIN_AP_STEP,
-  BROOM_ICON,
-  RESOURCE_TRANSFER_ICON,
+	ON_PAY_UPKEEP_STEP,
+	ON_GAIN_INCOME_STEP,
+	ON_GAIN_AP_STEP,
+	BROOM_ICON,
+	RESOURCE_TRANSFER_ICON,
 } from './defs';

--- a/packages/engine/src/actions/action_parameters.ts
+++ b/packages/engine/src/actions/action_parameters.ts
@@ -5,6 +5,7 @@ type ActionParameterMap = {
 	build: { id: string };
 	demolish: { id: string };
 	raise_pop: { role: PopulationRoleId };
+	royal_decree: { developmentId: string; landId: string };
 	[key: string]: Record<string, unknown>;
 };
 

--- a/packages/engine/src/effects/action_perform.ts
+++ b/packages/engine/src/effects/action_perform.ts
@@ -5,28 +5,37 @@ import { snapshotPlayer } from '../log';
 import { withStatSourceFrames } from '../stat_sources';
 
 export const actionPerform: EffectHandler = (effect, ctx, mult = 1) => {
-  const id = effect.params?.['id'] as string;
-  if (!id) throw new Error('action:perform requires id');
-  const params = effect.params as Record<string, unknown>;
-  for (let i = 0; i < Math.floor(mult); i++) {
-    const def = ctx.actions.get(id);
-    const before = snapshotPlayer(ctx.activePlayer, ctx);
-    const resolved = applyParamsToEffects(def.effects, params);
-    withStatSourceFrames(
-      ctx,
-      (_effect, _ctx, statKey) => ({
-        key: `action:${def.id}:${statKey}`,
-        kind: 'action',
-        id: def.id,
-        detail: 'Resolution',
-        longevity: 'permanent',
-      }),
-      () => {
-        runEffects(resolved, ctx);
-        ctx.passives.runResultMods(def.id, ctx);
-      },
-    );
-    const after = snapshotPlayer(ctx.activePlayer, ctx);
-    ctx.actionTraces.push({ id: def.id, before, after });
-  }
+	const id = effect.params?.['id'] as string;
+	if (!id) throw new Error('action:perform requires id');
+	const rawParams: Record<string, unknown> = effect.params ?? {};
+	const { params: nestedParams, ...otherParams } = rawParams;
+	const resolvedParams: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(otherParams)) {
+		if (key === 'id') continue;
+		resolvedParams[key] = value;
+	}
+	if (nestedParams && typeof nestedParams === 'object') {
+		Object.assign(resolvedParams, nestedParams as Record<string, unknown>);
+	}
+	for (let i = 0; i < Math.floor(mult); i++) {
+		const def = ctx.actions.get(id);
+		const before = snapshotPlayer(ctx.activePlayer, ctx);
+		const resolved = applyParamsToEffects(def.effects, resolvedParams);
+		withStatSourceFrames(
+			ctx,
+			(_effect, _ctx, statKey) => ({
+				key: `action:${def.id}:${statKey}`,
+				kind: 'action',
+				id: def.id,
+				detail: 'Resolution',
+				longevity: 'permanent',
+			}),
+			() => {
+				runEffects(resolved, ctx);
+				ctx.passives.runResultMods(def.id, ctx);
+			},
+		);
+		const after = snapshotPlayer(ctx.activePlayer, ctx);
+		ctx.actionTraces.push({ id: def.id, before, after });
+	}
 };

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -53,6 +53,9 @@ export type ActionCardProps = {
 	onMouseEnter?: () => void;
 	onMouseLeave?: () => void;
 	focus?: Focus | undefined;
+	badge?: React.ReactNode;
+	flipped?: boolean;
+	backFace?: ((opts: { focusClass: string }) => React.ReactNode) | undefined;
 };
 
 export default function ActionCard({
@@ -71,6 +74,9 @@ export default function ActionCard({
 	onMouseEnter,
 	onMouseLeave,
 	focus,
+	badge,
+	flipped = false,
+	backFace,
 }: ActionCardProps) {
 	const focusClass = (() => {
 		switch (focus) {
@@ -84,16 +90,25 @@ export default function ActionCard({
 				return 'from-rose-200/70 to-rose-100/40 dark:from-rose-900/40 dark:to-rose-800/20';
 		}
 	})();
-	return (
+	const baseCardClass = `panel-card flex h-full w-full flex-col items-start gap-2 border border-white/40 bg-gradient-to-br p-4 text-left shadow-lg shadow-amber-500/10 transition ${focusClass}`;
+	const stateClass = enabled
+		? 'hoverable cursor-pointer'
+		: 'cursor-not-allowed opacity-50';
+	const frontButton = (
 		<button
-			className={`relative panel-card flex h-full flex-col items-start gap-2 border border-white/40 bg-gradient-to-br p-4 text-left shadow-lg shadow-amber-500/10 transition ${
-				enabled ? 'hoverable cursor-pointer' : 'cursor-not-allowed opacity-50'
-			} ${focusClass}`}
+			className={`relative ${baseCardClass} ${stateClass} ${
+				backFace ? '[backface-visibility:hidden]' : ''
+			} ${flipped ? 'pointer-events-none' : ''}`}
 			title={tooltip}
-			onClick={enabled ? onClick : undefined}
-			onMouseEnter={onMouseEnter}
-			onMouseLeave={onMouseLeave}
+			onClick={enabled && !flipped ? onClick : undefined}
+			onMouseEnter={!flipped ? onMouseEnter : undefined}
+			onMouseLeave={!flipped ? onMouseLeave : undefined}
 		>
+			{badge && (
+				<div className="absolute left-2 top-2 text-xs text-white/80 dark:text-white/60">
+					{badge}
+				</div>
+			)}
 			<span className="text-base font-medium">{title}</span>
 			<div className="absolute top-2 right-2 flex flex-col items-end gap-1 text-right">
 				{renderCosts(costs, playerResources, actionCostResource, upkeep)}
@@ -106,7 +121,7 @@ export default function ActionCard({
 					</div>
 				)}
 			</div>
-			<ul className="text-sm list-disc pl-4 text-left">
+			<ul className="list-disc pl-4 text-left text-sm">
 				{implemented ? (
 					renderSummary(stripSummary(summary, requirements))
 				) : (
@@ -116,5 +131,27 @@ export default function ActionCard({
 				)}
 			</ul>
 		</button>
+	);
+	if (!backFace) {
+		return frontButton;
+	}
+
+	return (
+		<div className="relative h-full w-full [perspective:1600px]">
+			<div
+				className={`relative h-full w-full transition-transform duration-500 [transform-style:preserve-3d] ${
+					flipped ? '[transform:rotateY(180deg)]' : ''
+				}`}
+			>
+				{frontButton}
+				<div
+					className={`absolute inset-0 ${baseCardClass} ${
+						flipped ? '' : 'pointer-events-none'
+					} [transform:rotateY(180deg)] [backface-visibility:hidden]`}
+				>
+					{backFace({ focusClass })}
+				</div>
+			</div>
+		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- add content metadata and effects so Royal Decree expands, tills, builds a chosen development and reduces happiness
- extend the engine action performer and parameters to forward nested action params for the selected development
- update the web UI to support multi-step actions with a flipping card and choice grid for Royal Decree

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dc4cc4f65083259f3dcde43ab254ac