### PR TITLE
Refactor resolveAttack target handling

### DIFF
--- a/packages/engine/src/effects/attack.ts
+++ b/packages/engine/src/effects/attack.ts
@@ -6,339 +6,294 @@ import { runEffects } from '.';
 import { collectTriggerEffects } from '../triggers';
 import { withStatSourceFrames } from '../stat_sources';
 import { snapshotPlayer, type PlayerSnapshot } from '../log';
+import type { AttackEvaluationTargetLog, AttackTarget } from './attack.types';
+import {
+	attackTargetHandlers,
+	type AttackTargetHandlerMeta,
+} from './attack_target_handlers';
+
+export {
+	type AttackTarget,
+	type AttackEvaluationTargetLog,
+} from './attack.types';
 
 export interface AttackCalcOptions {
-  ignoreAbsorption?: boolean;
-  ignoreFortification?: boolean;
+	ignoreAbsorption?: boolean;
+	ignoreFortification?: boolean;
 }
-
-export type AttackTarget =
-  | { type: 'resource'; key: ResourceKey }
-  | { type: 'stat'; key: StatKey }
-  | { type: 'building'; id: string };
 
 export type AttackLogOwner = 'attacker' | 'defender';
 
 export interface AttackPowerLog {
-  base: number;
-  modified: number;
+	base: number;
+	modified: number;
 }
-
-interface AttackNumericTargetLog {
-  before: number;
-  damage: number;
-  after: number;
-}
-
-export type AttackEvaluationTargetLog =
-  | ({ type: 'resource'; key: ResourceKey } & AttackNumericTargetLog)
-  | ({ type: 'stat'; key: StatKey } & AttackNumericTargetLog)
-  | {
-      type: 'building';
-      id: string;
-      existed: boolean;
-      destroyed: boolean;
-      damage: number;
-    };
 
 export interface AttackEvaluationLog {
-  power: AttackPowerLog;
-  absorption: {
-    ignored: boolean;
-    before: number;
-    damageAfter: number;
-  };
-  fortification: {
-    ignored: boolean;
-    before: number;
-    damage: number;
-    after: number;
-  };
-  target: AttackEvaluationTargetLog;
+	power: AttackPowerLog;
+	absorption: {
+		ignored: boolean;
+		before: number;
+		damageAfter: number;
+	};
+	fortification: {
+		ignored: boolean;
+		before: number;
+		damage: number;
+		after: number;
+	};
+	target: AttackEvaluationTargetLog;
 }
 
