### PR TITLE
Implement happiness threshold controller

### DIFF
--- a/packages/engine/src/effects/resource_add.ts
+++ b/packages/engine/src/effects/resource_add.ts
@@ -2,15 +2,16 @@ import type { EffectHandler } from '.';
 import type { ResourceKey } from '../state';
 
 export const resourceAdd: EffectHandler = (effect, ctx, mult = 1) => {
-  const key = effect.params!['key'] as ResourceKey;
-  const amount = effect.params!['amount'] as number;
-  let total = amount * mult;
-  if (effect.round === 'up')
-    total = total >= 0 ? Math.ceil(total) : Math.floor(total);
-  else if (effect.round === 'down')
-    total = total >= 0 ? Math.floor(total) : Math.ceil(total);
-  const current = ctx.activePlayer.resources[key] || 0;
-  const newVal = current + total;
-  ctx.activePlayer.resources[key] = newVal < 0 ? 0 : newVal;
-  if (total > 0) ctx.recentResourceGains.push({ key, amount: total });
+	const key = effect.params!['key'] as ResourceKey;
+	const amount = effect.params!['amount'] as number;
+	let total = amount * mult;
+	if (effect.round === 'up')
+		total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+	else if (effect.round === 'down')
+		total = total >= 0 ? Math.floor(total) : Math.ceil(total);
+	const current = ctx.activePlayer.resources[key] || 0;
+	const newVal = current + total;
+	ctx.activePlayer.resources[key] = newVal < 0 ? 0 : newVal;
+	if (total > 0) ctx.recentResourceGains.push({ key, amount: total });
+	ctx.services.handleTieredResourceChange(ctx, key);
 };

--- a/packages/engine/src/effects/resource_remove.ts
+++ b/packages/engine/src/effects/resource_remove.ts
@@ -2,18 +2,19 @@ import type { EffectHandler } from '.';
 import type { ResourceKey } from '../state';
 
 export const resourceRemove: EffectHandler = (effect, ctx, mult = 1) => {
-  const key = effect.params!['key'] as ResourceKey;
-  const amount = effect.params!['amount'] as number;
-  let total = amount * mult;
-  if (effect.round === 'up')
-    total = total >= 0 ? Math.ceil(total) : Math.floor(total);
-  else if (effect.round === 'down')
-    total = total >= 0 ? Math.floor(total) : Math.ceil(total);
-  if (total < 0) total = 0;
-  const have = ctx.activePlayer.resources[key] || 0;
-  const allowShortfall = Boolean(effect.meta?.['allowShortfall']);
-  const removed = total;
-  if (!allowShortfall && have < removed)
-    throw new Error(`Insufficient ${key}: need ${removed}, have ${have}`);
-  ctx.activePlayer.resources[key] = have - removed;
+	const key = effect.params!['key'] as ResourceKey;
+	const amount = effect.params!['amount'] as number;
+	let total = amount * mult;
+	if (effect.round === 'up')
+		total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+	else if (effect.round === 'down')
+		total = total >= 0 ? Math.floor(total) : Math.ceil(total);
+	if (total < 0) total = 0;
+	const have = ctx.activePlayer.resources[key] || 0;
+	const allowShortfall = Boolean(effect.meta?.['allowShortfall']);
+	const removed = total;
+	if (!allowShortfall && have < removed)
+		throw new Error(`Insufficient ${key}: need ${removed}, have ${have}`);
+	ctx.activePlayer.resources[key] = have - removed;
+	ctx.services.handleTieredResourceChange(ctx, key);
 };

