### PR TITLE
Improve passive duration metadata handling

### DIFF
--- a/packages/web/src/translation/effects/formatters/passive.ts
+++ b/packages/web/src/translation/effects/formatters/passive.ts
@@ -4,20 +4,112 @@ import {
 	describeEffects,
 } from '../factory';
 import { PHASES, PASSIVE_INFO } from '@kingdom-builder/contents';
+import type { EffectDef, EngineContext } from '@kingdom-builder/engine';
+
+type PassiveDurationMeta = {
+	label: string;
+	icon?: string;
+	phaseId?: string;
+	source: 'manual' | 'phase' | 'fallback';
+};
+
+function resolvePhaseMeta(ctx: EngineContext, id: string | undefined) {
+	if (!id) return undefined;
+	return (
+		ctx.phases.find((phase) => phase.id === id) ??
+		PHASES.find((p) => p.id === id)
+	);
+}
+
+function resolveDurationMeta(
+	eff: EffectDef<Record<string, unknown>>,
+	ctx: EngineContext,
+): PassiveDurationMeta | null {
+	const params = eff.params ?? {};
+	const manualLabel =
+		typeof params['durationLabel'] === 'string'
+			? params['durationLabel']
+			: undefined;
+	const manualIcon =
+		typeof params['durationIcon'] === 'string'
+			? params['durationIcon']
+			: undefined;
+	const durationPhaseId =
+		typeof params['durationPhaseId'] === 'string'
+			? params['durationPhaseId']
+			: undefined;
+
+	let label = manualLabel;
+	let icon = manualIcon;
+	let source: PassiveDurationMeta['source'] | undefined;
+	let phaseId: string | undefined;
+
+	if (durationPhaseId) {
+		phaseId = durationPhaseId;
+		const phase = resolvePhaseMeta(ctx, durationPhaseId);
+		if (!label && phase?.label) {
+			label = phase.label;
+			source = 'phase';
+		}
+		if (!icon && phase?.icon) icon = phase.icon;
+	}
+
+	if (!label && params['onUpkeepPhase']) {
+		phaseId = 'upkeep';
+		const phase = resolvePhaseMeta(ctx, 'upkeep');
+		if (phase?.label) {
+			label = phase.label;
+			source = 'phase';
+		} else {
+			label = 'Upkeep';
+			source = 'fallback';
+		}
+		if (!icon && phase?.icon) icon = phase.icon;
+	}
+
+	if (label) {
+		if (!source) source = manualLabel ? 'manual' : 'phase';
+		return { label, icon, phaseId, source };
+	}
+
+	if (icon) {
+		if (phaseId) {
+			const phase = resolvePhaseMeta(ctx, phaseId);
+			if (phase?.label) {
+				return { label: phase.label, icon, phaseId, source: source ?? 'phase' };
+			}
+		}
+		if (params['onUpkeepPhase']) {
+			return { label: 'Upkeep', icon, phaseId: 'upkeep', source: 'fallback' };
+		}
+	}
+
+	return null;
+}
+
+function formatDuration(
+	meta: PassiveDurationMeta,
+	{ includePhase }: { includePhase: boolean },
+) {
+	const icon = meta.icon ? `${meta.icon} ` : '';
+	const suffix =
+		includePhase && meta.source !== 'manual' && meta.phaseId ? ' Phase' : '';
+	return `${icon}${meta.label}${suffix}`;
+}
 
 registerEffectFormatter('passive', 'add', {
 	summarize: (eff, ctx) => {
 		const inner = summarizeEffects(eff.effects || [], ctx);
-		const upkeepLabel =
-			PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
-		return eff.params?.['onUpkeepPhase']
-			? [
-					{
-						title: `⏳ Until next ${upkeepLabel}`,
-						items: inner,
-					},
-				]
-			: inner;
+		const duration = resolveDurationMeta(eff, ctx);
+		if (!duration) return inner;
+		return [
+			{
+				title: `⏳ Until next ${formatDuration(duration, {
+					includePhase: false,
+				})}`,
+				items: inner,
+			},
+		];
 	},
 	describe: (eff, ctx) => {
 		const icon =
@@ -26,16 +118,16 @@ registerEffectFormatter('passive', 'add', {
 			(eff.params?.['name'] as string | undefined) ?? PASSIVE_INFO.label;
 		const prefix = icon ? `${icon} ` : '';
 		const inner = describeEffects(eff.effects || [], ctx);
-		const upkeepLabel =
-			PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
-		return eff.params?.['onUpkeepPhase']
-			? [
-					{
-						title: `${prefix}${name} – Until your next ${upkeepLabel} Phase`,
-						items: inner,
-					},
-				]
-			: inner;
+		const duration = resolveDurationMeta(eff, ctx);
+		if (!duration) return inner;
+		return [
+			{
+				title: `${prefix}${name} – Until your next ${formatDuration(duration, {
+					includePhase: true,
+				})}`,
+				items: inner,
+			},
+		];
 	},
 	log: (eff, ctx) => {
 		const icon =
@@ -45,11 +137,13 @@ registerEffectFormatter('passive', 'add', {
 		const prefix = icon ? `${icon} ` : '';
 		const inner = describeEffects(eff.effects || [], ctx);
 		const items = [...(inner.length ? inner : [])];
-		const upkeepLabel =
-			PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
-		if (eff.params?.['onUpkeepPhase'])
+		const duration = resolveDurationMeta(eff, ctx);
+		if (duration)
 			items.push(
-				`${prefix}${name} duration: Until player's next ${upkeepLabel} Phase`,
+				`${prefix}${name} duration: Until player's next ${formatDuration(
+					duration,
+					{ includePhase: true },
+				)}`,
 			);
 		return { title: `${prefix}${name} added`, items };
 	},

--- a/packages/web/tests/hold-festival-action-translation.test.ts
+++ b/packages/web/tests/hold-festival-action-translation.test.ts
@@ -73,14 +73,16 @@ describe('hold festival action translation', () => {
 				? -(innerRes.params.amount as number)
 				: (innerRes.params.amount as number);
 		const armyAttack = ctx.actions.get('army_attack');
-		const upkeepLabel =
-			PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
+		const upkeepPhase = ctx.phases.find((p) => p.id === 'upkeep');
+		const upkeepLabel = upkeepPhase?.label || 'Upkeep';
+		const upkeepIcon = upkeepPhase?.icon;
+		const upkeepSummaryLabel = `${upkeepIcon ? `${upkeepIcon} ` : ''}${upkeepLabel}`;
 
 		expect(summary).toEqual([
 			`${happinessIcon}${sign(happinessAmt)}${happinessAmt}`,
 			`${fortIcon}${sign(fortAmt)}${fortAmt}`,
 			{
-				title: `⏳ Until next ${upkeepLabel}`,
+				title: `⏳ Until next ${upkeepSummaryLabel}`,
 				items: [
 					`${MODIFIER_INFO.result.icon}${armyAttack.icon}: ${happinessIcon}${sign(penaltyAmt)}${penaltyAmt}`,
 				],
@@ -127,14 +129,18 @@ describe('hold festival action translation', () => {
 				? -(innerRes.params.amount as number)
 				: (innerRes.params.amount as number);
 		const armyAttack = ctx.actions.get('army_attack');
-		const upkeepLabel =
-			PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
+		const upkeepPhase = ctx.phases.find((p) => p.id === 'upkeep');
+		const upkeepLabel = upkeepPhase?.label || 'Upkeep';
+		const upkeepIcon = upkeepPhase?.icon;
+		const upkeepDescriptionLabel = `${
+			upkeepIcon ? `${upkeepIcon} ` : ''
+		}${upkeepLabel} Phase`;
 
 		expect(desc).toEqual([
 			`${happinessInfo.icon}${sign(happinessAmt)}${happinessAmt} ${happinessInfo.label}`,
 			`${fortAmt >= 0 ? 'Gain' : 'Lose'} ${Math.abs(fortAmt)} ${fortInfo.icon} ${fortInfo.label}`,
 			{
-				title: `${passiveIcon ? `${passiveIcon} ` : ''}${passiveName} – Until your next ${upkeepLabel} Phase`,
+				title: `${passiveIcon ? `${passiveIcon} ` : ''}${passiveName} – Until your next ${upkeepDescriptionLabel}`,
 				items: [
 					`${MODIFIER_INFO.result.icon} ${MODIFIER_INFO.result.label} on ${armyAttack.icon} ${armyAttack.name}: Whenever it resolves, ${happinessInfo.icon}${sign(penaltyAmt)}${penaltyAmt} ${happinessInfo.label}`,
 				],
@@ -168,14 +174,18 @@ describe('hold festival action translation', () => {
 			innerRes.method === 'remove'
 				? -(innerRes.params.amount as number)
 				: (innerRes.params.amount as number);
-		const upkeepLabel =
-			PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
+		const upkeepPhase = ctx.phases.find((p) => p.id === 'upkeep');
+		const upkeepLabel = upkeepPhase?.label || 'Upkeep';
+		const upkeepIcon = upkeepPhase?.icon;
+		const upkeepDescriptionLabel = `${
+			upkeepIcon ? `${upkeepIcon} ` : ''
+		}${upkeepLabel} Phase`;
 
 		expect(log).toEqual([
 			`Played ${holdFestival.icon} ${holdFestival.name}`,
 			`  ${passiveIcon ? `${passiveIcon} ` : ''}${passiveName} added`,
 			`    ${MODIFIER_INFO.result.icon} ${MODIFIER_INFO.result.label} on ${armyAttack.icon} ${armyAttack.name}: Whenever it resolves, ${happinessInfo.icon}${sign(penaltyAmt)}${penaltyAmt} ${happinessInfo.label}`,
-			`    ${passiveIcon ? `${passiveIcon} ` : ''}${passiveName} duration: Until player's next ${upkeepLabel} Phase`,
+			`    ${passiveIcon ? `${passiveIcon} ` : ''}${passiveName} duration: Until player's next ${upkeepDescriptionLabel}`,
 		]);
 	});
 });

--- a/packages/web/tests/passive-duration-formatter.test.ts
+++ b/packages/web/tests/passive-duration-formatter.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+	summarizeEffects,
+	describeEffects,
+	logEffects,
+} from '../src/translation/effects';
+import { createEngine, type EffectDef } from '@kingdom-builder/engine';
+import { createContentFactory } from '../../engine/tests/factories/content';
+import type { PhaseDef } from '@kingdom-builder/engine/phases';
+import type { StartConfig } from '@kingdom-builder/engine/config/schema';
+import type { RuleSet } from '@kingdom-builder/engine/services';
+
+vi.mock('@kingdom-builder/engine', async () => {
+	return await import('../../engine/src');
+});
+
+function createSyntheticCtx() {
+	const content = createContentFactory();
+	const tierResourceKey = 'synthetic:resource:tier';
+	const phases: PhaseDef[] = [
+		{
+			id: 'phase:festival',
+			label: 'Festival',
+			icon: '🎉',
+			steps: [{ id: 'phase:festival:step' }],
+		},
+	];
+	const start: StartConfig = {
+		player: {
+			resources: { [tierResourceKey]: 0 },
+			stats: {},
+			population: {},
+			lands: [],
+		},
+	};
+	const rules: RuleSet = {
+		defaultActionAPCost: 1,
+		absorptionCapPct: 1,
+		absorptionRounding: 'down',
+		tieredResourceKey: tierResourceKey,
+		tierDefinitions: [],
+		slotsPerNewLand: 1,
+		maxSlotsPerLand: 1,
+		basePopulationCap: 1,
+	};
+	return createEngine({
+		actions: content.actions,
+		buildings: content.buildings,
+		developments: content.developments,
+		populations: content.populations,
+		phases,
+		start,
+		rules,
+	});
+}
+
+describe('passive formatter duration metadata', () => {
+	it('uses custom phase metadata when provided', () => {
+		const ctx = createSyntheticCtx();
+		const passive: EffectDef = {
+			type: 'passive',
+			method: 'add',
+			params: {
+				id: 'synthetic:passive:festival',
+				name: 'Festival Spirit',
+				icon: '✨',
+				durationPhaseId: 'phase:festival',
+			},
+			effects: [],
+		};
+
+		const summary = summarizeEffects([passive], ctx);
+		const description = describeEffects([passive], ctx);
+		const log = logEffects([passive], ctx);
+
+		expect(summary).toEqual([
+			{ title: '⏳ Until next 🎉 Festival', items: [] },
+		]);
+		expect(description).toEqual([
+			{
+				title: '✨ Festival Spirit – Until your next 🎉 Festival Phase',
+				items: [],
+			},
+		]);
+		expect(log).toEqual([
+			{
+				title: '✨ Festival Spirit added',
+				items: [
+					"✨ Festival Spirit duration: Until player's next 🎉 Festival Phase",
+				],
+			},
+		]);
+	});
+});

--- a/packages/web/tests/plow-action-translation.test.ts
+++ b/packages/web/tests/plow-action-translation.test.ts
@@ -44,8 +44,10 @@ describe('plow action translation', () => {
 		const till = ctx.actions.get('till');
 		const plow = ctx.actions.get('plow');
 		const passive = plow.effects.find((e: EffectDef) => e.type === 'passive');
-		const upkeepLabel =
-			PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
+		const upkeepPhase = ctx.phases.find((p) => p.id === 'upkeep');
+		const upkeepLabel = upkeepPhase?.label || 'Upkeep';
+		const upkeepIcon = upkeepPhase?.icon;
+		const upkeepSummaryLabel = `${upkeepIcon ? `${upkeepIcon} ` : ''}${upkeepLabel}`;
 		const costMod = passive?.effects.find(
 			(e: EffectDef) => e.type === 'cost_mod',
 		);
@@ -57,7 +59,7 @@ describe('plow action translation', () => {
 			`${expand.icon} ${expand.name}`,
 			`${till.icon} ${till.name}`,
 			{
-				title: `⏳ Until next ${upkeepLabel}`,
+				title: `⏳ Until next ${upkeepSummaryLabel}`,
 				items: [`💲: ${modIcon}+${modAmt}`],
 			},
 		]);
@@ -95,8 +97,12 @@ describe('plow action translation', () => {
 			| undefined;
 		const passiveName = passiveMeta?.name ?? PASSIVE_INFO.label;
 		const passiveIcon = passiveMeta?.icon ?? PASSIVE_INFO.icon;
-		const upkeepLabel =
-			PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
+		const upkeepPhase = ctx.phases.find((p) => p.id === 'upkeep');
+		const upkeepLabel = upkeepPhase?.label || 'Upkeep';
+		const upkeepIcon = upkeepPhase?.icon;
+		const upkeepDescriptionLabel = `${
+			upkeepIcon ? `${upkeepIcon} ` : ''
+		}${upkeepLabel} Phase`;
 		const expandLand = expand.effects.find((e: EffectDef) => e.type === 'land');
 		const landCount = (expandLand?.params as { count?: number })?.count ?? 0;
 		const expandHap = expand.effects.find(
@@ -121,7 +127,7 @@ describe('plow action translation', () => {
 				],
 			},
 			{
-				title: `${passiveIcon ? `${passiveIcon} ` : ''}${passiveName} – Until your next ${upkeepLabel} Phase`,
+				title: `${passiveIcon ? `${passiveIcon} ` : ''}${passiveName} – Until your next ${upkeepDescriptionLabel}`,
 				items: [
 					`💲 Cost Modifier on all actions: Increase cost by ${modIcon}${modAmt}`,
 				],


### PR DESCRIPTION
## Summary
- derive passive duration metadata from explicit phase IDs or labels before falling back to upkeep
- update passive translation tests to expect phase icons and dynamic labels
- add coverage for custom phase metadata using a synthetic context

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68dee9c337288325bf97eadc9cfb59cc