### PR TITLE
Fix log panel auto-scroll overshooting bottom

### DIFF
--- a/packages/web/src/components/LogPanel.tsx
+++ b/packages/web/src/components/LogPanel.tsx
@@ -82,12 +82,23 @@ export default function LogPanel() {
 		pendingScrollRef.current = true;
 	};
 
+	const scrollToBottom = React.useCallback(
+		(element: HTMLDivElement, behavior: ScrollBehavior) => {
+			const maxScrollTop = Math.max(
+				0,
+				element.scrollHeight - element.clientHeight,
+			);
+			element.scrollTo({ top: maxScrollTop, behavior });
+		},
+		[],
+	);
+
 	useEffect(() => {
 		if (!isExpanded) return;
 		const container = scrollRef.current;
 		if (!container) return;
-		container.scrollTo({ top: container.scrollHeight, behavior: 'auto' });
-	}, [isExpanded]);
+		scrollToBottom(container, 'auto');
+	}, [isExpanded, scrollToBottom]);
 
 	useEffect(() => {
 		const container = scrollRef.current;
@@ -97,7 +108,7 @@ export default function LogPanel() {
 		pendingScrollRef.current = true;
 
 		if (typeof ResizeObserver === 'undefined') {
-			container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+			scrollToBottom(container, 'smooth');
 			return;
 		}
 
@@ -106,10 +117,7 @@ export default function LogPanel() {
 			if (!pendingScrollRef.current) return;
 			pendingScrollRef.current = false;
 			raf = window.requestAnimationFrame(() => {
-				container.scrollTo({
-					top: container.scrollHeight,
-					behavior: 'smooth',
-				});
+				scrollToBottom(container, 'smooth');
 			});
 		});
 


### PR DESCRIPTION
## Summary
- adjust the log panel auto-scroll logic to always target the true maximum scroll position
- reuse the same helper for all auto-scroll calls to avoid stopping above the latest entry

## Testing
- npm run lint
- npm run test:coverage


------
https://chatgpt.com/codex/tasks/task_e_68ded33355948325b3d85286a3d9277e