### PR TITLE
Refactor action log hook resolution and building icon fallbacks

### DIFF
--- a/packages/web/src/translation/content/action.ts
+++ b/packages/web/src/translation/content/action.ts
@@ -6,60 +6,60 @@ import type { ContentTranslator, Summary } from './types';
 import { getActionLogHook } from './actionLogHooks';
 
 class ActionTranslator
-  implements ContentTranslator<string, Record<string, unknown>>
+	implements ContentTranslator<string, Record<string, unknown>>
 {
-  summarize(
-    id: string,
-    ctx: EngineContext,
-    opts?: Record<string, unknown>,
-  ): Summary {
-    const def = ctx.actions.get(id);
-    const effects = opts
-      ? applyParamsToEffects(def.effects, opts)
-      : def.effects;
-    const eff = summarizeEffects(effects, ctx);
-    return eff.length ? eff : [];
-  }
-  describe(
-    id: string,
-    ctx: EngineContext,
-    opts?: Record<string, unknown>,
-  ): Summary {
-    const def = ctx.actions.get(id);
-    const effects = opts
-      ? applyParamsToEffects(def.effects, opts)
-      : def.effects;
-    const eff = describeEffects(effects, ctx);
-    return eff.length ? eff : [];
-  }
-  log(
-    id: string,
-    ctx: EngineContext,
-    params?: Record<string, unknown>,
-  ): string[] {
-    const def = ctx.actions.get(id);
-    const icon = def.icon || '';
-    const label = def.name;
-    let message = `Played ${icon} ${label}`;
-    const extra = getActionLogHook(id)?.(ctx, params);
-    if (extra) message += extra;
-    const effects = params
-      ? applyParamsToEffects(def.effects, params)
-      : def.effects;
-    const effLogs = logEffects(effects, ctx);
-    const lines = [message];
-    function push(entry: unknown, depth: number) {
-      if (typeof entry === 'string')
-        lines.push(`${'  '.repeat(depth)}${entry}`);
-      else if (entry && typeof entry === 'object') {
-        const e = entry as { title: string; items: unknown[] };
-        lines.push(`${'  '.repeat(depth)}${e.title}`);
-        e.items.forEach((i) => push(i, depth + 1));
-      }
-    }
-    effLogs.forEach((e) => push(e, 1));
-    return lines;
-  }
+	summarize(
+		id: string,
+		ctx: EngineContext,
+		opts?: Record<string, unknown>,
+	): Summary {
+		const def = ctx.actions.get(id);
+		const effects = opts
+			? applyParamsToEffects(def.effects, opts)
+			: def.effects;
+		const eff = summarizeEffects(effects, ctx);
+		return eff.length ? eff : [];
+	}
+	describe(
+		id: string,
+		ctx: EngineContext,
+		opts?: Record<string, unknown>,
+	): Summary {
+		const def = ctx.actions.get(id);
+		const effects = opts
+			? applyParamsToEffects(def.effects, opts)
+			: def.effects;
+		const eff = describeEffects(effects, ctx);
+		return eff.length ? eff : [];
+	}
+	log(
+		id: string,
+		ctx: EngineContext,
+		params?: Record<string, unknown>,
+	): string[] {
+		const def = ctx.actions.get(id);
+		const icon = def.icon || '';
+		const label = def.name;
+		let message = `Played ${icon} ${label}`;
+		const extra = getActionLogHook(def)?.(ctx, params);
+		if (extra) message += extra;
+		const effects = params
+			? applyParamsToEffects(def.effects, params)
+			: def.effects;
+		const effLogs = logEffects(effects, ctx);
+		const lines = [message];
+		function push(entry: unknown, depth: number) {
+			if (typeof entry === 'string')
+				lines.push(`${'  '.repeat(depth)}${entry}`);
+			else if (entry && typeof entry === 'object') {
+				const e = entry as { title: string; items: unknown[] };
+				lines.push(`${'  '.repeat(depth)}${e.title}`);
+				e.items.forEach((i) => push(i, depth + 1));
+			}
+		}
+		effLogs.forEach((e) => push(e, 1));
+		return lines;
+	}
 }
 
 registerContentTranslator('action', new ActionTranslator());

