### PR TITLE
Refactor attack formatters into target-specific handlers

### DIFF
--- a/packages/web/src/translation/effects/formatters/attack.ts
+++ b/packages/web/src/translation/effects/formatters/attack.ts
@@ -1,417 +1,278 @@
-import {
-  BUILDINGS,
-  RESOURCES,
-  STATS,
-  Resource,
-  Stat,
-  type ResourceKey,
-  type StatKey,
-} from '@kingdom-builder/contents';
+import { STATS, Stat, type ResourceKey } from '@kingdom-builder/contents';
 import type {
-  AttackLog,
-  AttackOnDamageLogEntry,
-  AttackPlayerDiff,
-  EngineContext,
-  EffectDef,
+	AttackLog,
+	AttackOnDamageLogEntry,
+	EngineContext,
+	EffectDef,
 } from '@kingdom-builder/engine';
 import type { SummaryEntry } from '../../content';
 import {
-  registerEffectFormatter,
-  summarizeEffects,
-  describeEffects,
+	registerEffectFormatter,
+	summarizeEffects,
+	describeEffects,
 } from '../factory';
-import { formatStatValue } from '../../../utils/stats';
-import { createAttackTargetFormatter } from './attack/target-formatter';
+import {
+	resolveAttackTargetFormatter,
+	resolveAttackTargetFormatterFromLogTarget,
+	type AttackTarget,
+	type AttackTargetFormatter,
+	type TargetInfo,
+	type Mode,
+} from './attack/target-formatter';
 
-type Mode = 'summarize' | 'describe';
+const DAMAGE_EFFECT_CATEGORIES: Record<
+	string,
+	(item: SummaryEntry, mode: Mode) => SummaryEntry[]
+> = {
+	'action:perform': (item, mode) => [
+		mode === 'summarize' && typeof item !== 'string'
+			? (item as { title: string }).title
+			: item,
+	],
+};
 