--- a/packages/engine/src/setup/create_engine.ts
+++ b/packages/engine/src/setup/create_engine.ts
@@ -189,6 +189,7 @@ export function createEngine({
 	engineContext.game.currentPlayerIndex = 0;
 	engineContext.game.currentPhase = phases[0]?.id || '';
 	engineContext.game.currentStep = phases[0]?.steps[0]?.id || '';
+	services.initializeTierPassives(engineContext);
 	return engineContext;
 }
 

--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -3,158 +3,162 @@ import type { EffectDef } from '../effects';
 export const Resource: Record<string, string> = {};
 export type ResourceKey = string;
 export function setResourceKeys(keys: string[]) {
-  for (const key of Object.keys(Resource)) delete Resource[key];
-  for (const key of keys) Resource[key] = key;
+	for (const key of Object.keys(Resource)) delete Resource[key];
+	for (const key of keys) Resource[key] = key;
 }
 
 export const Stat: Record<string, string> = {};
 export type StatKey = string;
 export function setStatKeys(keys: string[]) {
-  for (const key of Object.keys(Stat)) delete Stat[key];
-  for (const key of keys) Stat[key] = key;
+	for (const key of Object.keys(Stat)) delete Stat[key];
+	for (const key of keys) Stat[key] = key;
 }
 
 export const Phase: Record<string, string> = {};
 export type PhaseId = string;
 export function setPhaseKeys(keys: string[]) {
-  for (const key of Object.keys(Phase)) delete Phase[key];
-  for (const id of keys) Phase[id.charAt(0).toUpperCase() + id.slice(1)] = id;
+	for (const key of Object.keys(Phase)) delete Phase[key];
+	for (const id of keys) Phase[id.charAt(0).toUpperCase() + id.slice(1)] = id;
 }
 
 export const PopulationRole: Record<string, string> = {};
 export type PopulationRoleId = string;
 export function setPopulationRoleKeys(keys: string[]) {
-  for (const key of Object.keys(PopulationRole)) delete PopulationRole[key];
-  for (const id of keys)
-    PopulationRole[id.charAt(0).toUpperCase() + id.slice(1)] = id;
+	for (const key of Object.keys(PopulationRole)) delete PopulationRole[key];
+	for (const id of keys)
+		PopulationRole[id.charAt(0).toUpperCase() + id.slice(1)] = id;
 }
 
 export interface StatSourceLink {
-  type?: string;
-  id?: string;
-  detail?: string;
-  extra?: Record<string, unknown>;
+	type?: string;
+	id?: string;
+	detail?: string;
+	extra?: Record<string, unknown>;
 }
 
 export interface StatSourceMeta {
-  key: string;
-  longevity: 'ongoing' | 'permanent';
-  kind?: string;
-  id?: string;
-  detail?: string;
-  instance?: string;
-  dependsOn?: StatSourceLink[];
-  removal?: StatSourceLink;
-  effect?: {
-    type?: string | undefined;
-    method?: string | undefined;
-  };
-  extra?: Record<string, unknown>;
+	key: string;
+	longevity: 'ongoing' | 'permanent';
+	kind?: string;
+	id?: string;
+	detail?: string;
+	instance?: string;
+	dependsOn?: StatSourceLink[];
+	removal?: StatSourceLink;
+	effect?: {
+		type?: string | undefined;
+		method?: string | undefined;
+	};
+	extra?: Record<string, unknown>;
 }
 
 export interface StatSourceContribution {
-  amount: number;
-  meta: StatSourceMeta;
+	amount: number;
+	meta: StatSourceMeta;
 }
 
 export type PlayerId = 'A' | 'B';
 
 export class Land {
-  id: string;
-  slotsMax: number;
-  slotsUsed = 0;
-  developments: string[] = [];
-  tilled = false;
-  upkeep?: Record<ResourceKey, number>;
-  onPayUpkeepStep?: EffectDef[];
-  onGainIncomeStep?: EffectDef[];
-  onGainAPStep?: EffectDef[];
-  constructor(id: string, slotsMax: number, tilled = false) {
-    this.id = id;
-    this.slotsMax = slotsMax;
-    this.tilled = tilled;
-  }
-  get slotsFree() {
-    return this.slotsMax - this.slotsUsed;
-  }
+	id: string;
+	slotsMax: number;
+	slotsUsed = 0;
+	developments: string[] = [];
+	tilled = false;
+	upkeep?: Record<ResourceKey, number>;
+	onPayUpkeepStep?: EffectDef[];
+	onGainIncomeStep?: EffectDef[];
+	onGainAPStep?: EffectDef[];
+	constructor(id: string, slotsMax: number, tilled = false) {
+		this.id = id;
+		this.slotsMax = slotsMax;
+		this.tilled = tilled;
+	}
+	get slotsFree() {
+		return this.slotsMax - this.slotsUsed;
+	}
 }
 
 export class PlayerState {
-  id: PlayerId;
-  name: string;
-  resources: Record<ResourceKey, number>;
-  stats: Record<StatKey, number>;
-  /**
-   * Tracks whether a stat has ever been non-zero. This allows the UI to hide
-   * stats that are zero and have never changed while still showing stats that
-   * returned to zero after previously having a value.
-   */
-  statsHistory: Record<StatKey, boolean>;
-  population: Record<PopulationRoleId, number>;
-  lands: Land[] = [];
-  buildings: Set<string> = new Set();
-  actions: Set<string> = new Set();
-  statSources: Record<StatKey, Record<string, StatSourceContribution>>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-  constructor(id: PlayerId, name: string) {
-    this.id = id;
-    this.name = name;
-    this.resources = {};
-    for (const key of Object.values(Resource)) {
-      this.resources[key] = 0;
-      Object.defineProperty(this, key, {
-        get: () => this.resources[key],
-        set: (v: number) => {
-          this.resources[key] = v;
-        },
-        enumerable: false,
-        configurable: true,
-      });
-    }
-    this.stats = {};
-    this.statsHistory = {};
-    this.statSources = {} as Record<
-      StatKey,
-      Record<string, StatSourceContribution>
-    >;
-    for (const key of Object.values(Stat)) {
-      this.stats[key] = 0;
-      this.statsHistory[key] = false;
-      this.statSources[key] = {};
-      Object.defineProperty(this, key, {
-        get: () => this.stats[key],
-        set: (v: number) => {
-          this.stats[key] = v;
-          if (v !== 0) this.statsHistory[key] = true;
-        },
-        enumerable: false,
-        configurable: true,
-      });
-    }
-    this.population = {};
-    for (const key of Object.values(PopulationRole)) {
-      this.population[key] = 0;
-    }
-  }
+	id: PlayerId;
+	name: string;
+	resources: Record<ResourceKey, number>;
+	stats: Record<StatKey, number>;
+	/**
+	 * Tracks whether a stat has ever been non-zero. This allows the UI to hide
+	 * stats that are zero and have never changed while still showing stats that
+	 * returned to zero after previously having a value.
+	 */
+	statsHistory: Record<StatKey, boolean>;
+	population: Record<PopulationRoleId, number>;
+	lands: Land[] = [];
+	buildings: Set<string> = new Set();
+	actions: Set<string> = new Set();
+	statSources: Record<StatKey, Record<string, StatSourceContribution>>;
+	skipPhases: Record<string, Record<string, true>>;
+	skipSteps: Record<string, Record<string, Record<string, true>>>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	[key: string]: any;
+	constructor(id: PlayerId, name: string) {
+		this.id = id;
+		this.name = name;
+		this.resources = {};
+		for (const key of Object.values(Resource)) {
+			this.resources[key] = 0;
+			Object.defineProperty(this, key, {
+				get: () => this.resources[key],
+				set: (v: number) => {
+					this.resources[key] = v;
+				},
+				enumerable: false,
+				configurable: true,
+			});
+		}
+		this.stats = {};
+		this.statsHistory = {};
+		this.statSources = {} as Record<
+			StatKey,
+			Record<string, StatSourceContribution>
+		>;
+		for (const key of Object.values(Stat)) {
+			this.stats[key] = 0;
+			this.statsHistory[key] = false;
+			this.statSources[key] = {};
+			Object.defineProperty(this, key, {
+				get: () => this.stats[key],
+				set: (v: number) => {
+					this.stats[key] = v;
+					if (v !== 0) this.statsHistory[key] = true;
+				},
+				enumerable: false,
+				configurable: true,
+			});
+		}
+		this.population = {};
+		for (const key of Object.values(PopulationRole)) {
+			this.population[key] = 0;
+		}
+		this.skipPhases = {};
+		this.skipSteps = {};
+	}
 }
 
 export class GameState {
-  turn = 1;
-  currentPlayerIndex = 0; // multi-player friendly
-  currentPhase = '';
-  currentStep = '';
-  phaseIndex = 0;
-  stepIndex = 0;
-  devMode = false;
-  players: PlayerState[];
-  constructor(aName = 'Player', bName = 'Opponent') {
-    this.players = [new PlayerState('A', aName), new PlayerState('B', bName)];
-  }
-  get active(): PlayerState {
-    return this.players[this.currentPlayerIndex]!;
-  }
-  get opponent(): PlayerState {
-    return this.players[(this.currentPlayerIndex + 1) % this.players.length]!;
-  }
+	turn = 1;
+	currentPlayerIndex = 0; // multi-player friendly
+	currentPhase = '';
+	currentStep = '';
+	phaseIndex = 0;
+	stepIndex = 0;
+	devMode = false;
+	players: PlayerState[];
+	constructor(aName = 'Player', bName = 'Opponent') {
+		this.players = [new PlayerState('A', aName), new PlayerState('B', bName)];
+	}
+	get active(): PlayerState {
+		return this.players[this.currentPlayerIndex]!;
+	}
+	get opponent(): PlayerState {
+		return this.players[(this.currentPlayerIndex + 1) % this.players.length]!;
+	}
 }

--- a/packages/engine/tests/happiness-tier-controller.test.ts
+++ b/packages/engine/tests/happiness-tier-controller.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import {
+	RULES,
+	PHASES,
+	Resource as CResource,
+} from '@kingdom-builder/contents';
+import {
+	happinessTier,
+	tierPassive,
+} from '@kingdom-builder/contents/config/builders';
+import { runEffects, getActionCosts } from '../src';
+import { createTestEngine } from './helpers';
+import { createContentFactory } from './factories/content';
+import type { RuleSet } from '../src/services';
+
+describe('happiness tier controller', () => {
+	it('swaps tier passives and updates skip markers when thresholds change', () => {
+		const [firstPhase, secondPhase] = PHASES;
+		const growthPhaseId = firstPhase?.id ?? '';
+		const upkeepPhaseId = secondPhase?.id ?? growthPhaseId;
+		const payUpkeepStepId =
+			secondPhase?.steps?.[0]?.id ?? firstPhase?.steps?.[0]?.id ?? '';
+
+		const customRules: RuleSet = {
+			...RULES,
+			tierDefinitions: [
+				happinessTier('test:tier:low')
+					.range(0, 2)
+					.passive(
+						tierPassive('test:passive:low')
+							.skipPhase(growthPhaseId)
+							.text((text) => text.removal('test.removal.low')),
+					)
+					.display((display) => display.removalCondition('test.removal.low'))
+					.build(),
+				happinessTier('test:tier:high')
+					.range(3)
+					.passive(
+						tierPassive('test:passive:high')
+							.skipStep(upkeepPhaseId, payUpkeepStepId)
+							.text((text) => text.removal('test.removal.high')),
+					)
+					.display((display) => display.removalCondition('test.removal.high'))
+					.build(),
+			],
+		};
+
+		const ctx = createTestEngine({ rules: customRules });
+		const player = ctx.activePlayer;
+		const happinessKey = customRules.tieredResourceKey;
+		const lowPassiveId = customRules.tierDefinitions[0]!.passive.id;
+		const highPassiveId = customRules.tierDefinitions[1]!.passive.id;
+
+		expect(ctx.passives.list(player.id)).toContain(lowPassiveId);
+		expect(player.skipPhases[growthPhaseId]?.[lowPassiveId]).toBe(true);
+
+		runEffects(
+			[
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: happinessKey, amount: 5 },
+				},
+			],
+			ctx,
+		);
+
+		const idsAfterGain = ctx.passives.list(player.id);
+		expect(idsAfterGain).toContain(highPassiveId);
+		expect(idsAfterGain).not.toContain(lowPassiveId);
+		expect(player.skipPhases[growthPhaseId]).toBeUndefined();
+		const highSkipBucket = player.skipSteps[upkeepPhaseId]?.[payUpkeepStepId];
+		expect(highSkipBucket?.[highPassiveId]).toBe(true);
+
+		const defsAfterGain = ctx.passives.values(player.id);
+		const highIndex = idsAfterGain.indexOf(highPassiveId);
+		expect(highIndex).toBeGreaterThan(-1);
+		const highMeta = defsAfterGain[highIndex]!.meta;
+		const highTier = customRules.tierDefinitions[1]!;
+		expect(highMeta?.source?.id).toBe(highTier.id);
+		expect(highMeta?.removal?.token).toBe(highTier.display?.removalCondition);
+		expect(highMeta?.removal?.text).toBe(highTier.passive.text?.removal);
+
+		runEffects(
+			[
+				{
+					type: 'resource',
+					method: 'remove',
+					params: { key: happinessKey, amount: 5 },
+				},
+			],
+			ctx,
+		);
+
+		expect(ctx.passives.list(player.id)).not.toContain(highPassiveId);
+		expect(player.skipSteps[upkeepPhaseId]).toBeUndefined();
+	});
+
+	it('applies tier passive modifiers additively with existing cost modifiers', () => {
+		const customRules: RuleSet = {
+			...RULES,
+			tierDefinitions: [
+				happinessTier('test:tier:base')
+					.range(0, 2)
+					.passive(
+						tierPassive('test:passive:base').text((text) =>
+							text.summary('test.base'),
+						),
+					)
+					.build(),
+				happinessTier('test:tier:boosted')
+					.range(3)
+					.passive(
+						tierPassive('test:passive:boosted')
+							.effect({
+								type: 'cost_mod',
+								method: 'add',
+								params: {
+									id: 'tier:discount',
+									key: CResource.gold,
+									percent: 0.1,
+								},
+							})
+							.text((text) => text.summary('test.boosted')),
+					)
+					.build(),
+			],
+		};
+
+		const content = createContentFactory();
+		const costAction = content.action({
+			baseCosts: { [CResource.gold]: 20 },
+		});
+		const ctx = createTestEngine({
+			actions: content.actions,
+			rules: customRules,
+		});
+
+		const baseCost = getActionCosts(costAction.id, ctx)[CResource.gold] ?? 0;
+		expect(baseCost).toBeCloseTo(20);
+
+		ctx.passives.registerCostModifier('external', () => ({
+			percent: { [CResource.gold]: 0.05 },
+		}));
+
+		const withExternal =
+			getActionCosts(costAction.id, ctx)[CResource.gold] ?? 0;
+		expect(withExternal).toBeCloseTo(20 * (1 + 0.05));
+
+		runEffects(
+			[
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: customRules.tieredResourceKey, amount: 3 },
+				},
+			],
+			ctx,
+		);
+
+		const idsAfterGain = ctx.passives.list(ctx.activePlayer.id);
+		const boostedPassiveId = customRules.tierDefinitions[1]!.passive.id;
+		expect(idsAfterGain).toContain(boostedPassiveId);
+
+		const withTierPassive =
+			getActionCosts(costAction.id, ctx)[CResource.gold] ?? 0;
+		expect(withTierPassive).toBeCloseTo(20 * (1 + 0.05 + 0.1));
+
+		runEffects(
+			[
+				{
+					type: 'resource',
+					method: 'remove',
+					params: { key: customRules.tieredResourceKey, amount: 3 },
+				},
+			],
+			ctx,
+		);
+
+		const afterDrop = getActionCosts(costAction.id, ctx)[CResource.gold] ?? 0;
+		expect(afterDrop).toBeCloseTo(20 * (1 + 0.05));
+	});
+});

