### PR TITLE
Refactor stat source evaluator dependency collectors

### DIFF
--- a/packages/engine/src/stat_sources/index.ts
+++ b/packages/engine/src/stat_sources/index.ts
@@ -1,8 +1,16 @@
-export { collectEvaluatorDependencies } from './dependencies';
+export {
+	collectEvaluatorDependencies,
+	evaluatorDependencyCollectorRegistry,
+	registerEvaluatorDependencyCollector,
+} from './dependencies';
 export { withStatSourceFrames } from './frames';
 export {
 	applyStatDelta,
 	recordEffectStatDelta,
 	resolveStatSourceMeta,
 } from './resolver';
-export type { StatSourceFrame, StatSourceMetaPartial } from './types';
+export type {
+	StatSourceFrame,
+	StatSourceMetaPartial,
+	EvaluatorDependencyCollector,
+} from './types';

--- a/packages/engine/src/stat_sources/types.ts
+++ b/packages/engine/src/stat_sources/types.ts
@@ -1,5 +1,6 @@
 import type { EffectDef } from '../effects';
 import type { EngineContext } from '../context';
+import type { EvaluatorDef } from '../evaluators';
 import type {
 	PlayerState,
 	StatKey,
@@ -29,3 +30,7 @@ export type StatSourceFrame = (
 ) => StatSourceMetaPartial | undefined;
 
 export type { PlayerState, StatKey, StatSourceLink, StatSourceMeta };
+
+export interface EvaluatorDependencyCollector {
+	(evaluator: EvaluatorDef): StatSourceLink[];
+}


### PR DESCRIPTION
## Summary
- introduce a registry of evaluator dependency collectors for stat source lookups
- expose registration utilities and collector interface so callers can extend the dependency gathering
- expand stat source metadata tests to cover registry-driven overrides

## Testing
- npm run test:coverage *(fails: packages/engine/tests/happiness-tier-controller.test.ts due to existing assertions on passive listing shape)*

------
https://chatgpt.com/codex/tasks/task_e_68dec8f09c8083258e4a6bc9954913f6