### PR TITLE
Align result modifier descriptions across cards

### DIFF
--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -51,11 +51,12 @@ const resultModifier = modifierInfo.result;
 const costModifier = modifierInfo.cost;
 const RESULT_MODIFIER_LABEL = `${resultModifier.icon} ${resultModifier.label}`;
 const COST_MODIFIER_LABEL = `${costModifier.icon} ${costModifier.label}`;
+const RESULT_MODIFIER_INFO = modifierInfo.result;
 
 registerModifierEvalHandler('development', {
 	summarize: (eff, evaluation, ctx) => {
 		const summary = formatDevelopment(
-			RESULT_MODIFIER_LABEL,
+			RESULT_MODIFIER_INFO,
 			eff,
 			evaluation,
 			ctx,
@@ -65,7 +66,7 @@ registerModifierEvalHandler('development', {
 	},
 	describe: (eff, evaluation, ctx) => {
 		const description = formatDevelopment(
-			RESULT_MODIFIER_LABEL,
+			RESULT_MODIFIER_INFO,
 			eff,
 			evaluation,
 			ctx,
@@ -78,7 +79,7 @@ registerModifierEvalHandler('development', {
 registerModifierEvalHandler('population', {
 	summarize: (eff, evaluation, ctx) => {
 		const summary = formatPopulation(
-			RESULT_MODIFIER_LABEL,
+			RESULT_MODIFIER_INFO,
 			eff,
 			evaluation,
 			ctx,
@@ -87,7 +88,7 @@ registerModifierEvalHandler('population', {
 	},
 	describe: (eff, evaluation, ctx) => {
 		const description = formatPopulation(
-			RESULT_MODIFIER_LABEL,
+			RESULT_MODIFIER_INFO,
 			eff,
 			evaluation,
 			ctx,
@@ -100,17 +101,12 @@ registerModifierEvalHandler('transfer_pct', {
 	summarize: (eff, _evaluation, ctx) => {
 		const { icon, name } = getActionInfo(ctx, 'plunder');
 		const amount = Number(eff.params?.['adjust'] ?? 0);
-		const target = formatTargetLabel(icon, name);
-		const effect = `${RESOURCE_TRANSFER_ICON} ${increaseOrDecrease(
-			amount,
-		)} transfer by ${Math.abs(amount)}%`;
+		const targetIcon = icon && icon.trim() ? icon : name;
+		const sign = amount >= 0 ? '+' : '';
 		return [
-			formatResultModifierClause(
-				RESULT_MODIFIER_LABEL,
-				target,
-				RESULT_EVENT_TRANSFER,
-				effect,
-			),
+			`${RESULT_MODIFIER_INFO.icon}${targetIcon}: ${RESOURCE_TRANSFER_ICON}${sign}${Math.abs(
+				amount,
+			)}%`,
 		];
 	},
 	describe: (eff, _evaluation, ctx) => {
@@ -206,12 +202,12 @@ registerEffectFormatter('result_mod', 'add', {
 		const { icon: actionIcon, name: actionName } = actionId
 			? getActionInfo(ctx, actionId)
 			: { icon: '', name: 'all actions' };
-		const target = formatTargetLabel(actionIcon, actionName);
 		return wrapResultModifierEntries(
-			RESULT_MODIFIER_LABEL,
+			RESULT_MODIFIER_INFO,
 			sub,
-			target,
+			{ icon: actionIcon, name: actionName },
 			RESULT_EVENT_RESOLVE,
+			{ mode: 'summary' },
 		);
 	},
 	describe: (eff, ctx) => {
@@ -227,12 +223,12 @@ registerEffectFormatter('result_mod', 'add', {
 		const actionInfo = actionId
 			? getActionInfo(ctx, actionId)
 			: { icon: '', name: 'all actions' };
-		const target = formatTargetLabel(actionInfo.icon, actionInfo.name);
 		return wrapResultModifierEntries(
-			RESULT_MODIFIER_LABEL,
+			RESULT_MODIFIER_INFO,
 			sub,
-			target,
+			actionInfo,
 			RESULT_EVENT_RESOLVE,
+			{ mode: 'describe' },
 		);
 	},
 });

--- a/packages/web/src/translation/effects/formatters/passive.ts
+++ b/packages/web/src/translation/effects/formatters/passive.ts
@@ -7,18 +7,13 @@ import { PHASES, PASSIVE_INFO } from '@kingdom-builder/contents';
 
 registerEffectFormatter('passive', 'add', {
 	summarize: (eff, ctx) => {
-		const icon =
-			(eff.params?.['icon'] as string | undefined) ?? PASSIVE_INFO.icon;
-		const name =
-			(eff.params?.['name'] as string | undefined) ?? PASSIVE_INFO.label;
-		const prefix = icon ? `${icon} ` : '';
 		const inner = summarizeEffects(eff.effects || [], ctx);
 		const upkeepLabel =
 			PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
 		return eff.params?.['onUpkeepPhase']
 			? [
 					{
-						title: `${prefix}${name} – Until next ${upkeepLabel}`,
+						title: `⏳ Until next ${upkeepLabel}`,
 						items: inner,
 					},
 				]

--- a/packages/web/tests/hold-festival-action-translation.test.ts
+++ b/packages/web/tests/hold-festival-action-translation.test.ts
@@ -60,11 +60,6 @@ describe('hold festival action translation', () => {
 		const passive = holdFestival.effects.find(
 			(e: EffectDef) => e.type === 'passive',
 		) as EffectDef;
-		const passiveMeta = passive.params as
-			| { name?: string; icon?: string }
-			| undefined;
-		const passiveName = passiveMeta?.name ?? PASSIVE_INFO.label;
-		const passiveIcon = passiveMeta?.icon ?? PASSIVE_INFO.icon;
 		const resMod = passive.effects?.find(
 			(e: EffectDef) => e.type === 'result_mod',
 		) as EffectDef;
@@ -85,9 +80,9 @@ describe('hold festival action translation', () => {
 			`${happinessIcon}${sign(happinessAmt)}${happinessAmt}`,
 			`${fortIcon}${sign(fortAmt)}${fortAmt}`,
 			{
-				title: `${passiveIcon ? `${passiveIcon} ` : ''}${passiveName} – Until next ${upkeepLabel}`,
+				title: `⏳ Until next ${upkeepLabel}`,
 				items: [
-					`${MODIFIER_INFO.result.icon} ${MODIFIER_INFO.result.label} on ${armyAttack.icon} ${armyAttack.name}: Whenever it resolves, ${happinessIcon}${sign(penaltyAmt)}${penaltyAmt}`,
+					`${MODIFIER_INFO.result.icon}${armyAttack.icon}: ${happinessIcon}${sign(penaltyAmt)}${penaltyAmt}`,
 				],
 			},
 		]);

--- a/packages/web/tests/modifier-eval-handlers.test.ts
+++ b/packages/web/tests/modifier-eval-handlers.test.ts
@@ -71,7 +71,7 @@ describe('modifier evaluation handlers', () => {
 		const farm = ctx.developments.get('farm');
 		const happiness = RESOURCES[Resource.happiness];
 		expect(summary).toEqual([
-			`${MODIFIER_INFO.result.icon} ${MODIFIER_INFO.result.label} on ${farm.icon} ${farm.name}: Whenever it grants resources, gain ${happiness.icon}-2 more`,
+			`${MODIFIER_INFO.result.icon}${farm.icon}: ${happiness.icon}-2`,
 		]);
 		expect(description).toEqual([
 			`${MODIFIER_INFO.result.icon} ${MODIFIER_INFO.result.label} on ${farm.icon} ${farm.name}: Whenever it grants resources, gain ${happiness.icon}-2 more of that resource`,

--- a/packages/web/tests/plow-action-translation.test.ts
+++ b/packages/web/tests/plow-action-translation.test.ts
@@ -44,11 +44,6 @@ describe('plow action translation', () => {
 		const till = ctx.actions.get('till');
 		const plow = ctx.actions.get('plow');
 		const passive = plow.effects.find((e: EffectDef) => e.type === 'passive');
-		const passiveMeta = passive?.params as
-			| { name?: string; icon?: string }
-			| undefined;
-		const passiveName = passiveMeta?.name ?? PASSIVE_INFO.label;
-		const passiveIcon = passiveMeta?.icon ?? PASSIVE_INFO.icon;
 		const upkeepLabel =
 			PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
 		const costMod = passive?.effects.find(
@@ -62,7 +57,7 @@ describe('plow action translation', () => {
 			`${expand.icon} ${expand.name}`,
 			`${till.icon} ${till.name}`,
 			{
-				title: `${passiveIcon ? `${passiveIcon} ` : ''}${passiveName} – Until next ${upkeepLabel}`,
+				title: `⏳ Until next ${upkeepLabel}`,
 				items: [`💲: ${modIcon}+${modAmt}`],
 			},
 		]);

--- a/packages/web/tests/raiders-guild-translation.test.ts
+++ b/packages/web/tests/raiders-guild-translation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
 	describeContent,
 	splitSummary,
+	summarizeContent,
 	type Summary,
 } from '../src/translation/content';
 import { createEngine } from '@kingdom-builder/engine';
@@ -13,6 +14,8 @@ import {
 	PHASES,
 	GAME_START,
 	RULES,
+	MODIFIER_INFO,
+	POPULATION_INFO,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
@@ -56,5 +59,38 @@ describe('raiders guild translation', () => {
 		expect(JSON.stringify({ effects, description })).not.toMatch(
 			/Immediately|🎯/,
 		);
+	});
+
+	it('summarizes market modifier compactly', () => {
+		const ctx = createCtx();
+		const summary = summarizeContent('building', 'market', ctx);
+		const market = ctx.buildings.get('market');
+		expect(market).toBeDefined();
+		const tax = ctx.actions.get('tax');
+		const expected = `${MODIFIER_INFO.result.icon}${POPULATION_INFO.icon}(${tax.icon}): 🧺+1`;
+		const lines = summary.flatMap((entry) =>
+			typeof entry === 'string'
+				? [entry]
+				: Array.isArray(entry.items)
+					? (entry.items as string[])
+					: [],
+		);
+		expect(lines).toContain(expected);
+	});
+
+	it('summarizes mill modifier compactly', () => {
+		const ctx = createCtx();
+		const summary = summarizeContent('building', 'mill', ctx);
+		const farm = ctx.developments.get('farm');
+		expect(farm).toBeDefined();
+		const expected = `${MODIFIER_INFO.result.icon}${farm.icon}: 🧺+1`;
+		const lines = summary.flatMap((entry) =>
+			typeof entry === 'string'
+				? [entry]
+				: Array.isArray(entry.items)
+					? (entry.items as string[])
+					: [],
+		);
+		expect(lines).toContain(expected);
 	});
 });

--- a/tests/integration/market-translation.test.ts
+++ b/tests/integration/market-translation.test.ts
@@ -2,56 +2,55 @@ import { describe, it, expect } from 'vitest';
 import { createEngine } from '@kingdom-builder/engine';
 import { summarizeContent } from '@kingdom-builder/web/translation/content';
 import {
-  PHASES,
-  POPULATIONS,
-  GAME_START,
-  RULES,
+	PHASES,
+	POPULATIONS,
+	GAME_START,
+	RULES,
+	MODIFIER_INFO,
+	POPULATION_INFO,
 } from '@kingdom-builder/contents';
 import { createContentFactory } from '../../packages/engine/tests/factories/content';
 
 describe('Building translation with population bonus', () => {
-  it('mentions population and related action', () => {
-    const content = createContentFactory();
-    const action = content.action({ name: 'work', icon: '🛠️', effects: [] });
-    const building = content.building({
-      onBuild: [
-        {
-          type: 'result_mod',
-          method: 'add',
-          params: {
-            amount: 1,
-            evaluation: { type: 'population', id: action.id },
-          },
-        },
-      ],
-    });
-    const ctx = createEngine({
-      actions: content.actions,
-      buildings: content.buildings,
-      developments: content.developments,
-      populations: POPULATIONS,
-      phases: PHASES,
-      start: GAME_START,
-      rules: RULES,
-    });
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const summary = summarizeContent('building', building.id, ctx) as unknown;
-    function flatten(items: unknown[]): string[] {
-      return items.flatMap((i) =>
-        typeof i === 'string'
-          ? [i]
-          : Array.isArray((i as { items?: unknown[] }).items)
-            ? flatten((i as { items: unknown[] }).items)
-            : [],
-      );
-    }
-    const lines = flatten(summary as unknown[]);
-    expect(
-      lines.some(
-        (l) => l.includes('Population through') && l.includes(action.name),
-      ),
-    ).toBe(true);
-    expect(ctx.actions.get(action.id)).toBeDefined();
-    expect(ctx.buildings.get(building.id)).toBeDefined();
-  });
+	it('mentions population and related action', () => {
+		const content = createContentFactory();
+		const action = content.action({ name: 'work', icon: '🛠️', effects: [] });
+		const building = content.building({
+			onBuild: [
+				{
+					type: 'result_mod',
+					method: 'add',
+					params: {
+						amount: 1,
+						evaluation: { type: 'population', id: action.id },
+					},
+				},
+			],
+		});
+		const ctx = createEngine({
+			actions: content.actions,
+			buildings: content.buildings,
+			developments: content.developments,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		const summary = summarizeContent('building', building.id, ctx) as unknown;
+		function flatten(items: unknown[]): string[] {
+			return items.flatMap((i) =>
+				typeof i === 'string'
+					? [i]
+					: Array.isArray((i as { items?: unknown[] }).items)
+						? flatten((i as { items: unknown[] }).items)
+						: [],
+			);
+		}
+		const lines = flatten(summary as unknown[]);
+		const expected = `${MODIFIER_INFO.result.icon}${POPULATION_INFO.icon}(${action.icon}): 🧺+1`;
+		expect(lines.includes(expected)).toBe(true);
+		expect(ctx.actions.get(action.id)).toBeDefined();
+		expect(ctx.buildings.get(building.id)).toBeDefined();
+	});
 });


### PR DESCRIPTION
## Summary
- add shared helpers for result modifier phrasing and targets
- refactor the result modifier formatter to use the shared helpers and keep plunder descriptions focused on the action
- update translation tests for Raider's Guild and Hold Festival to match the unified wording

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68ded24dd9b88325a2355c6963218f3c