### PR TITLE
Improve player panel layout

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -100,8 +100,8 @@ function GameLayout() {
 				</div>
 
 				<div className="grid grid-cols-1 gap-y-6 gap-x-6 lg:grid-cols-[minmax(0,1fr)_30rem]">
-					<section className="relative flex min-h-[275px] items-stretch rounded-3xl bg-white/70 shadow-2xl dark:bg-slate-900/70 dark:shadow-slate-900/50 frosted-surface">
-						<div className="flex flex-1 items-stretch overflow-hidden rounded-3xl divide-x divide-white/50 dark:divide-white/10">
+					<section className="relative flex min-h-[275px] items-stretch rounded-3xl bg-white/70 p-2 shadow-2xl dark:bg-slate-900/70 dark:shadow-slate-900/50 frosted-surface">
+						<div className="flex flex-1 items-stretch gap-4 rounded-3xl p-2">
 							{playerPanels}
 						</div>
 					</section>

--- a/packages/web/src/components/player/BuildingDisplay.tsx
+++ b/packages/web/src/components/player/BuildingDisplay.tsx
@@ -3,6 +3,7 @@ import type { EngineContext } from '@kingdom-builder/engine';
 import { describeContent, splitSummary } from '../../translation';
 import { useGameEngine } from '../../state/GameContext';
 import { useAnimate } from '../../utils/useAutoAnimate';
+import { HOVER_CARD_BG } from './constants';
 
 interface BuildingDisplayProps {
 	player: EngineContext['activePlayer'];
@@ -13,40 +14,44 @@ const BuildingDisplay: React.FC<BuildingDisplayProps> = ({ player }) => {
 	if (player.buildings.size === 0) return null;
 	const animateBuildings = useAnimate<HTMLDivElement>();
 	return (
-		<div ref={animateBuildings} className="mt-3 flex w-full flex-wrap gap-3">
-			{Array.from(player.buildings).map((b) => {
-				const name = ctx.buildings.get(b)?.name || b;
-				const icon = ctx.buildings.get(b)?.icon || '';
-				const upkeep = ctx.buildings.get(b)?.upkeep;
-				const title = `${icon} ${name}`;
-				return (
-					<div
-						key={b}
-						className="panel-card flex min-w-[9rem] flex-col items-center gap-1 px-4 py-3 text-center text-sm font-semibold text-slate-700 hoverable dark:text-slate-100"
-						onMouseEnter={() => {
-							const full = describeContent('building', b, ctx, {
-								installed: true,
-							});
-							const { effects, description } = splitSummary(full);
-							handleHoverCard({
-								title,
-								effects,
-								requirements: [],
-								upkeep,
-								...(description && { description }),
-								bgClass:
-									'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
-							});
-						}}
-						onMouseLeave={clearHoverCard}
-					>
-						<span className="font-medium">
-							{icon} {name}
-						</span>
-					</div>
-				);
-			})}
-		</div>
+		<section className="panel-section">
+			<header className="panel-section__heading">
+				<span className="text-base leading-none">🏰</span>
+				<span className="panel-section__label">Buildings</span>
+			</header>
+			<div ref={animateBuildings} className="flex w-full flex-wrap gap-3">
+				{Array.from(player.buildings).map((b) => {
+					const name = ctx.buildings.get(b)?.name || b;
+					const icon = ctx.buildings.get(b)?.icon || '';
+					const upkeep = ctx.buildings.get(b)?.upkeep;
+					const title = `${icon} ${name}`;
+					return (
+						<div
+							key={b}
+							className="panel-chip hoverable"
+							onMouseEnter={() => {
+								const full = describeContent('building', b, ctx, {
+									installed: true,
+								});
+								const { effects, description } = splitSummary(full);
+								handleHoverCard({
+									title,
+									effects,
+									requirements: [],
+									upkeep,
+									...(description && { description }),
+									bgClass: HOVER_CARD_BG,
+								});
+							}}
+							onMouseLeave={clearHoverCard}
+						>
+							<span className="text-base leading-none">{icon}</span>
+							<span className="font-semibold">{name}</span>
+						</div>
+					);
+				})}
+			</div>
+		</section>
 	);
 };
 

--- a/packages/web/src/components/player/LandDisplay.tsx
+++ b/packages/web/src/components/player/LandDisplay.tsx
@@ -8,6 +8,7 @@ import type { EngineContext } from '@kingdom-builder/engine';
 import { describeContent, splitSummary } from '../../translation';
 import { useGameEngine } from '../../state/GameContext';
 import { useAnimate } from '../../utils/useAutoAnimate';
+import { HOVER_CARD_BG } from './constants';
 
 interface LandDisplayProps {
 	player: EngineContext['activePlayer'];
@@ -29,8 +30,7 @@ const LandTile: React.FC<{
 			requirements: [],
 			effectsTitle: DEVELOPMENTS_INFO.label,
 			...(description && { description }),
-			bgClass:
-				'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+			bgClass: HOVER_CARD_BG,
 		});
 	};
 	const animateSlots = useAnimate<HTMLDivElement>();
@@ -69,8 +69,7 @@ const LandTile: React.FC<{
 										effects,
 										requirements: [],
 										...(description && { description }),
-										bgClass:
-											'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+										bgClass: HOVER_CARD_BG,
 									});
 								}}
 								onMouseLeave={(e) => {
@@ -99,8 +98,7 @@ const LandTile: React.FC<{
 										description: `Use ${developAction.icon || ''} ${developAction.name} to build here`,
 									}),
 									requirements: [],
-									bgClass:
-										'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+									bgClass: HOVER_CARD_BG,
 								});
 							}}
 							onMouseLeave={(e) => {
@@ -136,21 +134,27 @@ const LandDisplay: React.FC<LandDisplayProps> = ({ player }) => {
 	if (player.lands.length === 0) return null;
 	const animateLands = useAnimate<HTMLDivElement>();
 	return (
-		<div
-			ref={animateLands}
-			className="mt-3 grid w-full grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
-		>
-			{player.lands.map((land) => (
-				<LandTile
-					key={land.id}
-					land={land}
-					ctx={ctx}
-					handleHoverCard={handleHoverCard}
-					clearHoverCard={clearHoverCard}
-					developAction={developAction}
-				/>
-			))}
-		</div>
+		<section className="panel-section">
+			<header className="panel-section__heading">
+				<span className="text-base leading-none">{LAND_INFO.icon}</span>
+				<span className="panel-section__label">{LAND_INFO.label}</span>
+			</header>
+			<div
+				ref={animateLands}
+				className="grid w-full grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+			>
+				{player.lands.map((land) => (
+					<LandTile
+						key={land.id}
+						land={land}
+						ctx={ctx}
+						handleHoverCard={handleHoverCard}
+						clearHoverCard={clearHoverCard}
+						developAction={developAction}
+					/>
+				))}
+			</div>
+		</section>
 	);
 };
 

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -13,6 +13,7 @@ import type {
 	PlayerId,
 } from '@kingdom-builder/engine';
 import { useAnimate } from '../../utils/useAutoAnimate';
+import { HOVER_CARD_BG } from './constants';
 
 export const ICON_MAP: Record<string, string> = {
 	cost_mod: modifierInfo.cost.icon,
@@ -80,40 +81,57 @@ export default function PassiveDisplay({
 
 	const animatePassives = useAnimate<HTMLDivElement>();
 	return (
-		<div
-			ref={animatePassives}
-			className="panel-card flex w-fit items-center gap-3 px-4 py-3 text-lg"
-		>
-			{entries.map(({ summary: passive, def }) => {
-				const icon = getIcon(passive, def.effects);
-				const items = describeEffects(def.effects || [], ctx);
-				const upkeepLabel =
-					PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
-				const sections = def.onUpkeepPhase
-					? [{ title: `Until your next ${upkeepLabel} Phase`, items }]
-					: items;
-				const passiveName = passive.name ?? PASSIVE_INFO.label;
-				return (
-					<span
-						key={passive.id}
-						className="hoverable cursor-pointer"
-						onMouseEnter={() => {
-							const { effects, description } = splitSummary(sections);
-							handleHoverCard({
-								title: `${icon} ${passiveName || PASSIVE_INFO.label}`,
-								effects,
-								requirements: [],
-								...(description && { description }),
-								bgClass:
-									'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
-							});
-						}}
-						onMouseLeave={clearHoverCard}
-					>
-						{icon}
-					</span>
-				);
-			})}
-		</div>
+		<section className="panel-section">
+			<header className="panel-section__heading">
+				<span className="text-base leading-none">{PASSIVE_INFO.icon}</span>
+				<span className="panel-section__label">{PASSIVE_INFO.label}</span>
+			</header>
+			<div
+				ref={animatePassives}
+				className="flex w-full flex-wrap items-center gap-2 text-lg"
+			>
+				{entries.map(({ summary: passive, def }) => {
+					const icon = getIcon(passive, def.effects);
+					const items = describeEffects(def.effects || [], ctx);
+					const upkeepLabel =
+						PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
+					const sections = def.onUpkeepPhase
+						? [{ title: `Until your next ${upkeepLabel} Phase`, items }]
+						: items;
+					const passiveName = passive.name ?? PASSIVE_INFO.label;
+					return (
+						<button
+							key={passive.id}
+							type="button"
+							className="panel-chip hoverable"
+							onMouseEnter={() => {
+								const { effects, description } = splitSummary(sections);
+								handleHoverCard({
+									title: `${icon} ${passiveName || PASSIVE_INFO.label}`,
+									effects,
+									requirements: [],
+									...(description && { description }),
+									bgClass: HOVER_CARD_BG,
+								});
+							}}
+							onMouseLeave={clearHoverCard}
+							onClick={() => {
+								const { effects, description } = splitSummary(sections);
+								handleHoverCard({
+									title: `${icon} ${passiveName || PASSIVE_INFO.label}`,
+									effects,
+									requirements: [],
+									...(description && { description }),
+									bgClass: HOVER_CARD_BG,
+								});
+							}}
+						>
+							<span className="text-base leading-none">{icon}</span>
+							<span className="font-semibold">{passiveName}</span>
+						</button>
+					);
+				})}
+			</div>
+		</section>
 	);
 }

--- a/packages/web/src/components/player/PlayerPanel.tsx
+++ b/packages/web/src/components/player/PlayerPanel.tsx
@@ -68,9 +68,9 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
 	return (
 		<div
 			ref={panelRef}
-			className={`player-panel flex min-h-[320px] flex-col gap-2 text-slate-800 dark:text-slate-100 ${className}`}
+			className={`player-panel flex min-h-[320px] flex-col gap-4 text-slate-800 dark:text-slate-100 ${className}`}
 		>
-			<h3 className="text-lg font-semibold tracking-tight">
+			<h3 className="flex items-center justify-between text-lg font-semibold tracking-tight">
 				{isActive && (
 					<span role="img" aria-label="active player" className="mr-1">
 						👑
@@ -80,12 +80,16 @@ const PlayerPanel: React.FC<PlayerPanelProps> = ({
 			</h3>
 			<div
 				ref={animateBar}
-				className="panel-card flex w-fit flex-wrap items-center gap-3 px-4 py-3"
+				className="panel-card flex w-full items-center gap-4 overflow-hidden px-5 py-4"
 			>
-				<ResourceBar player={player} />
-				<PopulationInfo player={player} />
+				<div className="flex min-w-0 flex-1 items-center gap-2">
+					<ResourceBar player={player} />
+				</div>
+				<div className="flex flex-none items-center gap-2">
+					<PopulationInfo player={player} />
+				</div>
 			</div>
-			<div ref={animateSections} className="flex flex-col gap-2">
+			<div ref={animateSections} className="flex flex-col gap-4">
 				<LandDisplay player={player} />
 				<BuildingDisplay player={player} />
 				<PassiveDisplay player={player} />

--- a/packages/web/src/components/player/PopulationInfo.tsx
+++ b/packages/web/src/components/player/PopulationInfo.tsx
@@ -9,6 +9,7 @@ import { formatStatValue, getStatBreakdownSummary } from '../../utils/stats';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { useGameEngine } from '../../state/GameContext';
 import { useValueChangeIndicators } from '../../utils/useValueChangeIndicators';
+import { HOVER_CARD_BG } from './constants';
 
 interface StatButtonProps {
 	statKey: keyof typeof STATS;
@@ -79,8 +80,7 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
 			effectsTitle: POPULATION_ARCHETYPE_INFO.label,
 			requirements: [],
 			description: POPULATION_INFO.description,
-			bgClass:
-				'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+			bgClass: HOVER_CARD_BG,
 		});
 
 	const showStatCard = (statKey: string) => {
@@ -93,14 +93,13 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
 			effectsTitle: 'Breakdown',
 			requirements: [],
 			description: info.description,
-			bgClass:
-				'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+			bgClass: HOVER_CARD_BG,
 		});
 	};
 
 	return (
-		<>
-			<div className="h-6 border-l border-white/40 dark:border-white/10" />
+		<div className="flex flex-nowrap items-center gap-2 text-sm sm:gap-3">
+			<div className="hidden h-6 border-l border-white/40 sm:block dark:border-white/10" />
 			<div
 				role="button"
 				tabIndex={0}
@@ -137,8 +136,7 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
 												effects: [],
 												requirements: [],
 												description: info.description,
-												bgClass:
-													'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+												bgClass: HOVER_CARD_BG,
 											});
 										}}
 										onMouseLeave={(e) => {
@@ -152,8 +150,7 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
 												effects: [],
 												requirements: [],
 												description: info.description,
-												bgClass:
-													'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+												bgClass: HOVER_CARD_BG,
 											});
 										}}
 										onBlur={(e) => {
@@ -167,8 +164,7 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
 												effects: [],
 												requirements: [],
 												description: info.description,
-												bgClass:
-													'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+												bgClass: HOVER_CARD_BG,
 											});
 										}}
 									>
