### PR TITLE
Refactor log icon rendering to use registry

### DIFF
--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -1,446 +1,455 @@
 import {
-  EVALUATORS,
-  type EffectDef,
-  type EngineContext,
+	EVALUATORS,
+	type EffectDef,
+	type EngineContext,
 } from '@kingdom-builder/engine';
 import {
-  RESOURCES,
-  STATS,
-  POPULATION_ROLES,
-  LAND_INFO,
-  SLOT_INFO,
-  PASSIVE_INFO,
-  POPULATION_INFO,
-  type ResourceKey,
+	RESOURCES,
+	STATS,
+	POPULATION_ROLES,
+	LAND_INFO,
+	SLOT_INFO,
+	PASSIVE_INFO,
+	POPULATION_INFO,
+	type ResourceKey,
 } from '@kingdom-builder/contents';
 import { formatStatValue, statDisplaysAsPercent } from '../utils/stats';
 interface StepDef {
-  id: string;
-  title?: string;
-  triggers?: string[];
-  effects?: EffectDef[];
+	id: string;
+	title?: string;
+	triggers?: string[];
+	effects?: EffectDef[];
 }
 import { logContent, type Land } from './content';
 
 export interface PlayerSnapshot {
-  resources: Record<string, number>;
-  stats: Record<string, number>;
-  buildings: string[];
-  lands: {
-    id: string;
-    slotsMax: number;
-    slotsUsed: number;
-    developments: string[];
-  }[];
-  passives: string[];
+	resources: Record<string, number>;
+	stats: Record<string, number>;
+	buildings: string[];
+	lands: {
+		id: string;
+		slotsMax: number;
+		slotsUsed: number;
+		developments: string[];
+	}[];
+	passives: string[];
 }
 
 export function snapshotPlayer(
-  player: {
-    id: string;
-    resources: Record<string, number>;
-    stats: Record<string, number>;
-    buildings: Set<string>;
-    lands: Land[];
-  },
-  ctx: EngineContext,
+	player: {
+		id: string;
+		resources: Record<string, number>;
+		stats: Record<string, number>;
+		buildings: Set<string>;
+		lands: Land[];
+	},
+	ctx: EngineContext,
 ): PlayerSnapshot {
-  return {
-    resources: { ...player.resources },
-    stats: { ...player.stats },
-    buildings: Array.from(player.buildings ?? []),
-    lands: player.lands.map((l) => ({
-      id: l.id,
-      slotsMax: l.slotsMax,
-      slotsUsed: l.slotsUsed,
-      developments: [...l.developments],
-    })),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-    passives: ctx.passives.list(player.id as any),
-  };
+	return {
+		resources: { ...player.resources },
+		stats: { ...player.stats },
+		buildings: Array.from(player.buildings ?? []),
+		lands: player.lands.map((l) => ({
+			id: l.id,
+			slotsMax: l.slotsMax,
+			slotsUsed: l.slotsUsed,
+			developments: [...l.developments],
+		})),
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+		passives: ctx.passives.list(player.id as any),
+	};
 }
 
 export function diffSnapshots(
-  before: PlayerSnapshot,
-  after: PlayerSnapshot,
-  ctx: EngineContext,
-  resourceKeys: ResourceKey[] = Object.keys({
-    ...before.resources,
-    ...after.resources,
-  }) as ResourceKey[],
+	before: PlayerSnapshot,
+	after: PlayerSnapshot,
+	ctx: EngineContext,
+	resourceKeys: ResourceKey[] = Object.keys({
+		...before.resources,
+		...after.resources,
+	}) as ResourceKey[],
 ): string[] {
-  const changes: string[] = [];
-  for (const key of resourceKeys) {
-    const b = before.resources[key] ?? 0;
-    const a = after.resources[key] ?? 0;
-    if (a !== b) {
-      const info = RESOURCES[key];
-      const icon = info?.icon ? `${info.icon} ` : '';
-      const label = info?.label ?? key;
-      const delta = a - b;
-      changes.push(
-        `${icon}${label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a})`,
-      );
-    }
-  }
-  for (const key of Object.keys(after.stats)) {
-    const b = before.stats[key] ?? 0;
-    const a = after.stats[key] ?? 0;
-    if (a !== b) {
-      const info = STATS[key as keyof typeof STATS];
-      const icon = info?.icon ? `${info.icon} ` : '';
-      const label = info?.label ?? key;
-      const delta = a - b;
-      if (statDisplaysAsPercent(key)) {
-        const bPerc = b * 100;
-        const aPerc = a * 100;
-        const dPerc = delta * 100;
-        changes.push(
-          `${icon}${label} ${dPerc >= 0 ? '+' : ''}${dPerc}% (${bPerc}→${aPerc}%)`,
-        );
-      } else {
-        changes.push(
-          `${icon}${label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a})`,
-        );
-      }
-    }
-  }
-  const beforeB = new Set(before.buildings);
-  const afterB = new Set(after.buildings);
-  for (const id of afterB)
-    if (!beforeB.has(id)) {
-      const label = logContent('building', id, ctx)[0] ?? id;
-      changes.push(`${label} built`);
-    }
-  for (const land of after.lands) {
-    const prev = before.lands.find((l) => l.id === land.id);
-    if (!prev) {
-      changes.push(`${LAND_INFO.icon} +1 ${LAND_INFO.label}`);
-      continue;
-    }
-    for (const dev of land.developments)
-      if (!prev.developments.includes(dev)) {
-        const label = logContent('development', dev, ctx)[0] ?? dev;
-        changes.push(`${LAND_INFO.icon} +${label}`);
-      }
-  }
-  const beforeSlots = before.lands.reduce((sum, l) => sum + l.slotsMax, 0);
-  const afterSlots = after.lands.reduce((sum, l) => sum + l.slotsMax, 0);
-  const newLandSlots = after.lands
-    .filter((l) => !before.lands.some((b) => b.id === l.id))
-    .reduce((sum, l) => sum + l.slotsMax, 0);
-  const slotDelta = afterSlots - newLandSlots - beforeSlots;
-  if (slotDelta !== 0)
-    changes.push(
-      `${SLOT_INFO.icon} ${SLOT_INFO.label} ${slotDelta >= 0 ? '+' : ''}${slotDelta} (${beforeSlots}→${beforeSlots + slotDelta})`,
-    );
-  const beforeP = new Set(before.passives);
-  const afterP = new Set(after.passives);
-  for (const id of beforeP)
-    if (!afterP.has(id)) changes.push(`${PASSIVE_INFO.label} ${id} removed`);
-  return changes;
+	const changes: string[] = [];
+	for (const key of resourceKeys) {
+		const b = before.resources[key] ?? 0;
+		const a = after.resources[key] ?? 0;
+		if (a !== b) {
+			const info = RESOURCES[key];
+			const icon = info?.icon ? `${info.icon} ` : '';
+			const label = info?.label ?? key;
+			const delta = a - b;
+			changes.push(
+				`${icon}${label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a})`,
+			);
+		}
+	}
+	for (const key of Object.keys(after.stats)) {
+		const b = before.stats[key] ?? 0;
+		const a = after.stats[key] ?? 0;
+		if (a !== b) {
+			const info = STATS[key as keyof typeof STATS];
+			const icon = info?.icon ? `${info.icon} ` : '';
+			const label = info?.label ?? key;
+			const delta = a - b;
+			if (statDisplaysAsPercent(key)) {
+				const bPerc = b * 100;
+				const aPerc = a * 100;
+				const dPerc = delta * 100;
+				changes.push(
+					`${icon}${label} ${dPerc >= 0 ? '+' : ''}${dPerc}% (${bPerc}→${aPerc}%)`,
+				);
+			} else {
+				changes.push(
+					`${icon}${label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a})`,
+				);
+			}
+		}
+	}
+	const beforeB = new Set(before.buildings);
+	const afterB = new Set(after.buildings);
+	for (const id of afterB)
+		if (!beforeB.has(id)) {
+			const label = logContent('building', id, ctx)[0] ?? id;
+			changes.push(`${label} built`);
+		}
+	for (const land of after.lands) {
+		const prev = before.lands.find((l) => l.id === land.id);
+		if (!prev) {
+			changes.push(`${LAND_INFO.icon} +1 ${LAND_INFO.label}`);
+			continue;
+		}
+		for (const dev of land.developments)
+			if (!prev.developments.includes(dev)) {
+				const label = logContent('development', dev, ctx)[0] ?? dev;
+				changes.push(`${LAND_INFO.icon} +${label}`);
+			}
+	}
+	const beforeSlots = before.lands.reduce((sum, l) => sum + l.slotsMax, 0);
+	const afterSlots = after.lands.reduce((sum, l) => sum + l.slotsMax, 0);
+	const newLandSlots = after.lands
+		.filter((l) => !before.lands.some((b) => b.id === l.id))
+		.reduce((sum, l) => sum + l.slotsMax, 0);
+	const slotDelta = afterSlots - newLandSlots - beforeSlots;
+	if (slotDelta !== 0)
+		changes.push(
+			`${SLOT_INFO.icon} ${SLOT_INFO.label} ${slotDelta >= 0 ? '+' : ''}${slotDelta} (${beforeSlots}→${beforeSlots + slotDelta})`,
+		);
+	const beforeP = new Set(before.passives);
+	const afterP = new Set(after.passives);
+	for (const id of beforeP)
+		if (!afterP.has(id)) changes.push(`${PASSIVE_INFO.label} ${id} removed`);
+	return changes;
 }
 
 interface ResourceSourceEntry {
-  icons: string;
-  mods: string;
+	icons: string;
+	mods: string;
 }
 
 type ResourceSourceMeta = Record<string, unknown> & {
-  type?: string;
-  id?: string;
-  landId?: string;
-  count?: number;
+	type?: string;
+	id?: string;
+	landId?: string;
+	count?: number;
 };
 
 function isResourceSourceMeta(value: unknown): value is ResourceSourceMeta {
-  return typeof value === 'object' && value !== null && 'type' in value;
+	return typeof value === 'object' && value !== null && 'type' in value;
 }
 
 export type EvaluatorIconRenderer = (
-  ev: { type: string; params?: Record<string, unknown> },
-  entry: ResourceSourceEntry,
-  ctx: EngineContext,
+	ev: { type: string; params?: Record<string, unknown> },
+	entry: ResourceSourceEntry,
+	ctx: EngineContext,
 ) => void;
 