-type DamageEffectFormatter = (item: SummaryEntry, mode: Mode) => SummaryEntry[];
-
-const DAMAGE_EFFECT_CATEGORIES: Record<string, DamageEffectFormatter> = {
-  'action:perform': (item, mode) => [
-    mode === 'summarize' && typeof item !== 'string'
-      ? (item as { title: string }).title
-      : item,
-  ],
+type BaseEntryResult = {
+	entry: SummaryEntry;
+	formatter: AttackTargetFormatter;
+	info: TargetInfo;
+	target: AttackTarget;
+	targetLabel: string;
 };
 
 function categorizeDamageEffects(
-  def: EffectDef,
-  item: SummaryEntry,
-  mode: Mode,
+	def: EffectDef,
+	item: SummaryEntry,
+	mode: Mode,
 ): { actions: SummaryEntry[]; others: SummaryEntry[] } {
-  const key = `${def.type}:${def.method}`;
-  const handler = DAMAGE_EFFECT_CATEGORIES[key];
-  if (handler) return { actions: handler(item, mode), others: [] };
-  return { actions: [], others: [item] };
+	const key = `${def.type}:${def.method}`;
+	const handler = DAMAGE_EFFECT_CATEGORIES[key];
+	if (handler) return { actions: handler(item, mode), others: [] };
+	return { actions: [], others: [item] };
 }
 
 function ownerLabel(owner: 'attacker' | 'defender') {
-  return owner === 'attacker' ? 'You' : 'Opponent';
+	return owner === 'attacker' ? 'You' : 'Opponent';
 }
 
-function formatNumber(value: number): string {
-  if (Number.isInteger(value)) return value.toString();
-  return value.toLocaleString(undefined, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  });
-}
-
-function formatPercent(value: number): string {
-  return `${formatNumber(value * 100)}%`;
-}
-
-function formatSigned(value: number): string {
-  const formatted = formatNumber(Math.abs(value));
-  return `${value >= 0 ? '+' : '-'}${formatted}`;
-}
-
-function formatStatSigned(key: string, value: number): string {
-  const formatted = formatStatValue(key, Math.abs(value));
-  return `${value >= 0 ? '+' : '-'}${formatted}`;
-}
-
-function getBuildingDisplay(id: string): { icon: string; label: string } {
-  try {
-    const def = BUILDINGS.get(id);
-    return { icon: def.icon ?? '', label: def.name ?? id };
-  } catch {
-    return { icon: '', label: id };
-  }
-}
-
-function getTargetInfo(eff: EffectDef<Record<string, unknown>>): {
-  target:
-    | { type: 'resource'; key: ResourceKey }
-    | { type: 'stat'; key: StatKey }
-    | { type: 'building'; id: string };
-  info: { icon: string; label: string };
-} {
-  const targetParam = eff.params?.['target'] as
-    | { type: 'resource'; key: ResourceKey }
-    | { type: 'stat'; key: StatKey }
-    | { type: 'building'; id: string }
-    | undefined;
-  if (targetParam?.type === 'stat')
-    return { target: targetParam, info: STATS[targetParam.key] };
-  if (targetParam?.type === 'building')
-    return { target: targetParam, info: getBuildingDisplay(targetParam.id) };
-  const key: ResourceKey =
-    targetParam && targetParam.type === 'resource'
-      ? targetParam.key
-      : Resource.castleHP;
-  return { target: { type: 'resource', key }, info: RESOURCES[key] };
-}
-
-function baseEntry(
-  eff: EffectDef<Record<string, unknown>>,
-  mode: Mode,
-): { entry: SummaryEntry; target: { icon: string; label: string } } {
-  const army = STATS[Stat.armyStrength];
-  const absorption = STATS[Stat.absorption];
-  const fort = STATS[Stat.fortificationStrength];
-  const { target, info } = getTargetInfo(eff);
-  const targetLabel = iconLabel(info.icon, info.label);
-  const targetFormatter = createAttackTargetFormatter(target);
-
-  if (mode === 'summarize') {
-    return {
-      entry: targetFormatter.summarizeBaseEntry({
-        army,
-        fort,
-        info,
-        targetLabel,
-      }),
-      target: info,
-    };
-  }
-
-  const ignoreAbsorption = Boolean(eff.params?.['ignoreAbsorption']);
-  const ignoreFortification = Boolean(eff.params?.['ignoreFortification']);
-  return {
-    entry: {
-      title: `Attack opponent with your ${army.icon} ${army.label}`,
-      items: [
-        ignoreAbsorption
-          ? `Ignoring ${absorption.icon} ${absorption.label} damage reduction`
-          : `${absorption.icon} ${absorption.label} damage reduction applied`,
-        ...(ignoreFortification
-          ? [`Damage applied directly to opponent's ${targetLabel}`]
-          : targetFormatter.describeFortificationItems({
-              fort,
-              info,
-              targetLabel,
-            })),
-      ],
-    },
-    target: info,
-  };
+function buildBaseEntry(
+	eff: EffectDef<Record<string, unknown>>,
+	mode: Mode,
+): BaseEntryResult {
+	const army = STATS[Stat.armyStrength];
+	const absorption = STATS[Stat.absorption];
+	const fort = STATS[Stat.fortificationStrength];
+	const { formatter, target, info, targetLabel } =
+		resolveAttackTargetFormatter(eff);
+	const ignoreAbsorption = Boolean(eff.params?.['ignoreAbsorption']);
+	const ignoreFortification = Boolean(eff.params?.['ignoreFortification']);
+	const entry = formatter.buildBaseEntry({
+		mode,
+		army,
+		absorption,
+		fort,
+		info,
+		target,
+		targetLabel,
+		ignoreAbsorption,
+		ignoreFortification,
+	});
+	return { entry, formatter, info, target, targetLabel };
 }
 
 function summarizeOnDamage(
-  eff: EffectDef<Record<string, unknown>>,
-  ctx: EngineContext,
-  mode: Mode,
+	eff: EffectDef<Record<string, unknown>>,
+	ctx: EngineContext,
+	mode: Mode,
+	base: BaseEntryResult,
 ): SummaryEntry | null {
-  const onDamage = eff.params?.['onDamage'] as
-    | { attacker?: EffectDef[]; defender?: EffectDef[] }
-    | undefined;
-  if (!onDamage) return null;
-  const { target, info } = getTargetInfo(eff);
-  const targetFormatter = createAttackTargetFormatter(target);
-  const format = mode === 'summarize' ? summarizeEffects : describeEffects;
-  const attackerDefs = onDamage.attacker ?? [];
-  const defenderDefs = onDamage.defender ?? [];
-  const attackerEntries = format(attackerDefs, ctx);
-  const defenderEntries = format(defenderDefs, ctx);
-  const items: SummaryEntry[] = [];
-  const actionItems: SummaryEntry[] = [];
+	const onDamage = eff.params?.['onDamage'] as
+		| { attacker?: EffectDef[]; defender?: EffectDef[] }
+		| undefined;
+	if (!onDamage) return null;
+	const { formatter, info, target, targetLabel } = base;
+	const format = mode === 'summarize' ? summarizeEffects : describeEffects;
+	const attackerDefs = onDamage.attacker ?? [];
+	const defenderDefs = onDamage.defender ?? [];
+	const attackerEntries = format(attackerDefs, ctx);
+	const defenderEntries = format(defenderDefs, ctx);
+	const items: SummaryEntry[] = [];
+	const actionItems: SummaryEntry[] = [];
 
-  const collect = (
-    defs: EffectDef[],
-    entries: SummaryEntry[],
-    suffix: string,
-  ) => {
-    entries.forEach((entry, index) => {
-      const def = defs[index]!;
-      const { actions, others } = categorizeDamageEffects(def, entry, mode);
-      actionItems.push(...actions);
-      others.forEach((other) => {
-        if (typeof other === 'string') items.push(`${other} ${suffix}`);
-        else items.push({ ...other, title: `${other.title} ${suffix}` });
-      });
-    });
-  };
+	const collect = (
+		defs: EffectDef[],
+		entries: SummaryEntry[],
+		suffix: string,
+	) => {
+		entries.forEach((entry, index) => {
+			const def = defs[index]!;
+			const { actions, others } = categorizeDamageEffects(def, entry, mode);
+			actionItems.push(...actions);
+			others.forEach((other) => {
+				if (typeof other === 'string') items.push(`${other} ${suffix}`);
+				else items.push({ ...other, title: `${other.title} ${suffix}` });
+			});
+		});
+	};
 
-  collect(defenderDefs, defenderEntries, 'for opponent');
-  collect(attackerDefs, attackerEntries, 'for you');
+	collect(defenderDefs, defenderEntries, 'for opponent');
+	collect(attackerDefs, attackerEntries, 'for you');
 
-  const combined = items.concat(actionItems);
-  if (!combined.length) return null;
-  const summaryTarget =
-    target.type === 'building' ? info.icon || info.label : info.icon;
-  const describeTarget =
-    target.type === 'building'
-      ? iconLabel(info.icon, info.label)
-      : `${info.icon} ${info.label}`;
-  return {
-    title: targetFormatter.onDamageTitle(mode, {
-      info,
-      summaryTarget,
-      describeTarget,
-    }),
-    items: combined,
-  };
+	const combined = items.concat(actionItems);
+	if (!combined.length) return null;
+	return {
+		title: formatter.buildOnDamageTitle(mode, { info, target, targetLabel }),
+		items: combined,
+	};
 }
 
 function fallbackLog(
-  eff: EffectDef<Record<string, unknown>>,
-  ctx: EngineContext,
+	eff: EffectDef<Record<string, unknown>>,
+	ctx: EngineContext,
 ): SummaryEntry[] {
-  const { entry } = baseEntry(eff, 'describe');
-  const onDamage = summarizeOnDamage(eff, ctx, 'describe');
-  const parts: SummaryEntry[] = [entry];
-  if (onDamage) parts.push(onDamage);
-  return parts;
+	const base = buildBaseEntry(eff, 'describe');
+	const onDamage = summarizeOnDamage(eff, ctx, 'describe', base);
+	const parts: SummaryEntry[] = [base.entry];
+	if (onDamage) parts.push(onDamage);
+	return parts;
 }
 
 function buildEvaluationEntry(log: AttackLog['evaluation']): SummaryEntry {
-  const army = STATS[Stat.armyStrength];
-  const absorption = STATS[Stat.absorption];
-  const fort = STATS[Stat.fortificationStrength];
-  const targetInfo =
-    log.target.type === 'building'
-      ? getBuildingDisplay(log.target.id)
-      : log.target.type === 'stat'
-        ? STATS[log.target.key as StatKey]
-        : RESOURCES[log.target.key as ResourceKey];
-  const targetLabel = iconLabel(targetInfo.icon, targetInfo.label);
-  const formatter = createAttackTargetFormatter(
-    log.target.type === 'building'
-      ? { type: 'building', id: log.target.id }
-      : log.target.type === 'stat'
-        ? { type: 'stat', key: log.target.key as StatKey }
-        : { type: 'resource', key: log.target.key as ResourceKey },
-  );
-  return formatter.buildEvaluationEntry(log, {
-    army,
-    absorption,
-    fort,
-    info: targetInfo,
-    targetLabel,
-    formatNumber,
-    formatPercent,
-    formatStatValue,
-  });
-}
-
-interface DiffFormatOptions {
-  percent?: number;
-  showPercent?: boolean;
-}
-
-function iconLabel(icon: string | undefined, label: string): string {
-  return icon ? `${icon} ${label}` : label;
-}
-
-function formatResourceDiff(
-  prefix: string,
-  diff: AttackPlayerDiff,
-  options?: DiffFormatOptions,
-): string {
-  const info = RESOURCES[diff.key as ResourceKey];
-  const icon = info?.icon || '';
-  const label = info?.label || diff.key;
-  const displayLabel = iconLabel(icon, label);
-  const delta = diff.after - diff.before;
-  const before = formatNumber(diff.before);
-  const after = formatNumber(diff.after);
-  if (options?.percent !== undefined) {
-    const magnitude = Math.abs(options.percent);
-    return `${prefix}: ${displayLabel} ${
-      delta >= 0 ? '+' : '-'
-    }${formatNumber(magnitude)}% (${before}→${after}) (${formatSigned(delta)})`;
-  }
-  if (options?.showPercent && diff.before !== 0 && delta !== 0) {
-    const pct = (delta / diff.before) * 100;
-    return `${prefix}: ${displayLabel} ${formatSigned(pct)}% (${before}→${after}) (${formatSigned(delta)})`;
-  }
-  return `${prefix}: ${displayLabel} ${formatSigned(delta)} (${before}→${after})`;
-}
-
-function formatStatDiff(prefix: string, diff: AttackPlayerDiff): string {
-  const info = STATS[diff.key as StatKey];
-  const icon = info?.icon || '';
-  const label = info?.label || diff.key;
-  const displayLabel = iconLabel(icon, label);
-  const delta = diff.after - diff.before;
-  const before = formatStatValue(String(diff.key), diff.before);
-  const after = formatStatValue(String(diff.key), diff.after);
-  return `${prefix}: ${displayLabel} ${formatStatSigned(String(diff.key), delta)} (${before}→${after})`;
-}
-
-function renderDiff(
-  prefix: string,
-  diff: AttackPlayerDiff,
-  options?: DiffFormatOptions,
-): string {
-  if (diff.type === 'resource')
-    return formatResourceDiff(prefix, diff, options);
-  return formatStatDiff(prefix, diff);
+	const { formatter, info, target, targetLabel } =
+		resolveAttackTargetFormatterFromLogTarget(log.target);
+	const army = STATS[Stat.armyStrength];
+	const absorption = STATS[Stat.absorption];
+	const fort = STATS[Stat.fortificationStrength];
+	return formatter.buildEvaluationEntry(log, {
+		army,
+		absorption,
+		fort,
+		info,
+		target,
+		targetLabel,
+	});
 }
 
 function buildActionLog(
-  entry: AttackOnDamageLogEntry,
-  ctx: EngineContext,
+	entry: AttackOnDamageLogEntry,
+	ctx: EngineContext,
+	formatter: AttackTargetFormatter,
 ): SummaryEntry {
-  const id = entry.effect.params?.['id'] as string | undefined;
-  let icon = '';
-  let name = id || 'Unknown action';
-  const transferPercents = new Map<ResourceKey, number>();
-  if (id)
-    try {
-      const def = ctx.actions.get(id);
-      icon = def.icon || '';
-      name = def.name;
-      const walk = (effects: EffectDef[] | undefined) => {
-        if (!effects) return;
-        for (const eff of effects) {
-          if (
-            eff.type === 'resource' &&
-            eff.method === 'transfer' &&
-            eff.params
-          ) {
-            const key =
-              (eff.params['key'] as ResourceKey | undefined) ?? undefined;
-            const pct = eff.params['percent'] as number | undefined;
-            if (key && pct !== undefined && !transferPercents.has(key))
-              transferPercents.set(key, pct);
-          }
-          if (Array.isArray(eff.effects))
-            walk(eff.effects as EffectDef[] | undefined);
-        }
-      };
-      walk(def.effects as EffectDef[] | undefined);
-    } catch {
-      /* ignore missing action */
-    }
-  const items: SummaryEntry[] = [];
-  entry.defender.forEach((diff) => {
-    const percent =
-      diff.type === 'resource'
-        ? transferPercents.get(diff.key as ResourceKey)
-        : undefined;
-    const options =
-      percent !== undefined ? { percent } : { showPercent: true as const };
-    items.push(renderDiff(ownerLabel('defender'), diff, options));
-  });
-  entry.attacker.forEach((diff) =>
-    items.push(renderDiff(ownerLabel('attacker'), diff)),
-  );
-  return { title: `Triggered ${icon} ${name}`.trim(), items };
+	const id = entry.effect.params?.['id'] as string | undefined;
+	let icon = '';
+	let name = id || 'Unknown action';
+	const transferPercents = new Map<ResourceKey, number>();
+	if (id)
+		try {
+			const def = ctx.actions.get(id);
+			icon = def.icon || '';
+			name = def.name;
+			const walk = (effects: EffectDef[] | undefined) => {
+				if (!effects) return;
+				for (const eff of effects) {
+					if (
+						eff.type === 'resource' &&
+						eff.method === 'transfer' &&
+						eff.params
+					) {
+						const key =
+							(eff.params['key'] as ResourceKey | undefined) ?? undefined;
+						const pct = eff.params['percent'] as number | undefined;
+						if (key && pct !== undefined && !transferPercents.has(key))
+							transferPercents.set(key, pct);
+					}
+					if (Array.isArray(eff.effects))
+						walk(eff.effects as EffectDef[] | undefined);
+				}
+			};
+			walk(def.effects as EffectDef[] | undefined);
+		} catch {
+			/* ignore missing action */
+		}
+	const items: SummaryEntry[] = [];
+	entry.defender.forEach((diff) => {
+		const percent =
+			diff.type === 'resource'
+				? transferPercents.get(diff.key as ResourceKey)
+				: undefined;
+		items.push(
+			formatter.formatDiff(
+				ownerLabel('defender'),
+				diff,
+				percent !== undefined ? { percent } : { showPercent: true as const },
+			),
+		);
+	});
+	entry.attacker.forEach((diff) =>
+		items.push(formatter.formatDiff(ownerLabel('attacker'), diff)),
+	);
+	return { title: `Triggered ${icon} ${name}`.trim(), items };
 }
 
 function buildOnDamageEntry(
-  log: AttackLog['onDamage'],
-  ctx: EngineContext,
-  eff: EffectDef<Record<string, unknown>>,
+	logEntries: AttackLog['onDamage'],
+	ctx: EngineContext,
+	eff: EffectDef<Record<string, unknown>>,
 ): SummaryEntry | null {
-  if (!log.length) return null;
-  const { target, info } = getTargetInfo(eff);
-  const targetFormatter = createAttackTargetFormatter(target);
-  const items: SummaryEntry[] = [];
-  const defenderEntries = log.filter((entry) => entry.owner === 'defender');
-  const attackerEntries = log.filter((entry) => entry.owner === 'attacker');
-  const ordered = defenderEntries.concat(attackerEntries);
-  for (const entry of ordered) {
-    if (entry.effect.type === 'action' && entry.effect.method === 'perform') {
-      items.push(buildActionLog(entry, ctx));
-      continue;
-    }
-    const percent =
-      entry.effect.type === 'resource' &&
-      entry.effect.method === 'transfer' &&
-      entry.effect.params
-        ? (entry.effect.params['percent'] as number | undefined)
-        : undefined;
-    entry.defender.forEach((diff) => {
-      if (percent !== undefined)
-        items.push(renderDiff(ownerLabel('defender'), diff, { percent }));
-      else items.push(renderDiff(ownerLabel('defender'), diff));
-    });
-    entry.attacker.forEach((diff) =>
-      items.push(renderDiff(ownerLabel('attacker'), diff)),
-    );
-  }
-  if (!items.length) return null;
-  return {
-    title: targetFormatter.onDamageLogTitle(info),
-    items,
-  };
+	if (!logEntries.length) return null;
+	const { formatter, info, target } = resolveAttackTargetFormatter(eff);
+	const items: SummaryEntry[] = [];
+	const defenderEntries = logEntries.filter(
+		(entry) => entry.owner === 'defender',
+	);
+	const attackerEntries = logEntries.filter(
+		(entry) => entry.owner === 'attacker',
+	);
+	const ordered = defenderEntries.concat(attackerEntries);
+	for (const entry of ordered) {
+		if (entry.effect.type === 'action' && entry.effect.method === 'perform') {
+			items.push(buildActionLog(entry, ctx, formatter));
+			continue;
+		}
+		const percent =
+			entry.effect.type === 'resource' &&
+			entry.effect.method === 'transfer' &&
+			entry.effect.params
+				? (entry.effect.params['percent'] as number | undefined)
+				: undefined;
+		entry.defender.forEach((diff) => {
+			if (percent !== undefined)
+				items.push(
+					formatter.formatDiff(ownerLabel('defender'), diff, { percent }),
+				);
+			else items.push(formatter.formatDiff(ownerLabel('defender'), diff));
+		});
+		entry.attacker.forEach((diff) =>
+			items.push(formatter.formatDiff(ownerLabel('attacker'), diff)),
+		);
+	}
+	if (!items.length) return null;
+	return {
+		title: formatter.onDamageLogTitle(info, target),
+		items,
+	};
 }
 
 registerEffectFormatter('attack', 'perform', {
-  summarize: (eff, ctx) => {
-    const { entry } = baseEntry(eff, 'summarize');
-    const parts: SummaryEntry[] = [entry];
-    const onDamage = summarizeOnDamage(eff, ctx, 'summarize');
-    if (onDamage) parts.push(onDamage);
-    return parts;
-  },
-  describe: (eff, ctx) => {
-    const { entry } = baseEntry(eff, 'describe');
-    const parts: SummaryEntry[] = [entry];
-    const onDamage = summarizeOnDamage(eff, ctx, 'describe');
-    if (onDamage) parts.push(onDamage);
-    return parts;
-  },
-  log: (eff, ctx) => {
-    const log = ctx.pullEffectLog<AttackLog>('attack:perform');
-    if (!log) return fallbackLog(eff, ctx);
-    const entries: SummaryEntry[] = [buildEvaluationEntry(log.evaluation)];
-    const onDamage = buildOnDamageEntry(log.onDamage, ctx, eff);
-    if (onDamage) entries.push(onDamage);
-    return entries;
-  },
+	summarize: (eff, ctx) => {
+		const base = buildBaseEntry(eff, 'summarize');
+		const parts: SummaryEntry[] = [base.entry];
+		const onDamage = summarizeOnDamage(eff, ctx, 'summarize', base);
+		if (onDamage) parts.push(onDamage);
+		return parts;
+	},
+	describe: (eff, ctx) => {
+		const base = buildBaseEntry(eff, 'describe');
+		const parts: SummaryEntry[] = [base.entry];
+		const onDamage = summarizeOnDamage(eff, ctx, 'describe', base);
+		if (onDamage) parts.push(onDamage);
+		return parts;
+	},
+	log: (eff, ctx) => {
+		const log = ctx.pullEffectLog<AttackLog>('attack:perform');
+		if (!log) return fallbackLog(eff, ctx);
+		const entries: SummaryEntry[] = [buildEvaluationEntry(log.evaluation)];
+		const onDamage = buildOnDamageEntry(log.onDamage, ctx, eff);
+		if (onDamage) entries.push(onDamage);
+		return entries;
+	},
 });

--- a/packages/web/src/translation/effects/formatters/attack/building.ts
+++ b/packages/web/src/translation/effects/formatters/attack/building.ts
@@ -1,0 +1,125 @@
+import { BUILDINGS } from '@kingdom-builder/contents';
+import type { AttackLog } from '@kingdom-builder/engine';
+import {
+	buildDescribeEntry,
+	buildingFortificationItems,
+	formatDiffCommon,
+	formatNumber,
+	formatPercent,
+	getBuildingDisplay,
+	iconLabel,
+} from './shared';
+import type { AttackTargetFormatter } from './types';
+import type { SummaryEntry } from '../../../content';
+
+const buildingFormatter: AttackTargetFormatter<{
+	type: 'building';
+	id: string;
+}> = {
+	type: 'building',
+	parseEffectTarget(effect) {
+		const targetParam = effect.params?.['target'] as
+			| { type: 'building'; id: string }
+			| undefined;
+		if (targetParam?.type === 'building') {
+			return targetParam;
+		}
+		const [id] = BUILDINGS.keys();
+		return { type: 'building', id: id ?? 'unknown_building' };
+	},
+	normalizeLogTarget(target) {
+		const buildingTarget = target as Extract<
+			AttackLog['evaluation']['target'],
+			{ type: 'building' }
+		>;
+		return { type: 'building', id: buildingTarget.id };
+	},
+	getInfo(target) {
+		return getBuildingDisplay(target.id);
+	},
+	getTargetLabel(info) {
+		return iconLabel(info.icon, info.label);
+	},
+	buildBaseEntry(context) {
+		if (context.mode === 'summarize') {
+			return `${context.army.icon} destroy opponent's ${context.targetLabel}`;
+		}
+		return buildDescribeEntry(context, buildingFortificationItems(context));
+	},
+	buildOnDamageTitle(mode, { info, targetLabel }) {
+		const summaryTarget = info.icon || info.label;
+		const describeTarget = targetLabel;
+		return mode === 'summarize'
+			? `On opponent ${summaryTarget} destruction`
+			: `On opponent ${describeTarget} destruction`;
+	},
+	buildEvaluationEntry(log, context) {
+		const { army, absorption, fort, targetLabel } = context;
+		const target = log.target as Extract<
+			AttackLog['evaluation']['target'],
+			{ type: 'building' }
+		>;
+		const absorptionPart = log.absorption.ignored
+			? `${absorption.icon} ignored`
+			: `${absorption.icon}${formatPercent(log.absorption.before)}`;
+		const fortPart = log.fortification.ignored
+			? `${fort.icon} ignored`
+			: `${fort.icon}${formatNumber(log.fortification.before)}`;
+
+		const title = `Damage evaluation: ${army.icon}${formatNumber(
+			log.power.modified,
+		)} vs. ${absorptionPart} ${fortPart} ${targetLabel}`;
+		const items: SummaryEntry[] = [];
+
+		if (log.absorption.ignored) {
+			items.push(
+				`${army.icon}${formatNumber(log.power.modified)} ignores ${absorption.icon} ${absorption.label}`,
+			);
+		} else {
+			items.push(
+				`${army.icon}${formatNumber(log.power.modified)} vs. ${absorption.icon}${formatPercent(
+					log.absorption.before,
+				)} --> ${army.icon}${formatNumber(log.absorption.damageAfter)}`,
+			);
+		}
+
+		if (log.fortification.ignored) {
+			items.push(
+				`${army.icon}${formatNumber(log.absorption.damageAfter)} bypasses ${fort.icon} ${fort.label}`,
+			);
+		} else {
+			const remaining = Math.max(
+				0,
+				log.absorption.damageAfter - log.fortification.damage,
+			);
+			items.push(
+				`${army.icon}${formatNumber(log.absorption.damageAfter)} vs. ${fort.icon}${formatNumber(
+					log.fortification.before,
+				)} --> ${fort.icon}${formatNumber(log.fortification.after)} ${army.icon}${formatNumber(
+					remaining,
+				)}`,
+			);
+		}
+
+		if (!target.existed) {
+			items.push(`No ${targetLabel} to destroy`);
+		} else {
+			const damageText = `${army.icon}${formatNumber(target.damage)}`;
+			items.push(
+				target.destroyed
+					? `${damageText} destroys ${targetLabel}`
+					: `${damageText} fails to destroy ${targetLabel}`,
+			);
+		}
+
+		return { title, items };
+	},
+	formatDiff(prefix, diff, options) {
+		return formatDiffCommon(prefix, diff, options);
+	},
+	onDamageLogTitle(info) {
+		return `${iconLabel(info.icon, info.label)} destruction trigger evaluation`;
+	},
+};
+
+export default buildingFormatter;

--- a/packages/web/src/translation/effects/formatters/attack/resource.ts
+++ b/packages/web/src/translation/effects/formatters/attack/resource.ts
@@ -1,0 +1,65 @@
+import {
+	RESOURCES,
+	Resource,
+	type ResourceKey,
+} from '@kingdom-builder/contents';
+import type { AttackLog } from '@kingdom-builder/engine';
+import {
+	buildDescribeEntry,
+	buildStandardEvaluationEntry,
+	defaultFortificationItems,
+	formatDiffCommon,
+	iconLabel,
+} from './shared';
+import type { AttackTargetFormatter } from './types';
+
+const resourceFormatter: AttackTargetFormatter<{
+	type: 'resource';
+	key: ResourceKey;
+}> = {
+	type: 'resource',
+	parseEffectTarget(effect) {
+		const targetParam = effect.params?.['target'] as
+			| { type: 'resource'; key: ResourceKey }
+			| undefined;
+		if (targetParam?.type === 'resource') {
+			return targetParam;
+		}
+		return { type: 'resource', key: Resource.castleHP };
+	},
+	normalizeLogTarget(target) {
+		const resourceTarget = target as Extract<
+			AttackLog['evaluation']['target'],
+			{ type: 'resource' }
+		>;
+		return { type: 'resource', key: resourceTarget.key as ResourceKey };
+	},
+	getInfo(target) {
+		return RESOURCES[target.key];
+	},
+	getTargetLabel(info) {
+		return iconLabel(info.icon, info.label);
+	},
+	buildBaseEntry(context) {
+		if (context.mode === 'summarize') {
+			return `${context.army.icon} opponent's ${context.fort.icon}${context.info.icon}`;
+		}
+		return buildDescribeEntry(context, defaultFortificationItems(context));
+	},
+	buildOnDamageTitle(mode, { info }) {
+		return mode === 'summarize'
+			? `On opponent ${info.icon} damage`
+			: `On opponent ${info.icon} ${info.label} damage`;
+	},
+	buildEvaluationEntry(log, context) {
+		return buildStandardEvaluationEntry(log, context, false);
+	},
+	formatDiff(prefix, diff, options) {
+		return formatDiffCommon(prefix, diff, options);
+	},
+	onDamageLogTitle(info) {
+		return `${info.icon} ${info.label} damage trigger evaluation`;
+	},
+};
+
+export default resourceFormatter;

--- a/packages/web/src/translation/effects/formatters/attack/shared.ts
+++ b/packages/web/src/translation/effects/formatters/attack/shared.ts
@@ -1,0 +1,218 @@
+import {
+	BUILDINGS,
+	RESOURCES,
+	STATS,
+	type ResourceKey,
+	type StatKey,
+} from '@kingdom-builder/contents';
+import type { AttackLog, AttackPlayerDiff } from '@kingdom-builder/engine';
+import { formatStatValue } from '../../../../utils/stats';
+import type { SummaryEntry } from '../../../content';
+import type {
+	AttackTarget,
+	BaseEntryContext,
+	DiffFormatOptions,
+	EvaluationContext,
+	TargetInfo,
+} from './types';
+
+export function iconLabel(icon: string | undefined, label: string): string {
+	return icon ? `${icon} ${label}` : label;
+}
+
+export function formatNumber(value: number): string {
+	if (Number.isInteger(value)) {
+		return value.toString();
+	}
+	return value.toLocaleString(undefined, {
+		minimumFractionDigits: 0,
+		maximumFractionDigits: 2,
+	});
+}
+
+export function formatPercent(value: number): string {
+	return `${formatNumber(value * 100)}%`;
+}
+
+function formatSigned(value: number): string {
+	const formatted = formatNumber(Math.abs(value));
+	return `${value >= 0 ? '+' : '-'}${formatted}`;
+}
+
+function formatStatSigned(key: string, value: number): string {
+	const formatted = formatStatValue(key, Math.abs(value));
+	return `${value >= 0 ? '+' : '-'}${formatted}`;
+}
+
+export function formatResourceDiff(
+	prefix: string,
+	diff: AttackPlayerDiff,
+	options?: DiffFormatOptions,
+): string {
+	const info = RESOURCES[diff.key as ResourceKey];
+	const icon = info?.icon || '';
+	const label = info?.label || diff.key;
+	const displayLabel = iconLabel(icon, label);
+	const delta = diff.after - diff.before;
+	const before = formatNumber(diff.before);
+	const after = formatNumber(diff.after);
+	if (options?.percent !== undefined) {
+		const magnitude = Math.abs(options.percent);
+		return `${prefix}: ${displayLabel} ${
+			delta >= 0 ? '+' : '-'
+		}${formatNumber(magnitude)}% (${before}→${after}) (${formatSigned(delta)})`;
+	}
+	if (options?.showPercent && diff.before !== 0 && delta !== 0) {
+		const pct = (delta / diff.before) * 100;
+		return `${prefix}: ${displayLabel} ${formatSigned(pct)}% (${before}→${after}) (${formatSigned(delta)})`;
+	}
+	return `${prefix}: ${displayLabel} ${formatSigned(delta)} (${before}→${after})`;
+}
+
+export function formatStatDiff(prefix: string, diff: AttackPlayerDiff): string {
+	const info = STATS[diff.key as StatKey];
+	const icon = info?.icon || '';
+	const label = info?.label || diff.key;
+	const displayLabel = iconLabel(icon, label);
+	const delta = diff.after - diff.before;
+	const before = formatStatValue(String(diff.key), diff.before);
+	const after = formatStatValue(String(diff.key), diff.after);
+	return `${prefix}: ${displayLabel} ${formatStatSigned(
+		String(diff.key),
+		delta,
+	)} (${before}→${after})`;
+}
+
+export function formatDiffCommon(
+	prefix: string,
+	diff: AttackPlayerDiff,
+	options?: DiffFormatOptions,
+): string {
+	if (diff.type === 'resource') {
+		return formatResourceDiff(prefix, diff, options);
+	}
+	if (diff.type === 'stat') {
+		return formatStatDiff(prefix, diff);
+	}
+	const exhaustive: never = diff;
+	throw new Error(`Unsupported attack diff: ${JSON.stringify(exhaustive)}`);
+}
+
+export function buildDescribeEntry(
+	context: BaseEntryContext<AttackTarget>,
+	fortificationItems: string[],
+): SummaryEntry {
+	const { army, absorption, ignoreAbsorption } = context;
+	const absorptionItem = ignoreAbsorption
+		? `Ignoring ${absorption.icon} ${absorption.label} damage reduction`
+		: `${absorption.icon} ${absorption.label} damage reduction applied`;
+	return {
+		title: `Attack opponent with your ${army.icon} ${army.label}`,
+		items: [absorptionItem, ...fortificationItems],
+	};
+}
+
+export function defaultFortificationItems(
+	context: BaseEntryContext<AttackTarget>,
+): string[] {
+	const { fort, targetLabel } = context;
+	return [
+		`Damage applied to opponent's ${fort.icon} ${fort.label}`,
+		`If opponent ${fort.icon} ${fort.label} reduced to 0, overflow remaining damage on opponent ${targetLabel}`,
+	];
+}
+
+export function buildingFortificationItems(
+	context: BaseEntryContext<AttackTarget>,
+): string[] {
+	const { fort, targetLabel } = context;
+	return [
+		`Damage applied to opponent's ${fort.icon} ${fort.label}`,
+		`If opponent ${fort.icon} ${fort.label} reduced to 0, overflow remaining damage attempts to destroy opponent ${targetLabel}`,
+	];
+}
+
+export function buildStandardEvaluationEntry(
+	log: AttackLog['evaluation'],
+	context: EvaluationContext<AttackTarget>,
+	isStat: boolean,
+): SummaryEntry {
+	const { army, absorption, fort, info } = context;
+	const absorptionPart = log.absorption.ignored
+		? `${absorption.icon} ignored`
+		: `${absorption.icon}${formatPercent(log.absorption.before)}`;
+	const fortPart = log.fortification.ignored
+		? `${fort.icon} ignored`
+		: `${fort.icon}${formatNumber(log.fortification.before)}`;
+	const target = log.target as Extract<
+		AttackLog['evaluation']['target'],
+		{ type: 'resource' | 'stat' }
+	>;
+	const title = `Damage evaluation: ${army.icon}${formatNumber(
+		log.power.modified,
+	)} vs. ${absorptionPart} ${fortPart} ${info.icon}${formatNumber(
+		target.before,
+	)}`;
+	const items: SummaryEntry[] = [];
+
+	if (log.absorption.ignored) {
+		items.push(
+			`${army.icon}${formatNumber(log.power.modified)} ignores ${absorption.icon} ${absorption.label}`,
+		);
+	} else {
+		items.push(
+			`${army.icon}${formatNumber(log.power.modified)} vs. ${absorption.icon}${formatPercent(
+				log.absorption.before,
+			)} --> ${army.icon}${formatNumber(log.absorption.damageAfter)}`,
+		);
+	}
+
+	if (log.fortification.ignored) {
+		items.push(
+			`${army.icon}${formatNumber(log.absorption.damageAfter)} bypasses ${fort.icon} ${fort.label}`,
+		);
+	} else {
+		const remaining = Math.max(
+			0,
+			log.absorption.damageAfter - log.fortification.damage,
+		);
+		items.push(
+			`${army.icon}${formatNumber(log.absorption.damageAfter)} vs. ${fort.icon}${formatNumber(
+				log.fortification.before,
+			)} --> ${fort.icon}${formatNumber(log.fortification.after)} ${army.icon}${formatNumber(
+				remaining,
+			)}`,
+		);
+	}
+
+	const formatTargetValue = (value: number) => {
+		if (isStat) {
+			return formatStatValue(String(target.key), value);
+		}
+		return formatNumber(value);
+	};
+	const targetDisplay = (value: number) => {
+		const formatted = formatTargetValue(value);
+		if (info.icon) {
+			return `${info.icon}${formatted}`;
+		}
+		return `${info.label} ${formatted}`;
+	};
+
+	items.push(
+		`${army.icon}${formatNumber(target.damage)} vs. ${targetDisplay(
+			target.before,
+		)} --> ${targetDisplay(target.after)}`,
+	);
+
+	return { title, items };
+}
+
+export function getBuildingDisplay(id: string): TargetInfo {
+	try {
+		const def = BUILDINGS.get(id);
+		return { icon: def.icon ?? '', label: def.name ?? id };
+	} catch {
+		return { icon: '', label: id };
+	}
+}

--- a/packages/web/src/translation/effects/formatters/attack/stat.ts
+++ b/packages/web/src/translation/effects/formatters/attack/stat.ts
@@ -1,0 +1,65 @@
+import { STATS, type StatKey } from '@kingdom-builder/contents';
+import type { AttackLog } from '@kingdom-builder/engine';
+import {
+	buildDescribeEntry,
+	buildStandardEvaluationEntry,
+	defaultFortificationItems,
+	formatDiffCommon,
+	iconLabel,
+} from './shared';
+import type { AttackTargetFormatter } from './types';
+
+const statFormatter: AttackTargetFormatter<{
+	type: 'stat';
+	key: StatKey;
+}> = {
+	type: 'stat',
+	parseEffectTarget(effect) {
+		const targetParam = effect.params?.['target'] as
+			| { type: 'stat'; key: StatKey }
+			| undefined;
+		if (targetParam?.type === 'stat') {
+			return targetParam;
+		}
+		const fallbackKey = Object.keys(STATS)[0] as StatKey | undefined;
+		if (!fallbackKey) {
+			throw new Error('No stat definitions available');
+		}
+		return { type: 'stat', key: fallbackKey };
+	},
+	normalizeLogTarget(target) {
+		const statTarget = target as Extract<
+			AttackLog['evaluation']['target'],
+			{ type: 'stat' }
+		>;
+		return { type: 'stat', key: statTarget.key as StatKey };
+	},
+	getInfo(target) {
+		return STATS[target.key];
+	},
+	getTargetLabel(info) {
+		return iconLabel(info.icon, info.label);
+	},
+	buildBaseEntry(context) {
+		if (context.mode === 'summarize') {
+			return `${context.army.icon} opponent's ${context.fort.icon}${context.info.icon}`;
+		}
+		return buildDescribeEntry(context, defaultFortificationItems(context));
+	},
+	buildOnDamageTitle(mode, { info }) {
+		return mode === 'summarize'
+			? `On opponent ${info.icon} damage`
+			: `On opponent ${info.icon} ${info.label} damage`;
+	},
+	buildEvaluationEntry(log, context) {
+		return buildStandardEvaluationEntry(log, context, true);
+	},
+	formatDiff(prefix, diff, options) {
+		return formatDiffCommon(prefix, diff, options);
+	},
+	onDamageLogTitle(info) {
+		return `${info.icon} ${info.label} damage trigger evaluation`;
+	},
+};
+
+export default statFormatter;

--- a/packages/web/src/translation/effects/formatters/attack/target-formatter.ts
+++ b/packages/web/src/translation/effects/formatters/attack/target-formatter.ts
@@ -1,219 +1,108 @@
-import type { SummaryEntry } from '../../../content';
-import type { AttackLog } from '@kingdom-builder/engine';
-import type { ResourceKey, StatKey } from '@kingdom-builder/contents';
+import type { EffectDef, AttackLog } from '@kingdom-builder/engine';
+import resourceFormatter from './resource';
+import statFormatter from './stat';
+import buildingFormatter from './building';
+import type { AttackTarget, AttackTargetFormatter, TargetInfo } from './types';
+export type {
+	Mode,
+	AttackTarget,
+	AttackTargetFormatter,
+	TargetInfo,
+} from './types';
 
-type Mode = 'summarize' | 'describe';
+export const ATTACK_TARGET_FORMATTERS = {
+	resource: resourceFormatter,
+	stat: statFormatter,
+	building: buildingFormatter,
+} as const;
 
-type TargetInfo = { icon: string; label: string };
-
-type AttackTarget =
-	| { type: 'resource'; key: ResourceKey }
-	| { type: 'stat'; key: StatKey }
-	| { type: 'building'; id: string };
-
-type StatInfo = { icon?: string; label: string };
-
-type AttackEvaluationTarget = AttackLog['evaluation']['target'];
-type NonBuildingEvaluationTarget = Extract<
-	AttackEvaluationTarget,
-	{ type: 'resource' | 'stat' }
->;
-type BuildingEvaluationTarget = Extract<
-	AttackEvaluationTarget,
-	{ type: 'building' }
->;
-
-type EvaluationContext = {
-	army: StatInfo;
-	absorption: StatInfo;
-	fort: StatInfo;
+export function resolveAttackTargetFormatter(
+	effect: EffectDef<Record<string, unknown>>,
+): {
+	formatter: AttackTargetFormatter;
+	target: AttackTarget;
 	info: TargetInfo;
 	targetLabel: string;
-	formatNumber: (value: number) => string;
-	formatPercent: (value: number) => string;
-	formatStatValue: (key: string, value: number) => string;
-};
+} {
+	const targetParam = effect.params?.['target'] as
+		| { type: AttackTarget['type'] }
+		| undefined;
+	const type = targetParam?.type ?? 'resource';
 
-type BaseEntryContext = {
-	army: StatInfo;
-	fort: StatInfo;
-	info: TargetInfo;
-	targetLabel: string;
-};
-
-type FortificationContext = {
-	fort: StatInfo;
-	info: TargetInfo;
-	targetLabel: string;
-};
-
-type OnDamageTitleContext = {
-	info: TargetInfo;
-	summaryTarget: string;
-	describeTarget: string;
-};
-
-type TargetFormatter = {
-	summarizeBaseEntry(context: BaseEntryContext): string;
-	describeFortificationItems(context: FortificationContext): string[];
-	onDamageTitle(mode: Mode, context: OnDamageTitleContext): string;
-	buildEvaluationEntry(
-		log: AttackLog['evaluation'],
-		context: EvaluationContext,
-	): SummaryEntry;
-	onDamageLogTitle(info: TargetInfo): string;
-};
-
-const defaultTargetFormatter: TargetFormatter = {
-	summarizeBaseEntry: ({ army, fort, info }) =>
-		`${army.icon} opponent's ${fort.icon}${info.icon}`,
-	describeFortificationItems: ({ fort, info }) => [
-		`Damage applied to opponent's ${fort.icon} ${fort.label}`,
-		`If opponent ${fort.icon} ${fort.label} reduced to 0, overflow remaining damage on opponent ${info.icon} ${info.label}`,
-	],
-	onDamageTitle: (mode, { info }) =>
-		mode === 'summarize'
-			? `On opponent ${info.icon} damage`
-			: `On opponent ${info.icon} ${info.label} damage`,
-	buildEvaluationEntry: (
-		log,
-		{
-			army,
-			absorption,
-			fort,
+	if (type === 'stat') {
+		const formatter = ATTACK_TARGET_FORMATTERS.stat;
+		const target = formatter.parseEffectTarget(effect);
+		const info = formatter.getInfo(target);
+		return {
+			formatter,
+			target,
 			info,
-			targetLabel: _targetLabel,
-			formatNumber,
-			formatPercent,
-			formatStatValue,
-		},
-	) => {
-		const target = log.target as NonBuildingEvaluationTarget;
-		const absorptionPart = log.absorption.ignored
-			? `${absorption.icon} ignored`
-			: `${absorption.icon}${formatPercent(log.absorption.before)}`;
-		const fortPart = log.fortification.ignored
-			? `${fort.icon} ignored`
-			: `${fort.icon}${formatNumber(log.fortification.before)}`;
-
-		const title = `Damage evaluation: ${army.icon}${formatNumber(log.power.modified)} vs. ${absorptionPart} ${fortPart} ${info.icon}${formatNumber(target.before)}`;
-		const items: SummaryEntry[] = [];
-
-		if (log.absorption.ignored) {
-			items.push(
-				`${army.icon}${formatNumber(log.power.modified)} ignores ${absorption.icon} ${absorption.label}`,
-			);
-		} else {
-			items.push(
-				`${army.icon}${formatNumber(log.power.modified)} vs. ${absorption.icon}${formatPercent(log.absorption.before)} --> ${army.icon}${formatNumber(log.absorption.damageAfter)}`,
-			);
-		}
-
-		if (log.fortification.ignored) {
-			items.push(
-				`${army.icon}${formatNumber(log.absorption.damageAfter)} bypasses ${fort.icon} ${fort.label}`,
-			);
-		} else {
-			const remaining = Math.max(
-				0,
-				log.absorption.damageAfter - log.fortification.damage,
-			);
-			items.push(
-				`${army.icon}${formatNumber(log.absorption.damageAfter)} vs. ${fort.icon}${formatNumber(log.fortification.before)} --> ${fort.icon}${formatNumber(log.fortification.after)} ${army.icon}${formatNumber(remaining)}`,
-			);
-		}
-
-		const formatTargetValue = (value: number) =>
-			target.type === 'stat'
-				? formatStatValue(String(target.key), value)
-				: formatNumber(value);
-		const targetDisplay = (value: number) =>
-			info.icon
-				? `${info.icon}${formatTargetValue(value)}`
-				: `${info.label} ${formatTargetValue(value)}`;
-
-		items.push(
-			`${army.icon}${formatNumber(target.damage)} vs. ${targetDisplay(target.before)} --> ${targetDisplay(target.after)}`,
-		);
-
-		return { title, items };
-	},
-	onDamageLogTitle: (info) =>
-		`${info.icon} ${info.label} damage trigger evaluation`,
-};
-
-const buildingTargetFormatter: TargetFormatter = {
-	summarizeBaseEntry: ({ army, targetLabel }) =>
-		`${army.icon} destroy opponent's ${targetLabel}`,
-	describeFortificationItems: ({ fort, targetLabel }) => [
-		`Damage applied to opponent's ${fort.icon} ${fort.label}`,
-		`If opponent ${fort.icon} ${fort.label} reduced to 0, overflow remaining damage attempts to destroy opponent ${targetLabel}`,
-	],
-	onDamageTitle: (mode, { summaryTarget, describeTarget }) =>
-		mode === 'summarize'
-			? `On opponent ${summaryTarget} destruction`
-			: `On opponent ${describeTarget} destruction`,
-	buildEvaluationEntry: (
-		log,
-		{ army, absorption, fort, targetLabel, formatNumber, formatPercent },
-	) => {
-		const target = log.target as BuildingEvaluationTarget;
-		const absorptionPart = log.absorption.ignored
-			? `${absorption.icon} ignored`
-			: `${absorption.icon}${formatPercent(log.absorption.before)}`;
-		const fortPart = log.fortification.ignored
-			? `${fort.icon} ignored`
-			: `${fort.icon}${formatNumber(log.fortification.before)}`;
-
-		const title = `Damage evaluation: ${army.icon}${formatNumber(log.power.modified)} vs. ${absorptionPart} ${fortPart} ${targetLabel}`;
-		const items: SummaryEntry[] = [];
-
-		if (log.absorption.ignored) {
-			items.push(
-				`${army.icon}${formatNumber(log.power.modified)} ignores ${absorption.icon} ${absorption.label}`,
-			);
-		} else {
-			items.push(
-				`${army.icon}${formatNumber(log.power.modified)} vs. ${absorption.icon}${formatPercent(log.absorption.before)} --> ${army.icon}${formatNumber(log.absorption.damageAfter)}`,
-			);
-		}
-
-		if (log.fortification.ignored) {
-			items.push(
-				`${army.icon}${formatNumber(log.absorption.damageAfter)} bypasses ${fort.icon} ${fort.label}`,
-			);
-		} else {
-			const remaining = Math.max(
-				0,
-				log.absorption.damageAfter - log.fortification.damage,
-			);
-			items.push(
-				`${army.icon}${formatNumber(log.absorption.damageAfter)} vs. ${fort.icon}${formatNumber(log.fortification.before)} --> ${fort.icon}${formatNumber(log.fortification.after)} ${army.icon}${formatNumber(remaining)}`,
-			);
-		}
-
-		if (!target.existed) {
-			items.push(`No ${targetLabel} to destroy`);
-		} else {
-			const damageText = `${army.icon}${formatNumber(target.damage)}`;
-			items.push(
-				target.destroyed
-					? `${damageText} destroys ${targetLabel}`
-					: `${damageText} fails to destroy ${targetLabel}`,
-			);
-		}
-
-		return { title, items };
-	},
-	onDamageLogTitle: (info) =>
-		`${info.icon} ${info.label} destruction trigger evaluation`,
-};
-
-export function createAttackTargetFormatter(
-	target: AttackTarget,
-): TargetFormatter {
-	if (target.type === 'building') {
-		return buildingTargetFormatter;
+			targetLabel: formatter.getTargetLabel(info, target),
+		};
 	}
-	return defaultTargetFormatter;
+
+	if (type === 'building') {
+		const formatter = ATTACK_TARGET_FORMATTERS.building;
+		const target = formatter.parseEffectTarget(effect);
+		const info = formatter.getInfo(target);
+		return {
+			formatter,
+			target,
+			info,
+			targetLabel: formatter.getTargetLabel(info, target),
+		};
+	}
+
+	const formatter = ATTACK_TARGET_FORMATTERS.resource;
+	const target = formatter.parseEffectTarget(effect);
+	const info = formatter.getInfo(target);
+	return {
+		formatter,
+		target,
+		info,
+		targetLabel: formatter.getTargetLabel(info, target),
+	};
+}
+
+export function resolveAttackTargetFormatterFromLogTarget(
+	target: AttackLog['evaluation']['target'],
+): {
+	formatter: AttackTargetFormatter;
+	target: AttackTarget;
+	info: TargetInfo;
+	targetLabel: string;
+} {
+	if (target.type === 'stat') {
+		const formatter = ATTACK_TARGET_FORMATTERS.stat;
+		const normalized = formatter.normalizeLogTarget(target);
+		const info = formatter.getInfo(normalized);
+		return {
+			formatter,
+			target: normalized,
+			info,
+			targetLabel: formatter.getTargetLabel(info, normalized),
+		};
+	}
+
+	if (target.type === 'building') {
+		const formatter = ATTACK_TARGET_FORMATTERS.building;
+		const normalized = formatter.normalizeLogTarget(target);
+		const info = formatter.getInfo(normalized);
+		return {
+			formatter,
+			target: normalized,
+			info,
+			targetLabel: formatter.getTargetLabel(info, normalized),
+		};
+	}
+
+	const formatter = ATTACK_TARGET_FORMATTERS.resource;
+	const normalized = formatter.normalizeLogTarget(target);
+	const info = formatter.getInfo(normalized);
+	return {
+		formatter,
+		target: normalized,
+		info,
+		targetLabel: formatter.getTargetLabel(info, normalized),
+	};
 }

--- a/packages/web/src/translation/effects/formatters/attack/types.ts
+++ b/packages/web/src/translation/effects/formatters/attack/types.ts
@@ -1,0 +1,75 @@
+import {
+	type AttackLog,
+	type AttackPlayerDiff,
+	type EffectDef,
+} from '@kingdom-builder/engine';
+import type { ResourceKey, StatKey } from '@kingdom-builder/contents';
+import type { SummaryEntry } from '../../../content';
+
+export type Mode = 'summarize' | 'describe';
+
+export type TargetInfo = { icon: string; label: string };
+
+export type AttackTarget =
+	| { type: 'resource'; key: ResourceKey }
+	| { type: 'stat'; key: StatKey }
+	| { type: 'building'; id: string };
+
+export type StatInfo = { icon?: string; label: string };
+
+export type BaseEntryContext<TTarget extends AttackTarget> = {
+	mode: Mode;
+	army: StatInfo;
+	absorption: StatInfo;
+	fort: StatInfo;
+	info: TargetInfo;
+	target: TTarget;
+	targetLabel: string;
+	ignoreAbsorption: boolean;
+	ignoreFortification: boolean;
+};
+
+export type OnDamageTitleContext<TTarget extends AttackTarget> = {
+	info: TargetInfo;
+	target: TTarget;
+	targetLabel: string;
+};
+
+export type EvaluationContext<TTarget extends AttackTarget> = {
+	army: StatInfo;
+	absorption: StatInfo;
+	fort: StatInfo;
+	info: TargetInfo;
+	target: TTarget;
+	targetLabel: string;
+};
+
+export type DiffFormatOptions = {
+	percent?: number;
+	showPercent?: boolean;
+};
+
+export interface AttackTargetFormatter<
+	TTarget extends AttackTarget = AttackTarget,
+> {
+	readonly type: TTarget['type'];
+	parseEffectTarget(effect: EffectDef<Record<string, unknown>>): TTarget;
+	normalizeLogTarget(target: AttackLog['evaluation']['target']): TTarget;
+	getInfo(target: TTarget): TargetInfo;
+	getTargetLabel(info: TargetInfo, target: TTarget): string;
+	buildBaseEntry(context: BaseEntryContext<TTarget>): SummaryEntry;
+	buildOnDamageTitle(
+		mode: Mode,
+		context: OnDamageTitleContext<TTarget>,
+	): string;
+	buildEvaluationEntry(
+		log: AttackLog['evaluation'],
+		context: EvaluationContext<TTarget>,
+	): SummaryEntry;
+	formatDiff(
+		prefix: string,
+		diff: AttackPlayerDiff,
+		options?: DiffFormatOptions,
+	): string;
+	onDamageLogTitle(info: TargetInfo, target: TTarget): string;
+}


### PR DESCRIPTION
## Summary
- extract attack target formatter types and shared helpers into dedicated modules
- provide resource, stat, and building formatter implementations registered via ATTACK_TARGET_FORMATTERS
- update attack effect formatter to delegate target-specific logic through the new interface

## Testing
- npx vitest run packages/web/tests/army-attack-translation.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dec8efcccc8325b157462bba280d53