@@ -196,7 +192,7 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
 						onHide={clearHoverCard}
 					/>
 				))}
-		</>
+		</div>
 	);
 };
 

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -3,6 +3,7 @@ import { RESOURCES } from '@kingdom-builder/contents';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { useGameEngine } from '../../state/GameContext';
 import { useValueChangeIndicators } from '../../utils/useValueChangeIndicators';
+import { HOVER_CARD_BG } from './constants';
 
 interface ResourceButtonProps {
 	resourceKey: keyof typeof RESOURCES;
@@ -67,9 +68,10 @@ interface ResourceBarProps {
 
 const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 	const { handleHoverCard, clearHoverCard } = useGameEngine();
+	const resourceKeys = Object.keys(RESOURCES) as (keyof typeof RESOURCES)[];
 	return (
-		<>
-			{(Object.keys(RESOURCES) as (keyof typeof RESOURCES)[]).map((k) => {
+		<div className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
+			{resourceKeys.map((k) => {
 				const info = RESOURCES[k];
 				const v = player.resources[k] ?? 0;
 				const showResourceCard = () =>
@@ -78,8 +80,7 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 						effects: [],
 						requirements: [],
 						description: info.description,
-						bgClass:
-							'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+						bgClass: HOVER_CARD_BG,
 					});
 				return (
 					<ResourceButton
@@ -91,7 +92,7 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 					/>
 				);
 			})}
-		</>
+		</div>
 	);
 };
 

--- a/packages/web/src/components/player/constants.ts
+++ b/packages/web/src/components/player/constants.ts
@@ -1,0 +1,3 @@
+export const HOVER_CARD_BG =
+	'bg-gradient-to-br from-white/80 to-white/60 ' +
+	'dark:from-slate-900/80 dark:to-slate-900/60';

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -44,7 +44,7 @@
 
 @layer components {
   .bar-item {
-    @apply flex items-center gap-1 whitespace-nowrap rounded-full border border-white/40 bg-white/50 px-3 py-1 text-sm font-semibold tabular-nums text-slate-700 shadow-sm shadow-white/30 transition appearance-none dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100;
+    @apply flex items-center gap-1 whitespace-nowrap rounded-full border border-white/40 bg-white/50 px-2.5 py-1 text-xs font-semibold tabular-nums text-slate-700 shadow-sm shadow-white/30 transition appearance-none sm:px-3 sm:text-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100;
   }
   .hoverable {
     @apply transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/60 hover:shadow-lg hover:shadow-amber-500/10 dark:hover:bg-white/10 dark:hover:shadow-black/30;
@@ -71,6 +71,18 @@
   }
   .player-panel .panel-card {
     @apply border-white/40 bg-white/80 dark:border-white/10 dark:bg-slate-900/60;
+  }
+  .panel-section {
+    @apply panel-card flex w-full flex-col gap-3 px-5 py-4;
+  }
+  .panel-section__heading {
+    @apply flex items-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-slate-500 dark:text-slate-300;
+  }
+  .panel-section__label {
+    @apply truncate text-[0.8rem] tracking-normal text-slate-700 dark:text-slate-100;
+  }
+  .panel-chip {
+    @apply inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/60 px-3 py-1 text-sm font-semibold text-slate-700 shadow-sm shadow-white/20 transition-colors dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100;
   }
   .value-change-indicator {
     @apply pointer-events-none font-black tracking-wide text-sm sm:text-base;


### PR DESCRIPTION
## Summary
- restyle the player panel so the resource/stat row stays on one line and each content area appears in its own card
- add a shared hover-card background helper and update chips/panel styling for clearer sections
- give the player pane container extra breathing room to better match the phase panel height

## Testing
- npm run lint -- --max-warnings=0
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68deda7bcb408325bda66f79d3ecd61a