--- a/packages/web/src/translation/content/actionLogHooks.ts
+++ b/packages/web/src/translation/content/actionLogHooks.ts
@@ -1,37 +1,128 @@
-import type { EngineContext } from '@kingdom-builder/engine';
+import type { EngineContext, EffectDef } from '@kingdom-builder/engine';
+import type { ActionConfig } from '@kingdom-builder/engine/config/schema';
 import { logContent } from './factory';
 
 export type ActionLogHook = (
-  ctx: EngineContext,
-  params?: Record<string, unknown>,
+	ctx: EngineContext,
+	params?: Record<string, unknown>,
 ) => string;
 
-const hooks = new Map<string, ActionLogHook>();
+const manualHooks = new Map<string, ActionLogHook>();
+const derivedCache = new Map<string, ActionLogHook | null>();
+const resolvers: ActionLogHookResolver[] = [];
 
-export function registerActionLogHook(id: string, hook: ActionLogHook) {
-  hooks.set(id, hook);
+type ActionLogHookResolver = (def: ActionConfig) => ActionLogHook | undefined;
+
+export function registerActionLogHook(id: string, hook: ActionLogHook): void {
+	manualHooks.set(id, hook);
+	derivedCache.set(id, hook);
 }
 
-export function getActionLogHook(id: string) {
-  return hooks.get(id);
+export function registerActionLogHookResolver(
+	resolver: ActionLogHookResolver,
+): void {
+	resolvers.push(resolver);
+	derivedCache.clear();
 }
 
-registerActionLogHook('develop', (ctx, params) => {
-  const id =
-    typeof (params as { id?: string })?.id === 'string'
-      ? (params as { id: string }).id
-      : undefined;
-  if (!id) return '';
-  const target = logContent('development', id, ctx)[0];
-  return target ? ` - ${target}` : '';
-});
+function findEffect(
+	effects: EffectDef[] | undefined,
+	predicate: (effect: EffectDef) => boolean,
+): EffectDef | undefined {
+	if (!effects) return undefined;
+	for (const effect of effects) {
+		if (predicate(effect)) return effect;
+		const nested = findEffect(effect.effects, predicate);
+		if (nested) return nested;
+	}
+	return undefined;
+}
 
-registerActionLogHook('build', (ctx, params) => {
-  const id =
-    typeof (params as { id?: string })?.id === 'string'
-      ? (params as { id: string }).id
-      : undefined;
-  if (!id) return '';
-  const target = logContent('building', id, ctx)[0];
-  return target ? ` - ${target}` : '';
-});
+function extractString(value: unknown): string | undefined {
+	return typeof value === 'string' ? value : undefined;
+}
+
+function extractTemplateParam(
+	params: Record<string, unknown> | undefined,
+	key: string,
+): string | undefined {
+	const raw = extractString(params?.[key]);
+	if (!raw) return undefined;
+	return raw.startsWith('$') ? raw.slice(1) : undefined;
+}
+
+function extractStaticParam(
+	params: Record<string, unknown> | undefined,
+	key: string,
+): string | undefined {
+	const raw = extractString(params?.[key]);
+	if (!raw) return undefined;
+	return raw.startsWith('$') ? undefined : raw;
+}
+
+function createLinkedContentResolver({
+	effectType,
+	method,
+	contentType,
+	paramKey = 'id',
+}: {
+	effectType: string;
+	method: string;
+	contentType: string;
+	paramKey?: string;
+}): ActionLogHookResolver {
+	return (def) => {
+		const effect = findEffect(def.effects, (candidate) => {
+			return candidate.type === effectType && candidate.method === method;
+		});
+		if (!effect) return undefined;
+		const templateParam = extractTemplateParam(effect.params, paramKey);
+		const staticValue = extractStaticParam(effect.params, paramKey);
+		return (ctx, params) => {
+			let targetId: string | undefined;
+			if (templateParam) {
+				targetId = extractString(params?.[templateParam]);
+			}
+			if (!targetId) {
+				targetId = extractString(params?.[paramKey]);
+			}
+			if (!targetId) {
+				targetId = staticValue;
+			}
+			if (!targetId) return '';
+			const target = logContent(contentType, targetId, ctx)[0];
+			return target ? ` - ${target}` : '';
+		};
+	};
+}
+
+export function getActionLogHook(def: ActionConfig): ActionLogHook | undefined {
+	const manual = manualHooks.get(def.id);
+	if (manual) return manual;
+	if (derivedCache.has(def.id)) return derivedCache.get(def.id) ?? undefined;
+	for (const resolver of resolvers) {
+		const hook = resolver(def);
+		if (hook) {
+			derivedCache.set(def.id, hook);
+			return hook;
+		}
+	}
+	derivedCache.set(def.id, null);
+	return undefined;
+}
+
+registerActionLogHookResolver(
+	createLinkedContentResolver({
+		effectType: 'building',
+		method: 'add',
+		contentType: 'building',
+	}),
+);
+
+registerActionLogHookResolver(
+	createLinkedContentResolver({
+		effectType: 'development',
+		method: 'add',
+		contentType: 'development',
+	}),
+);

--- a/packages/web/src/translation/content/building.ts
+++ b/packages/web/src/translation/content/building.ts
@@ -4,22 +4,22 @@ import type { ContentTranslator, Summary } from './types';
 import { PhasedTranslator } from './phased';
 import type { PhasedDef } from './phased';
 import { withInstallation } from './decorators';
+import { resolveBuildingDisplay } from './buildingIcons';
 
 class BuildingCore implements ContentTranslator<string> {
-  private phased = new PhasedTranslator();
-  summarize(id: string, ctx: EngineContext): Summary {
-    const def = ctx.buildings.get(id);
-    return this.phased.summarize(def as unknown as PhasedDef, ctx);
-  }
-  describe(id: string, ctx: EngineContext): Summary {
-    const def = ctx.buildings.get(id);
-    return this.phased.describe(def as unknown as PhasedDef, ctx);
-  }
-  log(id: string, ctx: EngineContext): string[] {
-    const def = ctx.buildings.get(id);
-    const icon = def.icon || ctx.actions.get('build').icon || '';
-    return [`${icon}${def.name}`];
-  }
+	private phased = new PhasedTranslator();
+	summarize(id: string, ctx: EngineContext): Summary {
+		const def = ctx.buildings.get(id);
+		return this.phased.summarize(def as unknown as PhasedDef, ctx);
+	}
+	describe(id: string, ctx: EngineContext): Summary {
+		const def = ctx.buildings.get(id);
+		return this.phased.describe(def as unknown as PhasedDef, ctx);
+	}
+	log(id: string, ctx: EngineContext): string[] {
+		const { name, icon } = resolveBuildingDisplay(id, ctx);
+		return [`${icon}${name}`];
+	}
 }
 
 registerContentTranslator('building', withInstallation(new BuildingCore()));

--- a/packages/web/src/translation/content/buildingIcons.ts
+++ b/packages/web/src/translation/content/buildingIcons.ts
@@ -1,0 +1,37 @@
+import type { EngineContext } from '@kingdom-builder/engine';
+
+const FALLBACK_ICONS = new Map<string, string>();
+
+export function registerBuildingIconFallback(id: string, icon: string): void {
+	FALLBACK_ICONS.set(id, icon);
+}
+
+export function resolveBuildingIcon(id: string, ctx: EngineContext): string {
+	return resolveBuildingDisplay(id, ctx).icon;
+}
+
+export function resolveBuildingDisplay(
+	id: string,
+	ctx: EngineContext,
+): { name: string; icon: string } {
+	let name = id;
+	let icon = '';
+	try {
+		const def = ctx.buildings.get(id);
+		if (def?.name) {
+			name = def.name;
+		}
+		if (def?.icon) {
+			icon = def.icon;
+		}
+	} catch {
+		// ignore missing building definitions
+	}
+	if (!icon) {
+		const fallback = FALLBACK_ICONS.get(id);
+		if (fallback) {
+			icon = fallback;
+		}
+	}
+	return { name, icon };
+}

--- a/packages/web/src/translation/effects/formatters/building.ts
+++ b/packages/web/src/translation/effects/formatters/building.ts
@@ -1,32 +1,15 @@
 import { registerEffectFormatter } from '../factory';
+import { resolveBuildingDisplay } from '../../content/buildingIcons';
 
 registerEffectFormatter('building', 'add', {
-  summarize: (eff, ctx) => {
-    const id = eff.params?.['id'] as string;
-    let name = id;
-    let icon = '';
-    try {
-      const def = ctx.buildings.get(id);
-      name = def.name;
-      icon = def.icon || '';
-    } catch {
-      // ignore
-    }
-    if (!icon) icon = ctx.actions.get('build').icon || '';
-    return `${icon}${name}`;
-  },
-  describe: (eff, ctx) => {
-    const id = eff.params?.['id'] as string;
-    let name = id;
-    let icon = '';
-    try {
-      const def = ctx.buildings.get(id);
-      name = def.name;
-      icon = def.icon || '';
-    } catch {
-      // ignore
-    }
-    if (!icon) icon = ctx.actions.get('build').icon || '';
-    return `Construct ${icon}${name}`;
-  },
+	summarize: (eff, ctx) => {
+		const id = eff.params?.['id'] as string;
+		const { name, icon } = resolveBuildingDisplay(id, ctx);
+		return `${icon}${name}`;
+	},
+	describe: (eff, ctx) => {
+		const id = eff.params?.['id'] as string;
+		const { name, icon } = resolveBuildingDisplay(id, ctx);
+		return `Construct ${icon}${name}`;
+	},
 });

--- a/tests/integration/action-log-hooks.test.ts
+++ b/tests/integration/action-log-hooks.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { createEngine } from '@kingdom-builder/engine';
+import {
+	PHASES,
+	POPULATIONS,
+	GAME_START,
+	RULES,
+	BUILDINGS,
+	DEVELOPMENTS,
+	createBuildingRegistry,
+	createDevelopmentRegistry,
+} from '@kingdom-builder/contents';
+import { logContent } from '@kingdom-builder/web/translation/content';
+import { createContentFactory } from '../../packages/engine/tests/factories/content';
+
+describe('content-driven action log hooks', () => {
+	it('render linked targets for actions without relying on build/develop ids', () => {
+		const content = createContentFactory();
+		const hall = content.building({ name: 'Custom Hall', icon: '🏯' });
+		const plainHall = content.building({ name: 'Plain Hall' });
+		const improvement = content.development({
+			name: 'Custom Improvement',
+			icon: '🌿',
+		});
+		const idToken = ['$', 'id'].join('');
+		const landIdToken = ['$', 'landId'].join('');
+
+		const construct = content.action({
+			name: 'Construct Hall',
+			icon: '🚧',
+			effects: [
+				{
+					type: 'building',
+					method: 'add',
+					params: { id: idToken },
+				},
+			],
+		});
+
+		const establish = content.action({
+			name: 'Establish Improvement',
+			icon: '✨',
+			effects: [
+				{
+					type: 'development',
+					method: 'add',
+					params: { id: idToken, landId: landIdToken },
+				},
+			],
+		});
+
+		const constructStatic = content.action({
+			name: 'Construct Static Hall',
+			icon: '🏗️',
+			effects: [
+				{
+					type: 'building',
+					method: 'add',
+					params: { id: plainHall.id },
+				},
+			],
+		});
+
+		const buildings = createBuildingRegistry();
+		for (const [id, def] of BUILDINGS.entries()) buildings.add(id, def);
+		buildings.add(hall.id, hall);
+		buildings.add(plainHall.id, plainHall);
+
+		const developments = createDevelopmentRegistry();
+		for (const [id, def] of DEVELOPMENTS.entries()) developments.add(id, def);
+		developments.add(improvement.id, improvement);
+
+		const ctx = createEngine({
+			actions: content.actions,
+			buildings,
+			developments,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+
+		const buildingLog = logContent('action', construct.id, ctx, {
+			id: hall.id,
+		});
+		if (hall.icon) {
+			expect(buildingLog[0]).toContain(hall.icon);
+		}
+		expect(buildingLog[0]).toContain(hall.name);
+
+		const landId = ctx.activePlayer.lands[0]?.id;
+		const developmentLog = logContent('action', establish.id, ctx, {
+			id: improvement.id,
+			landId,
+		});
+		if (improvement.icon) {
+			expect(developmentLog[0]).toContain(improvement.icon);
+		}
+		expect(developmentLog[0]).toContain(improvement.name);
+
+		const staticLog = logContent('action', constructStatic.id, ctx);
+		expect(staticLog[0]).toContain(plainHall.name);
+
+		const buildingLabel = logContent('building', plainHall.id, ctx)[0];
+		expect(buildingLabel).toBe(plainHall.name);
+	});
+});


### PR DESCRIPTION
## Summary
- replace hardcoded build/develop hooks with a content-driven action log hook resolver derived from action effects
- centralize building icon resolution and apply it to building translators and resource source modifier rendering
- add coverage for custom action IDs to ensure logs and icons render without depending on build/develop actions

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68dedaf7e0008325ad1a632aff79ab60