### PR TITLE
Improve typing for attack target handlers

### DIFF
--- a/packages/engine/src/effects/attack_target_handlers/building.ts
+++ b/packages/engine/src/effects/attack_target_handlers/building.ts
@@ -1,10 +1,10 @@
 import { runEffects } from '..';
-import type { AttackTargetHandler } from './index';
+import type { AttackTargetHandler, AttackTargetMutationResult } from './index';
 import type { BuildingAttackTarget } from '../attack.types';
 
 const buildingHandler: AttackTargetHandler<
 	BuildingAttackTarget,
-	{ existed: boolean; destroyed: boolean }
+	AttackTargetMutationResult<'building'>
 > = {
 	applyDamage(target, damage, ctx, defender, meta) {
 		const existed = defender.buildings.has(target.id);

--- a/packages/engine/src/effects/attack_target_handlers/index.ts
+++ b/packages/engine/src/effects/attack_target_handlers/index.ts
@@ -1,12 +1,6 @@
 import type { EngineContext } from '../../context';
 import type { PlayerState } from '../../state';
-import type {
-	AttackEvaluationTargetLog,
-	AttackTarget,
-	BuildingAttackTarget,
-	ResourceAttackTarget,
-	StatAttackTarget,
-} from '../attack.types';
+import type { AttackEvaluationTargetLog, AttackTarget } from '../attack.types';
 
 import buildingHandler from './building';
 import resourceHandler from './resource';
@@ -16,6 +10,21 @@ export interface AttackTargetHandlerMeta {
 	defenderIndex: number;
 	originalIndex: number;
 }
+
+export type AttackTargetType = AttackTarget['type'];
+
+type AttackTargetForType<T extends AttackTargetType> = Extract<
+	AttackTarget,
+	{ type: T }
+>;
+
+export type AttackTargetMutationResult<T extends AttackTargetType> = T extends
+	| 'resource'
+	| 'stat'
+	? { before: number; after: number }
+	: T extends 'building'
+		? { existed: boolean; destroyed: boolean }
+		: never;
 
 export interface AttackTargetHandler<
 	T extends AttackTarget,
@@ -39,17 +48,9 @@ export interface AttackTargetHandler<
 }
 
 export type AttackTargetHandlerMap = {
-	resource: AttackTargetHandler<
-		ResourceAttackTarget,
-		{ before: number; after: number }
-	>;
-	stat: AttackTargetHandler<
-		StatAttackTarget,
-		{ before: number; after: number }
-	>;
-	building: AttackTargetHandler<
-		BuildingAttackTarget,
-		{ existed: boolean; destroyed: boolean }
+	[Type in AttackTargetType]: AttackTargetHandler<
+		AttackTargetForType<Type>,
+		AttackTargetMutationResult<Type>
 	>;
 };
 

--- a/packages/engine/src/effects/attack_target_handlers/resource.ts
+++ b/packages/engine/src/effects/attack_target_handlers/resource.ts
@@ -1,9 +1,9 @@
-import type { AttackTargetHandler } from './index';
+import type { AttackTargetHandler, AttackTargetMutationResult } from './index';
 import type { ResourceAttackTarget } from '../attack.types';
 
 const resourceHandler: AttackTargetHandler<
 	ResourceAttackTarget,
-	{ before: number; after: number }
+	AttackTargetMutationResult<'resource'>
 > = {
 	applyDamage(target, damage, _ctx, defender) {
 		const before = defender.resources[target.key] || 0;

--- a/packages/engine/src/effects/attack_target_handlers/stat.ts
+++ b/packages/engine/src/effects/attack_target_handlers/stat.ts
@@ -1,9 +1,9 @@
-import type { AttackTargetHandler } from './index';
+import type { AttackTargetHandler, AttackTargetMutationResult } from './index';
 import type { StatAttackTarget } from '../attack.types';
 
 const statHandler: AttackTargetHandler<
 	StatAttackTarget,
-	{ before: number; after: number }
+	AttackTargetMutationResult<'stat'>
 > = {
 	applyDamage(target, damage, _ctx, defender) {
 		const before = defender.stats[target.key] || 0;


### PR DESCRIPTION
## Summary
- add shared attack target typing utilities that map target type to handler mutation payloads
- update resource, stat, and building attack target handlers to use the shared mutation typing

## Testing
- npm run test -- resolveAttack *(fails: coverage threshold not met when running a narrowed suite)*
- npx vitest run packages/engine/tests/resolveAttack.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68deb9886b3c8325ab5405c60db2f0c7