### PR TITLE
Fix panel heights and add scrollbars

### DIFF
--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -39,7 +39,7 @@ const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
 	return (
 		<section
 			ref={ref}
-			className="relative flex h-full min-h-[275px] w-full flex-col gap-3 rounded-3xl border border-white/60 bg-white/75 px-6 py-6 shadow-2xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/50 frosted-surface"
+			className="relative flex h-[320px] w-full flex-col gap-3 overflow-hidden rounded-3xl border border-white/60 bg-white/75 px-6 py-6 shadow-2xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/50 frosted-surface"
 		>
 			<div className="absolute -top-6 left-4 rounded-full border border-white/60 bg-white/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-700 shadow-sm dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-200 frosted-surface">
 				<span>
@@ -81,7 +81,7 @@ const PhasePanel = React.forwardRef<HTMLDivElement>((_, ref) => {
 			</div>
 			<ul
 				ref={phaseStepsRef}
-				className="flex-1 space-y-3 overflow-hidden text-left text-sm"
+				className="flex-1 space-y-3 overflow-y-auto text-left text-sm custom-scrollbar"
 			>
 				{phaseSteps.map((s, i) => {
 					const stepClasses = [

--- a/packages/web/src/components/player/PlayerPanel.tsx
+++ b/packages/web/src/components/player/PlayerPanel.tsx
@@ -22,7 +22,7 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
 	const animateSections = useAnimate<HTMLDivElement>();
 	return (
 		<div
-			className={`player-panel flex h-full flex-col gap-2 text-slate-800 dark:text-slate-100 ${className}`}
+			className={`player-panel flex h-[320px] flex-col gap-2 overflow-y-auto text-slate-800 custom-scrollbar dark:text-slate-100 ${className}`}
 		>
 			<h3 className="text-lg font-semibold tracking-tight">
 				{isActive && (


### PR DESCRIPTION
## Summary
- set the phase panel to a fixed 320px height and enable scrolling with the shared custom scrollbar styling
- align the player panels to the same fixed height and scrolling behavior so overflow content remains accessible

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68debd818b288325baad279147935afd