### PR TITLE
chore: streamline test workflow

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,6 +6,6 @@ set -e
 # Run lint-staged on changed files
 npx lint-staged
 
-# Run type checking, linting, and tests with coverage
-npm test
+# Run the fast Vitest suite without redundant lint/type checks
+npm run test:quick
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,9 @@
 ```ts
 const content = createContentFactory();
 const effect = {
-  type: 'resource',
-  method: 'add',
-  params: { key: CResource.gold, amount: 2 },
+	type: 'resource',
+	method: 'add',
+	params: { key: CResource.gold, amount: 2 },
 };
 const action = content.action({ effects: [effect] });
 const ctx = createTestEngine(content);
@@ -43,11 +43,11 @@ expect(ctx.activePlayer.gold).toBe(before + effect.params.amount);
 
 ```ts
 fc.assert(
-  fc.property(resourceMapArb, (costs) => {
-    const content = createContentFactory();
-    const action = content.action({ baseCosts: costs });
-    // ...assert invariants
-  }),
+	fc.property(resourceMapArb, (costs) => {
+		const content = createContentFactory();
+		const action = content.action({ baseCosts: costs });
+		// ...assert invariants
+	}),
 );
 ```
 
@@ -79,8 +79,8 @@ fc.assert(
 
 # Agent discovery log
 
-- 2025-08-31: Run tests with `npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`; avoid running extra test commands.
-- 2025-08-31: `git commit` triggers a Husky pre-commit hook running lint-staged, type checking, linting and tests.
+- 2025-08-31: Run tests with `npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`; avoid running extra test commands unless specifically asked.
+- 2025-08-31: `git commit` triggers a Husky pre-commit hook running lint-staged and the fast Vitest suite.
 - 2025-08-31: Use `rg` for code searches; `grep -R` and `ls -R` are discouraged for performance.
 - 2025-08-31: Registries can validate entries with Zod schemas; invalid data will throw during `add`.
 - 2025-08-31: A quick Node script can scan content files to detect duplicate icons across actions, buildings, stats, population roles and developments.
@@ -100,7 +100,7 @@ fc.assert(
 - 2025-08-31: Trigger handling now uses `collectTriggerEffects`; direct
   `runTrigger` helper has been removed. Switch the active player index when
   resolving triggers for non-active players.
-- 2025-08-31: `npm run test:coverage` requires `@vitest/coverage-v8`; install with `npm install --no-save @vitest/coverage-v8` if missing.
+- 2025-08-31: `npm run test:coverage` (also used by `npm run test:ci`) requires `@vitest/coverage-v8`; install with `npm install --no-save @vitest/coverage-v8` if missing.
 - 2025-08-31: `performAction` returns sub-action traces via `ctx.actionTraces` for nested log attribution.
 - 2025-08-31: Use `buildInfo(registry, { id: icon })` to derive icon/label maps from content registries.
 - 2025-08-31: Compose effects with `effect(type, method).param(key, value)` to avoid manual `{ type, method, params }` objects.
@@ -182,14 +182,14 @@ Tests live in:
 - `packages/engine/tests` for unit tests
 - `tests/integration` for integration tests
 
-To run the test suite and capture a reliable summary without redundant
+To run the fast test suite and capture a reliable summary without redundant
 checks, execute:
 
 ```sh
