### PR TITLE
Refactor phase tests to use synthetic content fixtures

### DIFF
--- a/packages/engine/tests/factories/content.ts
+++ b/packages/engine/tests/factories/content.ts
@@ -1,114 +1,122 @@
 import {
-  createActionRegistry,
-  createBuildingRegistry,
-  createDevelopmentRegistry,
-  createPopulationRegistry,
+	createActionRegistry,
+	createBuildingRegistry,
+	createDevelopmentRegistry,
+	createPopulationRegistry,
 } from '@kingdom-builder/contents';
 import type {
-  ActionConfig,
-  BuildingConfig,
-  DevelopmentConfig,
-  PopulationConfig,
+	ActionConfig,
+	BuildingConfig,
+	DevelopmentConfig,
+	PopulationConfig,
 } from '../../src/config/schema';
 import type { Registry } from '../../src/registry';
 
 let seq = 0;
 function nextId(prefix: string) {
-  seq += 1;
-  return `${prefix}_${seq}`;
+	seq += 1;
+	return `${prefix}_${seq}`;
 }
 
 export interface ContentFactory {
-  actions: Registry<ActionConfig>;
-  buildings: Registry<BuildingConfig>;
-  developments: Registry<DevelopmentConfig>;
-  populations: Registry<PopulationConfig>;
-  action(def?: Partial<ActionConfig>): ActionConfig;
-  building(def?: Partial<BuildingConfig>): BuildingConfig;
-  development(def?: Partial<DevelopmentConfig>): DevelopmentConfig;
-  population(def?: Partial<PopulationConfig>): PopulationConfig;
+	actions: Registry<ActionConfig>;
+	buildings: Registry<BuildingConfig>;
+	developments: Registry<DevelopmentConfig>;
+	populations: Registry<PopulationConfig>;
+	action(def?: Partial<ActionConfig>): ActionConfig;
+	building(def?: Partial<BuildingConfig>): BuildingConfig;
+	development(def?: Partial<DevelopmentConfig>): DevelopmentConfig;
+	population(def?: Partial<PopulationConfig>): PopulationConfig;
 }
 
 export function createContentFactory(): ContentFactory {
-  const actions = createActionRegistry();
-  const buildings = createBuildingRegistry();
-  const developments = createDevelopmentRegistry();
-  const populations = createPopulationRegistry();
+	const actions = createActionRegistry();
+	const buildings = createBuildingRegistry();
+	const developments = createDevelopmentRegistry();
+	const populations = createPopulationRegistry();
 
-  function action(def: Partial<ActionConfig> = {}): ActionConfig {
-    const id = def.id ?? nextId('action');
-    const built: ActionConfig = {
-      id,
-      name: def.name ?? id,
-      icon: def.icon,
-      baseCosts: def.baseCosts ?? {},
-      requirements: def.requirements ?? [],
-      effects: def.effects ?? [],
-      system: def.system,
-    };
-    actions.add(id, built);
-    return built;
-  }
+	function action(def: Partial<ActionConfig> = {}): ActionConfig {
+		const id = def.id ?? nextId('action');
+		const built: ActionConfig = {
+			id,
+			name: def.name ?? id,
+			icon: def.icon,
+			baseCosts: def.baseCosts ?? {},
+			requirements: def.requirements ?? [],
+			effects: def.effects ?? [],
+			system: def.system,
+		};
+		actions.add(id, built);
+		return built;
+	}
 
-  function building(def: Partial<BuildingConfig> = {}): BuildingConfig {
-    const id = def.id ?? nextId('building');
-    const built: BuildingConfig = {
-      id,
-      name: def.name ?? id,
-      icon: def.icon,
-      costs: def.costs ?? {},
-      onBuild: def.onBuild ?? [],
-      onGrowthPhase: def.onGrowthPhase ?? [],
-      onUpkeepPhase: def.onUpkeepPhase ?? [],
-      onBeforeAttacked: def.onBeforeAttacked ?? [],
-      onAttackResolved: def.onAttackResolved ?? [],
-    };
-    buildings.add(id, built);
-    return built;
-  }
+	function building(def: Partial<BuildingConfig> = {}): BuildingConfig {
+		const id = def.id ?? nextId('building');
+		const built: BuildingConfig = {
+			id,
+			name: def.name ?? id,
+			icon: def.icon,
+			costs: def.costs ?? {},
+			onBuild: def.onBuild ?? [],
+			onGrowthPhase: def.onGrowthPhase ?? [],
+			onUpkeepPhase: def.onUpkeepPhase ?? [],
+			onBeforeAttacked: def.onBeforeAttacked ?? [],
+			onAttackResolved: def.onAttackResolved ?? [],
+		};
+		buildings.add(id, built);
+		return built;
+	}
 
-  function development(
-    def: Partial<DevelopmentConfig> = {},
-  ): DevelopmentConfig {
-    const id = def.id ?? nextId('development');
-    const built: DevelopmentConfig = {
-      id,
-      name: def.name ?? id,
-      icon: def.icon,
-      onBuild: def.onBuild ?? [],
-      onGrowthPhase: def.onGrowthPhase ?? [],
-      onBeforeAttacked: def.onBeforeAttacked ?? [],
-      onAttackResolved: def.onAttackResolved ?? [],
-      system: def.system,
-      populationCap: def.populationCap,
-    };
-    developments.add(id, built);
-    return built;
-  }
+	function development(
+		def: Partial<DevelopmentConfig> = {},
+	): DevelopmentConfig {
+		const id = def.id ?? nextId('development');
+		const built: DevelopmentConfig = {
+			id,
+			name: def.name ?? id,
+			icon: def.icon,
+			onBuild: def.onBuild ?? [],
+			onGrowthPhase: def.onGrowthPhase ?? [],
+			onBeforeAttacked: def.onBeforeAttacked ?? [],
+			onAttackResolved: def.onAttackResolved ?? [],
+			onPayUpkeepStep: def.onPayUpkeepStep ?? [],
+			onGainIncomeStep: def.onGainIncomeStep ?? [],
+			onGainAPStep: def.onGainAPStep ?? [],
+			system: def.system,
+			populationCap: def.populationCap,
+			upkeep: def.upkeep,
+		};
+		developments.add(id, built);
+		return built;
+	}
 
-  function population(def: Partial<PopulationConfig> = {}): PopulationConfig {
-    const id = def.id ?? nextId('population');
-    const built: PopulationConfig = {
-      id,
-      name: def.name ?? id,
-      icon: def.icon,
-      onAssigned: def.onAssigned ?? [],
-      onUnassigned: def.onUnassigned ?? [],
-      onGrowthPhase: def.onGrowthPhase ?? [],
-      onUpkeepPhase: def.onUpkeepPhase ?? [],
-    };
-    populations.add(id, built);
-    return built;
-  }
+	function population(def: Partial<PopulationConfig> = {}): PopulationConfig {
+		const id = def.id ?? nextId('population');
+		const built: PopulationConfig = {
+			id,
+			name: def.name ?? id,
+			icon: def.icon,
+			onAssigned: def.onAssigned ?? [],
+			onUnassigned: def.onUnassigned ?? [],
+			onGrowthPhase: def.onGrowthPhase ?? [],
+			onUpkeepPhase: def.onUpkeepPhase ?? [],
+			onPayUpkeepStep: def.onPayUpkeepStep ?? [],
+			onGainIncomeStep: def.onGainIncomeStep ?? [],
+			onGainAPStep: def.onGainAPStep ?? [],
+			upkeep: def.upkeep,
+		};
+		populations.add(id, built);
+		return built;
+	}
 
-  return {
-    actions,
-    buildings,
-    developments,
-    populations,
-    action,
-    building,
-    development,
-    population,
-  };
+	return {
+		actions,
+		buildings,
+		developments,
+		populations,
+		action,
+		building,
+		development,
+		population,
+	};
 }