+type MetaIconRenderer = (
+	meta: ResourceSourceMeta,
+	ctx: EngineContext,
+) => string;
+
 function evaluateCount(
-  ev: { type: string; params?: Record<string, unknown> },
-  ctx: EngineContext,
+	ev: { type: string; params?: Record<string, unknown> },
+	ctx: EngineContext,
 ): number {
-  const handler = EVALUATORS.get(ev.type);
-  return Number(handler(ev, ctx));
+	const handler = EVALUATORS.get(ev.type);
+	return Number(handler(ev, ctx));
 }
 
 function renderDevelopmentIcons(
-  ev: { type: string; params?: Record<string, unknown> },
-  entry: ResourceSourceEntry,
-  ctx: EngineContext,
+	ev: { type: string; params?: Record<string, unknown> },
+	entry: ResourceSourceEntry,
+	ctx: EngineContext,
 ): void {
-  const count = evaluateCount(ev, ctx);
-  const id = (ev.params as Record<string, string> | undefined)?.['id'];
-  const icon = id ? ctx.developments.get(id)?.icon || '' : '';
-  entry.icons += icon.repeat(count);
+	const count = evaluateCount(ev, ctx);
+	const id = (ev.params as Record<string, string> | undefined)?.['id'];
+	const icon = id ? ctx.developments.get(id)?.icon || '' : '';
+	entry.icons += icon.repeat(count);
 }
 
 function renderPopulationIcons(
-  ev: { type: string; params?: Record<string, unknown> },
-  entry: ResourceSourceEntry,
-  ctx: EngineContext,
+	ev: { type: string; params?: Record<string, unknown> },
+	entry: ResourceSourceEntry,
+	ctx: EngineContext,
 ): void {
-  const count = evaluateCount(ev, ctx);
-  const role = (ev.params as Record<string, string> | undefined)?.['role'] as
-    | keyof typeof POPULATION_ROLES
-    | undefined;
-  const icon = role
-    ? POPULATION_ROLES[role]?.icon || role
-    : POPULATION_INFO.icon;
-  entry.icons += icon.repeat(count);
+	const count = evaluateCount(ev, ctx);
+	const role = (ev.params as Record<string, string> | undefined)?.['role'] as
+		| keyof typeof POPULATION_ROLES
+		| undefined;
+	const icon = role
+		? POPULATION_ROLES[role]?.icon || role
+		: POPULATION_INFO.icon;
+	entry.icons += icon.repeat(count);
 }
 
 export const EVALUATOR_ICON_RENDERERS: Record<string, EvaluatorIconRenderer> = {
-  development: renderDevelopmentIcons,
-  population: renderPopulationIcons,
+	development: renderDevelopmentIcons,
+	population: renderPopulationIcons,
+};
+
+function renderPopulationMetaIcons(
+	meta: ResourceSourceMeta,
+	_ctx: EngineContext,
+): string {
+	const role = meta.id as keyof typeof POPULATION_ROLES | undefined;
+	const icon = role
+		? POPULATION_ROLES[role]?.icon || role
+		: POPULATION_INFO.icon;
+	if (!icon) return '';
+	if (meta.count === undefined) return icon;
+	const rawCount = Number(meta.count);
+	if (!Number.isFinite(rawCount)) return icon;
+	const normalizedCount = rawCount > 0 ? Math.max(1, Math.round(rawCount)) : 0;
+	if (normalizedCount === 0) return '';
+	return icon.repeat(normalizedCount);
+}
+
+function renderDevelopmentMetaIcons(
+	meta: ResourceSourceMeta,
+	ctx: EngineContext,
+): string {
+	if (!meta.id) return '';
+	return ctx.developments.get(meta.id)?.icon || '';
+}
+
+function renderBuildingMetaIcons(
+	meta: ResourceSourceMeta,
+	ctx: EngineContext,
+): string {
+	if (!meta.id) return '';
+	return ctx.buildings.get(meta.id)?.icon || '';
+}
+
+function renderLandMetaIcons(): string {
+	return LAND_INFO.icon || '';
+}
+
+const META_ICON_RENDERERS: Record<string, MetaIconRenderer> = {
+	population: renderPopulationMetaIcons,
+	development: renderDevelopmentMetaIcons,
+	building: renderBuildingMetaIcons,
+	land: renderLandMetaIcons,
 };
 
 function appendMetaSourceIcons(
-  entry: ResourceSourceEntry,
-  source: unknown,
-  ctx: EngineContext,
+	entry: ResourceSourceEntry,
+	source: unknown,
+	ctx: EngineContext,
 ) {
-  if (!isResourceSourceMeta(source) || !source.type) return;
-  const meta = source;
-  switch (meta.type) {
-    case 'population': {
-      const role = meta.id as keyof typeof POPULATION_ROLES | undefined;
-      const icon = role
-        ? POPULATION_ROLES[role]?.icon || role
-        : POPULATION_INFO.icon;
-      if (!icon) break;
-      if (meta.count === undefined) {
-        entry.icons += icon;
-        break;
-      }
-      const rawCount = Number(meta.count);
-      if (!Number.isFinite(rawCount)) {
-        entry.icons += icon;
-        break;
-      }
-      const normalizedCount =
-        rawCount > 0 ? Math.max(1, Math.round(rawCount)) : 0;
-      if (normalizedCount === 0) break;
-      entry.icons += icon.repeat(normalizedCount);
-      break;
-    }
-    case 'development': {
-      if (meta.id) {
-        const icon = ctx.developments.get(meta.id)?.icon || '';
-        entry.icons += icon;
-      }
-      break;
-    }
-    case 'building': {
-      if (meta.id) {
-        const icon = ctx.buildings.get(meta.id)?.icon || '';
-        entry.icons += icon;
-      }
-      break;
-    }
-    case 'land': {
-      entry.icons += LAND_INFO.icon || '';
-      break;
-    }
-    default:
-      break;
-  }
+	if (!isResourceSourceMeta(source) || !source.type) return;
+	const renderer = META_ICON_RENDERERS[source.type];
+	if (!renderer) return;
+	const icons = renderer(source, ctx);
+	if (icons) entry.icons += icons;
 }
 
 function collectResourceSources(
-  step: StepDef | undefined,
-  ctx: EngineContext,
+	step: StepDef | undefined,
+	ctx: EngineContext,
 ): Record<string, string> {
-  const map: Record<string, ResourceSourceEntry> = {};
-  for (const eff of step?.effects || []) {
-    if (eff.evaluator && eff.effects) {
-      const inner = eff.effects.find((e) => e.type === 'resource');
-      if (!inner) continue;
-      const key = inner.params?.['key'] as string | undefined;
-      if (!key) continue;
-      const entry = map[key] || { icons: '', mods: '' };
-      const ev = eff.evaluator as {
-        type: string;
-        params?: Record<string, unknown>;
-      };
-      try {
-        EVALUATOR_ICON_RENDERERS[ev.type]?.(ev, entry, ctx);
-        const idParam = ev.params?.['id'];
-        const target =
-          ev.params && 'id' in ev.params
-            ? `${ev.type}:${String(idParam)}`
-            : ev.type;
-        const passives = ctx.passives as unknown as {
-          evaluationMods?: Map<string, Map<string, unknown>>;
-        };
-        const modsMap = passives.evaluationMods?.get(target);
-        if (modsMap) {
-          for (const key of modsMap.keys()) {
-            if (!key.endsWith(`_${ctx.activePlayer.id}`)) continue;
-            const base = key.replace(`_${ctx.activePlayer.id}`, '');
-            const parts = base.split('_');
-            let icon = '';
-            for (let i = parts.length; i > 0; i--) {
-              const candidate = parts.slice(0, i).join('_');
-              try {
-                icon = ctx.buildings.get(candidate)?.icon || '';
-              } catch {
-                /* ignore */
-              }
-              if (icon) break;
-            }
-            if (!icon) icon = ctx.actions.get('build').icon || '';
-            entry.mods += icon;
-          }
-        }
-      } catch {
-        // ignore missing evaluators
-      }
-      map[key] = entry;
-    }
-    if (eff.type === 'resource') {
-      const key = eff.params?.['key'] as string | undefined;
-      if (!key) continue;
-      const entry = map[key] || { icons: '', mods: '' };
-      const meta = eff.meta?.['source'];
-      appendMetaSourceIcons(entry, meta, ctx);
-      map[key] = entry;
-    }
-  }
-  const result: Record<string, string> = {};
-  for (const [key, { icons, mods }] of Object.entries(map)) {
-    let part = icons;
-    if (mods) part += `+${mods}`;
-    result[key] = part;
-  }
-  return result;
+	const map: Record<string, ResourceSourceEntry> = {};
+	for (const eff of step?.effects || []) {
+		if (eff.evaluator && eff.effects) {
+			const inner = eff.effects.find((e) => e.type === 'resource');
+			if (!inner) continue;
+			const key = inner.params?.['key'] as string | undefined;
+			if (!key) continue;
+			const entry = map[key] || { icons: '', mods: '' };
+			const ev = eff.evaluator as {
+				type: string;
+				params?: Record<string, unknown>;
+			};
+			try {
+				EVALUATOR_ICON_RENDERERS[ev.type]?.(ev, entry, ctx);
+				const idParam = ev.params?.['id'];
+				const target =
+					ev.params && 'id' in ev.params
+						? `${ev.type}:${String(idParam)}`
+						: ev.type;
+				const passives = ctx.passives as unknown as {
+					evaluationMods?: Map<string, Map<string, unknown>>;
+				};
+				const modsMap = passives.evaluationMods?.get(target);
+				if (modsMap) {
+					for (const key of modsMap.keys()) {
+						if (!key.endsWith(`_${ctx.activePlayer.id}`)) continue;
+						const base = key.replace(`_${ctx.activePlayer.id}`, '');
+						const parts = base.split('_');
+						let icon = '';
+						for (let i = parts.length; i > 0; i--) {
+							const candidate = parts.slice(0, i).join('_');
+							try {
+								icon = ctx.buildings.get(candidate)?.icon || '';
+							} catch {
+								/* ignore */
+							}
+							if (icon) break;
+						}
+						if (!icon) icon = ctx.actions.get('build').icon || '';
+						entry.mods += icon;
+					}
+				}
+			} catch {
+				// ignore missing evaluators
+			}
+			map[key] = entry;
+		}
+		if (eff.type === 'resource') {
+			const key = eff.params?.['key'] as string | undefined;
+			if (!key) continue;
+			const entry = map[key] || { icons: '', mods: '' };
+			const meta = eff.meta?.['source'];
+			appendMetaSourceIcons(entry, meta, ctx);
+			map[key] = entry;
+		}
+	}
+	const result: Record<string, string> = {};
+	for (const [key, { icons, mods }] of Object.entries(map)) {
+		let part = icons;
+		if (mods) part += `+${mods}`;
+		result[key] = part;
+	}
+	return result;
 }
 
 function findStatPctBreakdown(
-  step: StepDef | undefined,
-  statKey: string,
+	step: StepDef | undefined,
+	statKey: string,
 ): { role: string; percentStat: string } | undefined {
-  const walk = (
-    effects: EffectDef[] | undefined,
-    currentRole: string | undefined,
-  ): { role: string; percentStat: string } | undefined => {
-    if (!effects) return undefined;
-    for (const eff of effects) {
-      let role = currentRole;
-      if (eff.evaluator?.type === 'population') {
-        role = (eff.evaluator.params as Record<string, string> | undefined)?.[
-          'role'
-        ];
-      }
-      if (eff.type === 'stat' && eff.method === 'add_pct') {
-        const params = eff.params as Record<string, string> | undefined;
-        if (params?.['key'] === statKey && params?.['percentStat'] && role) {
-          return { role, percentStat: params['percentStat'] };
-        }
-      }
-      const nested = walk(eff.effects, role);
-      if (nested) return nested;
-    }
-    return undefined;
-  };
-  return walk(step?.effects, undefined);
+	const walk = (
+		effects: EffectDef[] | undefined,
+		currentRole: string | undefined,
+	): { role: string; percentStat: string } | undefined => {
+		if (!effects) return undefined;
+		for (const eff of effects) {
+			let role = currentRole;
+			if (eff.evaluator?.type === 'population') {
+				role = (eff.evaluator.params as Record<string, string> | undefined)?.[
+					'role'
+				];
+			}
+			if (eff.type === 'stat' && eff.method === 'add_pct') {
+				const params = eff.params as Record<string, string> | undefined;
+				if (params?.['key'] === statKey && params?.['percentStat'] && role) {
+					return { role, percentStat: params['percentStat'] };
+				}
+			}
+			const nested = walk(eff.effects, role);
+			if (nested) return nested;
+		}
+		return undefined;
+	};
+	return walk(step?.effects, undefined);
 }
 
 export function diffStepSnapshots(
-  before: PlayerSnapshot,
-  after: PlayerSnapshot,
-  step: StepDef | undefined,
-  ctx: EngineContext,
-  resourceKeys: ResourceKey[] = Object.keys({
-    ...before.resources,
-    ...after.resources,
-  }) as ResourceKey[],
+	before: PlayerSnapshot,
+	after: PlayerSnapshot,
+	step: StepDef | undefined,
+	ctx: EngineContext,
+	resourceKeys: ResourceKey[] = Object.keys({
+		...before.resources,
+		...after.resources,
+	}) as ResourceKey[],
 ): string[] {
-  const changes: string[] = [];
-  const sources = collectResourceSources(step, ctx);
-  for (const key of resourceKeys) {
-    const b = before.resources[key] ?? 0;
-    const a = after.resources[key] ?? 0;
-    if (a !== b) {
-      const info = RESOURCES[key];
-      const icon = info?.icon ? `${info.icon} ` : '';
-      const label = info?.label ?? key;
-      const delta = a - b;
-      let line = `${icon}${label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a})`;
-      const src = sources[key];
-      if (src)
-        line += ` (${info?.icon || key}${delta >= 0 ? '+' : ''}${delta} from ${src})`;
-      changes.push(line);
-    }
-  }
-  for (const key of Object.keys(after.stats)) {
-    const b = before.stats[key] ?? 0;
-    const a = after.stats[key] ?? 0;
-    if (a !== b) {
-      const info = STATS[key as keyof typeof STATS];
-      const iconOnly = info?.icon || '';
-      const icon = iconOnly ? `${iconOnly} ` : '';
-      const label = info?.label ?? key;
-      const delta = a - b;
-      const bStr = formatStatValue(key, b);
-      const aStr = formatStatValue(key, a);
-      const dStr = formatStatValue(key, delta);
-      let line = `${icon}${label} ${delta >= 0 ? '+' : ''}${dStr} (${bStr}→${aStr})`;
-      if (!statDisplaysAsPercent(key)) {
-        const breakdown = findStatPctBreakdown(step, key);
-        if (breakdown && delta > 0) {
-          const role = breakdown.role as keyof typeof POPULATION_ROLES;
-          const count = ctx.activePlayer.population[role] ?? 0;
-          const popIcon = POPULATION_ROLES[role]?.icon || '';
-          const pctStat = breakdown.percentStat as keyof typeof STATS;
-          const growth = ctx.activePlayer.stats[pctStat] ?? 0;
-          const growthIcon = STATS[pctStat]?.icon || '';
-          const growthStr = formatStatValue(breakdown.percentStat, growth);
-          line += ` (${iconOnly}${bStr} + (${popIcon}${count} * ${growthIcon}${growthStr}) = ${iconOnly}${aStr})`;
-        }
-      }
-      changes.push(line);
-    }
-  }
-  const beforeB = new Set(before.buildings);
-  const afterB = new Set(after.buildings);
-  for (const id of afterB)
-    if (!beforeB.has(id)) {
-      const label = logContent('building', id, ctx)[0] ?? id;
-      changes.push(`${label} built`);
-    }
-  for (const land of after.lands) {
-    const prev = before.lands.find((l) => l.id === land.id);
-    if (!prev) {
-      changes.push(`${LAND_INFO.icon} +1 ${LAND_INFO.label}`);
-      continue;
-    }
-    for (const dev of land.developments)
-      if (!prev.developments.includes(dev)) {
-        const label = logContent('development', dev, ctx)[0] ?? dev;
-        changes.push(`${LAND_INFO.icon} +${label}`);
-      }
-  }
-  const beforeSlots = before.lands.reduce((sum, l) => sum + l.slotsMax, 0);
-  const afterSlots = after.lands.reduce((sum, l) => sum + l.slotsMax, 0);
-  const newLandSlots = after.lands
-    .filter((l) => !before.lands.some((b) => b.id === l.id))
-    .reduce((sum, l) => sum + l.slotsMax, 0);
-  const slotDelta = afterSlots - newLandSlots - beforeSlots;
-  if (slotDelta !== 0)
-    changes.push(
-      `${SLOT_INFO.icon} ${SLOT_INFO.label} ${slotDelta >= 0 ? '+' : ''}${slotDelta} (${beforeSlots}→${beforeSlots + slotDelta})`,
-    );
-  const beforeP = new Set(before.passives);
-  const afterP = new Set(after.passives);
-  for (const id of beforeP)
-    if (!afterP.has(id)) changes.push(`${PASSIVE_INFO.label} ${id} removed`);
-  return changes;
+	const changes: string[] = [];
+	const sources = collectResourceSources(step, ctx);
+	for (const key of resourceKeys) {
+		const b = before.resources[key] ?? 0;
+		const a = after.resources[key] ?? 0;
+		if (a !== b) {
+			const info = RESOURCES[key];
+			const icon = info?.icon ? `${info.icon} ` : '';
+			const label = info?.label ?? key;
+			const delta = a - b;
+			let line = `${icon}${label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a})`;
+			const src = sources[key];
+			if (src)
+				line += ` (${info?.icon || key}${delta >= 0 ? '+' : ''}${delta} from ${src})`;
+			changes.push(line);
+		}
+	}
+	for (const key of Object.keys(after.stats)) {
+		const b = before.stats[key] ?? 0;
+		const a = after.stats[key] ?? 0;
+		if (a !== b) {
+			const info = STATS[key as keyof typeof STATS];
+			const iconOnly = info?.icon || '';
+			const icon = iconOnly ? `${iconOnly} ` : '';
+			const label = info?.label ?? key;
+			const delta = a - b;
+			const bStr = formatStatValue(key, b);
+			const aStr = formatStatValue(key, a);
+			const dStr = formatStatValue(key, delta);
+			let line = `${icon}${label} ${delta >= 0 ? '+' : ''}${dStr} (${bStr}→${aStr})`;
+			if (!statDisplaysAsPercent(key)) {
+				const breakdown = findStatPctBreakdown(step, key);
+				if (breakdown && delta > 0) {
+					const role = breakdown.role as keyof typeof POPULATION_ROLES;
+					const count = ctx.activePlayer.population[role] ?? 0;
+					const popIcon = POPULATION_ROLES[role]?.icon || '';
+					const pctStat = breakdown.percentStat as keyof typeof STATS;
+					const growth = ctx.activePlayer.stats[pctStat] ?? 0;
+					const growthIcon = STATS[pctStat]?.icon || '';
+					const growthStr = formatStatValue(breakdown.percentStat, growth);
+					line += ` (${iconOnly}${bStr} + (${popIcon}${count} * ${growthIcon}${growthStr}) = ${iconOnly}${aStr})`;
+				}
+			}
+			changes.push(line);
+		}
+	}
+	const beforeB = new Set(before.buildings);
+	const afterB = new Set(after.buildings);
+	for (const id of afterB)
+		if (!beforeB.has(id)) {
+			const label = logContent('building', id, ctx)[0] ?? id;
+			changes.push(`${label} built`);
+		}
+	for (const land of after.lands) {
+		const prev = before.lands.find((l) => l.id === land.id);
+		if (!prev) {
+			changes.push(`${LAND_INFO.icon} +1 ${LAND_INFO.label}`);
+			continue;
+		}
+		for (const dev of land.developments)
+			if (!prev.developments.includes(dev)) {
+				const label = logContent('development', dev, ctx)[0] ?? dev;
+				changes.push(`${LAND_INFO.icon} +${label}`);
+			}
+	}
+	const beforeSlots = before.lands.reduce((sum, l) => sum + l.slotsMax, 0);
+	const afterSlots = after.lands.reduce((sum, l) => sum + l.slotsMax, 0);
+	const newLandSlots = after.lands
+		.filter((l) => !before.lands.some((b) => b.id === l.id))
+		.reduce((sum, l) => sum + l.slotsMax, 0);
+	const slotDelta = afterSlots - newLandSlots - beforeSlots;
+	if (slotDelta !== 0)
+		changes.push(
+			`${SLOT_INFO.icon} ${SLOT_INFO.label} ${slotDelta >= 0 ? '+' : ''}${slotDelta} (${beforeSlots}→${beforeSlots + slotDelta})`,
+		);
+	const beforeP = new Set(before.passives);
+	const afterP = new Set(after.passives);
+	for (const id of beforeP)
+		if (!afterP.has(id)) changes.push(`${PASSIVE_INFO.label} ${id} removed`);
+	return changes;
 }

