### PR TITLE
Build contents against engine declarations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,9 @@
 ```ts
 const content = createContentFactory();
 const effect = {
-  type: 'resource',
-  method: 'add',
-  params: { key: CResource.gold, amount: 2 },
+	type: 'resource',
+	method: 'add',
+	params: { key: CResource.gold, amount: 2 },
 };
 const action = content.action({ effects: [effect] });
 const ctx = createTestEngine(content);
@@ -43,11 +43,11 @@ expect(ctx.activePlayer.gold).toBe(before + effect.params.amount);
 
 ```ts
 fc.assert(
-  fc.property(resourceMapArb, (costs) => {
-    const content = createContentFactory();
-    const action = content.action({ baseCosts: costs });
-    // ...assert invariants
-  }),
+	fc.property(resourceMapArb, (costs) => {
+		const content = createContentFactory();
+		const action = content.action({ baseCosts: costs });
+		// ...assert invariants
+	}),
 );
 ```
 
@@ -85,9 +85,6 @@ fc.assert(
 - 2025-08-31: Registries can validate entries with Zod schemas; invalid data will throw during `add`.
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
 - 2025-08-31: `npm run dev` prebuilds `@kingdom-builder/contents` via a `predev` script to avoid missing dist files.
-- 2025-09-24: That prebuild currently fails in this environment (the contents TypeScript project rejects engine sources outside
-  its `rootDir`). To launch Vite for screenshots, run it from the web workspace instead:
-  `npm run --workspace @kingdom-builder/web dev -- --host 0.0.0.0 --port 4173`.
 - 2025-08-31: Player snapshots now require the engine context to include active passive IDs; use `snapshotPlayer(player, ctx)`.
 - 2025-08-31: `handleEndTurn` will not advance phases if a player has remaining AP; automated tests must spend or clear AP first.
 - 2025-08-31: Log entries include `playerId` so the web UI can style messages per player.

--- a/packages/contents/package.json
+++ b/packages/contents/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "@kingdom-builder/contents",
-  "version": "0.1.0",
-  "private": false,
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "test": "vitest run"
-  },
-  "dependencies": {
-    "@kingdom-builder/engine": "^0.1.0"
-  },
-  "devDependencies": {
-    "typescript": "^5.5.4",
-    "vitest": "^3.2.4"
-  }
+	"name": "@kingdom-builder/contents",
+	"version": "0.1.0",
+	"private": false,
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "tsc --build tsconfig.json",
+		"test": "vitest run"
+	},
+	"dependencies": {
+		"@kingdom-builder/engine": "^0.1.0"
+	},
+	"devDependencies": {
+		"typescript": "^5.5.4",
+		"vitest": "^3.2.4"
+	}
 }

--- a/packages/contents/tsconfig.json
+++ b/packages/contents/tsconfig.json
@@ -1,11 +1,19 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist",
-    "composite": true,
-    "declaration": true
-  },
-  "include": ["src"],
-  "exclude": ["dist", "tests"]
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"composite": true,
+		"declaration": true,
+		"paths": {
+			"@kingdom-builder/engine": ["packages/engine/dist/index"],
+			"@kingdom-builder/engine/*": ["packages/engine/dist/*"],
+			"@kingdom-builder/contents": ["packages/contents/src/index"],
+			"@kingdom-builder/contents/*": ["packages/contents/src/*"],
+			"@kingdom-builder/*": ["packages/*/src"]
+		}
+	},
+	"include": ["src"],
+	"exclude": ["dist", "tests"],
+	"references": [{ "path": "../engine/tsconfig.json" }]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,29 +2,33 @@ import path from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  resolve: {
-    alias: {
-      '@kingdom-builder/engine': path.resolve(__dirname, 'packages/engine/src'),
-      '@kingdom-builder/contents': path.resolve(
-        __dirname,
-        'packages/contents/src',
-      ),
-      '@kingdom-builder/web': path.resolve(__dirname, 'packages/web/src'),
-    },
-  },
-  test: {
-    include: ['**/*.test.ts', '**/*.test.tsx'],
-    exclude: ['**/node_modules/**'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'html'],
-      exclude: ['packages/web/**', 'packages/contents/**'],
-      thresholds: {
-        statements: 80,
-        branches: 80,
-        functions: 80,
-        lines: 80,
-      },
-    },
-  },
+	resolve: {
+		alias: {
+			'@kingdom-builder/engine': path.resolve(__dirname, 'packages/engine/src'),
+			'@kingdom-builder/contents': path.resolve(
+				__dirname,
+				'packages/contents/src',
+			),
+			'@kingdom-builder/web': path.resolve(__dirname, 'packages/web/src'),
+		},
+	},
+	test: {
+		include: ['**/*.test.ts', '**/*.test.tsx'],
+		exclude: ['**/node_modules/**'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'html'],
+			exclude: [
+				'packages/web/**',
+				'packages/contents/**',
+				'packages/**/dist/**',
+			],
+			thresholds: {
+				statements: 80,
+				branches: 80,
+				functions: 80,
+				lines: 80,
+			},
+		},
+	},
 });


### PR DESCRIPTION
## Summary
- add a project reference from `@kingdom-builder/contents` to the engine package and remap its path aliases to consume the engine build output
- switch the contents build script to `tsc --build` so dev builds compile the engine first and exclude `dist` artifacts from coverage reporting
- drop the outdated predev failure note from the agent discovery log now that the build graph works

## Testing
- npm run build --workspace @kingdom-builder/contents
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dedd8347d883259451d644cac0e365