### PR TITLE
Respect happiness skip markers in turn flow

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -51,4 +51,8 @@ export { applyParamsToEffects } from './utils';
 export { snapshotPlayer } from './log';
 export type { PlayerSnapshot, ActionTrace } from './log';
 export type { ActionParameters as ActionParams } from './actions/action_parameters';
-export type { AdvanceResult } from './phases/advance';
+export type {
+	AdvanceResult,
+	AdvanceSkip,
+	AdvanceSkipSource,
+} from './phases/advance';

--- a/packages/engine/src/phases/advance.ts
+++ b/packages/engine/src/phases/advance.ts
@@ -4,12 +4,27 @@ import { withStatSourceFrames } from '../stat_sources';
 import type { EngineContext } from '../context';
 import type { EffectDef } from '../effects';
 import type { PlayerState, StatKey } from '../state';
+import type { PassiveMetadata } from '../services';
+
+export interface AdvanceSkipSource {
+	id: string;
+	detail?: string;
+	meta?: PassiveMetadata;
+}
+
+export interface AdvanceSkip {
+	type: 'phase' | 'step';
+	phaseId: string;
+	stepId?: string;
+	sources: AdvanceSkipSource[];
+}
 
 export interface AdvanceResult {
 	phase: string;
 	step: string;
 	effects: EffectDef[];
 	player: PlayerState;
+	skipped?: AdvanceSkip;
 }
 
 function createPhaseStatFrame(
@@ -66,44 +81,76 @@ function runTriggerBundles(
 	});
 }
 