-export type AttackPlayerDiff =
-  | {
-      type: 'resource';
-      key: ResourceKey;
-      before: number;
-      after: number;
-    }
-  | {
-      type: 'stat';
-      key: StatKey;
-      before: number;
-      after: number;
-    };
+interface AttackResourceDiff {
+	type: 'resource';
+	key: ResourceKey;
+	before: number;
+	after: number;
+}
+
+interface AttackStatDiff {
+	type: 'stat';
+	key: StatKey;
+	before: number;
+	after: number;
+}
+
+export type AttackPlayerDiff = AttackResourceDiff | AttackStatDiff;
 
 export interface AttackOnDamageLogEntry {
-  owner: AttackLogOwner;
-  effect: EffectDef;
-  attacker: AttackPlayerDiff[];
-  defender: AttackPlayerDiff[];
+	owner: AttackLogOwner;
+	effect: EffectDef;
+	attacker: AttackPlayerDiff[];
+	defender: AttackPlayerDiff[];
 }
 
 export interface AttackLog {
-  evaluation: AttackEvaluationLog;
-  onDamage: AttackOnDamageLogEntry[];
+	evaluation: AttackEvaluationLog;
+	onDamage: AttackOnDamageLogEntry[];
 }
 
 interface AttackResolution {
-  damageDealt: number;
-  evaluation: AttackEvaluationLog;
+	damageDealt: number;
+	evaluation: AttackEvaluationLog;
 }
 
 function diffPlayerSnapshots(
-  before: PlayerSnapshot,
-  after: PlayerSnapshot,
+	before: PlayerSnapshot,
+	after: PlayerSnapshot,
 ): AttackPlayerDiff[] {
-  const diffs: AttackPlayerDiff[] = [];
-  const resourceKeys = new Set<ResourceKey>(
-    // Cast snapshot keys to ResourceKey so downstream consumers can rely on
-    // resource metadata lookups during logging.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    Object.keys({ ...before.resources, ...after.resources }) as ResourceKey[],
-  );
-  for (const key of resourceKeys) {
-    const beforeVal = before.resources[key] ?? 0;
-    const afterVal = after.resources[key] ?? 0;
-    if (beforeVal !== afterVal)
-      diffs.push({
-        type: 'resource',
-        key,
-        before: beforeVal,
-        after: afterVal,
-      });
-  }
-  const statKeys = new Set<StatKey>(
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    Object.keys({ ...before.stats, ...after.stats }) as StatKey[],
-  );
-  for (const key of statKeys) {
-    const beforeVal = before.stats[key] ?? 0;
-    const afterVal = after.stats[key] ?? 0;
-    if (beforeVal !== afterVal)
-      diffs.push({
-        type: 'stat',
-        key,
-        before: beforeVal,
-        after: afterVal,
-      });
-  }
-  return diffs;
+	const diffs: AttackPlayerDiff[] = [];
+	const resourceKeys = new Set<ResourceKey>(
+		// Cast snapshot keys to ResourceKey so downstream consumers can rely on
+		// resource metadata lookups during logging.
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+		Object.keys({ ...before.resources, ...after.resources }) as ResourceKey[],
+	);
+	for (const key of resourceKeys) {
+		const beforeVal = before.resources[key] ?? 0;
+		const afterVal = after.resources[key] ?? 0;
+		if (beforeVal !== afterVal)
+			diffs.push({
+				type: 'resource',
+				key,
+				before: beforeVal,
+				after: afterVal,
+			});
+	}
+	const statKeys = new Set<StatKey>(
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+		Object.keys({ ...before.stats, ...after.stats }) as StatKey[],
+	);
+	for (const key of statKeys) {
+		const beforeVal = before.stats[key] ?? 0;
+		const afterVal = after.stats[key] ?? 0;
+		if (beforeVal !== afterVal)
+			diffs.push({
+				type: 'stat',
+				key,
+				before: beforeVal,
+				after: afterVal,
+			});
+	}
+	return diffs;
 }
 
 function applyAbsorption(
-  damage: number,
-  absorption: number,
-  rounding: 'up' | 'down' | 'nearest',
+	damage: number,
+	absorption: number,
+	rounding: 'up' | 'down' | 'nearest',
 ): number {
-  if (absorption <= 0) return damage;
-  const reduced = damage * (1 - absorption);
-  if (rounding === 'down') return Math.floor(reduced);
-  if (rounding === 'up') return Math.ceil(reduced);
-  return Math.round(reduced);
+	if (absorption <= 0) return damage;
+	const reduced = damage * (1 - absorption);
+	if (rounding === 'down') return Math.floor(reduced);
+	if (rounding === 'up') return Math.ceil(reduced);
+	return Math.round(reduced);
 }
 
 export function resolveAttack(
-  defender: PlayerState,
-  damage: number,
-  ctx: EngineContext,
-  target: AttackTarget,
-  opts: AttackCalcOptions = {},
-  baseDamage = damage,
+	defender: PlayerState,
+	damage: number,
+	ctx: EngineContext,
+	target: AttackTarget,
+	opts: AttackCalcOptions = {},
+	baseDamage = damage,
 ): AttackResolution {
-  const original = ctx.game.currentPlayerIndex;
-  const defenderIndex = ctx.game.players.indexOf(defender);
+	const original = ctx.game.currentPlayerIndex;
+	const defenderIndex = ctx.game.players.indexOf(defender);
 
-  ctx.game.currentPlayerIndex = defenderIndex;
-  const pre = collectTriggerEffects('onBeforeAttacked', ctx, defender);
+	ctx.game.currentPlayerIndex = defenderIndex;
+	const pre = collectTriggerEffects('onBeforeAttacked', ctx, defender);
 
-  for (const bundle of pre)
-    withStatSourceFrames(ctx, bundle.frames, () =>
-      runEffects(bundle.effects, ctx),
-    );
+	for (const bundle of pre)
+		withStatSourceFrames(ctx, bundle.frames, () =>
+			runEffects(bundle.effects, ctx),
+		);
 
-  if (pre.length) runEffects(pre, ctx);
+	if (pre.length) runEffects(pre, ctx);
 
-  ctx.game.currentPlayerIndex = original;
+	ctx.game.currentPlayerIndex = original;
 
-  const absorption = opts.ignoreAbsorption
-    ? 0
-    : Math.min(
-        (defender.absorption as number) || 0,
-        ctx.services.rules.absorptionCapPct,
-      );
-  const damageAfterAbsorption = opts.ignoreAbsorption
-    ? damage
-    : applyAbsorption(
-        damage,
-        absorption,
-        ctx.services.rules.absorptionRounding,
-      );
+	const absorption = opts.ignoreAbsorption
+		? 0
+		: Math.min(
+				(defender.absorption as number) || 0,
+				ctx.services.rules.absorptionCapPct,
+			);
+	const damageAfterAbsorption = opts.ignoreAbsorption
+		? damage
+		: applyAbsorption(
+				damage,
+				absorption,
+				ctx.services.rules.absorptionRounding,
+			);
 
-  const fortBefore = (defender.fortificationStrength as number) || 0;
-  const fortDamage = opts.ignoreFortification
-    ? 0
-    : Math.min(fortBefore, damageAfterAbsorption);
-  const fortAfter = opts.ignoreFortification
-    ? fortBefore
-    : Math.max(0, fortBefore - fortDamage);
-  if (!opts.ignoreFortification) defender.fortificationStrength = fortAfter;
+	const fortBefore = (defender.fortificationStrength as number) || 0;
+	const fortDamage = opts.ignoreFortification
+		? 0
+		: Math.min(fortBefore, damageAfterAbsorption);
+	const fortAfter = opts.ignoreFortification
+		? fortBefore
+		: Math.max(0, fortBefore - fortDamage);
+	if (!opts.ignoreFortification) defender.fortificationStrength = fortAfter;
 
-  const targetDamage = Math.max(0, damageAfterAbsorption - fortDamage);
-  let targetLog: AttackEvaluationTargetLog;
+	const targetDamage = Math.max(0, damageAfterAbsorption - fortDamage);
+	const handlerMeta: AttackTargetHandlerMeta = {
+		defenderIndex,
+		originalIndex: original,
+	};
+	const handler = attackTargetHandlers[target.type];
+	const mutation = handler.applyDamage(
+		target as never,
+		targetDamage,
+		ctx,
+		defender,
+		handlerMeta,
+	);
+	const targetLog = handler.buildLog(
+		target as never,
+		targetDamage,
+		ctx,
+		defender,
+		handlerMeta,
+		mutation as never,
+	);
 
-  if (target.type === 'stat') {
-    const before = defender.stats[target.key] || 0;
-    const after = Math.max(0, before - targetDamage);
-    if (targetDamage > 0) defender.stats[target.key] = after;
-    targetLog = {
-      type: 'stat',
-      key: target.key,
-      before,
-      damage: targetDamage,
-      after,
-    };
-  } else if (target.type === 'resource') {
-    const before = defender.resources[target.key] || 0;
-    const after = Math.max(0, before - targetDamage);
-    if (targetDamage > 0) defender.resources[target.key] = after;
-    targetLog = {
-      type: 'resource',
-      key: target.key,
-      before,
-      damage: targetDamage,
-      after,
-    };
-  } else {
-    const existed = defender.buildings.has(target.id);
-    let destroyed = false;
-    if (targetDamage > 0 && existed) {
-      const originalIndex = ctx.game.currentPlayerIndex;
-      ctx.game.currentPlayerIndex = defenderIndex;
-      try {
-        runEffects(
-          [
-            {
-              type: 'building',
-              method: 'remove',
-              params: { id: target.id },
-            },
-          ],
-          ctx,
-        );
-      } finally {
-        ctx.game.currentPlayerIndex = originalIndex;
-      }
-      destroyed = !defender.buildings.has(target.id);
-    }
-    targetLog = {
-      type: 'building',
-      id: target.id,
-      existed,
-      destroyed,
-      damage: targetDamage,
-    };
-  }
+	ctx.game.currentPlayerIndex = defenderIndex;
+	const post = collectTriggerEffects('onAttackResolved', ctx, defender);
 
-  ctx.game.currentPlayerIndex = defenderIndex;
-  const post = collectTriggerEffects('onAttackResolved', ctx, defender);
+	for (const bundle of post)
+		withStatSourceFrames(ctx, bundle.frames, () =>
+			runEffects(bundle.effects, ctx),
+		);
 
-  for (const bundle of post)
-    withStatSourceFrames(ctx, bundle.frames, () =>
-      runEffects(bundle.effects, ctx),
-    );
-  
-  if ((defender.fortificationStrength || 0) < 0)
-    defender.fortificationStrength = 0;
+	if ((defender.fortificationStrength || 0) < 0)
+		defender.fortificationStrength = 0;
 
-  if (post.length) runEffects(post, ctx);
+	if (post.length) runEffects(post, ctx);
 
-  ctx.game.currentPlayerIndex = original;
+	ctx.game.currentPlayerIndex = original;
 
-  return {
-    damageDealt: targetDamage,
-    evaluation: {
-      power: { base: baseDamage, modified: damage },
-      absorption: {
-        ignored: Boolean(opts.ignoreAbsorption),
-        before: absorption,
-        damageAfter: damageAfterAbsorption,
-      },
-      fortification: {
-        ignored: Boolean(opts.ignoreFortification),
-        before: fortBefore,
-        damage: fortDamage,
-        after: fortAfter,
-      },
-      target: targetLog,
-    },
-  };
+	return {
+		damageDealt: targetDamage,
+		evaluation: {
+			power: { base: baseDamage, modified: damage },
+			absorption: {
+				ignored: Boolean(opts.ignoreAbsorption),
+				before: absorption,
+				damageAfter: damageAfterAbsorption,
+			},
+			fortification: {
+				ignored: Boolean(opts.ignoreFortification),
+				before: fortBefore,
+				damage: fortDamage,
+				after: fortAfter,
+			},
+			target: targetLog,
+		},
+	};
 }
 
 export const attackPerform: EffectHandler = (effect, ctx) => {
-  const attacker = ctx.activePlayer;
-  const defender = ctx.opponent;
-  const params = effect.params || {};
-  const target = params['target'] as AttackTarget | undefined;
-  if (!target) return;
+	const attacker = ctx.activePlayer;
+	const defender = ctx.opponent;
+	const params = effect.params || {};
+	const target = params['target'] as AttackTarget | undefined;
+	if (!target) return;
 
-  const baseDamage = (attacker.armyStrength as number) || 0;
-  const evaluationKey =
-    target.type === 'building' ? target.id : target.key;
-  const mods: ResourceGain[] = [{ key: evaluationKey, amount: baseDamage }];
-  ctx.passives.runEvaluationMods('attack:power', ctx, mods);
-  const modifiedDamage = mods[0]!.amount;
+	const baseDamage = (attacker.armyStrength as number) || 0;
+	const evaluationKey = target.type === 'building' ? target.id : target.key;
+	const mods: ResourceGain[] = [{ key: evaluationKey, amount: baseDamage }];
+	ctx.passives.runEvaluationMods('attack:power', ctx, mods);
+	const modifiedDamage = mods[0]!.amount;
 
-  const { onDamage, ...calcOpts } = params as {
-    onDamage?: { attacker?: EffectDef[]; defender?: EffectDef[] };
-  } & AttackCalcOptions;
+	const { onDamage, ...calcOpts } = params as {
+		onDamage?: { attacker?: EffectDef[]; defender?: EffectDef[] };
+	} & AttackCalcOptions;
 
-  const result = resolveAttack(
-    defender,
-    modifiedDamage,
-    ctx,
-    target,
-    calcOpts,
-    baseDamage,
-  );
+	const result = resolveAttack(
+		defender,
+		modifiedDamage,
+		ctx,
+		target,
+		calcOpts,
+		baseDamage,
+	);
 
-  const onDamageLogs: AttackOnDamageLogEntry[] = [];
+	const onDamageLogs: AttackOnDamageLogEntry[] = [];
 
-  if (result.damageDealt > 0 && onDamage) {
-    const runList = (owner: AttackLogOwner, defs: EffectDef[] | undefined) => {
-      if (!defs?.length) return;
-      const defenderIndex = ctx.game.players.indexOf(defender);
-      const original = ctx.game.currentPlayerIndex;
-      if (owner === 'defender') ctx.game.currentPlayerIndex = defenderIndex;
-      try {
-        for (const def of defs) {
-          const beforeAttacker = snapshotPlayer(attacker, ctx);
-          const beforeDefender = snapshotPlayer(defender, ctx);
-          runEffects([def], ctx);
-          const afterAttacker = snapshotPlayer(attacker, ctx);
-          const afterDefender = snapshotPlayer(defender, ctx);
-          onDamageLogs.push({
-            owner,
-            effect: def,
-            attacker: diffPlayerSnapshots(beforeAttacker, afterAttacker),
-            defender: diffPlayerSnapshots(beforeDefender, afterDefender),
-          });
-        }
-      } finally {
-        if (owner === 'defender') ctx.game.currentPlayerIndex = original;
-      }
-    };
+	if (result.damageDealt > 0 && onDamage) {
+		const runList = (owner: AttackLogOwner, defs: EffectDef[] | undefined) => {
+			if (!defs?.length) return;
+			const defenderIndex = ctx.game.players.indexOf(defender);
+			const original = ctx.game.currentPlayerIndex;
+			if (owner === 'defender') ctx.game.currentPlayerIndex = defenderIndex;
+			try {
+				for (const def of defs) {
+					const beforeAttacker = snapshotPlayer(attacker, ctx);
+					const beforeDefender = snapshotPlayer(defender, ctx);
+					runEffects([def], ctx);
+					const afterAttacker = snapshotPlayer(attacker, ctx);
+					const afterDefender = snapshotPlayer(defender, ctx);
+					onDamageLogs.push({
+						owner,
+						effect: def,
+						attacker: diffPlayerSnapshots(beforeAttacker, afterAttacker),
+						defender: diffPlayerSnapshots(beforeDefender, afterDefender),
+					});
+				}
+			} finally {
+				if (owner === 'defender') ctx.game.currentPlayerIndex = original;
+			}
+		};
 
-    runList('defender', onDamage.defender);
-    runList('attacker', onDamage.attacker);
-  }
+		runList('defender', onDamage.defender);
+		runList('attacker', onDamage.attacker);
+	}
 
-  ctx.pushEffectLog('attack:perform', {
-    evaluation: result.evaluation,
-    onDamage: onDamageLogs,
-  });
+	ctx.pushEffectLog('attack:perform', {
+		evaluation: result.evaluation,
+		onDamage: onDamageLogs,
+	});
 };
 
 export default attackPerform;