--- a/packages/web/tests/log-source-icons.test.ts
+++ b/packages/web/tests/log-source-icons.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { createEngine, runEffects } from '@kingdom-builder/engine';
+import {
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	RESOURCES,
+	Resource,
+	LAND_INFO,
+	POPULATION_INFO,
+} from '@kingdom-builder/contents';
+import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
+
+const RESOURCE_KEYS = [Resource.gold] as const;
+
+describe('log resource source icon registry', () => {
+	const createCtx = () =>
+		createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+
+	const scenarios = [
+		{
+			name: 'population',
+			getMeta: (ctx: ReturnType<typeof createCtx>) => {
+				const [roleId] = ctx.populations.keys();
+				expect(roleId).toBeTruthy();
+				const icon = roleId
+					? ctx.populations.get(roleId)?.icon || roleId
+					: POPULATION_INFO.icon || '';
+				expect(icon).toBeTruthy();
+				return {
+					meta: { type: 'population', id: roleId, count: 2 },
+					expected: icon.repeat(2),
+				} as const;
+			},
+		},
+		{
+			name: 'development',
+			getMeta: (ctx: ReturnType<typeof createCtx>) => {
+				const devId = ctx.developments
+					.keys()
+					.find((id) => Boolean(ctx.developments.get(id)?.icon));
+				expect(devId).toBeTruthy();
+				const icon = devId ? ctx.developments.get(devId)?.icon || '' : '';
+				expect(icon).toBeTruthy();
+				return {
+					meta: { type: 'development', id: devId },
+					expected: icon,
+				} as const;
+			},
+		},
+		{
+			name: 'building',
+			getMeta: (ctx: ReturnType<typeof createCtx>) => {
+				const buildingId = ctx.buildings
+					.keys()
+					.find((id) => Boolean(ctx.buildings.get(id)?.icon));
+				expect(buildingId).toBeTruthy();
+				const icon = buildingId
+					? ctx.buildings.get(buildingId)?.icon || ''
+					: '';
+				expect(icon).toBeTruthy();
+				return {
+					meta: { type: 'building', id: buildingId },
+					expected: icon,
+				} as const;
+			},
+		},
+		{
+			name: 'land',
+			getMeta: () => {
+				expect(LAND_INFO.icon).toBeTruthy();
+				return {
+					meta: { type: 'land' },
+					expected: LAND_INFO.icon || '',
+				} as const;
+			},
+		},
+	] as const;
+
+	for (const { name, getMeta } of scenarios) {
+		it(`renders icons for ${name} meta sources`, () => {
+			const ctx = createCtx();
+			const { meta, expected } = getMeta(ctx);
+			const effect = {
+				type: 'resource' as const,
+				method: 'add' as const,
+				params: { key: Resource.gold, amount: 2 },
+				meta: { source: meta },
+			};
+			const step = { id: `meta-icons-${name}`, effects: [effect] };
+			const before = snapshotPlayer(ctx.activePlayer, ctx);
+			runEffects([effect], ctx);
+			const after = snapshotPlayer(ctx.activePlayer, ctx);
+			const lines = diffStepSnapshots(before, after, step, ctx, RESOURCE_KEYS);
+			const goldInfo = RESOURCES[Resource.gold];
+			const goldLine = lines.find((l) =>
+				l.startsWith(`${goldInfo.icon} ${goldInfo.label}`),
+			);
+			expect(goldLine).toBeTruthy();
+			const match = goldLine?.match(/ from (.+)\)$/);
+			expect(match?.[1]).toBe(expected);
+		});
+	}
+});

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -1,190 +1,191 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
-  createEngine,
-  runEffects,
-  performAction,
-  advance,
-  collectTriggerEffects,
+	createEngine,
+	runEffects,
+	performAction,
+	advance,
+	collectTriggerEffects,
 } from '@kingdom-builder/engine';
 import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
