### PR TITLE
Limit stored log entries in GameContext

### DIFF
--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -38,6 +38,7 @@ export const TIME_SCALE_OPTIONS = [1, 2, 5, 100] as const;
 export type TimeScale = (typeof TIME_SCALE_OPTIONS)[number];
 const TIME_SCALE_STORAGE_KEY = 'kingdom-builder:time-scale';
 const ACTION_EFFECT_DELAY = 600;
+const MAX_LOG_ENTRIES = 250;
 
 function readStoredTimeScale(): TimeScale | null {
 	if (typeof window === 'undefined') return null;
@@ -141,7 +142,6 @@ export function GameProvider({
 	const [, setTick] = useState(0);
 	const refresh = () => setTick((t) => t + 1);
 
-	const MAX_LOG_ENTRIES = 250;
 	const [log, setLog] = useState<LogEntry[]>([]);
 	const [logOverflowed, setLogOverflowed] = useState(false);
 	const [hoverCard, setHoverCard] = useState<HoverCard | null>(null);
@@ -195,11 +195,11 @@ export function GameProvider({
 				playerId: p.id,
 			}));
 			const combined = [...prev, ...items];
-			if (combined.length > MAX_LOG_ENTRIES) {
+			const next = combined.slice(-MAX_LOG_ENTRIES);
+			if (next.length < combined.length) {
 				setLogOverflowed(true);
-				return combined.slice(-MAX_LOG_ENTRIES);
 			}
-			return combined;
+			return next;
 		});
 	};
 


### PR DESCRIPTION
## Summary
- define a shared MAX_LOG_ENTRIES constant in the web game context so the log buffer is capped consistently
- trim accumulated log entries to the last MAX_LOG_ENTRIES items and preserve the overflow flag when the limit is exceeded

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68deb96aed888325b8230c94e64f18f0