--- a/packages/engine/src/effects/attack.types.ts
+++ b/packages/engine/src/effects/attack.types.ts
@@ -1,0 +1,35 @@
+import type { ResourceKey, StatKey } from '../state';
+
+export type ResourceAttackTarget = { type: 'resource'; key: ResourceKey };
+export type StatAttackTarget = { type: 'stat'; key: StatKey };
+export type BuildingAttackTarget = { type: 'building'; id: string };
+
+export type AttackTarget =
+	| ResourceAttackTarget
+	| StatAttackTarget
+	| BuildingAttackTarget;
+
+export interface AttackNumericTargetLog {
+	before: number;
+	damage: number;
+	after: number;
+}
+
+export type ResourceAttackEvaluationTargetLog = ResourceAttackTarget &
+	AttackNumericTargetLog;
+
+export type StatAttackEvaluationTargetLog = StatAttackTarget &
+	AttackNumericTargetLog;
+
+export interface BuildingAttackEvaluationTargetLog {
+	type: 'building';
+	id: string;
+	existed: boolean;
+	destroyed: boolean;
+	damage: number;
+}
+
+export type AttackEvaluationTargetLog =
+	| ResourceAttackEvaluationTargetLog
+	| StatAttackEvaluationTargetLog
+	| BuildingAttackEvaluationTargetLog;

