### PR TITLE
Refine player pane layout

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -30,7 +30,7 @@ function GameLayout() {
 	}, [playerHeights]);
 	const playerPanels = ctx.game.players.map((p, i) => {
 		const isActive = p.id === ctx.activePlayer.id;
-		const sideClass = i === 0 ? 'pr-6' : 'pl-6';
+		const sideClass = i === 0 ? 'lg:pr-6' : 'lg:pl-6';
 		const colorClass =
 			i === 0
 				? isActive
@@ -100,8 +100,8 @@ function GameLayout() {
 				</div>
 
 				<div className="grid grid-cols-1 gap-y-6 gap-x-6 lg:grid-cols-[minmax(0,1fr)_30rem]">
-					<section className="relative flex min-h-[275px] items-stretch rounded-3xl bg-white/70 shadow-2xl dark:bg-slate-900/70 dark:shadow-slate-900/50 frosted-surface">
-						<div className="flex flex-1 items-stretch overflow-hidden rounded-3xl divide-x divide-white/50 dark:divide-white/10">
+					<section className="relative flex min-h-[275px] items-stretch rounded-3xl bg-white/70 p-6 shadow-2xl dark:bg-slate-900/70 dark:shadow-slate-900/50 frosted-surface">
+						<div className="flex w-full flex-col gap-6 lg:flex-row lg:items-stretch lg:gap-8">
 							{playerPanels}
 						</div>
 					</section>

--- a/packages/web/src/components/player/BuildingDisplay.tsx
+++ b/packages/web/src/components/player/BuildingDisplay.tsx
@@ -13,7 +13,7 @@ const BuildingDisplay: React.FC<BuildingDisplayProps> = ({ player }) => {
 	if (player.buildings.size === 0) return null;
 	const animateBuildings = useAnimate<HTMLDivElement>();
 	return (
-		<div ref={animateBuildings} className="mt-3 flex w-full flex-wrap gap-3">
+		<div ref={animateBuildings} className="flex w-full flex-wrap gap-3">
 			{Array.from(player.buildings).map((b) => {
 				const name = ctx.buildings.get(b)?.name || b;
 				const icon = ctx.buildings.get(b)?.icon || '';

--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -138,7 +138,7 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
 	return (
 		<div
 			ref={animateLands}
-			className="mt-3 grid w-full grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+			className="grid w-full grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
 		>
 			{player.lands.map((land) => (
 				<LandTile


### PR DESCRIPTION
## Summary
- refresh the player panel with reusable section cards so resources, lands, structures and passives read as distinct areas while keeping the stats/resource bar on one line
- add spacing between opponent panels in the game layout and reuse filtered passive entries to avoid recomputing per render
- drop redundant margins from land and building displays so they sit flush inside the new section surfaces

## Testing
- npm run lint
- npm run test:coverage


------
https://chatgpt.com/codex/tasks/task_e_68ded3093004832584bd6c1778af94c5