--- a/packages/engine/tests/phases/fixtures.ts
+++ b/packages/engine/tests/phases/fixtures.ts
@@ -1,0 +1,244 @@
+import { createEngine } from '../../src/index.ts';
+import type { PhaseDef } from '../../src/phases.ts';
+import type { StartConfig } from '../../src/config/schema.ts';
+import type { RuleSet } from '../../src/services/index.ts';
+import { createContentFactory } from '../factories/content.ts';
+
+const resourceKeys = {
+	ap: 'synthetic:resource:ap',
+	gold: 'synthetic:resource:gold',
+} as const;
+
+const statKeys = {
+	army: 'synthetic:stat:army-strength',
+	fort: 'synthetic:stat:fort-strength',
+	growth: 'synthetic:stat:growth',
+	war: 'synthetic:stat:war-weariness',
+} as const;
+
+const phaseIds = {
+	growth: 'synthetic:phase:growth',
+	upkeep: 'synthetic:phase:upkeep',
+	main: 'synthetic:phase:main',
+} as const;
+
+const stepIds = {
+	growthTriggers: 'synthetic:step:growth:triggers',
+	gainIncome: 'synthetic:step:growth:gain-income',
+	gainAp: 'synthetic:step:growth:gain-ap',
+	upkeepTriggers: 'synthetic:step:upkeep:triggers',
+	payUpkeep: 'synthetic:step:upkeep:pay',
+	warRecovery: 'synthetic:step:upkeep:war-recovery',
+	main: 'synthetic:step:main',
+} as const;
+
+const AP_GAIN_PER_COUNCIL = 2;
+const FARM_INCOME = 4;
+const BASE_AP = 0;
+const AP_COMPENSATION = 1;
+const BASE_GROWTH = 0.5;
+const COUNCIL_UPKEEP = 1;
+const LEGION_UPKEEP = 2;
+const FORTIFIER_UPKEEP = 2;
+const STARTING_COUNCILS = 1;
+
+export function createPhaseTestEnvironment() {
+	const content = createContentFactory();
+
+	const farm = content.development({
+		id: 'synthetic:development:farm',
+		onGainIncomeStep: [
+			{
+				type: 'resource',
+				method: 'add',
+				params: { key: resourceKeys.gold, amount: FARM_INCOME },
+			},
+		],
+	});
+
+	const council = content.population({
+		id: 'synthetic:population:council',
+		onGainAPStep: [
+			{
+				type: 'resource',
+				method: 'add',
+				params: { key: resourceKeys.ap, amount: AP_GAIN_PER_COUNCIL },
+			},
+		],
+		onPayUpkeepStep: [
+			{
+				type: 'resource',
+				method: 'remove',
+				params: { key: resourceKeys.gold, amount: COUNCIL_UPKEEP },
+			},
+		],
+	});
+
+	const legion = content.population({
+		id: 'synthetic:population:legion',
+		onGrowthPhase: [
+			{
+				type: 'stat',
+				method: 'add_pct',
+				params: { key: statKeys.army, percentStat: statKeys.growth },
+				round: 'up',
+			},
+		],
+		onPayUpkeepStep: [
+			{
+				type: 'resource',
+				method: 'remove',
+				params: { key: resourceKeys.gold, amount: LEGION_UPKEEP },
+			},
+		],
+	});
+
+	const fortifier = content.population({
+		id: 'synthetic:population:fortifier',
+		onGrowthPhase: [
+			{
+				type: 'stat',
+				method: 'add_pct',
+				params: { key: statKeys.fort, percentStat: statKeys.growth },
+				round: 'up',
+			},
+		],
+		onPayUpkeepStep: [
+			{
+				type: 'resource',
+				method: 'remove',
+				params: { key: resourceKeys.gold, amount: FORTIFIER_UPKEEP },
+			},
+		],
+	});
+
+	const phases: PhaseDef[] = [
+		{
+			id: phaseIds.growth,
+			steps: [
+				{ id: stepIds.growthTriggers, triggers: ['onGrowthPhase'] },
+				{ id: stepIds.gainIncome, triggers: ['onGainIncomeStep'] },
+				{ id: stepIds.gainAp, triggers: ['onGainAPStep'] },
+			],
+		},
+		{
+			id: phaseIds.upkeep,
+			steps: [
+				{ id: stepIds.upkeepTriggers, triggers: ['onUpkeepPhase'] },
+				{ id: stepIds.payUpkeep, triggers: ['onPayUpkeepStep'] },
+				{
+					id: stepIds.warRecovery,
+					effects: [
+						{
+							evaluator: {
+								type: 'compare',
+								params: {
+									left: { type: 'stat', params: { key: statKeys.war } },
+									operator: 'gt',
+									right: 0,
+								},
+							},
+							effects: [
+								{
+									type: 'stat',
+									method: 'remove',
+									params: { key: statKeys.war, amount: 1 },
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+		{
+			id: phaseIds.main,
+			action: true,
+			steps: [{ id: stepIds.main }],
+		},
+	];
+
+	const start: StartConfig = {
+		player: {
+			resources: {
+				[resourceKeys.ap]: BASE_AP,
+				[resourceKeys.gold]: 0,
+			},
+			stats: {
+				[statKeys.army]: 0,
+				[statKeys.fort]: 0,
+				[statKeys.growth]: BASE_GROWTH,
+				[statKeys.war]: 0,
+			},
+			population: {
+				[council.id]: STARTING_COUNCILS,
+				[legion.id]: 0,
+				[fortifier.id]: 0,
+			},
+			lands: [{ developments: [farm.id] }],
+		},
+		players: {
+			B: {
+				resources: {
+					[resourceKeys.ap]: BASE_AP + AP_COMPENSATION,
+				},
+			},
+		},
+	};
+
+	const rules: RuleSet = {
+		defaultActionAPCost: 1,
+		absorptionCapPct: 1,
+		absorptionRounding: 'down',
+		tieredResourceKey: resourceKeys.gold,
+		tierDefinitions: [
+			{
+				id: 'synthetic:tier:baseline',
+				range: { min: 0 },
+				effect: { incomeMultiplier: 1 },
+				passive: { id: 'synthetic:passive:baseline' },
+			},
+		],
+		slotsPerNewLand: 1,
+		maxSlotsPerLand: 1,
+		basePopulationCap: 6,
+	};
+
+	const ctx = createEngine({
+		actions: content.actions,
+		buildings: content.buildings,
+		developments: content.developments,
+		populations: content.populations,
+		phases,
+		start,
+		rules,
+	});
+
+	return {
+		ctx,
+		phases,
+		ids: {
+			phases: phaseIds,
+			steps: stepIds,
+		},
+		roles: {
+			council: council.id,
+			legion: legion.id,
+			fortifier: fortifier.id,
+		},
+		resources: resourceKeys,
+		stats: statKeys,
+		values: {
+			baseAp: BASE_AP,
+			apCompensation: AP_COMPENSATION,
+			baseGrowth: BASE_GROWTH,
+			councilApGain: AP_GAIN_PER_COUNCIL,
+			farmIncome: FARM_INCOME,
+			upkeep: {
+				council: COUNCIL_UPKEEP,
+				legion: LEGION_UPKEEP,
+				fortifier: FORTIFIER_UPKEEP,
+			},
+			startingCouncils: STARTING_COUNCILS,
+		},
+	} as const;
+}

--- a/packages/engine/tests/phases/growth.test.ts
+++ b/packages/engine/tests/phases/growth.test.ts
@@ -1,201 +1,176 @@
 import { describe, it, expect } from 'vitest';
-import { advance, Stat } from '../../src';
-import {
-  PHASES,
-  GAME_START,
-  Resource as CResource,
-  Stat as CStat,
-  PopulationRole,
-  DEVELOPMENTS,
-  POPULATIONS,
-} from '@kingdom-builder/contents';
-import { createTestEngine } from '../helpers.ts';
-
-const growthPhase = PHASES[0];
-const growthId = growthPhase.id;
-const farmId = Array.from(
-  (DEVELOPMENTS as unknown as { map: Map<string, unknown> }).map.keys(),
-).find((id) => DEVELOPMENTS.get(id)?.onGainIncomeStep) as string;
-const farmGoldGain = Number(
-  DEVELOPMENTS.get(farmId)?.onGainIncomeStep?.[0]?.effects?.find(
-    (e) => e.type === 'resource' && e.method === 'add',
-  )?.params?.amount ?? 0,
-);
-const councilApGain = Number(
-  POPULATIONS.get(PopulationRole.Council)?.onGainAPStep?.find(
-    (e) => e.type === 'resource' && e.method === 'add',
-  )?.params?.amount ?? 0,
-);
+import { advance } from '../../src/index.ts';
+import { createPhaseTestEnvironment } from './fixtures.ts';
 
 describe('Growth phase', () => {
-  it('triggers population and development effects', () => {
-    const ctx = createTestEngine();
-    const player = ctx.activePlayer;
-    const apBefore = player.ap;
-    const goldBefore = player.gold;
-    while (ctx.game.currentPhase === growthId) advance(ctx);
-    const councils = player.population[PopulationRole.Council];
-    expect(player.ap).toBe(apBefore + councilApGain * councils);
-    expect(player.gold).toBe(goldBefore + farmGoldGain);
-  });
+	it('triggers population and development effects', () => {
+		const { ctx, ids, roles, resources, values } = createPhaseTestEnvironment();
+		const player = ctx.activePlayer;
+		const apBefore = player.resources[resources.ap];
+		const goldBefore = player.resources[resources.gold];
+		while (ctx.game.currentPhase === ids.phases.growth) advance(ctx);
+		const councils = player.population[roles.council];
+		expect(player.resources[resources.ap]).toBe(
+			apBefore + values.councilApGain * councils,
+		);
+		expect(player.resources[resources.gold]).toBe(
+			goldBefore + values.farmIncome,
+		);
+	});
 
-  it('applies player B compensation at start and not during growth', () => {
-    const ctx = createTestEngine();
-    const baseAp = GAME_START.player.resources?.[CResource.ap] || 0;
-    const comp =
-      (GAME_START.players?.B?.resources?.[CResource.ap] || 0) - baseAp;
-    expect(ctx.game.players[0].ap).toBe(baseAp);
-    expect(ctx.game.players[1].ap).toBe(baseAp + comp);
+	it('applies player B compensation at start and not during growth', () => {
+		const { ctx, phases, ids, roles, resources, values } =
+			createPhaseTestEnvironment();
+		const baseAp = values.baseAp;
+		const comp = values.apCompensation;
+		const playerA = ctx.game.players[0]!;
+		const playerB = ctx.game.players[1]!;
+		expect(playerA.resources[resources.ap]).toBe(baseAp);
+		expect(playerB.resources[resources.ap]).toBe(baseAp + comp);
 
-    const gainApIdx = growthPhase.steps.findIndex((s) => s.id === 'gain-ap');
+		const growthPhaseIndex = phases.findIndex(
+			(phase) => phase.id === ids.phases.growth,
+		);
+		const gainApIdx = phases[growthPhaseIndex]!.steps.findIndex(
+			(step) => step.id === ids.steps.gainAp,
+		);
 
-    // Player growth
-    let player = ctx.activePlayer;
-    player.ap = 0;
-    ctx.game.currentPhase = growthId;
-    ctx.game.currentStep = 'gain-ap';
-    ctx.game.stepIndex = gainApIdx;
-    advance(ctx);
-    const councilsA = player.population[PopulationRole.Council];
-    expect(player.ap).toBe(councilApGain * councilsA);
+		ctx.game.currentPlayerIndex = 0;
+		ctx.game.phaseIndex = growthPhaseIndex;
+		ctx.game.stepIndex = gainApIdx;
+		ctx.game.currentPhase = ids.phases.growth;
+		ctx.game.currentStep = ids.steps.gainAp;
+		playerA.resources[resources.ap] = 0;
+		advance(ctx);
+		const councilsA = playerA.population[roles.council];
+		expect(playerA.resources[resources.ap]).toBe(
+			values.councilApGain * councilsA,
+		);
 
-    // Opponent growth (compensation already applied)
-    ctx.game.currentPlayerIndex = 1;
-    ctx.game.currentPhase = growthId;
-    ctx.game.currentStep = 'gain-ap';
-    ctx.game.stepIndex = gainApIdx;
-    player = ctx.activePlayer;
-    player.ap = 0;
-    advance(ctx);
-    const councilsB = player.population[PopulationRole.Council];
-    expect(player.ap).toBe(councilApGain * councilsB);
+		ctx.game.currentPlayerIndex = 1;
+		ctx.game.phaseIndex = growthPhaseIndex;
+		ctx.game.stepIndex = gainApIdx;
+		ctx.game.currentPhase = ids.phases.growth;
+		ctx.game.currentStep = ids.steps.gainAp;
+		playerB.resources[resources.ap] = 0;
+		advance(ctx);
+		const councilsB = playerB.population[roles.council];
+		expect(playerB.resources[resources.ap]).toBe(
+			values.councilApGain * councilsB,
+		);
 
-    // Subsequent opponent growth phases
-    for (let i = 0; i < 3; i++) {
-      ctx.game.currentPlayerIndex = 1;
-      ctx.game.currentPhase = growthId;
-      ctx.game.currentStep = 'gain-ap';
-      ctx.game.stepIndex = gainApIdx;
-      player.ap = 0;
-      advance(ctx);
-      expect(player.ap).toBe(councilApGain * councilsB);
-    }
-  });
+		for (let i = 0; i < 3; i++) {
+			ctx.game.currentPlayerIndex = 1;
+			ctx.game.phaseIndex = growthPhaseIndex;
+			ctx.game.stepIndex = gainApIdx;
+			ctx.game.currentPhase = ids.phases.growth;
+			ctx.game.currentStep = ids.steps.gainAp;
+			playerB.resources[resources.ap] = 0;
+			advance(ctx);
+			expect(playerB.resources[resources.ap]).toBe(
+				values.councilApGain * councilsB,
+			);
+		}
+	});
 
-  it('grows legion and fortifier stats', () => {
-    const ctx = createTestEngine();
-    ctx.activePlayer.population[PopulationRole.Legion] = 1;
-    ctx.activePlayer.population[PopulationRole.Fortifier] = 1;
-    ctx.activePlayer.stats[Stat.armyStrength] = 8;
-    ctx.activePlayer.stats[Stat.fortificationStrength] = 4;
-    const player = ctx.activePlayer;
-    const growth = player.stats[Stat.growth];
-    while (ctx.game.currentPhase === growthId) advance(ctx);
-    const expectedArmy = Math.ceil(8 + 8 * growth);
-    const expectedFort = Math.ceil(4 + 4 * growth);
-    expect(player.stats[Stat.armyStrength]).toBe(expectedArmy);
-    expect(player.stats[Stat.fortificationStrength]).toBe(expectedFort);
-    expect(Number.isInteger(player.stats[Stat.armyStrength])).toBe(true);
-    expect(Number.isInteger(player.stats[Stat.fortificationStrength])).toBe(
-      true,
-    );
-    expect(player.stats[Stat.armyStrength]).toBeGreaterThanOrEqual(0);
-    expect(player.stats[Stat.fortificationStrength]).toBeGreaterThanOrEqual(0);
-  });
+	it('grows legion and fortifier stats', () => {
+		const { ctx, ids, roles, stats } = createPhaseTestEnvironment();
+		const player = ctx.activePlayer;
+		player.population[roles.legion] = 1;
+		player.population[roles.fortifier] = 1;
+		player.stats[stats.army] = 8;
+		player.stats[stats.fort] = 4;
+		const growth = player.stats[stats.growth];
+		while (ctx.game.currentPhase === ids.phases.growth) advance(ctx);
+		const expectedArmy = Math.ceil(8 + 8 * growth);
+		const expectedFort = Math.ceil(4 + 4 * growth);
+		expect(player.stats[stats.army]).toBe(expectedArmy);
+		expect(player.stats[stats.fort]).toBe(expectedFort);
+		expect(Number.isInteger(player.stats[stats.army])).toBe(true);
+		expect(Number.isInteger(player.stats[stats.fort])).toBe(true);
+		expect(player.stats[stats.army]).toBeGreaterThanOrEqual(0);
+		expect(player.stats[stats.fort]).toBeGreaterThanOrEqual(0);
+	});
 
-  it('scales strength additively with multiple leaders', () => {
-    const ctx = createTestEngine();
-    ctx.activePlayer.population[PopulationRole.Legion] = 2;
-    ctx.activePlayer.population[PopulationRole.Fortifier] = 2;
-    ctx.activePlayer.stats[Stat.armyStrength] = 10;
-    ctx.activePlayer.stats[Stat.fortificationStrength] = 10;
-    const growth = ctx.activePlayer.stats[Stat.growth];
-    while (ctx.game.currentPhase === growthId) advance(ctx);
-    const expectedArmy = Math.ceil(10 + 10 * growth * 2);
-    const expectedFort = Math.ceil(10 + 10 * growth * 2);
-    expect(ctx.activePlayer.stats[Stat.armyStrength]).toBe(expectedArmy);
-    expect(ctx.activePlayer.stats[Stat.fortificationStrength]).toBe(
-      expectedFort,
-    );
-    expect(Number.isInteger(ctx.activePlayer.stats[Stat.armyStrength])).toBe(
-      true,
-    );
-    expect(
-      Number.isInteger(ctx.activePlayer.stats[Stat.fortificationStrength]),
-    ).toBe(true);
-    expect(ctx.activePlayer.stats[Stat.armyStrength]).toBeGreaterThanOrEqual(0);
-    expect(
-      ctx.activePlayer.stats[Stat.fortificationStrength],
-    ).toBeGreaterThanOrEqual(0);
-  });
+	it('scales strength additively with multiple leaders', () => {
+		const { ctx, ids, roles, stats } = createPhaseTestEnvironment();
+		const player = ctx.activePlayer;
+		player.population[roles.legion] = 2;
+		player.population[roles.fortifier] = 2;
+		player.stats[stats.army] = 10;
+		player.stats[stats.fort] = 10;
+		const growth = player.stats[stats.growth];
+		while (ctx.game.currentPhase === ids.phases.growth) advance(ctx);
+		const expectedArmy = Math.ceil(10 + 10 * growth * 2);
+		const expectedFort = Math.ceil(10 + 10 * growth * 2);
+		expect(player.stats[stats.army]).toBe(expectedArmy);
+		expect(player.stats[stats.fort]).toBe(expectedFort);
+		expect(Number.isInteger(player.stats[stats.army])).toBe(true);
+		expect(Number.isInteger(player.stats[stats.fort])).toBe(true);
+		expect(player.stats[stats.army]).toBeGreaterThanOrEqual(0);
+		expect(player.stats[stats.fort]).toBeGreaterThanOrEqual(0);
+	});
 
-  describe('strength growth scenarios', () => {
-    const baseArmy = 5;
-    const baseFort = 5;
-    const baseGrowth = Number(GAME_START.player.stats?.[CStat.growth] ?? 0);
-    it.each([
-      {
-        label: '0 fortifiers',
-        legions: 0,
-        fortifiers: 0,
-        expArmy: Math.ceil(baseArmy + baseArmy * baseGrowth * 0),
-        expFort: Math.ceil(baseFort + baseFort * baseGrowth * 0),
-      },
-      {
-        label: '3 fortifiers',
-        legions: 0,
-        fortifiers: 3,
-        expArmy: Math.ceil(baseArmy + baseArmy * baseGrowth * 0),
-        expFort: Math.ceil(baseFort + baseFort * baseGrowth * 3),
-      },
-      {
-        label: '15 fortifiers',
-        legions: 0,
-        fortifiers: 15,
-        expArmy: Math.ceil(baseArmy + baseArmy * baseGrowth * 0),
-        expFort: Math.ceil(baseFort + baseFort * baseGrowth * 15),
-      },
-      {
-        label: '5 fortifiers and 5 legions',
-        legions: 5,
-        fortifiers: 5,
-        expArmy: Math.ceil(baseArmy + baseArmy * baseGrowth * 5),
-        expFort: Math.ceil(baseFort + baseFort * baseGrowth * 5),
-      },
-    ])('$label', ({ legions, fortifiers, expArmy, expFort }) => {
-      const ctx = createTestEngine();
-      const player = ctx.activePlayer;
-      player.population[PopulationRole.Legion] = legions;
-      player.population[PopulationRole.Fortifier] = fortifiers;
-      player.stats[Stat.armyStrength] = baseArmy;
-      player.stats[Stat.fortificationStrength] = baseFort;
-      while (ctx.game.currentPhase === growthId) advance(ctx);
-      expect(player.stats[Stat.armyStrength]).toBe(expArmy);
-      expect(player.stats[Stat.fortificationStrength]).toBe(expFort);
-      expect(Number.isInteger(player.stats[Stat.armyStrength])).toBe(true);
-      expect(Number.isInteger(player.stats[Stat.fortificationStrength])).toBe(
-        true,
-      );
-      expect(player.stats[Stat.armyStrength]).toBeGreaterThanOrEqual(0);
-      expect(player.stats[Stat.fortificationStrength]).toBeGreaterThanOrEqual(
-        0,
-      );
-    });
+	describe('strength growth scenarios', () => {
+		const baseArmy = 5;
+		const baseFort = 5;
 
-    it('never drops below zero', () => {
-      const ctx = createTestEngine();
-      const player = ctx.activePlayer;
-      player.population[PopulationRole.Legion] = 1;
-      player.population[PopulationRole.Fortifier] = 1;
-      player.stats[Stat.armyStrength] = -5;
-      player.stats[Stat.fortificationStrength] = -5;
-      while (ctx.game.currentPhase === growthId) advance(ctx);
-      expect(player.stats[Stat.armyStrength]).toBe(0);
-      expect(player.stats[Stat.fortificationStrength]).toBe(0);
-      expect(Number.isInteger(player.stats[Stat.armyStrength])).toBe(true);
-      expect(Number.isInteger(player.stats[Stat.fortificationStrength])).toBe(
-        true,
-      );
-    });
-  });
+		it.each([
+			{
+				label: '0 fortifiers',
+				legions: 0,
+				fortifiers: 0,
+			},
+			{
+				label: '3 fortifiers',
+				legions: 0,
+				fortifiers: 3,
+			},
+			{
+				label: '15 fortifiers',
+				legions: 0,
+				fortifiers: 15,
+			},
+			{
+				label: '5 fortifiers and 5 legions',
+				legions: 5,
+				fortifiers: 5,
+			},
+		])('$label', ({ legions, fortifiers }) => {
+			const { ctx, ids, roles, stats, values } = createPhaseTestEnvironment();
+			const player = ctx.activePlayer;
+			player.population[roles.legion] = legions;
+			player.population[roles.fortifier] = fortifiers;
+			player.stats[stats.army] = baseArmy;
+			player.stats[stats.fort] = baseFort;
+			const baseGrowth = values.baseGrowth;
+			while (ctx.game.currentPhase === ids.phases.growth) advance(ctx);
+			const expectedArmy = Math.ceil(
+				baseArmy + baseArmy * baseGrowth * legions,
+			);
+			const expectedFort = Math.ceil(
+				baseFort + baseFort * baseGrowth * fortifiers,
+			);
+			expect(player.stats[stats.army]).toBe(expectedArmy);
+			expect(player.stats[stats.fort]).toBe(expectedFort);
+			expect(Number.isInteger(player.stats[stats.army])).toBe(true);
+			expect(Number.isInteger(player.stats[stats.fort])).toBe(true);
+			expect(player.stats[stats.army]).toBeGreaterThanOrEqual(0);
+			expect(player.stats[stats.fort]).toBeGreaterThanOrEqual(0);
+		});
+
+		it('never drops below zero', () => {
+			const { ctx, ids, roles, stats } = createPhaseTestEnvironment();
+			const player = ctx.activePlayer;
+			player.population[roles.legion] = 1;
+			player.population[roles.fortifier] = 1;
+			player.stats[stats.army] = -5;
+			player.stats[stats.fort] = -5;
+			while (ctx.game.currentPhase === ids.phases.growth) advance(ctx);
+			expect(player.stats[stats.army]).toBe(0);
+			expect(player.stats[stats.fort]).toBe(0);
+			expect(Number.isInteger(player.stats[stats.army])).toBe(true);
+			expect(Number.isInteger(player.stats[stats.fort])).toBe(true);
+		});
+	});
 });

--- a/tests/integration/turn-cycle.test.ts
+++ b/tests/integration/turn-cycle.test.ts
@@ -1,41 +1,81 @@
 import { describe, it, expect } from 'vitest';
 import { createEngine, advance } from '@kingdom-builder/engine';
-import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
-} from '@kingdom-builder/contents';
+import type { PhaseDef } from '@kingdom-builder/engine';
+import type { StartConfig } from '@kingdom-builder/engine/config/schema';
+import type { RuleSet } from '@kingdom-builder/engine/services';
+import { createContentFactory } from '../../packages/engine/tests/factories/content';
+
+const resources = {
+	ap: 'turn:resource:ap',
+	gold: 'turn:resource:gold',
+} as const;
+
+const phaseIds = {
+	growth: 'turn:phase:growth',
+	upkeep: 'turn:phase:upkeep',
+	main: 'turn:phase:main',
+} as const;
+
+const phases: PhaseDef[] = [
+	{ id: phaseIds.growth, steps: [{ id: 'turn:step:growth' }] },
+	{ id: phaseIds.upkeep, steps: [{ id: 'turn:step:upkeep' }] },
+	{ id: phaseIds.main, action: true, steps: [{ id: 'turn:step:main' }] },
+];
+
+const start: StartConfig = {
+	player: {
+		resources: { [resources.ap]: 0, [resources.gold]: 0 },
+		stats: {},
+		population: {},
+		lands: [],
+	},
+};
+
+const rules: RuleSet = {
+	defaultActionAPCost: 1,
+	absorptionCapPct: 1,
+	absorptionRounding: 'down',
+	tieredResourceKey: resources.gold,
+	tierDefinitions: [
+		{
+			id: 'turn:tier:baseline',
+			range: { min: 0 },
+			effect: { incomeMultiplier: 1 },
+			passive: { id: 'turn:passive:baseline' },
+		},
+	],
+	slotsPerNewLand: 1,
+	maxSlotsPerLand: 1,
+	basePopulationCap: 1,
+};
 
 describe('Turn cycle integration', () => {
-  it('advances players through all phases sequentially', () => {
-    const ctx = createEngine({
-      actions: ACTIONS,
-      buildings: BUILDINGS,
-      developments: DEVELOPMENTS,
-      populations: POPULATIONS,
-      phases: PHASES,
-      start: GAME_START,
-      rules: RULES,
-    });
-    const [growthId, , mainId] = PHASES.map((p) => p.id);
-    // player A development & upkeep
-    while (ctx.game.currentPhase !== mainId) advance(ctx);
-    expect(ctx.game.currentPlayerIndex).toBe(0);
-    expect(ctx.game.currentPhase).toBe(mainId);
-    // end main for player A
-    advance(ctx);
-    // player B development & upkeep
-    while (ctx.game.currentPhase !== mainId) advance(ctx);
-    expect(ctx.game.currentPlayerIndex).toBe(1);
-    expect(ctx.game.currentPhase).toBe(mainId);
-    // end main for player B
-    advance(ctx);
-    expect(ctx.game.turn).toBe(2);
-    expect(ctx.game.currentPlayerIndex).toBe(0);
-    expect(ctx.game.currentPhase).toBe(growthId);
-  });
+	it('advances players through all phases sequentially', () => {
+		const content = createContentFactory();
+		const ctx = createEngine({
+			actions: content.actions,
+			buildings: content.buildings,
+			developments: content.developments,
+			populations: content.populations,
+			phases,
+			start,
+			rules,
+		});
+
+		while (ctx.game.currentPhase !== phaseIds.main) advance(ctx);
+		expect(ctx.game.currentPlayerIndex).toBe(0);
+		expect(ctx.game.currentPhase).toBe(phaseIds.main);
+
+		advance(ctx);
+
+		while (ctx.game.currentPhase !== phaseIds.main) advance(ctx);
+		expect(ctx.game.currentPlayerIndex).toBe(1);
+		expect(ctx.game.currentPhase).toBe(phaseIds.main);
+
+		advance(ctx);
+
+		expect(ctx.game.turn).toBe(2);
+		expect(ctx.game.currentPlayerIndex).toBe(0);
+		expect(ctx.game.currentPhase).toBe(phaseIds.growth);
+	});
 });


### PR DESCRIPTION
## Summary
- add a reusable synthetic phase fixture with bespoke resources, populations, developments, and phases for growth/upkeep tests
- update growth and upkeep phase tests to rely on the synthetic IDs and effects instead of contents defaults
- extend the test content factory to copy step-specific hooks and switch the turn-cycle integration test to a local minimal engine config

## Testing
- npx vitest run packages/engine/tests/phases/growth.test.ts packages/engine/tests/phases/upkeep.test.ts tests/integration/turn-cycle.test.ts
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68deb9b05ebc832580f095edac80077e