--- a/packages/engine/src/effects/attack_target_handlers/building.ts
+++ b/packages/engine/src/effects/attack_target_handlers/building.ts
@@ -1,0 +1,46 @@
+import { runEffects } from '..';
+import type { AttackTargetHandler } from './index';
+import type { BuildingAttackTarget } from '../attack.types';
+
+const buildingHandler: AttackTargetHandler<
+	BuildingAttackTarget,
+	{ existed: boolean; destroyed: boolean }
+> = {
+	applyDamage(target, damage, ctx, defender, meta) {
+		const existed = defender.buildings.has(target.id);
+		let destroyed = false;
+
+		if (damage > 0 && existed) {
+			const { defenderIndex, originalIndex } = meta;
+			ctx.game.currentPlayerIndex = defenderIndex;
+			try {
+				runEffects(
+					[
+						{
+							type: 'building',
+							method: 'remove',
+							params: { id: target.id },
+						},
+					],
+					ctx,
+				);
+			} finally {
+				ctx.game.currentPlayerIndex = originalIndex;
+			}
+			destroyed = !defender.buildings.has(target.id);
+		}
+
+		return { existed, destroyed };
+	},
+	buildLog(target, damage, _ctx, _defender, _meta, mutation) {
+		return {
+			type: 'building',
+			id: target.id,
+			existed: mutation.existed,
+			destroyed: mutation.destroyed,
+			damage,
+		};
+	},
+};
+
+export default buildingHandler;

--- a/packages/engine/src/effects/attack_target_handlers/index.ts
+++ b/packages/engine/src/effects/attack_target_handlers/index.ts
@@ -1,0 +1,60 @@
+import type { EngineContext } from '../../context';
+import type { PlayerState } from '../../state';
+import type {
+	AttackEvaluationTargetLog,
+	AttackTarget,
+	BuildingAttackTarget,
+	ResourceAttackTarget,
+	StatAttackTarget,
+} from '../attack.types';
+
+import buildingHandler from './building';
+import resourceHandler from './resource';
+import statHandler from './stat';
+
+export interface AttackTargetHandlerMeta {
+	defenderIndex: number;
+	originalIndex: number;
+}
+
+export interface AttackTargetHandler<
+	T extends AttackTarget,
+	Mutation = unknown,
+> {
+	applyDamage(
+		target: T,
+		damage: number,
+		ctx: EngineContext,
+		defender: PlayerState,
+		meta: AttackTargetHandlerMeta,
+	): Mutation;
+	buildLog(
+		target: T,
+		damage: number,
+		ctx: EngineContext,
+		defender: PlayerState,
+		meta: AttackTargetHandlerMeta,
+		mutation: Mutation,
+	): AttackEvaluationTargetLog;
+}
+
+export type AttackTargetHandlerMap = {
+	resource: AttackTargetHandler<
+		ResourceAttackTarget,
+		{ before: number; after: number }
+	>;
+	stat: AttackTargetHandler<
+		StatAttackTarget,
+		{ before: number; after: number }
+	>;
+	building: AttackTargetHandler<
+		BuildingAttackTarget,
+		{ existed: boolean; destroyed: boolean }
+	>;
+};
+
+export const attackTargetHandlers: AttackTargetHandlerMap = {
+	resource: resourceHandler,
+	stat: statHandler,
+	building: buildingHandler,
+};

--- a/packages/engine/src/effects/attack_target_handlers/resource.ts
+++ b/packages/engine/src/effects/attack_target_handlers/resource.ts
@@ -1,0 +1,25 @@
+import type { AttackTargetHandler } from './index';
+import type { ResourceAttackTarget } from '../attack.types';
+
+const resourceHandler: AttackTargetHandler<
+	ResourceAttackTarget,
+	{ before: number; after: number }
+> = {
+	applyDamage(target, damage, _ctx, defender) {
+		const before = defender.resources[target.key] || 0;
+		const after = Math.max(0, before - damage);
+		if (damage > 0) defender.resources[target.key] = after;
+		return { before, after };
+	},
+	buildLog(target, damage, _ctx, _defender, _meta, mutation) {
+		return {
+			type: 'resource',
+			key: target.key,
+			before: mutation.before,
+			damage,
+			after: mutation.after,
+		};
+	},
+};
+
+export default resourceHandler;

--- a/packages/engine/src/effects/attack_target_handlers/stat.ts
+++ b/packages/engine/src/effects/attack_target_handlers/stat.ts
@@ -1,0 +1,25 @@
+import type { AttackTargetHandler } from './index';
+import type { StatAttackTarget } from '../attack.types';
+
+const statHandler: AttackTargetHandler<
+	StatAttackTarget,
+	{ before: number; after: number }
+> = {
+	applyDamage(target, damage, _ctx, defender) {
+		const before = defender.stats[target.key] || 0;
+		const after = Math.max(0, before - damage);
+		if (damage > 0) defender.stats[target.key] = after;
+		return { before, after };
+	},
+	buildLog(target, damage, _ctx, _defender, _meta, mutation) {
+		return {
+			type: 'stat',
+			key: target.key,
+			before: mutation.before,
+			damage,
+			after: mutation.after,
+		};
+	},
+};
+
+export default statHandler;