--- a/packages/engine/tests/helpers.ts
+++ b/packages/engine/tests/helpers.ts
@@ -1,39 +1,43 @@
 import { createEngine } from '../src/index.ts';
 import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
 } from '@kingdom-builder/contents';
 import type {
-  ActionConfig as ActionDef,
-  BuildingConfig as BuildingDef,
-  DevelopmentConfig as DevelopmentDef,
-  PopulationConfig as PopulationDef,
-  StartConfig,
+	ActionConfig as ActionDef,
+	BuildingConfig as BuildingDef,
+	DevelopmentConfig as DevelopmentDef,
+	PopulationConfig as PopulationDef,
+	StartConfig,
 } from '../src/config/schema.ts';
 import type { Registry } from '../src/registry.ts';
 import type { PhaseDef } from '../src/phases.ts';
+import type { RuleSet } from '../src/services';
 
 const BASE: {
-  actions: Registry<ActionDef>;
-  buildings: Registry<BuildingDef>;
-  developments: Registry<DevelopmentDef>;
-  populations: Registry<PopulationDef>;
-  phases: PhaseDef[];
-  start: StartConfig;
+	actions: Registry<ActionDef>;
+	buildings: Registry<BuildingDef>;
+	developments: Registry<DevelopmentDef>;
+	populations: Registry<PopulationDef>;
+	phases: PhaseDef[];
+	start: StartConfig;
 } = {
-  actions: ACTIONS,
-  buildings: BUILDINGS,
-  developments: DEVELOPMENTS,
-  populations: POPULATIONS,
-  phases: PHASES,
-  start: GAME_START,
+	actions: ACTIONS,
+	buildings: BUILDINGS,
+	developments: DEVELOPMENTS,
+	populations: POPULATIONS,
+	phases: PHASES,
+	start: GAME_START,
 };
 
-export function createTestEngine(overrides: Partial<typeof BASE> = {}) {
-  return createEngine({ ...BASE, ...overrides, rules: RULES });
+type EngineOverrides = Partial<typeof BASE> & { rules?: RuleSet };
+
+export function createTestEngine(overrides: EngineOverrides = {}) {
+	const { rules, ...rest } = overrides;
+	return createEngine({ ...BASE, ...rest, rules: rules ?? RULES });
 }


### PR DESCRIPTION
## Summary
- add metadata types and tier lifecycle management to the engine services
- react to tiered resource gains/losses by swapping tier passives and tracking skip flags
- expand test utilities and add coverage for the happiness tier controller behaviors

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68debe3770e8832584158e0ebd3dc070