### PR TITLE
feat: support multi-step action choices

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -324,6 +324,57 @@ export function createActionRegistry() {
 		focus: 'economy',
 	});
 
+	registry.add('demo_choice_once', {
+		...action()
+			.id('demo_choice_once')
+			.name('Demo: Choose Reward')
+			.icon('🎲')
+			.cost(Resource.ap, 1)
+			.effectGroup(
+				'Pick your prize',
+				effect(Types.Resource, ResourceMethods.ADD)
+					.params(resourceParams().key(Resource.gold).amount(2))
+					.build(),
+				effect(Types.Resource, ResourceMethods.ADD)
+					.params(resourceParams().key(Resource.happiness).amount(2))
+					.build(),
+			)
+			.build(),
+		category: 'basic',
+		order: 8,
+		focus: 'economy',
+	});
+
+	registry.add('demo_choice_twice', {
+		...action()
+			.id('demo_choice_twice')
+			.name('Demo: Story Path')
+			.icon('📜')
+			.cost(Resource.ap, 1)
+			.effectGroup(
+				'Choose the opening',
+				effect(Types.Resource, ResourceMethods.ADD)
+					.params(resourceParams().key(Resource.gold).amount(3))
+					.build(),
+				effect(Types.Resource, ResourceMethods.ADD)
+					.params(resourceParams().key(Resource.happiness).amount(1))
+					.build(),
+			)
+			.effectGroup(
+				'Choose the finale',
+				effect(Types.Stat, StatMethods.ADD)
+					.params(statParams().key(Stat.fortificationStrength).amount(1))
+					.build(),
+				effect(Types.Resource, ResourceMethods.ADD)
+					.params(resourceParams().key(Resource.ap).amount(1))
+					.build(),
+			)
+			.build(),
+		category: 'basic',
+		order: 9,
+		focus: 'economy',
+	});
+
 	registry.add(
 		'plunder',
 		action()

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -1240,7 +1240,7 @@ class BaseBuilder<T extends { id: string; name: string }> {
 
 export class ActionBuilder extends BaseBuilder<ActionConfig> {
 	constructor() {
-		super({ effects: [] }, 'Action');
+		super({ effects: [], effectGroups: [] }, 'Action');
 	}
 	cost(key: ResourceKey, amount: number) {
 		this.config.baseCosts = this.config.baseCosts || {};
@@ -1255,6 +1255,31 @@ export class ActionBuilder extends BaseBuilder<ActionConfig> {
 	}
 	effect(effect: EffectConfig) {
 		this.config.effects.push(effect);
+		return this;
+	}
+	effectGroup(
+		first: string | EffectConfig | EffectBuilder,
+		...rest: (EffectConfig | EffectBuilder)[]
+	) {
+		let label: string | undefined;
+		let options: (EffectConfig | EffectBuilder)[];
+		if (typeof first === 'string') {
+			label = first;
+			options = rest;
+		} else {
+			options = [first, ...rest];
+		}
+		if (options.length < 2)
+			throw new Error(
+				'Action effectGroup() requires at least two effect options to choose from.',
+			);
+		const effects = options.map((option) => resolveEffectConfig(option));
+		const group = {
+			...(label ? { title: label } : {}),
+			effects,
+		};
+		this.config.effectGroups = this.config.effectGroups || [];
+		this.config.effectGroups.push(group);
 		return this;
 	}
 	system(flag = true) {

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 import type { EffectDef } from '../effects';
 
 const requirementSchema = z.object({
-  type: z.string(),
-  method: z.string(),
-  params: z.record(z.unknown()).optional(),
-  message: z.string().optional(),
+	type: z.string(),
+	method: z.string(),
+	params: z.record(z.unknown()).optional(),
+	message: z.string().optional(),
 });
 
 export type RequirementConfig = z.infer<typeof requirementSchema>;
@@ -14,130 +14,136 @@ export type RequirementConfig = z.infer<typeof requirementSchema>;
 const costBagSchema = z.record(z.string(), z.number());
 
 const evaluatorSchema = z.object({
-  type: z.string(),
-  params: z.record(z.unknown()).optional(),
+	type: z.string(),
+	params: z.record(z.unknown()).optional(),
 });
 
 // Effect
 export const effectSchema: z.ZodType<EffectDef> = z.lazy(() =>
-  z.object({
-    type: z.string().optional(),
-    method: z.string().optional(),
-    params: z.record(z.unknown()).optional(),
-    effects: z.array(effectSchema).optional(),
-    evaluator: evaluatorSchema.optional(),
-    round: z.enum(['up', 'down']).optional(),
-    meta: z.record(z.unknown()).optional(),
-  }),
+	z.object({
+		type: z.string().optional(),
+		method: z.string().optional(),
+		params: z.record(z.unknown()).optional(),
+		effects: z.array(effectSchema).optional(),
+		evaluator: evaluatorSchema.optional(),
+		round: z.enum(['up', 'down']).optional(),
+		meta: z.record(z.unknown()).optional(),
+	}),
 );
 
 export type EffectConfig = EffectDef;
 
+const actionEffectGroupSchema = z.object({
+	title: z.string().optional(),
+	effects: z.array(effectSchema),
+});
+
 // Action
 export const actionSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  baseCosts: costBagSchema.optional(),
-  requirements: z.array(requirementSchema).optional(),
-  effects: z.array(effectSchema),
-  system: z.boolean().optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	baseCosts: costBagSchema.optional(),
+	requirements: z.array(requirementSchema).optional(),
+	effects: z.array(effectSchema),
+	effectGroups: z.array(actionEffectGroupSchema).optional(),
+	system: z.boolean().optional(),
 });
 
 export type ActionConfig = z.infer<typeof actionSchema>;
 
 // Building
 export const buildingSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  costs: costBagSchema,
-  upkeep: costBagSchema.optional(),
-  onBuild: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onUpkeepPhase: z.array(effectSchema).optional(),
-  onBeforeAttacked: z.array(effectSchema).optional(),
-  onAttackResolved: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	costs: costBagSchema,
+	upkeep: costBagSchema.optional(),
+	onBuild: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onUpkeepPhase: z.array(effectSchema).optional(),
+	onBeforeAttacked: z.array(effectSchema).optional(),
+	onAttackResolved: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type BuildingConfig = z.infer<typeof buildingSchema>;
 
 // Development
 export const developmentSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  upkeep: costBagSchema.optional(),
-  onBuild: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onBeforeAttacked: z.array(effectSchema).optional(),
-  onAttackResolved: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
-  system: z.boolean().optional(),
-  populationCap: z.number().optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	upkeep: costBagSchema.optional(),
+	onBuild: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onBeforeAttacked: z.array(effectSchema).optional(),
+	onAttackResolved: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
+	system: z.boolean().optional(),
+	populationCap: z.number().optional(),
 });
 
 export type DevelopmentConfig = z.infer<typeof developmentSchema>;
 
 // Population
 export const populationSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  upkeep: costBagSchema.optional(),
-  onAssigned: z.array(effectSchema).optional(),
-  onUnassigned: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onUpkeepPhase: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	upkeep: costBagSchema.optional(),
+	onAssigned: z.array(effectSchema).optional(),
+	onUnassigned: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onUpkeepPhase: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type PopulationConfig = z.infer<typeof populationSchema>;
 
 // Game config
 const landStartSchema = z.object({
-  developments: z.array(z.string()).optional(),
-  slotsMax: z.number().optional(),
-  slotsUsed: z.number().optional(),
-  tilled: z.boolean().optional(),
-  upkeep: costBagSchema.optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	developments: z.array(z.string()).optional(),
+	slotsMax: z.number().optional(),
+	slotsUsed: z.number().optional(),
+	tilled: z.boolean().optional(),
+	upkeep: costBagSchema.optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 const playerStartSchema = z.object({
-  resources: z.record(z.string(), z.number()).optional(),
-  stats: z.record(z.string(), z.number()).optional(),
-  population: z.record(z.string(), z.number()).optional(),
-  lands: z.array(landStartSchema).optional(),
+	resources: z.record(z.string(), z.number()).optional(),
+	stats: z.record(z.string(), z.number()).optional(),
+	population: z.record(z.string(), z.number()).optional(),
+	lands: z.array(landStartSchema).optional(),
 });
 
 export const startConfigSchema = z.object({
-  player: playerStartSchema,
-  players: z.record(z.string(), playerStartSchema).optional(),
+	player: playerStartSchema,
+	players: z.record(z.string(), playerStartSchema).optional(),
 });
 
 export type PlayerStartConfig = z.infer<typeof playerStartSchema>;
 export type StartConfig = z.infer<typeof startConfigSchema>;
 
 export const gameConfigSchema = z.object({
-  start: startConfigSchema.optional(),
-  actions: z.array(actionSchema).optional(),
-  buildings: z.array(buildingSchema).optional(),
-  developments: z.array(developmentSchema).optional(),
-  populations: z.array(populationSchema).optional(),
+	start: startConfigSchema.optional(),
+	actions: z.array(actionSchema).optional(),
+	buildings: z.array(buildingSchema).optional(),
+	developments: z.array(developmentSchema).optional(),
+	populations: z.array(populationSchema).optional(),
 });
 
 export type GameConfig = z.infer<typeof gameConfigSchema>;
 
 export function validateGameConfig(config: unknown): GameConfig {
-  return gameConfigSchema.parse(config);
+	return gameConfigSchema.parse(config);
 }

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -37,6 +37,23 @@ function stripSummary(
 	return filtered.length > 0 ? filtered : undefined;
 }
 
+export type MultiStepOption = {
+	key: string;
+	label: React.ReactNode;
+	description?: React.ReactNode;
+	onSelect: () => void;
+};
+
+export type MultiStepConfig = {
+	icon?: React.ReactNode;
+	isActive: boolean;
+	totalSteps: number;
+	currentStep?: number;
+	title?: React.ReactNode;
+	options?: MultiStepOption[];
+	onCancel?: () => void;
+};
+
 export type ActionCardProps = {
 	title: React.ReactNode;
 	costs: Record<string, number>;
@@ -53,6 +70,7 @@ export type ActionCardProps = {
 	onMouseEnter?: () => void;
 	onMouseLeave?: () => void;
 	focus?: Focus | undefined;
+	multiStep?: MultiStepConfig;
 };
 
 export default function ActionCard({
@@ -71,6 +89,7 @@ export default function ActionCard({
 	onMouseEnter,
 	onMouseLeave,
 	focus,
+	multiStep,
 }: ActionCardProps) {
 	const focusClass = (() => {
 		switch (focus) {
@@ -84,37 +103,148 @@ export default function ActionCard({
 				return 'from-rose-200/70 to-rose-100/40 dark:from-rose-900/40 dark:to-rose-800/20';
 		}
 	})();
+	const isFlipped = Boolean(multiStep?.isActive);
+	const showCancel = Boolean(multiStep?.isActive && multiStep.onCancel);
+	const options = multiStep?.options ?? [];
+	const currentStep = multiStep?.currentStep ?? 0;
+	const totalSteps = multiStep?.totalSteps ?? 0;
+	const multiStepIcon = multiStep ? (multiStep.icon ?? '🔀') : null;
+	const clickable = enabled && !isFlipped;
+
 	return (
-		<button
+		<div
 			className={`relative panel-card flex h-full flex-col items-start gap-2 border border-white/40 bg-gradient-to-br p-4 text-left shadow-lg shadow-amber-500/10 transition ${
-				enabled ? 'hoverable cursor-pointer' : 'cursor-not-allowed opacity-50'
+				clickable
+					? 'hoverable cursor-pointer'
+					: enabled
+						? ''
+						: 'cursor-not-allowed opacity-50'
 			} ${focusClass}`}
 			title={tooltip}
-			onClick={enabled ? onClick : undefined}
+			role="button"
+			tabIndex={clickable ? 0 : -1}
+			aria-disabled={!clickable && enabled ? true : undefined}
+			onClick={(event) => {
+				if (!clickable) return;
+				onClick?.();
+				event.stopPropagation();
+			}}
 			onMouseEnter={onMouseEnter}
 			onMouseLeave={onMouseLeave}
 		>
-			<span className="text-base font-medium">{title}</span>
-			<div className="absolute top-2 right-2 flex flex-col items-end gap-1 text-right">
-				{renderCosts(costs, playerResources, actionCostResource, upkeep)}
-				{requirements.length > 0 && (
-					<div className="flex flex-col items-end gap-0.5 text-xs text-rose-500 dark:text-rose-300">
-						<div className="whitespace-nowrap">
-							Req
-							{requirementIcons.length > 0 && ` ${requirementIcons.join('')}`}
+			{multiStepIcon && (
+				<span
+					className="pointer-events-none absolute left-3 top-3 text-lg"
+					aria-hidden
+				>
+					{multiStepIcon}
+				</span>
+			)}
+			<div className="relative h-full w-full" style={{ perspective: '1200px' }}>
+				<div
+					className="relative h-full w-full transition-transform duration-500"
+					style={{
+						transformStyle: 'preserve-3d',
+						transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
+					}}
+				>
+					<div
+						className="absolute inset-0 flex flex-col gap-2"
+						style={{
+							backfaceVisibility: 'hidden',
+							WebkitBackfaceVisibility: 'hidden',
+						}}
+					>
+						<span
+							className={`text-base font-medium ${multiStepIcon ? 'ml-6' : ''}`}
+						>
+							{title}
+						</span>
+						<div className="absolute top-2 right-2 flex flex-col items-end gap-1 text-right">
+							{renderCosts(costs, playerResources, actionCostResource, upkeep)}
+							{requirements.length > 0 && (
+								<div className="flex flex-col items-end gap-0.5 text-xs text-rose-500 dark:text-rose-300">
+									<div className="whitespace-nowrap">
+										Req
+										{requirementIcons.length > 0 &&
+											` ${requirementIcons.join('')}`}
+									</div>
+								</div>
+							)}
 						</div>
+						<ul className="text-sm list-disc pl-4 text-left">
+							{implemented ? (
+								renderSummary(stripSummary(summary, requirements))
+							) : (
+								<li className="italic text-rose-500 dark:text-rose-300">
+									Not implemented yet
+								</li>
+							)}
+						</ul>
 					</div>
-				)}
+					{multiStep && (
+						<div
+							className="absolute inset-0 flex h-full w-full flex-col rounded-2xl bg-white/90 p-4 text-left shadow-inner dark:bg-slate-900/90"
+							style={{
+								transform: 'rotateY(180deg)',
+								backfaceVisibility: 'hidden',
+								WebkitBackfaceVisibility: 'hidden',
+							}}
+						>
+							<div className="flex items-start justify-between gap-2">
+								<div>
+									<p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-300">
+										Step {Math.min(currentStep + 1, totalSteps)} of{' '}
+										{Math.max(totalSteps, 1)}
+									</p>
+									<p className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+										{multiStep.title ?? 'Choose an effect'}
+									</p>
+								</div>
+								{showCancel && (
+									<button
+										type="button"
+										onClick={(event) => {
+											event.stopPropagation();
+											multiStep.onCancel?.();
+										}}
+										className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/60 bg-white/80 text-sm font-semibold text-slate-700 shadow transition hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-100 dark:hover:bg-slate-800"
+										aria-label="Cancel action"
+									>
+										×
+									</button>
+								)}
+							</div>
+							<div className="mt-4 flex flex-col gap-2">
+								{options.length > 0 ? (
+									options.map((option) => (
+										<button
+											key={option.key}
+											type="button"
+											onClick={(event) => {
+												event.stopPropagation();
+												option.onSelect();
+											}}
+											className="flex flex-col items-start gap-1 rounded-xl border border-slate-200 bg-white/70 px-4 py-3 text-left text-sm font-medium text-slate-800 shadow hover:border-amber-400 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-100 dark:hover:border-amber-400/60 dark:hover:bg-slate-800"
+										>
+											<span>{option.label}</span>
+											{option.description && (
+												<span className="text-xs font-normal text-slate-500 dark:text-slate-300">
+													{option.description}
+												</span>
+											)}
+										</button>
+									))
+								) : (
+									<div className="rounded-xl border border-dashed border-slate-300 px-4 py-6 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-300">
+										No options available
+									</div>
+								)}
+							</div>
+						</div>
+					)}
+				</div>
 			</div>
-			<ul className="text-sm list-disc pl-4 text-left">
-				{implemented ? (
-					renderSummary(stripSummary(summary, requirements))
-				) : (
-					<li className="italic text-rose-500 dark:text-rose-300">
-						Not implemented yet
-					</li>
-				)}
-			</ul>
-		</button>
+		</div>
 	);
 }

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { getActionCosts, getActionRequirements } from '@kingdom-builder/engine';
+import type { EffectConfig } from '@kingdom-builder/engine/config/schema';
 import {
 	RESOURCES,
 	POPULATION_ROLES,
@@ -16,6 +17,7 @@ import {
 	type Summary,
 } from '../../translation';
 import ActionCard from './ActionCard';
+import type { MultiStepConfig } from './ActionCard';
 import { useGameEngine } from '../../state/GameContext';
 import { isActionPhaseActive } from '../../utils/isActionPhaseActive';
 import { getRequirementIcons } from '../../utils/getRequirementIcons';
@@ -28,6 +30,7 @@ interface Action {
 	order?: number;
 	category?: string;
 	focus?: Focus;
+	effectGroups?: ActionEffectGroup[];
 }
 interface Development {
 	id: string;
@@ -44,6 +47,20 @@ interface Building {
 }
 
 type DisplayPlayer = ReturnType<typeof useGameEngine>['ctx']['activePlayer'];
+
+interface ActionEffectGroup {
+	title?: string;
+	effects: EffectConfig[];
+}
+
+interface MultiStepState {
+	action: Action;
+	groups: ActionEffectGroup[];
+	index: number;
+	selections: number[];
+	isFlipped: boolean;
+	pendingIndex?: number;
+}
 
 function isResourceKey(key: string): key is ResourceKey {
 	return key in RESOURCES;
@@ -89,8 +106,80 @@ function GenericActions({
 		handleHoverCard,
 		clearHoverCard,
 		actionCostResource,
+		logMessage,
 	} = useGameEngine();
 	const formatRequirement = (req: string) => req;
+	const [multiStepState, setMultiStepState] = useState<MultiStepState | null>(
+		null,
+	);
+	useEffect(() => {
+		if (!canInteract) {
+			setMultiStepState(null);
+		}
+	}, [canInteract]);
+	useEffect(() => {
+		if (!multiStepState) return;
+		if (multiStepState.isFlipped) return;
+		if (multiStepState.pendingIndex === undefined) return;
+		const timer = window.setTimeout(() => {
+			setMultiStepState((prev) => {
+				if (!prev) return prev;
+				const nextIndex = prev.pendingIndex;
+				if (nextIndex === undefined) return prev;
+				if (nextIndex >= prev.groups.length) {
+					logMessage(
+						'Demo: All actions of multi-step action chosen, if i had engine support I would now execute..',
+					);
+					clearHoverCard();
+					return null;
+				}
+				return {
+					action: prev.action,
+					groups: prev.groups,
+					index: nextIndex,
+					selections: prev.selections,
+					isFlipped: true,
+				} satisfies MultiStepState;
+			});
+		}, 450);
+		return () => window.clearTimeout(timer);
+	}, [multiStepState, logMessage, clearHoverCard]);
+	useEffect(() => {
+		if (!multiStepState) return;
+		const stillExists = actions.some(
+			(candidate) => candidate.id === multiStepState.action.id,
+		);
+		if (!stillExists) setMultiStepState(null);
+	}, [actions, multiStepState]);
+
+	const startMultiStep = (action: Action, groups: ActionEffectGroup[]) => {
+		if (groups.length === 0) return;
+		clearHoverCard();
+		setMultiStepState({
+			action,
+			groups,
+			index: 0,
+			selections: Array.from({ length: groups.length }, () => -1),
+			isFlipped: true,
+		});
+	};
+	const cancelMultiStep = () => {
+		clearHoverCard();
+		setMultiStepState(null);
+	};
+	const selectOption = (optionIndex: number) => {
+		setMultiStepState((prev) => {
+			if (!prev) return prev;
+			const selections = [...prev.selections];
+			selections[prev.index] = optionIndex;
+			return {
+				...prev,
+				selections,
+				isFlipped: false,
+				pendingIndex: prev.index + 1,
+			};
+		});
+	};
 	const entries = useMemo(() => {
 		return actions
 			.map((action) => {
@@ -112,13 +201,21 @@ function GenericActions({
 					formatRequirement,
 				);
 				const requirementIcons = getRequirementIcons(action.id, ctx);
+				const definition = ctx.actions.get(action.id) as Action | undefined;
+				const groups = definition?.effectGroups ?? [];
+				const hasMultiStep = groups.length > 0;
+				const isActiveMultiStep = multiStepState?.action.id === action.id;
 				const canPay = Object.entries(costs).every(
 					([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
 				);
 				const meetsReq = requirements.length === 0;
 				const summary = summaries.get(action.id);
-				const implemented = (summary?.length ?? 0) > 0; // TODO: implement action effects
-				const enabled = canPay && meetsReq && canInteract && implemented;
+				const implemented = hasMultiStep || (summary?.length ?? 0) > 0; // TODO: implement action effects
+				const disabledByChoice = Boolean(
+					multiStepState && multiStepState.action.id !== action.id,
+				);
+				const enabled =
+					canPay && meetsReq && canInteract && implemented && !disabledByChoice;
 				const insufficientTooltip = formatMissingResources(
 					costs,
 					player.resources,
@@ -129,7 +226,50 @@ function GenericActions({
 						? requirements.join(', ')
 						: !canPay
 							? (insufficientTooltip ?? 'Cannot pay costs')
-							: undefined;
+							: disabledByChoice
+								? 'Finish the current multi-step action first'
+								: undefined;
+				const summaryForCard =
+					summary && summary.length > 0
+						? summary
+						: hasMultiStep
+							? ['Choose which effect should resolve for each step.']
+							: summary;
+				const activeIndex =
+					hasMultiStep && isActiveMultiStep
+						? Math.min(multiStepState?.index ?? 0, groups.length - 1)
+						: 0;
+				const activeGroup = hasMultiStep ? groups[activeIndex] : undefined;
+				const multiStepOptions =
+					hasMultiStep && isActiveMultiStep && multiStepState?.isFlipped
+						? (activeGroup?.effects ?? []).map((effect, optionIndex) => {
+								const detailParts = [effect.type, effect.method]
+									.filter(Boolean)
+									.join(' · ');
+								return {
+									key: `${action.id}-step-${activeIndex}-option-${optionIndex}`,
+									label: `Option ${optionIndex + 1}`,
+									description: detailParts.length > 0 ? detailParts : undefined,
+									onSelect: () => selectOption(optionIndex),
+								};
+							})
+						: undefined;
+				const baseTitle = groups[0]?.title;
+				const stepTitle = isActiveMultiStep ? activeGroup?.title : baseTitle;
+				const multiStepConfig: MultiStepConfig | undefined = hasMultiStep
+					? {
+							icon: '🔀',
+							isActive: Boolean(isActiveMultiStep && multiStepState?.isFlipped),
+							totalSteps: groups.length,
+							currentStep: isActiveMultiStep ? (multiStepState?.index ?? 0) : 0,
+							...(stepTitle ? { title: stepTitle } : {}),
+							...(multiStepOptions ? { options: multiStepOptions } : {}),
+							...(isActiveMultiStep ? { onCancel: cancelMultiStep } : {}),
+						}
+					: undefined;
+				const multiStepProps = multiStepConfig
+					? { multiStep: multiStepConfig }
+					: {};
 				return (
 					<ActionCard
 						key={action.id}
@@ -143,13 +283,23 @@ function GenericActions({
 						actionCostResource={actionCostResource}
 						requirements={requirements}
 						requirementIcons={requirementIcons}
-						summary={summary}
+						summary={summaryForCard}
 						implemented={implemented}
 						enabled={enabled}
 						tooltip={title}
 						focus={(ctx.actions.get(action.id) as Action | undefined)?.focus}
+						{...multiStepProps}
 						onClick={() => {
 							if (!canInteract) return;
+							if (hasMultiStep) {
+								if (multiStepState) {
+									if (multiStepState.action.id !== action.id) return;
+									return;
+								}
+								if (!enabled) return;
+								startMultiStep(action, groups);
+								return;
+							}
 							void handlePerform(action);
 						}}
 						onMouseEnter={() => {
@@ -160,7 +310,14 @@ function GenericActions({
 								effects,
 								requirements,
 								costs,
-								...(description && { description }),
+								...(description
+									? { description }
+									: hasMultiStep
+										? {
+												description:
+													'Choose which option you want to resolve before the action continues.',
+											}
+										: {}),
 								...(!implemented && {
 									description: 'Not implemented yet',
 									descriptionClass: 'italic text-red-600',
@@ -195,6 +352,22 @@ function RaisePopOptions({
 	} = useGameEngine();
 	const formatRequirement = (req: string) => req;
 	const requirementIcons = getRequirementIcons(action.id, ctx);
+	const baseDefinition = ctx.actions.get(action.id) as Action | undefined;
+	const multiStepIndicator: MultiStepConfig | undefined =
+		baseDefinition?.effectGroups && baseDefinition.effectGroups.length > 0
+			? {
+					icon: '🔀',
+					isActive: false,
+					totalSteps: baseDefinition.effectGroups.length,
+					currentStep: 0,
+					...(baseDefinition.effectGroups[0]?.title
+						? { title: baseDefinition.effectGroups[0]?.title }
+						: {}),
+				}
+			: undefined;
+	const multiStepProps = multiStepIndicator
+		? { multiStep: multiStepIndicator }
+		: {};
 	return (
 		<>
 			{[
@@ -247,6 +420,7 @@ function RaisePopOptions({
 						enabled={enabled}
 						tooltip={title}
 						focus={(ctx.actions.get(action.id) as Action | undefined)?.focus}
+						{...multiStepProps}
 						onClick={() => {
 							if (!canInteract) return;
 							void handlePerform(action, { role });
@@ -369,6 +543,22 @@ function DevelopOptions({
 		clearHoverCard,
 		actionCostResource,
 	} = useGameEngine();
+	const baseDefinition = ctx.actions.get(action.id) as Action | undefined;
+	const multiStepIndicator: MultiStepConfig | undefined =
+		baseDefinition?.effectGroups && baseDefinition.effectGroups.length > 0
+			? {
+					icon: '🔀',
+					isActive: false,
+					totalSteps: baseDefinition.effectGroups.length,
+					currentStep: 0,
+					...(baseDefinition.effectGroups[0]?.title
+						? { title: baseDefinition.effectGroups[0]?.title }
+						: {}),
+				}
+			: undefined;
+	const multiStepProps = multiStepIndicator
+		? { multiStep: multiStepIndicator }
+		: {};
 	const landIdForCost = player.lands[0]?.id as string;
 	const entries = useMemo(() => {
 		return developments
@@ -447,6 +637,7 @@ function DevelopOptions({
 							focus={
 								(ctx.developments.get(d.id) as Development | undefined)?.focus
 							}
+							{...multiStepProps}
 							onClick={() => {
 								if (!canInteract) return;
 								const landId = player.lands.find((l) => l.slotsFree > 0)?.id;
@@ -506,6 +697,22 @@ function BuildOptions({
 		clearHoverCard,
 		actionCostResource,
 	} = useGameEngine();
+	const baseDefinition = ctx.actions.get(action.id) as Action | undefined;
+	const multiStepIndicator: MultiStepConfig | undefined =
+		baseDefinition?.effectGroups && baseDefinition.effectGroups.length > 0
+			? {
+					icon: '🔀',
+					isActive: false,
+					totalSteps: baseDefinition.effectGroups.length,
+					currentStep: 0,
+					...(baseDefinition.effectGroups[0]?.title
+						? { title: baseDefinition.effectGroups[0]?.title }
+						: {}),
+				}
+			: undefined;
+	const multiStepProps = multiStepIndicator
+		? { multiStep: multiStepIndicator }
+		: {};
 	const entries = useMemo(() => {
 		const owned = player.buildings;
 		return buildings
@@ -574,6 +781,7 @@ function BuildOptions({
 							enabled={enabled}
 							tooltip={title}
 							focus={(ctx.buildings.get(b.id) as Building | undefined)?.focus}
+							{...multiStepProps}
 							onClick={() => {
 								if (!canInteract) return;
 								void handlePerform(action, { id: b.id });
@@ -626,6 +834,22 @@ function DemolishOptions({
 		clearHoverCard,
 		actionCostResource,
 	} = useGameEngine();
+	const baseDefinition = ctx.actions.get(action.id) as Action | undefined;
+	const multiStepIndicator: MultiStepConfig | undefined =
+		baseDefinition?.effectGroups && baseDefinition.effectGroups.length > 0
+			? {
+					icon: '🔀',
+					isActive: false,
+					totalSteps: baseDefinition.effectGroups.length,
+					currentStep: 0,
+					...(baseDefinition.effectGroups[0]?.title
+						? { title: baseDefinition.effectGroups[0]?.title }
+						: {}),
+				}
+			: undefined;
+	const multiStepProps = multiStepIndicator
+		? { multiStep: multiStepIndicator }
+		: {};
 	const entries = useMemo(() => {
 		return Array.from(player.buildings)
 			.map((id) => {
@@ -710,6 +934,7 @@ function DemolishOptions({
 							enabled={enabled}
 							tooltip={title}
 							focus={(ctx.buildings.get(id) as Building | undefined)?.focus}
+							{...multiStepProps}
 							onClick={() => {
 								if (!canInteract) return;
 								void handlePerform(action, { id });

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -105,6 +105,10 @@ interface GameEngineContextValue {
 	runUntilActionPhase: () => Promise<void>;
 	handleEndTurn: () => Promise<void>;
 	updateMainPhaseStep: (apStartOverride?: number) => void;
+	logMessage: (
+		entry: string | string[],
+		player?: EngineContext['activePlayer'],
+	) => void;
 	onExit?: () => void;
 	darkMode: boolean;
 	onToggleDark: () => void;
@@ -694,6 +698,9 @@ export function GameProvider({
 		runUntilActionPhase,
 		handleEndTurn,
 		updateMainPhaseStep,
+		logMessage: (entry, playerOverride) => {
+			addLog(entry, playerOverride);
+		},
 		darkMode,
 		onToggleDark,
 		timeScale,


### PR DESCRIPTION
## Summary
- allow action configs to declare effect groups so players can pick between grouped outcomes
- add demo actions to showcase single and multi-step choice flows
- update web action card/panel UI to handle multi-step selection with flip animation and cancel option

## Testing
- npm run typecheck
- npm run lint
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68ded94491ac8325a14f36cd4b16eabe