--- a/packages/engine/tests/resolveAttack.test.ts
+++ b/packages/engine/tests/resolveAttack.test.ts
@@ -1,350 +1,407 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { resolveAttack, runEffects, type EffectDef } from '../src/index.ts';
 import { createTestEngine } from './helpers.ts';
 import { Resource, Stat } from '../src/state/index.ts';
 import { createContentFactory } from './factories/content.ts';
+import {
+	attackTargetHandlers,
+	type AttackTargetHandler,
+} from '../src/effects/attack_target_handlers/index.ts';
+import type { ResourceAttackTarget } from '../src/effects/attack.types.ts';
 
 function makeAbsorptionEffect(amount: number): EffectDef {
-  return {
-    type: 'stat',
-    method: 'add',
-    params: { key: Stat.absorption, amount },
-  };
+	return {
+		type: 'stat',
+		method: 'add',
+		params: { key: Stat.absorption, amount },
+	};
 }
 
 describe('resolveAttack', () => {
-  it('runs onBeforeAttacked triggers before damage calc', () => {
-    const ctx = createTestEngine();
-    const defender = ctx.activePlayer;
-    ctx.passives.addPassive(
-      {
-        id: 'shield',
-        effects: [],
-        onBeforeAttacked: [makeAbsorptionEffect(0.5)],
-      },
-      ctx,
-    );
-    const result = resolveAttack(defender, 10, ctx, {
-      type: 'resource',
-      key: Resource.castleHP,
-    });
-    expect(result.damageDealt).toBe(5);
-  });
+	it('runs onBeforeAttacked triggers before damage calc', () => {
+		const ctx = createTestEngine();
+		const defender = ctx.activePlayer;
+		ctx.passives.addPassive(
+			{
+				id: 'shield',
+				effects: [],
+				onBeforeAttacked: [makeAbsorptionEffect(0.5)],
+			},
+			ctx,
+		);
+		const result = resolveAttack(defender, 10, ctx, {
+			type: 'resource',
+			key: Resource.castleHP,
+		});
+		expect(result.damageDealt).toBe(5);
+	});
 
-  it('applies fortification and castle damage before post triggers', () => {
-    const ctx = createTestEngine();
-    const attacker = ctx.activePlayer;
-    const defender = ctx.game.opponent;
-    defender.stats[Stat.fortificationStrength] = 1;
-    defender.gold = 100;
-    attacker.gold = 0;
-    const startHP = defender.resources[Resource.castleHP];
-    const startGold = defender.gold;
-    const result = resolveAttack(defender, 5, ctx, {
-      type: 'resource',
-      key: Resource.castleHP,
-    });
-    expect(result.damageDealt).toBe(4);
-    expect(defender.resources[Resource.castleHP]).toBe(
-      startHP - result.damageDealt,
-    );
-    expect(defender.fortificationStrength).toBe(0);
-    // ensure no content-driven effects run inside resolveAttack
-    expect(defender.gold).toBe(startGold);
-    expect(attacker.gold).toBe(0);
-    expect(defender.happiness).toBe(0);
-    expect(attacker.happiness).toBe(0);
-    expect(attacker.warWeariness).toBe(0);
-  });
+	it('applies fortification and castle damage before post triggers', () => {
+		const ctx = createTestEngine();
+		const attacker = ctx.activePlayer;
+		const defender = ctx.game.opponent;
+		defender.stats[Stat.fortificationStrength] = 1;
+		defender.gold = 100;
+		attacker.gold = 0;
+		const startHP = defender.resources[Resource.castleHP];
+		const startGold = defender.gold;
+		const result = resolveAttack(defender, 5, ctx, {
+			type: 'resource',
+			key: Resource.castleHP,
+		});
+		expect(result.damageDealt).toBe(4);
+		expect(defender.resources[Resource.castleHP]).toBe(
+			startHP - result.damageDealt,
+		);
+		expect(defender.fortificationStrength).toBe(0);
+		// ensure no content-driven effects run inside resolveAttack
+		expect(defender.gold).toBe(startGold);
+		expect(attacker.gold).toBe(0);
+		expect(defender.happiness).toBe(0);
+		expect(attacker.happiness).toBe(0);
+		expect(attacker.warWeariness).toBe(0);
+	});
 
-  it('rounds absorbed damage up when rules specify', () => {
-    const ctx = createTestEngine();
-    const defender = ctx.game.opponent;
-    ctx.services.rules.absorptionRounding = 'up';
-    defender.absorption = 0.5;
-    const start = defender.resources[Resource.castleHP];
-    const result = resolveAttack(defender, 1, ctx, {
-      type: 'resource',
-      key: Resource.castleHP,
-    });
-    expect(result.damageDealt).toBe(1);
-    expect(defender.resources[Resource.castleHP]).toBe(start - 1);
-  });
+	it('rounds absorbed damage up when rules specify', () => {
+		const ctx = createTestEngine();
+		const defender = ctx.game.opponent;
+		ctx.services.rules.absorptionRounding = 'up';
+		defender.absorption = 0.5;
+		const start = defender.resources[Resource.castleHP];
+		const result = resolveAttack(defender, 1, ctx, {
+			type: 'resource',
+			key: Resource.castleHP,
+		});
+		expect(result.damageDealt).toBe(1);
+		expect(defender.resources[Resource.castleHP]).toBe(start - 1);
+	});
 
-  it('rounds absorbed damage to nearest when rules specify', () => {
-    const ctx = createTestEngine();
-    const defender = ctx.game.opponent;
-    ctx.services.rules.absorptionRounding = 'nearest';
-    defender.absorption = 0.6;
-    const result = resolveAttack(defender, 1, ctx, {
-      type: 'resource',
-      key: Resource.castleHP,
-    });
-    expect(result.damageDealt).toBe(0);
-  });
+	it('rounds absorbed damage to nearest when rules specify', () => {
+		const ctx = createTestEngine();
+		const defender = ctx.game.opponent;
+		ctx.services.rules.absorptionRounding = 'nearest';
+		defender.absorption = 0.6;
+		const result = resolveAttack(defender, 1, ctx, {
+			type: 'resource',
+			key: Resource.castleHP,
+		});
+		expect(result.damageDealt).toBe(0);
+	});
 
-  it('can ignore absorption and fortification when options specify', () => {
-    const ctx = createTestEngine();
-    const defender = ctx.game.opponent;
-    defender.absorption = 0.5;
-    defender.stats[Stat.fortificationStrength] = 5;
-    const result = resolveAttack(
-      defender,
-      10,
-      ctx,
-      { type: 'resource', key: Resource.castleHP },
-      {
-        ignoreAbsorption: true,
-        ignoreFortification: true,
-      },
-    );
-    expect(result.damageDealt).toBe(10);
-    expect(defender.fortificationStrength).toBe(5);
-    expect(defender.resources[Resource.castleHP]).toBe(0);
-  });
+	it('can ignore absorption and fortification when options specify', () => {
+		const ctx = createTestEngine();
+		const defender = ctx.game.opponent;
+		defender.absorption = 0.5;
+		defender.stats[Stat.fortificationStrength] = 5;
+		const result = resolveAttack(
+			defender,
+			10,
+			ctx,
+			{ type: 'resource', key: Resource.castleHP },
+			{
+				ignoreAbsorption: true,
+				ignoreFortification: true,
+			},
+		);
+		expect(result.damageDealt).toBe(10);
+		expect(defender.fortificationStrength).toBe(5);
+		expect(defender.resources[Resource.castleHP]).toBe(0);
+	});
 
-  it('resolves post-damage triggers like watchtower removal', () => {
-    const content = createContentFactory();
-    const tower = content.development({
-      onBeforeAttacked: [
-        {
-          type: 'stat',
-          method: 'add',
-          params: { key: Stat.fortificationStrength, amount: 4 },
-        },
-      ],
-      onAttackResolved: [
-        {
-          type: 'resource',
-          method: 'add',
-          params: { key: Resource.gold, amount: 1 },
-        },
-      ],
-    });
-    const ctx = createTestEngine({ developments: content.developments });
-    const defender = ctx.game.opponent;
-    const landId = defender.lands[1].id;
-    ctx.game.currentPlayerIndex = 1; // switch to defender to build tower
-    runEffects(
-      [
-        {
-          type: 'development',
-          method: 'add',
-          params: { id: tower.id, landId },
-        },
-      ],
-      ctx,
-    );
-    ctx.game.currentPlayerIndex = 0; // attacker turn
-    const beforeGold = defender.gold;
-    const result = resolveAttack(defender, 4, ctx, {
-      type: 'resource',
-      key: Resource.castleHP,
-    });
-    expect(result.damageDealt).toBe(0);
-    expect(defender.resources[Resource.castleHP]).toBe(10);
-    expect(defender.fortificationStrength).toBe(0);
-    expect(defender.absorption).toBe(0);
-    expect(defender.gold).toBe(beforeGold + 1);
-  });
+	it('resolves post-damage triggers like watchtower removal', () => {
+		const content = createContentFactory();
+		const tower = content.development({
+			onBeforeAttacked: [
+				{
+					type: 'stat',
+					method: 'add',
+					params: { key: Stat.fortificationStrength, amount: 4 },
+				},
+			],
+			onAttackResolved: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: Resource.gold, amount: 1 },
+				},
+			],
+		});
+		const ctx = createTestEngine({ developments: content.developments });
+		const defender = ctx.game.opponent;
+		const landId = defender.lands[1].id;
+		ctx.game.currentPlayerIndex = 1; // switch to defender to build tower
+		runEffects(
+			[
+				{
+					type: 'development',
+					method: 'add',
+					params: { id: tower.id, landId },
+				},
+			],
+			ctx,
+		);
+		ctx.game.currentPlayerIndex = 0; // attacker turn
+		const beforeGold = defender.gold;
+		const result = resolveAttack(defender, 4, ctx, {
+			type: 'resource',
+			key: Resource.castleHP,
+		});
+		expect(result.damageDealt).toBe(0);
+		expect(defender.resources[Resource.castleHP]).toBe(10);
+		expect(defender.fortificationStrength).toBe(0);
+		expect(defender.absorption).toBe(0);
+		expect(defender.gold).toBe(beforeGold + 1);
+	});
 
