### PR TITLE
Refactor overview to use configurable data

### DIFF
--- a/packages/web/src/Overview.tsx
+++ b/packages/web/src/Overview.tsx
@@ -1,18 +1,6 @@
 import React from 'react';
 import Button from './components/common/Button';
 import {
-	ACTIONS as actionInfo,
-	LAND_INFO,
-	SLOT_INFO,
-	RESOURCES,
-	Resource,
-	PHASES,
-	POPULATION_ROLES,
-	PopulationRole,
-	STATS,
-	Stat,
-} from '@kingdom-builder/contents';
-import {
 	ShowcaseBackground,
 	ShowcaseLayout,
 	ShowcaseCard,
@@ -29,10 +17,17 @@ import {
 } from './components/overview/OverviewLayout';
 import type { OverviewSectionDef } from './components/overview/OverviewLayout';
 import { createOverviewSections } from './components/overview/sectionsData';
-import type { OverviewIconSet } from './components/overview/sectionsData';
+import type { OverviewContentSection } from './components/overview/sectionsData';
+import { buildOverviewIconSet } from './components/overview/overviewTokens';
+import type { OverviewTokenConfig } from './components/overview/overviewTokens';
+import { DEFAULT_OVERVIEW_CONTENT } from './components/overview/defaultContent';
 
-interface OverviewProps {
+export type { OverviewTokenConfig } from './components/overview/overviewTokens';
+
+export interface OverviewProps {
 	onBack: () => void;
+	tokenConfig?: OverviewTokenConfig;
+	content?: OverviewContentSection[];
 }
 
 const HERO_INTRO_TEXT = [
@@ -45,29 +40,17 @@ const HERO_PARAGRAPH_TEXT = [
 	'{build} clever construction, and {attack} daring raids decide who steers the crown.',
 ].join(' ');
 
-export default function Overview({ onBack }: OverviewProps) {
-	const icons: OverviewIconSet = {
-		expand: actionInfo.get('expand')?.icon,
-		build: actionInfo.get('build')?.icon,
-		attack: actionInfo.get('army_attack')?.icon,
-		develop: actionInfo.get('develop')?.icon,
-		raisePop: actionInfo.get('raise_pop')?.icon,
-		growth: PHASES.find((p) => p.id === 'growth')?.icon,
-		upkeep: PHASES.find((p) => p.id === 'upkeep')?.icon,
-		main: PHASES.find((p) => p.id === 'main')?.icon,
-		land: LAND_INFO.icon,
-		slot: SLOT_INFO.icon,
-		gold: RESOURCES[Resource.gold].icon,
-		ap: RESOURCES[Resource.ap].icon,
-		happiness: RESOURCES[Resource.happiness].icon,
-		castle: RESOURCES[Resource.castleHP].icon,
-		army: STATS[Stat.armyStrength].icon,
-		fort: STATS[Stat.fortificationStrength].icon,
-		council: POPULATION_ROLES[PopulationRole.Council].icon,
-		legion: POPULATION_ROLES[PopulationRole.Legion].icon,
-		fortifier: POPULATION_ROLES[PopulationRole.Fortifier].icon,
-		citizen: POPULATION_ROLES[PopulationRole.Citizen].icon,
-	};
+export default function Overview({
+	onBack,
+	tokenConfig,
+	content,
+}: OverviewProps) {
+	const icons = React.useMemo(
+		() => buildOverviewIconSet(tokenConfig),
+		[tokenConfig],
+	);
+
+	const sections = content ?? DEFAULT_OVERVIEW_CONTENT;
 
 	const tokens: Record<string, React.ReactNode> = {
 		castle: icons.castle,
@@ -83,6 +66,13 @@ export default function Overview({ onBack }: OverviewProps) {
 		slot: icons.slot,
 		gold: icons.gold,
 		main: icons.main,
+		growth: icons.growth,
+		upkeep: icons.upkeep,
+		happiness: icons.happiness,
+		council: icons.council,
+		legion: icons.legion,
+		fortifier: icons.fortifier,
+		citizen: icons.citizen,
 	};
 
 	const heroTokens: Record<string, React.ReactNode> = {
@@ -90,7 +80,7 @@ export default function Overview({ onBack }: OverviewProps) {
 		game: <strong>Kingdom Builder</strong>,
 	};
 
-	const sections: OverviewSectionDef[] = createOverviewSections(icons);
+	const renderedSections = createOverviewSections(icons, sections);
 
 	const renderSection = (section: OverviewSectionDef) => {
 		if (section.kind === 'paragraph') {
@@ -143,7 +133,7 @@ export default function Overview({ onBack }: OverviewProps) {
 					</p>
 
 					<div className={OVERVIEW_GRID_CLASS}>
-						{sections.map(renderSection)}
+						{renderedSections.map(renderSection)}
 					</div>
 				</ShowcaseCard>
 

--- a/packages/web/src/components/overview/defaultContent.ts
+++ b/packages/web/src/components/overview/defaultContent.ts
@@ -1,0 +1,129 @@
+import type { OverviewContentSection } from './sectionsData';
+
+export const DEFAULT_OVERVIEW_CONTENT: OverviewContentSection[] = [
+	{
+		kind: 'paragraph',
+		id: 'objective',
+		icon: 'castle',
+		title: 'Your Objective',
+		span: true,
+		paragraphs: [
+			'Keep your {castle} castle standing through every assault.',
+			"Plot daring turns that unravel your rival's engine.",
+			'Victory strikes when a stronghold falls or a ruler stalls out.',
+			'The final round crowns the monarch with the healthiest realm.',
+		],
+	},
+	{
+		kind: 'list',
+		id: 'turn-flow',
+		icon: 'growth',
+		title: 'Turn Flow',
+		span: true,
+		items: [
+			{
+				icon: 'growth',
+				label: 'Growth',
+				body: [
+					'Kickstarts your engine with income and {army} Army strength.',
+					'Stacks {fort} Fortification bonuses and triggers automatic boons.',
+				],
+			},
+			{
+				icon: 'upkeep',
+				label: 'Upkeep',
+				body: [
+					'Settles wages, ongoing effects, and any debts your realm has racked up.',
+				],
+			},
+			{
+				icon: 'main',
+				label: 'Main Phase',
+				body: [
+					'Both players secretly queue actions.',
+					'Reveal them in a flurry of {ap} AP-powered maneuvers.',
+				],
+			},
+		],
+	},
+	{
+		kind: 'list',
+		id: 'resources',
+		icon: 'gold',
+		title: 'Resources',
+		items: [
+			{
+				icon: 'gold',
+				label: 'Gold',
+				body: ['Fuels {build} buildings, diplomacy, and daring plays.'],
+			},
+			{
+				icon: 'ap',
+				label: 'Action Points',
+				body: ['Are the energy for every turn in the {main} Main phase.'],
+			},
+			{
+				icon: 'happiness',
+				label: 'Happiness',
+				body: ['Keeps the populace cheering instead of rioting.'],
+			},
+			{
+				icon: 'castle',
+				label: 'Castle HP',
+				body: ['Is your lifeline—lose it and the dynasty topples.'],
+			},
+		],
+	},
+	{
+		kind: 'paragraph',
+		id: 'land',
+		icon: 'land',
+		title: 'Land & Developments',
+		paragraphs: [
+			'Claim {land} land and slot in {slot} developments to unlock perks.',
+			'Farms pump {gold} gold while signature projects open slots or unleash passives.',
+		],
+	},
+	{
+		kind: 'list',
+		id: 'population',
+		icon: 'council',
+		title: 'Population Roles',
+		span: true,
+		items: [
+			{
+				icon: 'council',
+				label: 'Council',
+				body: ['Rallies extra {ap} Action Points each round.'],
+			},
+			{
+				icon: 'legion',
+				label: 'Legion',
+				body: [
+					'Reinforces {army} Army strength for devastating {attack} raids.',
+				],
+			},
+			{
+				icon: 'fortifier',
+				label: 'Fortifier',
+				body: ['Cements your defenses with persistent buffs.'],
+			},
+			{
+				icon: 'citizen',
+				label: 'Citizens',
+				body: ['Wait in the wings, ready to specialize as needed.'],
+			},
+		],
+	},
+	{
+		kind: 'paragraph',
+		id: 'actions',
+		icon: 'develop',
+		title: 'Actions & Strategy',
+		span: true,
+		paragraphs: [
+			'Spend {ap} AP to {expand} grow territory or {develop} upgrade key lands.',
+			'Field {raisePop} specialists or launch {attack} attacks to snowball momentum.',
+		],
+	},
+];

--- a/packages/web/src/components/overview/overviewTokens.ts
+++ b/packages/web/src/components/overview/overviewTokens.ts
@@ -1,0 +1,228 @@
+import type { ReactNode } from 'react';
+import {
+	ACTIONS as actionInfo,
+	LAND_INFO,
+	SLOT_INFO,
+	RESOURCES,
+	Resource,
+	PHASES,
+	POPULATION_ROLES,
+	PopulationRole,
+	STATS,
+	Stat,
+} from '@kingdom-builder/contents';
+import type { OverviewIconSet } from './sectionsData';
+
+type TokenCandidateInput = string | ReadonlyArray<string>;
+
+type OverviewTokenCategory<TKeys extends string> = Partial<
+	Record<TKeys, TokenCandidateInput>
+>;
+
+type TokenCategoryKeys = {
+	actions: 'expand' | 'build' | 'attack' | 'develop' | 'raisePop';
+	phases: 'growth' | 'upkeep' | 'main';
+	resources: 'gold' | 'ap' | 'happiness' | 'castle';
+	stats: 'army' | 'fort';
+	population: 'council' | 'legion' | 'fortifier' | 'citizen';
+};
+
+type OverviewTokenConfigResolved = {
+	[K in keyof TokenCategoryKeys]: Record<TokenCategoryKeys[K], string[]>;
+};
+
+const DEFAULT_TOKEN_CONFIG: OverviewTokenConfigResolved = {
+	actions: {
+		expand: ['expand'],
+		build: ['build'],
+		attack: ['army_attack', 'attack'],
+		develop: ['develop'],
+		raisePop: ['raise_pop'],
+	},
+	phases: {
+		growth: ['growth'],
+		upkeep: ['upkeep'],
+		main: ['main'],
+	},
+	resources: {
+		gold: [Resource.gold],
+		ap: [Resource.ap],
+		happiness: [Resource.happiness],
+		castle: [Resource.castleHP],
+	},
+	stats: {
+		army: [Stat.armyStrength],
+		fort: [Stat.fortificationStrength],
+	},
+	population: {
+		council: [PopulationRole.Council],
+		legion: [PopulationRole.Legion],
+		fortifier: [PopulationRole.Fortifier],
+		citizen: [PopulationRole.Citizen],
+	},
+};
+
+function isStringArray(
+	value: TokenCandidateInput,
+): value is ReadonlyArray<string> {
+	return Array.isArray(value);
+}
+
+function normalizeCandidates(input?: TokenCandidateInput): string[] {
+	if (!input) {
+		return [];
+	}
+	if (isStringArray(input)) {
+		return [...input];
+	}
+	return [input];
+}
+
+function mergeTokenCategory<TKeys extends string>(
+	defaults: Record<TKeys, string[]>,
+	overrides?: OverviewTokenCategory<TKeys>,
+): Record<TKeys, string[]> {
+	const result: Record<TKeys, string[]> = {} as Record<TKeys, string[]>;
+	for (const key of Object.keys(defaults) as TKeys[]) {
+		const overrideCandidates = normalizeCandidates(overrides?.[key]);
+		const merged = overrideCandidates.slice();
+		for (const candidate of defaults[key]) {
+			if (!merged.includes(candidate)) {
+				merged.push(candidate);
+			}
+		}
+		result[key] = merged;
+	}
+	return result;
+}
+
+export interface OverviewTokenConfig {
+	actions?: OverviewTokenCategory<TokenCategoryKeys['actions']>;
+	phases?: OverviewTokenCategory<TokenCategoryKeys['phases']>;
+	resources?: OverviewTokenCategory<TokenCategoryKeys['resources']>;
+	stats?: OverviewTokenCategory<TokenCategoryKeys['stats']>;
+	population?: OverviewTokenCategory<TokenCategoryKeys['population']>;
+}
+
+function mergeTokenConfig(
+	overrides?: OverviewTokenConfig,
+): OverviewTokenConfigResolved {
+	return {
+		// prettier-ignore
+		actions: mergeTokenCategory(
+                        DEFAULT_TOKEN_CONFIG.actions,
+                        overrides?.actions,
+                ),
+		// prettier-ignore
+		phases: mergeTokenCategory(
+                        DEFAULT_TOKEN_CONFIG.phases,
+                        overrides?.phases,
+                ),
+		// prettier-ignore
+		resources: mergeTokenCategory(
+                        DEFAULT_TOKEN_CONFIG.resources,
+                        overrides?.resources,
+                ),
+		// prettier-ignore
+		stats: mergeTokenCategory(
+                        DEFAULT_TOKEN_CONFIG.stats,
+                        overrides?.stats,
+                ),
+		// prettier-ignore
+		population: mergeTokenCategory(
+                        DEFAULT_TOKEN_CONFIG.population,
+                        overrides?.population,
+                ),
+	};
+}
+
+function resolveByCandidates<T>(
+	candidates: string[],
+	resolver: (candidate: string) => T | undefined,
+): T | undefined {
+	for (const candidate of candidates) {
+		const resolved = resolver(candidate);
+		if (resolved) {
+			return resolved;
+		}
+	}
+	return undefined;
+}
+
+function resolveActionIcon(candidates: string[]) {
+	const registry = actionInfo as unknown as {
+		has(id: string): boolean;
+		get(id: string): { icon?: ReactNode };
+	};
+	return resolveByCandidates(candidates, (id) => {
+		if (!registry.has(id)) {
+			return undefined;
+		}
+		return registry.get(id)?.icon;
+	});
+}
+
+function resolvePhaseIcon(candidates: string[]) {
+	return resolveByCandidates(
+		candidates,
+		(id) => PHASES.find((phase) => phase.id === id)?.icon,
+	);
+}
+
+function resolveResourceIcon(candidates: string[]) {
+	return resolveByCandidates(candidates, (id) => {
+		if (Object.prototype.hasOwnProperty.call(RESOURCES, id)) {
+			const key = id as keyof typeof RESOURCES;
+			return RESOURCES[key]?.icon;
+		}
+		return undefined;
+	});
+}
+
+function resolveStatIcon(candidates: string[]) {
+	return resolveByCandidates(candidates, (id) => {
+		if (Object.prototype.hasOwnProperty.call(STATS, id)) {
+			const key = id as keyof typeof STATS;
+			return STATS[key]?.icon;
+		}
+		return undefined;
+	});
+}
+
+function resolvePopulationIcon(candidates: string[]) {
+	return resolveByCandidates(candidates, (id) => {
+		if (Object.prototype.hasOwnProperty.call(POPULATION_ROLES, id)) {
+			const key = id as keyof typeof POPULATION_ROLES;
+			return POPULATION_ROLES[key]?.icon;
+		}
+		return undefined;
+	});
+}
+
+export function buildOverviewIconSet(
+	overrides?: OverviewTokenConfig,
+): OverviewIconSet {
+	const config = mergeTokenConfig(overrides);
+	return {
+		expand: resolveActionIcon(config.actions.expand),
+		build: resolveActionIcon(config.actions.build),
+		attack: resolveActionIcon(config.actions.attack),
+		develop: resolveActionIcon(config.actions.develop),
+		raisePop: resolveActionIcon(config.actions.raisePop),
+		growth: resolvePhaseIcon(config.phases.growth),
+		upkeep: resolvePhaseIcon(config.phases.upkeep),
+		main: resolvePhaseIcon(config.phases.main),
+		land: LAND_INFO.icon,
+		slot: SLOT_INFO.icon,
+		gold: resolveResourceIcon(config.resources.gold),
+		ap: resolveResourceIcon(config.resources.ap),
+		happiness: resolveResourceIcon(config.resources.happiness),
+		castle: resolveResourceIcon(config.resources.castle),
+		army: resolveStatIcon(config.stats.army),
+		fort: resolveStatIcon(config.stats.fort),
+		council: resolvePopulationIcon(config.population.council),
+		legion: resolvePopulationIcon(config.population.legion),
+		fortifier: resolvePopulationIcon(config.population.fortifier),
+		citizen: resolvePopulationIcon(config.population.citizen),
+	} satisfies OverviewIconSet;
+}

--- a/packages/web/src/components/overview/sectionsData.ts
+++ b/packages/web/src/components/overview/sectionsData.ts
@@ -54,6 +54,10 @@ export type OverviewContentSection =
 	| OverviewParagraphContent
 	| OverviewListContent;
 
+function spanProps(span?: boolean) {
+	return span === undefined ? {} : { span };
+}
+
 export function createOverviewSections(
 	icons: OverviewIconSet,
 	content: OverviewContentSection[],
@@ -65,8 +69,8 @@ export function createOverviewSections(
 				id: section.id,
 				icon: icons[section.icon],
 				title: section.title,
-				span: section.span,
 				paragraphs: section.paragraphs,
+				...spanProps(section.span),
 			} satisfies OverviewSectionDef;
 		}
 
@@ -75,12 +79,12 @@ export function createOverviewSections(
 			id: section.id,
 			icon: icons[section.icon],
 			title: section.title,
-			span: section.span,
 			items: section.items.map((item) => ({
 				icon: item.icon ? icons[item.icon] : undefined,
 				label: item.label,
 				body: item.body,
 			})),
+			...spanProps(section.span),
 		} satisfies OverviewSectionDef;
 	});
 }

--- a/packages/web/src/components/overview/sectionsData.ts
+++ b/packages/web/src/components/overview/sectionsData.ts
@@ -24,134 +24,63 @@ export interface OverviewIconSet {
 	citizen?: ReactNode;
 }
 
+export type OverviewIconKey = keyof OverviewIconSet;
+
+export type OverviewParagraphContent = {
+	kind: 'paragraph';
+	id: string;
+	icon: OverviewIconKey;
+	title: string;
+	span?: boolean;
+	paragraphs: string[];
+};
+
+export type OverviewListItemContent = {
+	icon?: OverviewIconKey;
+	label: string;
+	body: string[];
+};
+
+export type OverviewListContent = {
+	kind: 'list';
+	id: string;
+	icon: OverviewIconKey;
+	title: string;
+	span?: boolean;
+	items: OverviewListItemContent[];
+};
+
+export type OverviewContentSection =
+	| OverviewParagraphContent
+	| OverviewListContent;
+
 export function createOverviewSections(
 	icons: OverviewIconSet,
+	content: OverviewContentSection[],
 ): OverviewSectionDef[] {
-	return [
-		{
-			kind: 'paragraph',
-			id: 'objective',
-			icon: icons.castle,
-			title: 'Your Objective',
-			span: true,
-			paragraphs: [
-				'Keep your {castle} castle standing through every assault.',
-				"Plot daring turns that unravel your rival's engine.",
-				'Victory strikes when a stronghold falls or a ruler stalls out.',
-				'The final round crowns the monarch with the healthiest realm.',
-			],
-		},
-		{
+	return content.map((section) => {
+		if (section.kind === 'paragraph') {
+			return {
+				kind: 'paragraph',
+				id: section.id,
+				icon: icons[section.icon],
+				title: section.title,
+				span: section.span,
+				paragraphs: section.paragraphs,
+			} satisfies OverviewSectionDef;
+		}
+
+		return {
 			kind: 'list',
-			id: 'turn-flow',
-			icon: icons.growth,
-			title: 'Turn Flow',
-			span: true,
-			items: [
-				{
-					icon: icons.growth,
-					label: 'Growth',
-					body: [
-						'Kickstarts your engine with income and {army} Army strength.',
-						'Stacks {fort} Fortification bonuses and triggers automatic boons.',
-					],
-				},
-				{
-					icon: icons.upkeep,
-					label: 'Upkeep',
-					body: [
-						'Settles wages, ongoing effects, and any debts your realm has racked up.',
-					],
-				},
-				{
-					icon: icons.main,
-					label: 'Main Phase',
-					body: [
-						'Both players secretly queue actions.',
-						'Reveal them in a flurry of {ap} AP-powered maneuvers.',
-					],
-				},
-			],
-		},
-		{
-			kind: 'list',
-			id: 'resources',
-			icon: icons.gold,
-			title: 'Resources',
-			items: [
-				{
-					icon: icons.gold,
-					label: 'Gold',
-					body: ['Fuels {build} buildings, diplomacy, and daring plays.'],
-				},
-				{
-					icon: icons.ap,
-					label: 'Action Points',
-					body: ['Are the energy for every turn in the {main} Main phase.'],
-				},
-				{
-					icon: icons.happiness,
-					label: 'Happiness',
-					body: ['Keeps the populace cheering instead of rioting.'],
-				},
-				{
-					icon: icons.castle,
-					label: 'Castle HP',
-					body: ['Is your lifeline—lose it and the dynasty topples.'],
-				},
-			],
-		},
-		{
-			kind: 'paragraph',
-			id: 'land',
-			icon: icons.land,
-			title: 'Land & Developments',
-			paragraphs: [
-				'Claim {land} land and slot in {slot} developments to unlock perks.',
-				'Farms pump {gold} gold while signature projects open slots or unleash passives.',
-			],
-		},
-		{
-			kind: 'list',
-			id: 'population',
-			icon: icons.council,
-			title: 'Population Roles',
-			span: true,
-			items: [
-				{
-					icon: icons.council,
-					label: 'Council',
-					body: ['Rallies extra {ap} Action Points each round.'],
-				},
-				{
-					icon: icons.legion,
-					label: 'Legion',
-					body: [
-						'Reinforces {army} Army strength for devastating {attack} raids.',
-					],
-				},
-				{
-					icon: icons.fortifier,
-					label: 'Fortifier',
-					body: ['Cements your defenses with persistent buffs.'],
-				},
-				{
-					icon: icons.citizen,
-					label: 'Citizens',
-					body: ['Wait in the wings, ready to specialize as needed.'],
-				},
-			],
-		},
-		{
-			kind: 'paragraph',
-			id: 'actions',
-			icon: icons.develop,
-			title: 'Actions & Strategy',
-			span: true,
-			paragraphs: [
-				'Spend {ap} AP to {expand} grow territory or {develop} upgrade key lands.',
-				'Field {raisePop} specialists or launch {attack} attacks to snowball momentum.',
-			],
-		},
-	];
+			id: section.id,
+			icon: icons[section.icon],
+			title: section.title,
+			span: section.span,
+			items: section.items.map((item) => ({
+				icon: item.icon ? icons[item.icon] : undefined,
+				label: item.label,
+				body: item.body,
+			})),
+		} satisfies OverviewSectionDef;
+	});
 }

--- a/packages/web/tests/Overview.test.tsx
+++ b/packages/web/tests/Overview.test.tsx
@@ -1,0 +1,146 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import Overview, { type OverviewTokenConfig } from '../src/Overview';
+import type { OverviewContentSection } from '../src/components/overview/sectionsData';
+import {
+	ACTIONS,
+	PHASES,
+	RESOURCES,
+	POPULATION_ROLES,
+	STATS,
+} from '@kingdom-builder/contents';
+
+describe('<Overview />', () => {
+	it('renders supplied overview content using dynamic token fallbacks', () => {
+		const actionEntries = Array.from(
+			(
+				ACTIONS as unknown as {
+					map: Map<string, { icon?: React.ReactNode }>;
+				}
+			).map.entries(),
+		);
+		const [fallbackActionId, fallbackActionDef] = actionEntries[0]!;
+
+		const [fallbackPhase] = PHASES;
+
+		const resourceEntries = Object.entries(RESOURCES) as Array<
+			[string, { icon?: React.ReactNode }]
+		>;
+		const [fallbackGoldKey, fallbackGoldDef] = resourceEntries[0]!;
+		const [fallbackApKey, fallbackApDef] =
+			resourceEntries[1] ?? resourceEntries[0]!;
+
+		const statEntries = Object.entries(STATS) as Array<
+			[string, { icon?: React.ReactNode }]
+		>;
+		const [fallbackStatKey, fallbackStatDef] = statEntries[0]!;
+
+		const populationEntries = Object.entries(POPULATION_ROLES) as Array<
+			[string, { icon?: React.ReactNode }]
+		>;
+		const [fallbackPopulationKey, fallbackPopulationDef] =
+			populationEntries[0]!;
+
+		const tokenConfig: OverviewTokenConfig = {
+			actions: {
+				expand: ['missing-action', fallbackActionId],
+			},
+			phases: {
+				growth: ['missing-phase', fallbackPhase.id],
+			},
+			resources: {
+				gold: ['missing-gold', fallbackGoldKey],
+				ap: ['missing-ap', fallbackApKey],
+			},
+			stats: {
+				army: ['missing-army', fallbackStatKey],
+			},
+			population: {
+				council: ['missing-council', fallbackPopulationKey],
+			},
+		};
+
+		const customContent: OverviewContentSection[] = [
+			{
+				kind: 'paragraph',
+				id: 'custom-story',
+				icon: 'castle',
+				title: 'Custom Story',
+				span: true,
+				paragraphs: [
+					'Story {gold} keepers guard the realm.',
+					'Advisors {council} manage {ap} to fuel plans.',
+				],
+			},
+			{
+				kind: 'list',
+				id: 'custom-flow',
+				icon: 'growth',
+				title: 'Custom Flow',
+				items: [
+					{
+						icon: 'expand',
+						label: 'Advance',
+						body: [
+							'Execute {expand} during the {growth} sequence.',
+							'Strengthen {army} before moving out.',
+						],
+					},
+				],
+			},
+		];
+
+		render(
+			<Overview
+				onBack={vi.fn()}
+				tokenConfig={tokenConfig}
+				content={customContent}
+			/>,
+		);
+
+		expect(screen.queryByText('Your Objective')).not.toBeInTheDocument();
+
+		const storySection = screen.getByText('Custom Story').closest('section');
+		expect(storySection).not.toBeNull();
+		if (!storySection) {
+			return;
+		}
+		expect(storySection.textContent).not.toContain('{gold}');
+		expect(storySection.textContent).not.toContain('{council}');
+		expect(storySection.textContent).not.toContain('{ap}');
+
+		if (typeof fallbackGoldDef.icon === 'string') {
+			expect(storySection).toHaveTextContent(fallbackGoldDef.icon);
+		}
+		if (typeof fallbackPopulationDef.icon === 'string') {
+			expect(storySection).toHaveTextContent(fallbackPopulationDef.icon);
+		}
+		if (typeof fallbackApDef.icon === 'string') {
+			expect(storySection).toHaveTextContent(fallbackApDef.icon);
+		}
+
+		const flowSection = screen.getByText('Custom Flow').closest('section');
+		expect(flowSection).not.toBeNull();
+		if (!flowSection) {
+			return;
+		}
+		expect(flowSection.textContent).not.toContain('{expand}');
+		expect(flowSection.textContent).not.toContain('{growth}');
+		expect(flowSection.textContent).not.toContain('{army}');
+
+		if (typeof fallbackActionDef.icon === 'string') {
+			expect(flowSection).toHaveTextContent(fallbackActionDef.icon);
+		}
+		if (typeof fallbackPhase?.icon === 'string') {
+			expect(flowSection).toHaveTextContent(fallbackPhase.icon);
+		}
+		if (typeof fallbackStatDef.icon === 'string') {
+			expect(flowSection).toHaveTextContent(fallbackStatDef.icon);
+		}
+
+		expect(screen.getByText('Advance')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary
- add a helper module to resolve overview icons via configurable token ids
- move default overview narrative into data passed through `createOverviewSections`
- update the overview component to consume configurable content and add a jsdom test covering custom data

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68dee9a48a7c832594edadf7bf8d469c