-export function advance(engineContext: EngineContext): AdvanceResult {
-	const currentPhaseDefinition =
-		engineContext.phases[engineContext.game.phaseIndex]!;
-	const currentStepDefinition =
-		currentPhaseDefinition.steps[engineContext.game.stepIndex];
-	const actingPlayer = engineContext.activePlayer;
-	const appliedEffects: EffectDef[] = [];
-	const phaseFrame = createPhaseStatFrame(
-		currentPhaseDefinition.id,
-		currentStepDefinition?.id,
-	);
-	const triggerIds = currentStepDefinition?.triggers ?? [];
-	if (triggerIds.length > 0) {
-		runTriggerBundles(
-			triggerIds,
-			engineContext,
-			actingPlayer,
-			phaseFrame,
-			appliedEffects,
-		);
+function gatherSkipSources(
+	engineContext: EngineContext,
+	player: PlayerState,
+	sourceIds: string[],
+): AdvanceSkipSource[] {
+	return sourceIds.map((id) => {
+		const passive = engineContext.passives.get(id, player.id);
+		const entry: AdvanceSkipSource = { id };
+		if (passive?.detail !== undefined) {
+			entry.detail = passive.detail;
+		}
+		if (passive?.meta !== undefined) {
+			entry.meta = passive.meta;
+		}
+		return entry;
+	});
+}
+
+function resolvePhaseSkip(
+	engineContext: EngineContext,
+	player: PlayerState,
+	phaseId: string,
+): AdvanceSkip | undefined {
+	const skipSources = player.skipPhases[phaseId];
+	if (!skipSources) {
+		return undefined;
 	}
-	const stepEffects = currentStepDefinition?.effects;
-	if (stepEffects) {
-		withStatSourceFrames(engineContext, phaseFrame, () => {
-			runEffects(stepEffects, engineContext);
-		});
-		appliedEffects.push(...stepEffects);
+	const ids = Object.keys(skipSources);
+	if (ids.length === 0) {
+		return undefined;
 	}
-	if (currentStepDefinition) {
-		withStatSourceFrames(engineContext, phaseFrame, () => {
-			engineContext.passives.runResultMods(
-				currentStepDefinition.id,
-				engineContext,
-			);
-		});
+	return {
+		type: 'phase',
+		phaseId,
+		sources: gatherSkipSources(engineContext, player, ids),
+	};
+}
+
+function resolveStepSkip(
+	engineContext: EngineContext,
+	player: PlayerState,
+	phaseId: string,
+	stepId: string,
+): AdvanceSkip | undefined {
+	const skipMap = player.skipSteps[phaseId];
+	const bucket = skipMap?.[stepId];
+	if (!bucket) {
+		return undefined;
 	}
-	engineContext.game.stepIndex += 1;
-	if (engineContext.game.stepIndex >= currentPhaseDefinition.steps.length) {
+	const ids = Object.keys(bucket);
+	if (ids.length === 0) {
+		return undefined;
+	}
+	return {
+		type: 'step',
+		phaseId,
+		stepId,
+		sources: gatherSkipSources(engineContext, player, ids),
+	};
+}
+
+function moveToNext(engineContext: EngineContext, skipPhase: boolean): void {
+	const phaseIndex = engineContext.game.phaseIndex;
+	const phaseDefinition = engineContext.phases[phaseIndex]!;
+	if (skipPhase) {
+		engineContext.game.stepIndex = phaseDefinition.steps.length;
+	} else {
+		engineContext.game.stepIndex += 1;
+	}
+	if (engineContext.game.stepIndex >= phaseDefinition.steps.length) {
 		engineContext.game.stepIndex = 0;
 		engineContext.game.phaseIndex += 1;
 		if (engineContext.game.phaseIndex >= engineContext.phases.length) {
@@ -117,18 +164,78 @@ export function advance(engineContext: EngineContext): AdvanceResult {
 			}
 		}
 	}
-	const nextPhaseDefinition =
-		engineContext.phases[engineContext.game.phaseIndex]!;
-	const nextStepDefinition =
-		nextPhaseDefinition.steps[engineContext.game.stepIndex];
+	const nextPhaseIndex = engineContext.game.phaseIndex;
+	const nextStepIndex = engineContext.game.stepIndex;
+	const nextPhaseDefinition = engineContext.phases[nextPhaseIndex]!;
+	const nextStepDefinition = nextPhaseDefinition.steps[nextStepIndex];
 	engineContext.game.currentPhase = nextPhaseDefinition.id;
 	engineContext.game.currentStep = nextStepDefinition
 		? nextStepDefinition.id
 		: '';
+}
+
+export function advance(engineContext: EngineContext): AdvanceResult {
+	const phaseIndex = engineContext.game.phaseIndex;
+	const stepIndex = engineContext.game.stepIndex;
+	const currentPhaseDefinition = engineContext.phases[phaseIndex]!;
+	const currentStepDefinition = currentPhaseDefinition.steps[stepIndex];
+	const actingPlayer = engineContext.activePlayer;
+	const appliedEffects: EffectDef[] = [];
+
+	let skipped = resolvePhaseSkip(
+		engineContext,
+		actingPlayer,
+		currentPhaseDefinition.id,
+	);
+
+	if (!skipped && currentStepDefinition) {
+		skipped = resolveStepSkip(
+			engineContext,
+			actingPlayer,
+			currentPhaseDefinition.id,
+			currentStepDefinition.id,
+		);
+	}
+
+	if (!skipped) {
+		const phaseFrame = createPhaseStatFrame(
+			currentPhaseDefinition.id,
+			currentStepDefinition?.id,
+		);
+		const triggerIds = currentStepDefinition?.triggers ?? [];
+		if (triggerIds.length > 0) {
+			runTriggerBundles(
+				triggerIds,
+				engineContext,
+				actingPlayer,
+				phaseFrame,
+				appliedEffects,
+			);
+		}
+		const stepEffects = currentStepDefinition?.effects;
+		if (stepEffects) {
+			withStatSourceFrames(engineContext, phaseFrame, () => {
+				runEffects(stepEffects, engineContext);
+			});
+			appliedEffects.push(...stepEffects);
+		}
+		if (currentStepDefinition) {
+			withStatSourceFrames(engineContext, phaseFrame, () => {
+				engineContext.passives.runResultMods(
+					currentStepDefinition.id,
+					engineContext,
+				);
+			});
+		}
+	}
+
+	moveToNext(engineContext, skipped?.type === 'phase');
+
 	return {
 		phase: currentPhaseDefinition.id,
 		step: currentStepDefinition?.id || '',
 		effects: appliedEffects,
 		player: actingPlayer,
+		...(skipped ? { skipped } : {}),
 	};
 }

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -360,7 +360,7 @@ export class PassiveManager {
 			.map(([, v]) => v);
 	}
 
-	get(id: string, owner: PlayerId): StoredPassive | undefined {
+	get(id: string, owner: PlayerId): PassiveRecord | undefined {
 		return this.passives.get(this.makeKey(id, owner));
 	}
 }

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -20,7 +20,8 @@ type PassiveRecord = PassiveSummary & {
 	onAttackResolved?: EffectDef[];
 	owner: PlayerId;
 	frames: StatSourceFrame[];
-  meta?: PassiveMetadata;
+	detail?: string;
+	meta?: PassiveMetadata;
 };
 
 export type TierRange = {
@@ -173,25 +174,13 @@ export type EvaluationModifier = (
 	gains: ResourceGain[],
 ) => EvaluationModifierResult | void;
 
-type StoredPassive = {
-	effects?: EffectDef[];
-	onGrowthPhase?: EffectDef[];
-	onUpkeepPhase?: EffectDef[];
-	onBeforeAttacked?: EffectDef[];
-	onAttackResolved?: EffectDef[];
-	owner: PlayerId;
-	frames: StatSourceFrame[];
-	detail?: string;
-	meta?: PassiveMetadata;
-};
-
 export class PassiveManager {
 	private costMods: Map<string, CostModifier> = new Map();
 	private resultMods: Map<string, ResultModifier> = new Map();
 	private evaluationMods: Map<string, Map<string, EvaluationModifier>> =
 		new Map();
 	private evaluationIndex: Map<string, string> = new Map();
-	private passives: Map<string, StoredPassive> = new Map();
+	private passives: Map<string, PassiveRecord> = new Map();
 
 	private makeKey(id: string, owner: PlayerId) {
 		return `${id}_${owner}`;

--- a/packages/engine/tests/advance-skip.test.ts
+++ b/packages/engine/tests/advance-skip.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { RULES, PHASES } from '@kingdom-builder/contents';
+import {
+	happinessTier,
+	tierPassive,
+} from '@kingdom-builder/contents/config/builders';
+import { advance } from '../src';
+import { createTestEngine } from './helpers';
+import type { RuleSet } from '../src/services';
+
+const growthPhaseId = PHASES[0]?.id ?? '';
+const upkeepPhase =
+	PHASES.find((phase) => phase.id !== growthPhaseId) ?? PHASES[0];
+const upkeepPhaseId = upkeepPhase?.id ?? '';
+const warRecoveryStepId =
+	upkeepPhase?.steps.find((step) => step.id.includes('war-recovery'))?.id ?? '';
+const mainPhase =
+	PHASES[
+		(PHASES.findIndex((phase) => phase.id === upkeepPhaseId) + 1) %
+			PHASES.length
+	];
+
+const phaseSummary = 'test.summary.phase';
+const stepSummary = 'test.summary.step';
+
+describe('advance skip handling', () => {
+	it('skips an entire phase when markers are present', () => {
+		const customRules: RuleSet = {
+			...RULES,
+			tierDefinitions: [
+				happinessTier('test:tier:skip-phase')
+					.range(0, 5)
+					.passive(
+						tierPassive('test:passive:skip-phase')
+							.skipPhase(growthPhaseId)
+							.text((text) => text.summary(phaseSummary)),
+					)
+					.build(),
+			],
+		};
+
+		const ctx = createTestEngine({ rules: customRules });
+		const result = advance(ctx);
+
+		expect(result.effects).toHaveLength(0);
+		expect(result.phase).toBe(growthPhaseId);
+		expect(result.skipped?.type).toBe('phase');
+		expect(result.skipped?.phaseId).toBe(growthPhaseId);
+		expect(result.skipped?.sources[0]?.id).toBe(
+			customRules.tierDefinitions[0]?.passive.id,
+		);
+		expect(result.skipped?.sources[0]?.detail).toBe(phaseSummary);
+
+		expect(ctx.game.currentPhase).toBe(upkeepPhaseId);
+		const firstUpkeepStep =
+			PHASES.find((phase) => phase.id === upkeepPhaseId)?.steps[0]?.id ?? '';
+		expect(ctx.game.currentStep).toBe(firstUpkeepStep);
+	});
+
+	it('skips individual steps when markers are present', () => {
+		const customRules: RuleSet = {
+			...RULES,
+			tierDefinitions: [
+				happinessTier('test:tier:skip-step')
+					.range(0, 5)
+					.passive(
+						tierPassive('test:passive:skip-step')
+							.skipStep(upkeepPhaseId, warRecoveryStepId)
+							.text((text) => text.summary(stepSummary)),
+					)
+					.build(),
+			],
+		};
+
+		const ctx = createTestEngine({ rules: customRules });
+		const upkeepIndex = PHASES.findIndex((phase) => phase.id === upkeepPhaseId);
+		const stepIndex =
+			upkeepPhase?.steps.findIndex((step) => step.id === warRecoveryStepId) ??
+			0;
+
+		ctx.game.phaseIndex = upkeepIndex;
+		ctx.game.currentPhase = upkeepPhaseId;
+		ctx.game.stepIndex = stepIndex;
+		ctx.game.currentStep = warRecoveryStepId;
+
+		const result = advance(ctx);
+
+		expect(result.effects).toHaveLength(0);
+		expect(result.phase).toBe(upkeepPhaseId);
+		expect(result.step).toBe(warRecoveryStepId);
+		expect(result.skipped?.type).toBe('step');
+		expect(result.skipped?.phaseId).toBe(upkeepPhaseId);
+		expect(result.skipped?.stepId).toBe(warRecoveryStepId);
+		expect(result.skipped?.sources[0]?.detail).toBe(stepSummary);
+
+		expect(ctx.game.currentPhase).toBe(mainPhase?.id ?? '');
+		const expectedStep = mainPhase?.steps[0]?.id ?? '';
+		expect(ctx.game.currentStep).toBe(expectedStep);
+	});
+
+	it('collects metadata for every skip source to support logging', () => {
+		const customRules: RuleSet = {
+			...RULES,
+			tierDefinitions: [
+				happinessTier('test:tier:skip-phase')
+					.range(0, 5)
+					.passive(
+						tierPassive('test:passive:skip-phase')
+							.skipPhase(growthPhaseId)
+							.text((text) => text.summary(phaseSummary)),
+					)
+					.build(),
+			],
+		};
+
+		const ctx = createTestEngine({ rules: customRules });
+		ctx.passives.addPassive({ id: 'test:passive:extra' }, ctx, {
+			detail: 'Extra skip detail',
+			meta: {
+				source: {
+					id: 'test:extra',
+					icon: '🔥',
+					labelToken: 'tier.extra',
+				},
+			},
+		});
+		const skipBucket = ctx.activePlayer.skipPhases[growthPhaseId] ?? {};
+		skipBucket['test:passive:extra'] = true;
+		ctx.activePlayer.skipPhases[growthPhaseId] = skipBucket;
+
+		const result = advance(ctx);
+
+		const sources = result.skipped?.sources ?? [];
+		expect(result.skipped?.type).toBe('phase');
+		expect(sources).toHaveLength(2);
+		const byId = Object.fromEntries(
+			sources.map((source) => [source.id, source]),
+		);
+		const tierPassiveId = customRules.tierDefinitions[0]?.passive.id ?? '';
+		expect(byId[tierPassiveId]?.detail).toBe(phaseSummary);
+		expect(byId['test:passive:extra']?.detail).toBe('Extra skip detail');
+		expect(byId['test:passive:extra']?.meta?.source?.icon).toBe('🔥');
+		expect(byId['test:passive:extra']?.meta?.source?.labelToken).toBe(
+			'tier.extra',
+		);
+	});
+});

--- a/packages/web/src/utils/describeSkipEvent.ts
+++ b/packages/web/src/utils/describeSkipEvent.ts
@@ -1,0 +1,80 @@
+import type { AdvanceSkip } from '@kingdom-builder/engine';
+
+type PhaseLike = {
+	id: string;
+	label?: string;
+	icon?: string;
+};
+
+type StepLike = {
+	id: string;
+	title?: string;
+	icon?: string;
+};
+
+type HistoryItem = { text: string; italic?: boolean };
+
+type SkipDescription = {
+	logLines: string[];
+	history: { title: string; items: HistoryItem[] };
+};
+
+function renderLabel(
+	icon: string | undefined,
+	label: string | undefined,
+	fallback: string,
+) {
+	const trimmedLabel = label && label.trim().length > 0 ? label : fallback;
+	if (icon && icon.trim().length > 0) {
+		return `${icon} ${trimmedLabel}`;
+	}
+	return trimmedLabel;
+}
+
+function describeSources(skip: AdvanceSkip) {
+	if (!skip.sources.length) {
+		return { list: [] as string[], summary: 'Skipped' };
+	}
+	const list = skip.sources.map((source) => {
+		const icon = source.meta?.source?.icon ?? '';
+		const detail = source.detail;
+		const labelToken = source.meta?.source?.labelToken;
+		const id = source.meta?.source?.id ?? source.id;
+		const label = detail ?? labelToken ?? id;
+		if (icon) {
+			return `${icon} ${label}`;
+		}
+		return label;
+	});
+	return { list, summary: `Skipped due to: ${list.join(', ')}` };
+}
+
+export function describeSkipEvent(
+	skip: AdvanceSkip,
+	phase: PhaseLike,
+	step?: StepLike,
+): SkipDescription {
+	const phaseLabel = renderLabel(phase.icon, phase.label, phase.id);
+	if (skip.type === 'phase') {
+		const { list, summary } = describeSources(skip);
+		const header = `⏭️ ${phaseLabel} Phase skipped`;
+		const logLines = list.length
+			? [header, ...list.map((item) => `  • ${item}`)]
+			: [header];
+		const historyItems: HistoryItem[] = [{ text: summary, italic: true }];
+		return {
+			logLines,
+			history: { title: `${phaseLabel} Phase`, items: historyItems },
+		};
+	}
+
+	const stepLabel = renderLabel(step?.icon, step?.title, skip.stepId ?? '');
+	const { list, summary } = describeSources(skip);
+	const header = stepLabel ? `⏭️ ${stepLabel} skipped` : '⏭️ Step skipped';
+	const logLines = list.length
+		? [header, ...list.map((item) => `  • ${item}`)]
+		: [header];
+	const historyItems: HistoryItem[] = [{ text: summary, italic: true }];
+	const title = step?.title ?? skip.stepId ?? 'Skipped Step';
+	return { logLines, history: { title, items: historyItems } };
+}

--- a/packages/web/tests/describe-skip-event.test.ts
+++ b/packages/web/tests/describe-skip-event.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import type { AdvanceSkip } from '@kingdom-builder/engine';
+import { describeSkipEvent } from '../src/utils/describeSkipEvent';
+
+describe('describeSkipEvent', () => {
+	it('formats phase skip entries with source summaries', () => {
+		const skip: AdvanceSkip = {
+			type: 'phase',
+			phaseId: 'growth',
+			sources: [
+				{
+					id: 'passive:golden-age',
+					detail: 'Golden Age',
+					meta: { source: { id: 'tier:golden', icon: '✨' } },
+				},
+			],
+		};
+		const phase = { id: 'growth', label: 'Growth', icon: '🌱' };
+
+		const result = describeSkipEvent(skip, phase);
+
+		expect(result.logLines[0]).toContain('Phase skipped');
+		expect(result.logLines[1]).toContain('Golden Age');
+		expect(result.history.title).toBe('🌱 Growth Phase');
+		expect(result.history.items[0]?.italic).toBe(true);
+		expect(result.history.items[0]?.text).toContain('Golden Age');
+	});
+
+	it('formats step skip entries with fallback labels', () => {
+		const skip: AdvanceSkip = {
+			type: 'step',
+			phaseId: 'upkeep',
+			stepId: 'war-recovery',
+			sources: [
+				{
+					id: 'passive:morale-crash',
+					meta: { source: { id: 'tier:grim', labelToken: 'tier.grim' } },
+				},
+			],
+		};
+		const phase = { id: 'upkeep', label: 'Upkeep', icon: '🧹' };
+		const step = { id: 'war-recovery', title: 'War recovery', icon: '🛡️' };
+
+		const result = describeSkipEvent(skip, phase, step);
+
+		expect(result.logLines[0]).toContain('War recovery');
+		expect(result.logLines).toHaveLength(2);
+		expect(result.history.title).toBe('War recovery');
+		expect(result.history.items[0]?.text).toContain('tier.grim');
+	});
+
+	it('lists each skip source on separate log lines', () => {
+		const skip: AdvanceSkip = {
+			type: 'phase',
+			phaseId: 'twilight',
+			sources: [
+				{
+					id: 'passive:first',
+					detail: 'First Source',
+					meta: { source: { id: 'tier:first', icon: '✨' } },
+				},
+				{
+					id: 'passive:second',
+					meta: { source: { id: 'tier:second', icon: '⚔️' } },
+				},
+			],
+		};
+		const phase = { id: 'twilight', label: 'Twilight', icon: '🌒' };
+
+		const result = describeSkipEvent(skip, phase);
+
+		expect(result.logLines).toHaveLength(3);
+		expect(result.logLines[0]).toContain('Phase skipped');
+		expect(result.logLines[1]).toMatch(/^\s+• /);
+		expect(result.logLines[2]).toMatch(/^\s+• /);
+		expect(result.history.items[0]?.text).toContain('First Source');
+		expect(result.history.items[0]?.text).toContain('tier:second');
+	});
+});


### PR DESCRIPTION
## Summary
- extend the turn advance routine to resolve phase/step skip metadata and surface it with passives
- add engine and web helpers so skipped phases/steps create clear log and history entries
- cover the new behavior with engine integration tests plus describeSkipEvent unit tests

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dec3bb9c648325a81a9c23c0bfcc82