-  it('uses pre-attack stat boosts but ignores post-attack ones for damage', () => {
-    const ctx = createTestEngine();
-    const attacker = ctx.activePlayer;
-    const defender = ctx.game.opponent;
-    ctx.game.currentPlayerIndex = 1; // switch to defender to add passive
-    ctx.passives.addPassive(
-      {
-        id: 'bastion',
-        effects: [],
-        onBeforeAttacked: [
-          {
-            type: 'stat',
-            method: 'add',
-            params: { key: Stat.absorption, amount: 0.5 },
-          },
-          {
-            type: 'stat',
-            method: 'add',
-            params: { key: Stat.fortificationStrength, amount: 1 },
-          },
-        ],
-        onAttackResolved: [
-          {
-            type: 'stat',
-            method: 'add',
-            params: { key: Stat.absorption, amount: 0.5 },
-          },
-          {
-            type: 'stat',
-            method: 'add',
-            params: { key: Stat.fortificationStrength, amount: 5 },
-          },
-        ],
-      },
-      ctx,
-    );
-    ctx.game.currentPlayerIndex = 0; // attacker turn
+	it('uses pre-attack stat boosts but ignores post-attack ones for damage', () => {
+		const ctx = createTestEngine();
+		const attacker = ctx.activePlayer;
+		const defender = ctx.game.opponent;
+		ctx.game.currentPlayerIndex = 1; // switch to defender to add passive
+		ctx.passives.addPassive(
+			{
+				id: 'bastion',
+				effects: [],
+				onBeforeAttacked: [
+					{
+						type: 'stat',
+						method: 'add',
+						params: { key: Stat.absorption, amount: 0.5 },
+					},
+					{
+						type: 'stat',
+						method: 'add',
+						params: { key: Stat.fortificationStrength, amount: 1 },
+					},
+				],
+				onAttackResolved: [
+					{
+						type: 'stat',
+						method: 'add',
+						params: { key: Stat.absorption, amount: 0.5 },
+					},
+					{
+						type: 'stat',
+						method: 'add',
+						params: { key: Stat.fortificationStrength, amount: 5 },
+					},
+				],
+			},
+			ctx,
+		);
+		ctx.game.currentPlayerIndex = 0; // attacker turn
 
-    runEffects(
-      [
-        {
-          type: 'stat',
-          method: 'add',
-          params: { key: Stat.armyStrength, amount: 5 },
-        },
-      ],
-      ctx,
-    );
-    const startHP = defender.resources[Resource.castleHP];
-    const result = resolveAttack(
-      defender,
-      attacker.armyStrength as number,
-      ctx,
-      {
-        type: 'resource',
-        key: Resource.castleHP,
-      },
-    );
-    const rounding = ctx.services.rules.absorptionRounding;
-    const base = attacker.armyStrength as number;
-    const reduced =
-      rounding === 'down'
-        ? Math.floor(base * (1 - 0.5))
-        : rounding === 'up'
-          ? Math.ceil(base * (1 - 0.5))
-          : Math.round(base * (1 - 0.5));
-    const expected = Math.max(0, reduced - 1);
-    expect(result.damageDealt).toBe(expected);
-    expect(defender.resources[Resource.castleHP]).toBe(startHP - expected);
-    // post-attack boosts apply after damage calculation
-    expect(defender.absorption).toBe(1);
-    expect(defender.fortificationStrength).toBe(5);
-  });
+		runEffects(
+			[
+				{
+					type: 'stat',
+					method: 'add',
+					params: { key: Stat.armyStrength, amount: 5 },
+				},
+			],
+			ctx,
+		);
+		const startHP = defender.resources[Resource.castleHP];
+		const result = resolveAttack(
+			defender,
+			attacker.armyStrength as number,
+			ctx,
+			{
+				type: 'resource',
+				key: Resource.castleHP,
+			},
+		);
+		const rounding = ctx.services.rules.absorptionRounding;
+		const base = attacker.armyStrength as number;
+		const reduced =
+			rounding === 'down'
+				? Math.floor(base * (1 - 0.5))
+				: rounding === 'up'
+					? Math.ceil(base * (1 - 0.5))
+					: Math.round(base * (1 - 0.5));
+		const expected = Math.max(0, reduced - 1);
+		expect(result.damageDealt).toBe(expected);
+		expect(defender.resources[Resource.castleHP]).toBe(startHP - expected);
+		// post-attack boosts apply after damage calculation
+		expect(defender.absorption).toBe(1);
+		expect(defender.fortificationStrength).toBe(5);
+	});
 