-  RESOURCES,
-  Resource,
-  type ResourceKey,
-  ON_GAIN_INCOME_STEP,
-  ON_PAY_UPKEEP_STEP,
-  LAND_INFO,
-  POPULATION_INFO,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	RESOURCES,
+	Resource,
+	type ResourceKey,
+	ON_GAIN_INCOME_STEP,
+	ON_PAY_UPKEEP_STEP,
+	LAND_INFO,
+	POPULATION_INFO,
 } from '@kingdom-builder/contents';
 import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
 
 const RESOURCE_KEYS = Object.keys(RESOURCES) as ResourceKey[];
 
 vi.mock('@kingdom-builder/engine', async () => {
-  return await import('../../engine/src');
+	return await import('../../engine/src');
 });
 
 describe('log resource sources', () => {
-  it('ignores opponent mills when logging farm gains', () => {
-    const ctx = createEngine({
-      actions: ACTIONS,
-      buildings: BUILDINGS,
-      developments: DEVELOPMENTS,
-      populations: POPULATIONS,
-      phases: PHASES,
-      start: GAME_START,
-      rules: RULES,
-    });
-    // Give opponent a mill
-    ctx.game.currentPlayerIndex = 1;
-    runEffects(
-      [{ type: 'building', method: 'add', params: { id: 'mill' } }],
-      ctx,
-    );
-    ctx.game.currentPlayerIndex = 0;
+	it('ignores opponent mills when logging farm gains', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		// Give opponent a mill
+		ctx.game.currentPlayerIndex = 1;
+		runEffects(
+			[{ type: 'building', method: 'add', params: { id: 'mill' } }],
+			ctx,
+		);
+		ctx.game.currentPlayerIndex = 0;
 
-    const growthPhase = ctx.phases.find((p) => p.id === 'growth');
-    const step = growthPhase?.steps.find((s) => s.id === 'gain-income');
-    const before = snapshotPlayer(ctx.activePlayer, ctx);
-    const bundles = collectTriggerEffects(ON_GAIN_INCOME_STEP, ctx);
-    for (const bundle of bundles) runEffects(bundle.effects, ctx);
-    const effects = bundles.flatMap((bundle) => bundle.effects);
-    const after = snapshotPlayer(ctx.activePlayer, ctx);
-    const lines = diffStepSnapshots(
-      before,
-      after,
-      { ...step, effects } as typeof step,
-      ctx,
-      RESOURCE_KEYS,
-    );
-    const goldInfo = RESOURCES[Resource.gold];
-    const farmIcon = DEVELOPMENTS.get('farm')?.icon || '';
-    const b = before.resources[Resource.gold] ?? 0;
-    const a = after.resources[Resource.gold] ?? 0;
-    const delta = a - b;
-    expect(lines[0]).toBe(
-      `${goldInfo.icon} ${goldInfo.label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a}) (${goldInfo.icon}${delta >= 0 ? '+' : ''}${delta} from ${farmIcon})`,
-    );
-  });
+		const growthPhase = ctx.phases.find((p) => p.id === 'growth');
+		const step = growthPhase?.steps.find((s) => s.id === 'gain-income');
+		const before = snapshotPlayer(ctx.activePlayer, ctx);
+		const bundles = collectTriggerEffects(ON_GAIN_INCOME_STEP, ctx);
+		for (const bundle of bundles) runEffects(bundle.effects, ctx);
+		const effects = bundles.flatMap((bundle) => bundle.effects);
+		const after = snapshotPlayer(ctx.activePlayer, ctx);
+		const lines = diffStepSnapshots(
+			before,
+			after,
+			{ ...step, effects } as typeof step,
+			ctx,
+			RESOURCE_KEYS,
+		);
+		const goldInfo = RESOURCES[Resource.gold];
+		const farmIcon = DEVELOPMENTS.get('farm')?.icon || '';
+		const b = before.resources[Resource.gold] ?? 0;
+		const a = after.resources[Resource.gold] ?? 0;
+		const delta = a - b;
+		expect(lines[0]).toBe(
+			`${goldInfo.icon} ${goldInfo.label} ${delta >= 0 ? '+' : ''}${delta} (${b}→${a}) (${goldInfo.icon}${delta >= 0 ? '+' : ''}${delta} from ${farmIcon})`,
+		);
+	});
 
-  it('logs market bonus when taxing population', () => {
-    const ctx = createEngine({
-      actions: ACTIONS,
-      buildings: BUILDINGS,
-      developments: DEVELOPMENTS,
-      populations: POPULATIONS,
-      phases: PHASES,
-      start: GAME_START,
-      rules: RULES,
-    });
-    runEffects(
-      [{ type: 'building', method: 'add', params: { id: 'market' } }],
-      ctx,
-    );
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    const step = { id: 'tax', effects: ctx.actions.get('tax').effects };
-    const before = snapshotPlayer(ctx.activePlayer, ctx);
-    performAction('tax', ctx);
-    const after = snapshotPlayer(ctx.activePlayer, ctx);
-    const lines = diffStepSnapshots(before, after, step, ctx, RESOURCE_KEYS);
-    const goldInfo = RESOURCES[Resource.gold];
-    const populationIcon = '👥';
-    const marketIcon = BUILDINGS.get('market')?.icon || '';
-    const goldLine = lines.find((l) =>
-      l.startsWith(`${goldInfo.icon} ${goldInfo.label}`),
-    );
-    expect(goldLine).toMatch(
-      new RegExp(`from ${populationIcon}\\+${marketIcon}\\)$`),
-    );
-  });
+	it('logs market bonus when taxing population', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		runEffects(
+			[{ type: 'building', method: 'add', params: { id: 'market' } }],
+			ctx,
+		);
+		while (ctx.game.currentPhase !== 'main') advance(ctx);
+		const step = { id: 'tax', effects: ctx.actions.get('tax').effects };
+		const before = snapshotPlayer(ctx.activePlayer, ctx);
+		performAction('tax', ctx);
+		const after = snapshotPlayer(ctx.activePlayer, ctx);
+		const lines = diffStepSnapshots(before, after, step, ctx, RESOURCE_KEYS);
+		const goldInfo = RESOURCES[Resource.gold];
+		const populationIcon = POPULATION_INFO.icon;
+		expect(populationIcon).toBeTruthy();
+		const marketIcon = BUILDINGS.get('market')?.icon || '';
+		const goldLine = lines.find((l) =>
+			l.startsWith(`${goldInfo.icon} ${goldInfo.label}`),
+		);
+		expect(goldLine).toMatch(
+			new RegExp(`from ${populationIcon}\\+${marketIcon}\\)$`),
+		);
+	});
 