-npm run test:coverage >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log
+npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log
 ```
 
-This command runs the tests with coverage and saves the output to
+This command runs Vitest without coverage and saves the output to
 `/tmp/unit.log`. The `tail` command prints the final portion of the log so
 you can quickly confirm whether tests passed or inspect any failures.
 
@@ -197,11 +197,12 @@ you can quickly confirm whether tests passed or inspect any failures.
 verify the tail output looks correct, and proceed without running any
 extra test or build commands.
 
-The pre-commit hook already runs `lint-staged`, type checking, linting, and
-`npm test` (which triggers a `pretest` step). Running `npm test` manually
-would repeat those checks. GitHub Actions executes `npm run test:coverage`
-and `npm run build` for each pull request. Run these scripts locally only
-when debugging or when changes could affect them. See
+The pre-commit hook already runs `lint-staged` and `npm run test:quick`
+(which triggers the `pretest` dependency install step). Running the test
+command again manually would repeat those checks. GitHub Actions executes
+`npm run test:ci` (coverage) and `npm run build` for each pull request. Run
+these scripts locally only when debugging or when changes could affect
+them. See
 [CONTRIBUTING](CONTRIBUTING/AGENTS.md) for details.
 
 # Game overview

--- a/CONTRIBUTING/AGENTS.md
+++ b/CONTRIBUTING/AGENTS.md
@@ -43,9 +43,10 @@ tests); Markdown documentation and peripheral utilities like the repository
 - Tests are split into two levels:
   - **Unit tests** under `packages/engine/tests`.
   - **Integration tests** under `tests/integration`.
-- The pre-commit hook runs `npm test` for unit and integration tests on staged
-  files.
-- GitHub Actions runs `npm run test:coverage` and `npm run build` for every pull
+- The pre-commit hook runs `npm run test:quick` for unit and integration tests
+  on staged files after `lint-staged` handles formatting, linting, and type
+  checking.
+- GitHub Actions runs `npm run test:ci` (coverage) and `npm run build` for every pull
   request. Run these scripts locally only when working on related areas or
   debugging failures.
 - New features and bug fixes **must** include tests. Derive expectations from
@@ -80,9 +81,10 @@ expect(ctx.activePlayer.gold).toBe(before + effect.params.amount);
 - Keep commits focused; avoid mixing unrelated changes or drive-by edits.
 - Update documentation and tests in the same commit as the code change when
   possible.
-- Ensure the pre-commit hook passes before pushing. It runs `lint-staged`,
-  `npm run lint`, `npm run type-check`, and `npm test` on staged files.
-  Additional checks such as the production build run in CI.
+- Ensure the pre-commit hook passes before pushing. It runs `lint-staged`
+  (formatting, linting, and type checks on staged files) followed by
+  `npm run test:quick`. Additional checks such as the production build run in
+  CI.
 - Limit commit message subject lines to ~70 characters.
 
 For architectural details see [ARCHITECTURE](../docs/architecture/AGENTS.md). If in

--- a/package.json
+++ b/package.json
@@ -1,61 +1,63 @@
 {
-  "name": "kingdom-builder-engine",
-  "version": "0.1.0",
-  "private": true,
-  "type": "module",
-  "workspaces": [
-    "packages/*"
-  ],
-  "scripts": {
-    "predev": "npm run build --workspace @kingdom-builder/contents",
-    "dev": "vite",
-    "build": "tsc -b && vite build packages/web",
-    "preview": "vite preview",
-    "prelint": "node scripts/ensure-dev-dependencies.cjs",
-    "lint": "eslint . --ext .ts,.tsx --rulesdir scripts",
-    "typecheck": "tsc -b --noEmit --pretty false",
-    "fix": "eslint . --ext .ts,.tsx --fix --rulesdir scripts",
-    "check": "npm run typecheck && npm run lint",
-    "pretest": "node scripts/ensure-dev-dependencies.cjs && npm run check",
-    "test": "npm run test:coverage",
-    "pretest:coverage": "node scripts/ensure-dev-dependencies.cjs",
-    "test:coverage": "vitest run --coverage",
-    "format": "prettier .",
-    "prepare": "husky install"
-  },
-  "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "zod": "^3.23.8"
-  },
-  "devDependencies": {
-    "@testing-library/jest-dom": "^6.8.0",
-    "@testing-library/react": "^16.3.0",
-    "@types/node": "^20.14.10",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "@typescript-eslint/eslint-plugin": "^7.14.1",
-    "@typescript-eslint/parser": "^7.14.1",
-    "@vitejs/plugin-react": "^4.3.1",
-    "@vitest/coverage-v8": "^3.2.4",
-    "autoprefixer": "^10.4.21",
-    "eslint": "^8.57.0",
-    "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-unused-imports": "^3.1.0",
-    "fast-check": "^3.23.2",
-    "husky": "^9.1.7",
-    "jsdom": "^26.1.0",
-    "lint-staged": "^16.1.5",
-    "postcss": "^8.5.6",
-    "prettier": "^3.6.2",
-    "tailwindcss": "^3.4.17",
-    "typescript": "^5.5.4",
-    "vite": "^5.4.0",
-    "vitest": "^3.2.4"
-  },
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx,json,md}": "prettier --write",
-    "*.{js,jsx,ts,tsx}": "eslint --max-warnings=0 --rulesdir scripts",
-    "*.{ts,tsx}": "bash -c 'tsc --noEmit'"
-  }
+	"name": "kingdom-builder-engine",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"workspaces": [
+		"packages/*"
+	],
+	"scripts": {
+		"predev": "npm run build --workspace @kingdom-builder/contents",
+		"dev": "vite",
+		"build": "tsc -b && vite build packages/web",
+		"preview": "vite preview",
+		"prelint": "node scripts/ensure-dev-dependencies.cjs",
+		"lint": "eslint . --ext .ts,.tsx --rulesdir scripts",
+		"typecheck": "tsc -b --noEmit --pretty false",
+		"fix": "eslint . --ext .ts,.tsx --fix --rulesdir scripts",
+		"check": "npm run typecheck && npm run lint",
+		"pretest": "node scripts/ensure-dev-dependencies.cjs",
+		"test": "vitest run",
+		"test:quick": "npm test",
+		"pretest:coverage": "node scripts/ensure-dev-dependencies.cjs",
+		"test:coverage": "vitest run --coverage",
+		"test:ci": "npm run test:coverage",
+		"format": "prettier .",
+		"prepare": "husky install"
+	},
+	"dependencies": {
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"zod": "^3.23.8"
+	},
+	"devDependencies": {
+		"@testing-library/jest-dom": "^6.8.0",
+		"@testing-library/react": "^16.3.0",
+		"@types/node": "^20.14.10",
+		"@types/react": "^18.3.3",
+		"@types/react-dom": "^18.3.0",
+		"@typescript-eslint/eslint-plugin": "^7.14.1",
+		"@typescript-eslint/parser": "^7.14.1",
+		"@vitejs/plugin-react": "^4.3.1",
+		"@vitest/coverage-v8": "^3.2.4",
+		"autoprefixer": "^10.4.21",
+		"eslint": "^8.57.0",
+		"eslint-plugin-import": "^2.32.0",
+		"eslint-plugin-unused-imports": "^3.1.0",
+		"fast-check": "^3.23.2",
+		"husky": "^9.1.7",
+		"jsdom": "^26.1.0",
+		"lint-staged": "^16.1.5",
+		"postcss": "^8.5.6",
+		"prettier": "^3.6.2",
+		"tailwindcss": "^3.4.17",
+		"typescript": "^5.5.4",
+		"vite": "^5.4.0",
+		"vitest": "^3.2.4"
+	},
+	"lint-staged": {
+		"*.{js,jsx,ts,tsx,json,md}": "prettier --write",
+		"*.{js,jsx,ts,tsx}": "eslint --max-warnings=0 --rulesdir scripts",
+		"*.{ts,tsx}": "bash -c 'tsc --noEmit'"
+	}
 }


### PR DESCRIPTION
## Summary
- split the fast Vitest run from the coverage workflow and add a CI alias
- update the Husky pre-commit hook to run the quick Vitest suite after lint-staged
- refresh contributor docs to describe the local quick test versus CI coverage expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dedd6ee9448325a74ee9a1d041baf2