-  it('keeps buildings intact when damage is fully mitigated', () => {
-    const content = createContentFactory();
-    const bastion = content.building({});
-    const ctx = createTestEngine({ buildings: content.buildings });
-    const defender = ctx.game.opponent;
-    ctx.game.currentPlayerIndex = 1;
-    runEffects(
-      [
-        {
-          type: 'building',
-          method: 'add',
-          params: { id: bastion.id },
-        },
-      ],
-      ctx,
-    );
-    ctx.game.currentPlayerIndex = 0;
-    defender.absorption = 1;
-    defender.fortificationStrength = 0;
+	it('keeps buildings intact when damage is fully mitigated', () => {
+		const content = createContentFactory();
+		const bastion = content.building({});
+		const ctx = createTestEngine({ buildings: content.buildings });
+		const defender = ctx.game.opponent;
+		ctx.game.currentPlayerIndex = 1;
+		runEffects(
+			[
+				{
+					type: 'building',
+					method: 'add',
+					params: { id: bastion.id },
+				},
+			],
+			ctx,
+		);
+		ctx.game.currentPlayerIndex = 0;
+		defender.absorption = 1;
+		defender.fortificationStrength = 0;
 
-    const castleBefore = defender.resources[Resource.castleHP];
-    const result = resolveAttack(defender, 3, ctx, {
-      type: 'building',
-      id: bastion.id,
-    });
+		const castleBefore = defender.resources[Resource.castleHP];
+		const result = resolveAttack(defender, 3, ctx, {
+			type: 'building',
+			id: bastion.id,
+		});
 
-    expect(result.damageDealt).toBe(0);
-    expect(defender.buildings.has(bastion.id)).toBe(true);
-    expect(defender.resources[Resource.castleHP]).toBe(castleBefore);
-    expect(result.evaluation.target.type).toBe('building');
-    if (result.evaluation.target.type === 'building') {
-      expect(result.evaluation.target.existed).toBe(true);
-      expect(result.evaluation.target.destroyed).toBe(false);
-      expect(result.evaluation.target.damage).toBe(0);
-    }
-  });
+		expect(result.damageDealt).toBe(0);
+		expect(defender.buildings.has(bastion.id)).toBe(true);
+		expect(defender.resources[Resource.castleHP]).toBe(castleBefore);
+		expect(result.evaluation.target.type).toBe('building');
+		if (result.evaluation.target.type === 'building') {
+			expect(result.evaluation.target.existed).toBe(true);
+			expect(result.evaluation.target.destroyed).toBe(false);
+			expect(result.evaluation.target.damage).toBe(0);
+		}
+	});
 
-  it('destroys buildings without spilling damage onto the castle', () => {
-    const content = createContentFactory();
-    const fortress = content.building({
-      onBuild: [
-        {
-          type: 'stat',
-          method: 'add',
-          params: { key: Stat.fortificationStrength, amount: 3 },
-        },
-      ],
-    });
-    const ctx = createTestEngine({ buildings: content.buildings });
-    const defender = ctx.game.opponent;
-    ctx.game.currentPlayerIndex = 1;
-    runEffects(
-      [
-        {
-          type: 'building',
-          method: 'add',
-          params: { id: fortress.id },
-        },
-      ],
-      ctx,
-    );
-    ctx.game.currentPlayerIndex = 0;
+	it('destroys buildings without spilling damage onto the castle', () => {
+		const content = createContentFactory();
+		const fortress = content.building({
+			onBuild: [
+				{
+					type: 'stat',
+					method: 'add',
+					params: { key: Stat.fortificationStrength, amount: 3 },
+				},
+			],
+		});
+		const ctx = createTestEngine({ buildings: content.buildings });
+		const defender = ctx.game.opponent;
+		ctx.game.currentPlayerIndex = 1;
+		runEffects(
+			[
+				{
+					type: 'building',
+					method: 'add',
+					params: { id: fortress.id },
+				},
+			],
+			ctx,
+		);
+		ctx.game.currentPlayerIndex = 0;
 
-    const castleBefore = defender.resources[Resource.castleHP];
-    expect(defender.fortificationStrength).toBe(3);
+		const castleBefore = defender.resources[Resource.castleHP];
+		expect(defender.fortificationStrength).toBe(3);
 
-    const result = resolveAttack(defender, 5, ctx, {
-      type: 'building',
-      id: fortress.id,
-    });
+		const result = resolveAttack(defender, 5, ctx, {
+			type: 'building',
+			id: fortress.id,
+		});
 
-    expect(result.damageDealt).toBe(2);
-    expect(defender.buildings.has(fortress.id)).toBe(false);
-    expect(defender.resources[Resource.castleHP]).toBe(castleBefore);
-    expect(defender.fortificationStrength).toBe(0);
-    expect(result.evaluation.target.type).toBe('building');
-    if (result.evaluation.target.type === 'building') {
-      expect(result.evaluation.target.destroyed).toBe(true);
-      expect(result.evaluation.target.damage).toBe(result.damageDealt);
-    }
-  });
+		expect(result.damageDealt).toBe(2);
+		expect(defender.buildings.has(fortress.id)).toBe(false);
+		expect(defender.resources[Resource.castleHP]).toBe(castleBefore);
+		expect(defender.fortificationStrength).toBe(0);
+		expect(result.evaluation.target.type).toBe('building');
+		if (result.evaluation.target.type === 'building') {
+			expect(result.evaluation.target.destroyed).toBe(true);
+			expect(result.evaluation.target.damage).toBe(result.damageDealt);
+		}
+	});
 