-  it('includes upkeep sources when paying upkeep', () => {
-    const ctx = createEngine({
-      actions: ACTIONS,
-      buildings: BUILDINGS,
-      developments: DEVELOPMENTS,
-      populations: POPULATIONS,
-      phases: PHASES,
-      start: GAME_START,
-      rules: RULES,
-    });
-    runEffects(
-      [{ type: 'building', method: 'add', params: { id: 'raiders_guild' } }],
-      ctx,
-    );
-    const upkeepPhase = ctx.phases.find((p) => p.id === 'upkeep');
-    const step = upkeepPhase?.steps.find((s) => s.id === 'pay-upkeep');
-    const before = snapshotPlayer(ctx.activePlayer, ctx);
-    const bundles = collectTriggerEffects(ON_PAY_UPKEEP_STEP, ctx);
-    for (const bundle of bundles) runEffects(bundle.effects, ctx);
-    const effects = bundles.flatMap((bundle) => bundle.effects);
-    const after = snapshotPlayer(ctx.activePlayer, ctx);
-    const lines = diffStepSnapshots(
-      before,
-      after,
-      { ...step, effects } as typeof step,
-      ctx,
-      RESOURCE_KEYS,
-    );
-    const goldInfo = RESOURCES[Resource.gold];
-    const goldLine = lines.find((l) =>
-      l.startsWith(`${goldInfo.icon} ${goldInfo.label}`),
-    );
-    expect(goldLine).toBeTruthy();
-    const b = before.resources[Resource.gold] ?? 0;
-    const a = after.resources[Resource.gold] ?? 0;
-    const delta = a - b;
-    const icons = effects
-      .filter((eff) => eff.params?.['key'] === Resource.gold)
-      .map((eff) => {
-        const source = (
-          eff.meta as {
-            source?: { type?: string; id?: string; count?: number };
-          }
-        )?.source;
-        if (!source?.type) return '';
-        if (source.type === 'population') {
-          const role = source.id;
-          const icon = role
-            ? POPULATIONS.get(role)?.icon || role
-            : POPULATION_INFO.icon;
-          if (!icon) return '';
-          if (source.count === undefined) return icon;
-          const rawCount = Number(source.count);
-          if (!Number.isFinite(rawCount)) return icon;
-          const normalizedCount =
-            rawCount > 0 ? Math.max(1, Math.round(rawCount)) : 0;
-          if (normalizedCount === 0) return '';
-          return icon.repeat(normalizedCount);
-        }
-        if (source.type === 'development' && source.id)
-          return ctx.developments.get(source.id)?.icon || '';
-        if (source.type === 'building' && source.id)
-          return ctx.buildings.get(source.id)?.icon || '';
-        if (source.type === 'land') return LAND_INFO.icon || '';
-        return '';
-      })
-      .filter(Boolean)
-      .join('');
-    expect(icons).not.toBe('');
-    const raidersGuildIcon = BUILDINGS.get('raiders_guild')?.icon || '';
-    expect(raidersGuildIcon).not.toBe('');
-    expect(icons).toContain(raidersGuildIcon);
-    const zeroPopulationIcons = Object.entries(ctx.activePlayer.population)
-      .filter(([, count]) => count === 0)
-      .map(([role]) => POPULATIONS.get(role)?.icon)
-      .filter((icon): icon is string => Boolean(icon));
-    for (const icon of zeroPopulationIcons) {
-      expect(icons).not.toContain(icon);
-    }
-    expect(goldLine).toContain(
-      `${goldInfo.icon}${delta >= 0 ? '+' : ''}${delta} from ${icons}`,
-    );
-  });
+	it('includes upkeep sources when paying upkeep', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		runEffects(
+			[{ type: 'building', method: 'add', params: { id: 'raiders_guild' } }],
+			ctx,
+		);
+		const upkeepPhase = ctx.phases.find((p) => p.id === 'upkeep');
+		const step = upkeepPhase?.steps.find((s) => s.id === 'pay-upkeep');
+		const before = snapshotPlayer(ctx.activePlayer, ctx);
+		const bundles = collectTriggerEffects(ON_PAY_UPKEEP_STEP, ctx);
+		for (const bundle of bundles) runEffects(bundle.effects, ctx);
+		const effects = bundles.flatMap((bundle) => bundle.effects);
+		const after = snapshotPlayer(ctx.activePlayer, ctx);
+		const lines = diffStepSnapshots(
+			before,
+			after,
+			{ ...step, effects } as typeof step,
+			ctx,
+			RESOURCE_KEYS,
+		);
+		const goldInfo = RESOURCES[Resource.gold];
+		const goldLine = lines.find((l) =>
+			l.startsWith(`${goldInfo.icon} ${goldInfo.label}`),
+		);
+		expect(goldLine).toBeTruthy();
+		const b = before.resources[Resource.gold] ?? 0;
+		const a = after.resources[Resource.gold] ?? 0;
+		const delta = a - b;
+		const icons = effects
+			.filter((eff) => eff.params?.['key'] === Resource.gold)
+			.map((eff) => {
+				const source = (
+					eff.meta as {
+						source?: { type?: string; id?: string; count?: number };
+					}
+				)?.source;
+				if (!source?.type) return '';
+				if (source.type === 'population') {
+					const role = source.id;
+					const icon = role
+						? POPULATIONS.get(role)?.icon || role
+						: POPULATION_INFO.icon;
+					if (!icon) return '';
+					if (source.count === undefined) return icon;
+					const rawCount = Number(source.count);
+					if (!Number.isFinite(rawCount)) return icon;
+					const normalizedCount =
+						rawCount > 0 ? Math.max(1, Math.round(rawCount)) : 0;
+					if (normalizedCount === 0) return '';
+					return icon.repeat(normalizedCount);
+				}
+				if (source.type === 'development' && source.id)
+					return ctx.developments.get(source.id)?.icon || '';
+				if (source.type === 'building' && source.id)
+					return ctx.buildings.get(source.id)?.icon || '';
+				if (source.type === 'land') return LAND_INFO.icon || '';
+				return '';
+			})
+			.filter(Boolean)
+			.join('');
+		expect(icons).not.toBe('');
+		const raidersGuildIcon = BUILDINGS.get('raiders_guild')?.icon || '';
+		expect(raidersGuildIcon).not.toBe('');
+		expect(icons).toContain(raidersGuildIcon);
+		const zeroPopulationIcons = Object.entries(ctx.activePlayer.population)
+			.filter(([, count]) => count === 0)
+			.map(([role]) => POPULATIONS.get(role)?.icon)
+			.filter((icon): icon is string => Boolean(icon));
+		for (const icon of zeroPopulationIcons) {
+			expect(icons).not.toContain(icon);
+		}
+		expect(goldLine).toContain(
+			`${goldInfo.icon}${delta >= 0 ? '+' : ''}${delta} from ${icons}`,
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- add a dedicated registry of meta icon renderers for the log translation helpers
- refactor meta source handling to use the registry instead of switch logic
- expand translation tests to cover icon rendering for every meta source type

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68deb9977f7c8325b685fb5e8f455a06