### PR TITLE
Add general resource icon treatment to player resource bar

### DIFF
--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import { RESOURCES } from '@kingdom-builder/contents';
+import { RESOURCES, type ResourceKey } from '@kingdom-builder/contents';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { useGameEngine } from '../../state/GameContext';
 import { useValueChangeIndicators } from '../../utils/useValueChangeIndicators';
+import { GENERAL_RESOURCE_ICON } from '../../icons';
+
+const RESOURCE_CARD_BG =
+	'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60';
 
 interface ResourceButtonProps {
 	resourceKey: keyof typeof RESOURCES;
@@ -67,9 +71,13 @@ interface ResourceBarProps {
 
 const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 	const { handleHoverCard, clearHoverCard } = useGameEngine();
+	const resourceKeys = Object.keys(RESOURCES) as ResourceKey[];
 	return (
-		<>
-			{(Object.keys(RESOURCES) as (keyof typeof RESOURCES)[]).map((k) => {
+		<div className="resource-bar">
+			<span className="resource-bar__icon" aria-hidden="true">
+				{GENERAL_RESOURCE_ICON}
+			</span>
+			{resourceKeys.map((k) => {
 				const info = RESOURCES[k];
 				const v = player.resources[k] ?? 0;
 				const showResourceCard = () =>
@@ -78,8 +86,7 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 						effects: [],
 						requirements: [],
 						description: info.description,
-						bgClass:
-							'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
+						bgClass: RESOURCE_CARD_BG,
 					});
 				return (
 					<ResourceButton
@@ -91,7 +98,7 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 					/>
 				);
 			})}
-		</>
+		</div>
 	);
 };
 

--- a/packages/web/src/icons/index.ts
+++ b/packages/web/src/icons/index.ts
@@ -1,0 +1,1 @@
+export const GENERAL_RESOURCE_ICON = '🧺';

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -46,6 +46,41 @@
   .bar-item {
     @apply flex items-center gap-1 whitespace-nowrap rounded-full border border-white/40 bg-white/50 px-3 py-1 text-sm font-semibold tabular-nums text-slate-700 shadow-sm shadow-white/30 transition appearance-none dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100;
   }
+  .resource-bar {
+    @apply relative flex flex-wrap items-center gap-2 rounded-full pl-10 pr-3 py-1;
+  }
+  .resource-bar::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 9999px;
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0));
+    opacity: 0.9;
+    pointer-events: none;
+    z-index: 0;
+  }
+  .dark .resource-bar::before {
+    border-color: rgba(255, 255, 255, 0.15);
+    background: linear-gradient(135deg, rgba(148, 163, 184, 0.22), rgba(30, 41, 59, 0.05));
+  }
+  .resource-bar > * {
+    position: relative;
+    z-index: 1;
+  }
+  .resource-bar__icon {
+    @apply absolute left-3 flex h-6 w-6 items-center justify-center rounded-full text-base;
+    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), rgba(251, 191, 36, 0.55));
+    box-shadow: 0 4px 10px rgba(251, 191, 36, 0.25);
+    color: #92400e;
+    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.6);
+  }
+  .dark .resource-bar__icon {
+    background: radial-gradient(circle at 30% 30%, rgba(248, 250, 252, 0.9), rgba(234, 179, 8, 0.35));
+    box-shadow: 0 4px 10px rgba(202, 138, 4, 0.35);
+    color: #facc15;
+    text-shadow: 0 1px 2px rgba(17, 24, 39, 0.75);
+  }
   .hoverable {
     @apply transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/60 hover:shadow-lg hover:shadow-amber-500/10 dark:hover:bg-white/10 dark:hover:shadow-black/30;
   }

--- a/packages/web/src/translation/effects/formatters/modifier_helpers.ts
+++ b/packages/web/src/translation/effects/formatters/modifier_helpers.ts
@@ -1,5 +1,6 @@
 import type { EffectDef, EngineContext } from '@kingdom-builder/engine';
 import { POPULATION_INFO, RESOURCES } from '@kingdom-builder/contents';
+import { GENERAL_RESOURCE_ICON } from '../../../icons';
 import type {
 	ActionDef,
 	DevelopmentDef,
@@ -7,8 +8,6 @@ import type {
 } from '@kingdom-builder/contents';
 import { signed } from '../helpers';
 import type { SummaryEntry } from '../../content/types';
-
-const GENERIC_RESOURCE_ICON = '🧺';
 
 const joinParts = (...parts: Array<string | undefined>) =>
 	parts.filter(Boolean).join(' ').trim();
@@ -90,7 +89,7 @@ interface ResultModifierSource {
 }
 
 const resolveIcon = (icon?: string) =>
-	icon && icon.trim() ? icon : GENERIC_RESOURCE_ICON;
+	icon && icon.trim() ? icon : GENERAL_RESOURCE_ICON;
 
 export function formatGainFrom(
 	label: ResultModifierLabel,


### PR DESCRIPTION
## Summary
- wrap the player panel resource list in a decorative capsule that displays the general resource icon
- style the new capsule to match the frosted glass aesthetic without increasing the panel footprint
- centralize the general resource icon export for reuse in summaries and UI elements

## Testing
- npm run lint
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68dee4cfbdd08325aa96df0d6cc614b3