-  it('respects ignore flags when targeting buildings', () => {
-    const content = createContentFactory();
-    const stronghold = content.building({});
-    const ctx = createTestEngine({ buildings: content.buildings });
-    const defender = ctx.game.opponent;
-    ctx.game.currentPlayerIndex = 1;
-    runEffects(
-      [
-        {
-          type: 'building',
-          method: 'add',
-          params: { id: stronghold.id },
-        },
-      ],
-      ctx,
-    );
-    ctx.game.currentPlayerIndex = 0;
+	it('respects ignore flags when targeting buildings', () => {
+		const content = createContentFactory();
+		const stronghold = content.building({});
+		const ctx = createTestEngine({ buildings: content.buildings });
+		const defender = ctx.game.opponent;
+		ctx.game.currentPlayerIndex = 1;
+		runEffects(
+			[
+				{
+					type: 'building',
+					method: 'add',
+					params: { id: stronghold.id },
+				},
+			],
+			ctx,
+		);
+		ctx.game.currentPlayerIndex = 0;
 
-    defender.absorption = 0.9;
-    defender.fortificationStrength = 10;
-    const castleBefore = defender.resources[Resource.castleHP];
+		defender.absorption = 0.9;
+		defender.fortificationStrength = 10;
+		const castleBefore = defender.resources[Resource.castleHP];
 
-    const result = resolveAttack(
-      defender,
-      4,
-      ctx,
-      {
-        type: 'building',
-        id: stronghold.id,
-      },
-      { ignoreAbsorption: true, ignoreFortification: true },
-    );
+		const result = resolveAttack(
+			defender,
+			4,
+			ctx,
+			{
+				type: 'building',
+				id: stronghold.id,
+			},
+			{ ignoreAbsorption: true, ignoreFortification: true },
+		);
 
-    expect(result.damageDealt).toBe(4);
-    expect(result.evaluation.absorption.ignored).toBe(true);
-    expect(result.evaluation.fortification.ignored).toBe(true);
-    expect(defender.fortificationStrength).toBe(10);
-    expect(defender.resources[Resource.castleHP]).toBe(castleBefore);
-    expect(defender.buildings.has(stronghold.id)).toBe(false);
-    expect(result.evaluation.target.type).toBe('building');
-    if (result.evaluation.target.type === 'building')
-      expect(result.evaluation.target.destroyed).toBe(true);
-  });
+		expect(result.damageDealt).toBe(4);
+		expect(result.evaluation.absorption.ignored).toBe(true);
+		expect(result.evaluation.fortification.ignored).toBe(true);
+		expect(defender.fortificationStrength).toBe(10);
+		expect(defender.resources[Resource.castleHP]).toBe(castleBefore);
+		expect(defender.buildings.has(stronghold.id)).toBe(false);
+		expect(result.evaluation.target.type).toBe('building');
+		if (result.evaluation.target.type === 'building')
+			expect(result.evaluation.target.destroyed).toBe(true);
+	});
+
+	it('delegates target application to registered handlers', () => {
+		const ctx = createTestEngine();
+		const defender = ctx.game.opponent;
+		const target: ResourceAttackTarget = {
+			type: 'resource',
+			key: Resource.castleHP,
+		};
+
+		const originalHandler = attackTargetHandlers.resource;
+		const mutation = { before: defender.resources[target.key] ?? 0, after: 3 };
+		const applySpy = vi.fn<typeof originalHandler.applyDamage>(
+			(_target, damage, _ctx, _defender, _meta) => {
+				return { ...mutation, after: Math.max(0, mutation.before - damage) };
+			},
+		);
+		const buildSpy = vi.fn<typeof originalHandler.buildLog>(
+			(resourceTarget, damage, _ctx, _defender, _meta, mut) => ({
+				type: 'resource',
+				key: resourceTarget.key,
+				before: mut.before,
+				damage,
+				after: mut.after,
+			}),
+		);
+
+		const stubHandler: AttackTargetHandler<
+			ResourceAttackTarget,
+			typeof mutation
+		> = {
+			applyDamage: applySpy,
+			buildLog: buildSpy,
+		};
+
+		attackTargetHandlers.resource = stubHandler;
+
+		try {
+			const result = resolveAttack(defender, 2, ctx, target);
+			expect(applySpy).toHaveBeenCalledTimes(1);
+			expect(buildSpy).toHaveBeenCalledTimes(1);
+			const [applyTarget, appliedDamage] = applySpy.mock.calls[0]!;
+			expect(applyTarget).toEqual(target);
+			expect(appliedDamage).toBe(result.damageDealt);
+			const buildResult = buildSpy.mock.results[0]!.value;
+			expect(result.evaluation.target).toEqual(buildResult);
+			expect(applySpy.mock.invocationCallOrder[0]).toBeLessThan(
+				buildSpy.mock.invocationCallOrder[0]!,
+			);
+		} finally {
+			attackTargetHandlers.resource = originalHandler;
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- add shared attack target types and handler registration for resources, stats, and buildings
- delegate resolveAttack target mutations to the handler map while keeping absorption/fortification logic in place
- cover the new delegation by overriding the resource handler in resolveAttack tests

## Testing
- npx vitest run packages/engine/tests/resolveAttack.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc4a64bcdc8325afcf2e8da3fa08cf