### PR TITLE
feat(web): persist game state between sessions

### DIFF
--- a/packages/web/src/Menu.tsx
+++ b/packages/web/src/Menu.tsx
@@ -1,119 +1,29 @@
-import React from 'react';
-import Button from './components/common/Button';
+import React, { useMemo, useState } from 'react';
 import {
 	ShowcaseBackground,
 	ShowcaseLayout,
-	ShowcaseCard,
 	SHOWCASE_BADGE_CLASS,
 	SHOWCASE_INTRO_CLASS,
 } from './components/layouts/ShowcasePage';
+import ConfirmDialog from './components/common/ConfirmDialog';
+import { HighlightsSection } from './components/menu/HighlightsSection';
+import { CallToActionSection } from './components/menu/CallToActionSection';
+import type { SavedGameMeta } from './state/persistence';
 
 interface MenuProps {
 	onStart: () => void;
 	onStartDev: () => void;
 	onOverview: () => void;
 	onTutorial: () => void;
+	onContinue?: () => void;
+	onDiscardSave?: () => void;
+	savedGameMeta?: SavedGameMeta | null;
 }
-
-const HIGHLIGHTS = [
-	{
-		icon: '⚔️',
-		title: 'Lead Bold Campaigns',
-		description: [
-			'Chain daring orders and spring ambushes.',
-			'Steal momentum before rivals can react.',
-		].join(' '),
-	},
-	{
-		icon: '🌱',
-		title: 'Turbocharge Your Realm',
-		description: [
-			'Spin up booming economies and trigger population perks.',
-			'Let every turn snowball into the next.',
-		].join(' '),
-	},
-	{
-		icon: '🧠',
-		title: 'Forge Wild Combos',
-		description: [
-			'Unlock outrageous developments that bend the rules.',
-			'Stitch together synergies that reshape the map.',
-		].join(' '),
-	},
-];
-
-const KNOWLEDGE_CARD_CLASS = [
-	'mt-8 flex flex-col gap-4 rounded-2xl border border-white/60 bg-white/60 p-4',
-	'text-sm text-slate-600 shadow-inner dark:border-white/10 dark:bg-white/5',
-	'dark:text-slate-300/80',
-].join(' ');
-
-const GHOST_BUTTON_CLASS = [
-	'w-full rounded-full border border-slate-200/60 bg-white/50 px-5 py-2',
-	'text-sm font-semibold text-slate-700 hover:border-slate-300 hover:bg-white/80',
-	'dark:border-white/10 dark:bg-white/5 dark:text-slate-200',
-	'dark:hover:border-white/20 dark:hover:bg-white/10 sm:w-auto',
-].join(' ');
-
-const PRIMARY_BUTTON_CLASS = [
-	'w-full rounded-full px-5 py-3 text-base font-semibold shadow-lg',
-	'shadow-blue-500/30',
-].join(' ');
-
-const DEV_BUTTON_CLASS = [
-	'w-full rounded-full px-5 py-3 text-base font-semibold shadow-lg',
-	'shadow-purple-600/30 dark:shadow-purple-900/40',
-].join(' ');
-
-const CTA_CONTENT_LAYOUT_CLASS = [
-	'flex flex-col gap-6',
-	'sm:flex-row sm:items-center sm:justify-between',
-].join(' ');
-
-const CTA_DESCRIPTION_CLASS = [
-	'mt-2 text-sm text-slate-600',
-	'dark:text-slate-300/80',
-].join(' ');
-
-const CTA_BUTTON_COLUMN_CLASS = 'flex w-full flex-col gap-3 sm:w-64';
-
-const KNOWLEDGE_HEADER_LAYOUT_CLASS = [
-	'flex flex-col gap-4',
-	'sm:flex-row sm:items-center sm:justify-between',
-].join(' ');
-
-const KNOWLEDGE_TITLE_CLASS = [
-	'font-medium uppercase tracking-[0.3em] text-slate-500',
-	'dark:text-slate-400',
-].join(' ');
-
-const KNOWLEDGE_ACTIONS_CLASS = ['flex flex-col gap-3 sm:flex-row'].join(' ');
-
-const HIGHLIGHT_CARD_CLASS = [
-	'group relative overflow-hidden rounded-2xl border border-white/60 bg-white/70 p-6',
-	'shadow-lg transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl',
-	'dark:border-white/5 dark:bg-slate-900/70',
-].join(' ');
-
-const HIGHLIGHT_OVERLAY_CLASS = [
-	'absolute inset-0 bg-gradient-to-br from-amber-200/0 via-white/40 to-transparent opacity-0',
-	'transition-opacity duration-200 group-hover:opacity-100 dark:via-white/5',
-].join(' ');
 
 const INTRO_PARAGRAPH_TEXT = [
 	'Craft a flourishing dynasty with tactical choices,',
 	'evolving lands, and a thriving population.',
 	'Each turn is a new chapter in your royal saga.',
-].join(' ');
-
-const CTA_DESCRIPTION_TEXT = [
-	'Leap into the campaign or explore a sandbox tuned for rapid',
-	'iteration and experimentation.',
-].join(' ');
-
-const KNOWLEDGE_PARAGRAPH_TEXT = [
-	'Discover the systems behind every decision before stepping into the throne room,',
-	'or revisit the lore to sharpen your grand strategy.',
 ].join(' ');
 
 function HeroSection() {
@@ -131,117 +41,80 @@ function HeroSection() {
 	);
 }
 
-interface CallToActionProps {
-	onStart: () => void;
-	onStartDev: () => void;
-	onOverview: () => void;
-	onTutorial: () => void;
-}
-
-function CallToActionSection({
-	onStart,
-	onStartDev,
-	onOverview,
-	onTutorial,
-}: CallToActionProps) {
-	return (
-		<ShowcaseCard className="flex flex-col gap-8">
-			<div className={CTA_CONTENT_LAYOUT_CLASS}>
-				<div className="text-left">
-					<h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
-						Begin Your Reign
-					</h2>
-					{/* prettier-ignore */}
-					<p className={CTA_DESCRIPTION_CLASS}>
-                                        {CTA_DESCRIPTION_TEXT}
-                                </p>
-				</div>
-				<div className={CTA_BUTTON_COLUMN_CLASS}>
-					<Button
-						variant="primary"
-						className={PRIMARY_BUTTON_CLASS}
-						onClick={onStart}
-					>
-						Start New Game
-					</Button>
-					<Button
-						variant="dev"
-						className={DEV_BUTTON_CLASS}
-						onClick={onStartDev}
-					>
-						Start Dev/Debug Game
-					</Button>
-				</div>
-			</div>
-
-			<div className={KNOWLEDGE_CARD_CLASS}>
-				<div className={KNOWLEDGE_HEADER_LAYOUT_CLASS}>
-					{/* prettier-ignore */}
-					<div className={KNOWLEDGE_TITLE_CLASS}>
-                                        Learn The Basics
-                                </div>
-					<div className={KNOWLEDGE_ACTIONS_CLASS}>
-						<Button
-							variant="ghost"
-							className={GHOST_BUTTON_CLASS}
-							onClick={onTutorial}
-						>
-							Tutorial
-						</Button>
-						<Button
-							variant="ghost"
-							className={GHOST_BUTTON_CLASS}
-							onClick={onOverview}
-						>
-							Game Overview
-						</Button>
-					</div>
-				</div>
-				<p>{KNOWLEDGE_PARAGRAPH_TEXT}</p>
-			</div>
-		</ShowcaseCard>
-	);
-}
-
-function HighlightsSection() {
-	return (
-		<section className="grid w-full max-w-5xl grid-cols-1 gap-6 sm:grid-cols-3">
-			{HIGHLIGHTS.map(({ icon, title, description }) => (
-				<div key={title} className={HIGHLIGHT_CARD_CLASS}>
-					<div className={HIGHLIGHT_OVERLAY_CLASS} />
-					<div className="relative flex flex-col gap-3 text-left">
-						<div className="text-3xl">{icon}</div>
-						<h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-							{title}
-						</h3>
-						<p className="text-sm text-slate-600 dark:text-slate-300/80">
-							{description}
-						</p>
-					</div>
-				</div>
-			))}
-		</section>
-	);
-}
-
 export default function Menu({
 	onStart,
 	onStartDev,
 	onOverview,
 	onTutorial,
+	onContinue,
+	onDiscardSave,
+	savedGameMeta,
 }: MenuProps) {
+	const [overwriteDialogOpen, setOverwriteDialogOpen] = useState(false);
+	const hasSave = Boolean(savedGameMeta);
+
+	const handleStart = () => {
+		if (hasSave) {
+			setOverwriteDialogOpen(true);
+			return;
+		}
+		onStart();
+	};
+
+	const handleConfirmOverwrite = () => {
+		onDiscardSave?.();
+		setOverwriteDialogOpen(false);
+		onStart();
+	};
+
+	const handleContinue = () => {
+		onContinue?.();
+	};
+
+	const closeDialog = () => setOverwriteDialogOpen(false);
+
+	const description = useMemo(() => {
+		if (!savedGameMeta) {
+			return 'Starting a new game will overwrite your existing progress.';
+		}
+		return [
+			'Starting a new game will overwrite your current campaign at Turn',
+			`${savedGameMeta.turn}.`,
+		].join(' ');
+	}, [savedGameMeta]);
+
 	return (
 		<ShowcaseBackground>
 			<ShowcaseLayout>
 				<HeroSection />
 				<CallToActionSection
-					onStart={onStart}
+					onStart={handleStart}
 					onStartDev={onStartDev}
 					onOverview={onOverview}
 					onTutorial={onTutorial}
+					onContinue={hasSave ? handleContinue : undefined}
+					savedGameMeta={savedGameMeta}
 				/>
 				<HighlightsSection />
 			</ShowcaseLayout>
+			<ConfirmDialog
+				open={overwriteDialogOpen}
+				onClose={closeDialog}
+				title="Start a new game?"
+				description={<p>{description}</p>}
+				actions={[
+					{
+						label: 'Overwrite and start',
+						variant: 'danger',
+						onClick: handleConfirmOverwrite,
+					},
+					{
+						label: 'Cancel',
+						variant: 'ghost',
+						onClick: () => {},
+					},
+				]}
+			/>
 		</ShowcaseBackground>
 	);
 }

--- a/packages/web/src/Menu.tsx
+++ b/packages/web/src/Menu.tsx
@@ -7,7 +7,10 @@ import {
 } from './components/layouts/ShowcasePage';
 import ConfirmDialog from './components/common/ConfirmDialog';
 import { HighlightsSection } from './components/menu/HighlightsSection';
-import { CallToActionSection } from './components/menu/CallToActionSection';
+import {
+	CallToActionSection,
+	type CallToActionSectionProps,
+} from './components/menu/CallToActionSection';
 import type { SavedGameMeta } from './state/persistence';
 
 interface MenuProps {
@@ -48,10 +51,10 @@ export default function Menu({
 	onTutorial,
 	onContinue,
 	onDiscardSave,
-	savedGameMeta,
+	savedGameMeta = null,
 }: MenuProps) {
 	const [overwriteDialogOpen, setOverwriteDialogOpen] = useState(false);
-	const hasSave = Boolean(savedGameMeta);
+	const hasSave = savedGameMeta !== null;
 
 	const handleStart = () => {
 		if (hasSave) {
@@ -83,18 +86,26 @@ export default function Menu({
 		].join(' ');
 	}, [savedGameMeta]);
 
+	const callToActionProps: CallToActionSectionProps = {
+		onStart: handleStart,
+		onStartDev,
+		onOverview,
+		onTutorial,
+	};
+
+	if (hasSave && onContinue) {
+		callToActionProps.onContinue = handleContinue;
+	}
+
+	if (savedGameMeta !== null) {
+		callToActionProps.savedGameMeta = savedGameMeta;
+	}
+
 	return (
 		<ShowcaseBackground>
 			<ShowcaseLayout>
 				<HeroSection />
-				<CallToActionSection
-					onStart={handleStart}
-					onStartDev={onStartDev}
-					onOverview={onOverview}
-					onTutorial={onTutorial}
-					onContinue={hasSave ? handleContinue : undefined}
-					savedGameMeta={savedGameMeta}
-				/>
+				<CallToActionSection {...callToActionProps} />
 				<HighlightsSection />
 			</ShowcaseLayout>
 			<ConfirmDialog

--- a/packages/web/src/components/common/ConfirmDialog.tsx
+++ b/packages/web/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import Button from './Button';
+
+const DIALOG_BACKDROP_CLASS = [
+	'fixed inset-0 z-50 flex items-center justify-center',
+	'bg-slate-900/70 backdrop-blur-sm',
+].join(' ');
+
+const DIALOG_PANEL_CLASS = [
+	'mx-4 w-full max-w-lg rounded-3xl border border-white/30',
+	'bg-white/80 p-6 text-slate-800',
+	'shadow-2xl dark:border-white/10 dark:bg-slate-900/90',
+	'dark:text-slate-100',
+].join(' ');
+
+const DIALOG_HEADER_CLASS = 'flex items-start justify-between gap-4';
+
+const DIALOG_TITLE_CLASS = [
+	'text-lg font-semibold tracking-tight text-slate-900',
+	'dark:text-slate-100',
+].join(' ');
+
+const DIALOG_DESCRIPTION_CLASS = [
+	'mt-3 space-y-2 text-sm text-slate-600',
+	'dark:text-slate-300',
+].join(' ');
+
+const DIALOG_CLOSE_BUTTON_CLASS = [
+	'inline-flex h-9 w-9 items-center justify-center rounded-full',
+	'bg-white/70 text-slate-500 shadow-md transition',
+	'hover:bg-white',
+	'dark:bg-white/10 dark:text-slate-300 dark:hover:bg-white/20',
+].join(' ');
+
+const DIALOG_ACTIONS_CLASS = [
+	'mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end',
+].join(' ');
+
+const DIALOG_ACTION_BUTTON_CLASS = 'px-5 py-2.5 text-sm';
+
+export interface ConfirmDialogAction {
+	label: string;
+	onClick: () => void;
+	variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'ghost' | 'dev';
+}
+
+interface ConfirmDialogProps {
+	open: boolean;
+	title: string;
+	description: React.ReactNode;
+	actions: ConfirmDialogAction[];
+	onClose: () => void;
+}
+
+export default function ConfirmDialog({
+	open,
+	title,
+	description,
+	actions,
+	onClose,
+}: ConfirmDialogProps) {
+	if (!open) {
+		return null;
+	}
+	let renderedDescription: React.ReactNode;
+	if (typeof description === 'string') {
+		renderedDescription = <p>{description}</p>;
+	} else {
+		renderedDescription = description;
+	}
+
+	const headerTitle = <h2 className={DIALOG_TITLE_CLASS}>{title}</h2>;
+	const headerDescription = (
+		<div className={DIALOG_DESCRIPTION_CLASS}>{renderedDescription}</div>
+	);
+	const header = (
+		<div className={DIALOG_HEADER_CLASS}>
+			<div>
+				{headerTitle}
+				{headerDescription}
+			</div>
+			<button
+				type="button"
+				onClick={onClose}
+				className={DIALOG_CLOSE_BUTTON_CLASS}
+				aria-label="Close dialog"
+			>
+				×
+			</button>
+		</div>
+	);
+
+	const actionButtons = actions.map((action, index) => {
+		const defaultVariant = index === 0 ? 'primary' : 'secondary';
+		const resolvedVariant = action.variant ?? defaultVariant;
+		const handleActionClick = () => {
+			action.onClick();
+			onClose();
+		};
+		const buttonProps = {
+			key: action.label + index,
+			variant: resolvedVariant,
+			onClick: handleActionClick,
+			className: DIALOG_ACTION_BUTTON_CLASS,
+		} as const;
+		return <Button {...buttonProps}>{action.label}</Button>;
+	});
+
+	return (
+		<div className={DIALOG_BACKDROP_CLASS} role="dialog" aria-modal="true">
+			<div className={DIALOG_PANEL_CLASS}>
+				{header}
+				<div className={DIALOG_ACTIONS_CLASS}>{actionButtons}</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/game/GameLayoutFragments.tsx
+++ b/packages/web/src/components/game/GameLayoutFragments.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import Button from '../common/Button';
+import TimeControl from '../common/TimeControl';
+import {
+	GAME_OVERLAY_CLASS,
+	GAME_BUBBLE_TOP_CLASS,
+	GAME_BUBBLE_BOTTOM_CLASS,
+	GAME_BUBBLE_RIGHT_CLASS,
+	GAME_LIGHTING_CLASS,
+	LOADING_CARD_CLASS,
+	LOADING_TITLE_CLASS,
+	LOADING_TEXT_CLASS,
+	HEADER_CONTROLS_CLASS,
+} from './layoutClasses';
+
+type ButtonProps = React.ComponentProps<typeof Button>;
+
+type HeaderControlsProps = {
+	darkMode: boolean;
+	darkModeButtonProps: ButtonProps;
+	quitButtonProps: ButtonProps;
+};
+
+type LoadingCardProps = {
+	description: string;
+};
+
+export function GameBackdrop(): JSX.Element {
+	return (
+		<div className={GAME_OVERLAY_CLASS}>
+			<div className={GAME_BUBBLE_TOP_CLASS} />
+			<div className={GAME_BUBBLE_BOTTOM_CLASS} />
+			<div className={GAME_BUBBLE_RIGHT_CLASS} />
+			<div className={GAME_LIGHTING_CLASS} />
+		</div>
+	);
+}
+
+export function LoadingCardContent({
+	description,
+}: LoadingCardProps): JSX.Element {
+	return (
+		<div className={LOADING_CARD_CLASS}>
+			<h1 className={LOADING_TITLE_CLASS}>Loading your realm...</h1>
+			<p className={LOADING_TEXT_CLASS}>{description}</p>
+		</div>
+	);
+}
+
+export function HeaderControls({
+	darkMode,
+	darkModeButtonProps,
+	quitButtonProps,
+}: HeaderControlsProps): JSX.Element {
+	return (
+		<div className={HEADER_CONTROLS_CLASS}>
+			<TimeControl />
+			<Button {...darkModeButtonProps}>
+				{darkMode ? 'Light Mode' : 'Dark Mode'}
+			</Button>
+			<Button {...quitButtonProps}>Quit</Button>
+		</div>
+	);
+}

--- a/packages/web/src/components/game/layoutClasses.ts
+++ b/packages/web/src/components/game/layoutClasses.ts
@@ -1,0 +1,103 @@
+export const GAME_BACKGROUND_CLASS = [
+	'relative min-h-screen w-full overflow-hidden',
+	'bg-gradient-to-br from-amber-100 via-rose-100 to-sky-100',
+	'text-slate-900 dark:from-slate-950 dark:via-slate-900',
+	'dark:to-slate-950 dark:text-slate-100',
+].join(' ');
+
+export const GAME_OVERLAY_CLASS = 'pointer-events-none absolute inset-0';
+
+export const GAME_LIGHTING_CLASS = [
+	'absolute inset-0',
+	'bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.55),_rgba(255,255,255,0)_55%)]',
+	'dark:bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.6),_rgba(15,23,42,0)_60%)]',
+].join(' ');
+
+export const GAME_BUBBLE_TOP_CLASS = [
+	'absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full',
+	'bg-amber-300/30 blur-3xl dark:bg-amber-500/20',
+].join(' ');
+
+export const GAME_BUBBLE_BOTTOM_CLASS = [
+	'absolute -bottom-28 -left-16 h-80 w-80 rounded-full',
+	'bg-sky-300/30 blur-3xl dark:bg-sky-500/20',
+].join(' ');
+
+export const GAME_BUBBLE_RIGHT_CLASS = [
+	'absolute top-1/4 right-0 h-72 w-72 translate-x-1/3 rounded-full',
+	'bg-rose-300/30 blur-3xl dark:bg-rose-500/20',
+].join(' ');
+
+export const LOADING_CARD_CLASS = [
+	'w-full max-w-md rounded-3xl border border-white/60 bg-white/80 px-6 py-8',
+	'text-center shadow-2xl dark:border-white/10 dark:bg-slate-900/70',
+	'dark:shadow-slate-900/40',
+].join(' ');
+
+export const LOADING_WRAPPER_CLASS = [
+	'relative z-10 flex min-h-screen items-center justify-center px-4',
+].join(' ');
+
+export const LOADING_TITLE_CLASS = 'text-xl font-semibold tracking-tight';
+
+export const LOADING_TEXT_CLASS = [
+	'mt-3 text-sm text-slate-600',
+	'dark:text-slate-300',
+].join(' ');
+
+export const GAME_CONTENT_CLASS = [
+	'relative z-10 flex min-h-screen flex-col gap-8',
+	'px-4 py-8 sm:px-8 lg:px-12',
+].join(' ');
+
+export const GAME_HEADER_CARD_CLASS = [
+	'mb-4 flex items-center justify-between rounded-3xl',
+	'border border-white/50 bg-white/70 px-6 py-4 shadow-xl',
+	'dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/40',
+	'frosted-surface',
+].join(' ');
+
+export const GAME_TOGGLE_BUTTON_CLASS = [
+	'rounded-full px-4 py-2 text-sm font-semibold shadow-lg',
+	'shadow-slate-900/10 dark:shadow-black/30',
+].join(' ');
+
+export const GAME_QUIT_BUTTON_CLASS = [
+	'rounded-full px-4 py-2 text-sm font-semibold shadow-lg',
+	'shadow-rose-500/30',
+].join(' ');
+
+export const GAME_GRID_CLASS = [
+	'grid grid-cols-1 gap-y-6 gap-x-6',
+	'lg:grid-cols-[minmax(0,1fr)_30rem]',
+].join(' ');
+
+export const PRIMARY_COLUMN_CLASS = 'lg:col-start-1 lg:row-start-2';
+
+export const GAME_PLAYER_SECTION_CLASS = [
+	'relative flex min-h-[275px] items-stretch rounded-3xl',
+	'bg-white/70 shadow-2xl dark:bg-slate-900/70',
+	'dark:shadow-slate-900/50 frosted-surface',
+].join(' ');
+
+export const PLAYER_PANEL_WRAPPER_CLASS = [
+	'flex flex-1 items-stretch overflow-hidden rounded-3xl',
+	'divide-x divide-white/50 dark:divide-white/10',
+].join(' ');
+
+export const SECONDARY_COLUMN_CLASS = [
+	'flex w-full flex-col gap-6',
+	'lg:col-start-2 lg:row-start-2',
+].join(' ');
+
+export const HEADER_TITLE_CLASS = [
+	'text-2xl font-bold tracking-tight',
+	'sm:text-3xl',
+].join(' ');
+
+export const QUIT_NOTE_CLASS = [
+	'text-xs text-slate-500',
+	'dark:text-slate-400',
+].join(' ');
+
+export const HEADER_CONTROLS_CLASS = 'ml-4 flex items-center gap-3';

--- a/packages/web/src/components/menu/CallToActionSection.tsx
+++ b/packages/web/src/components/menu/CallToActionSection.tsx
@@ -1,0 +1,181 @@
+import React, { useMemo } from 'react';
+import Button from '../common/Button';
+import { ShowcaseCard } from '../layouts/ShowcasePage';
+import type { SavedGameMeta } from '../../state/persistence';
+
+const CTA_CONTENT_LAYOUT_CLASS = [
+	'flex flex-col gap-6',
+	'sm:flex-row sm:items-center sm:justify-between',
+].join(' ');
+
+const CTA_DESCRIPTION_CLASS = [
+	'mt-2 text-sm text-slate-600',
+	'dark:text-slate-300/80',
+].join(' ');
+
+const CTA_BUTTON_COLUMN_CLASS = 'flex w-full flex-col gap-3 sm:w-64';
+
+const PRIMARY_BUTTON_CLASS = [
+	'w-full rounded-full px-5 py-3 text-base font-semibold shadow-lg',
+	'shadow-blue-500/30',
+].join(' ');
+
+const CTA_HEADING_CLASS = [
+	'text-xl font-semibold text-slate-900',
+	'dark:text-slate-100',
+].join(' ');
+
+const DEV_BUTTON_CLASS = [
+	'w-full rounded-full px-5 py-3 text-base font-semibold shadow-lg',
+	'shadow-purple-600/30 dark:shadow-purple-900/40',
+].join(' ');
+
+const GHOST_BUTTON_CLASS = [
+	'w-full rounded-full border border-slate-200/60',
+	'bg-white/50 px-5 py-2 text-sm font-semibold text-slate-700',
+	'hover:border-slate-300 hover:bg-white/80',
+	'dark:border-white/10 dark:bg-white/5 dark:text-slate-200',
+	'dark:hover:border-white/20 dark:hover:bg-white/10 sm:w-auto',
+].join(' ');
+
+const KNOWLEDGE_CARD_CLASS = [
+	'mt-8 flex flex-col gap-4 rounded-2xl border border-white/60',
+	'bg-white/60 p-4 text-sm text-slate-600 shadow-inner',
+	'dark:border-white/10 dark:bg-white/5',
+	'dark:text-slate-300/80',
+].join(' ');
+
+const KNOWLEDGE_HEADER_LAYOUT_CLASS = [
+	'flex flex-col gap-4',
+	'sm:flex-row sm:items-center sm:justify-between',
+].join(' ');
+
+const KNOWLEDGE_TITLE_CLASS = [
+	'font-medium uppercase tracking-[0.3em] text-slate-500',
+	'dark:text-slate-400',
+].join(' ');
+
+const KNOWLEDGE_ACTIONS_CLASS = ['flex flex-col gap-3 sm:flex-row'].join(' ');
+
+const CTA_DESCRIPTION_TEXT = [
+	'Leap into the campaign or explore a sandbox tuned for rapid',
+	'iteration and experimentation.',
+].join(' ');
+
+const KNOWLEDGE_PARAGRAPH_TEXT = [
+	'Discover the systems behind every decision before stepping into',
+	'the throne room, or revisit the lore to sharpen your grand strategy.',
+].join(' ');
+
+export interface CallToActionSectionProps {
+	onStart: () => void;
+	onStartDev: () => void;
+	onOverview: () => void;
+	onTutorial: () => void;
+	onContinue?: () => void;
+	savedGameMeta?: SavedGameMeta | null;
+}
+
+export function CallToActionSection({
+	onStart,
+	onStartDev,
+	onOverview,
+	onTutorial,
+	onContinue,
+	savedGameMeta,
+}: CallToActionSectionProps) {
+	const hasSave = Boolean(savedGameMeta);
+	const continueLabel = useMemo(() => {
+		if (!savedGameMeta) {
+			return 'Continue game';
+		}
+		return `Continue game (turn ${savedGameMeta.turn})`;
+	}, [savedGameMeta]);
+	const startLabel = hasSave ? 'Start new game' : 'Start game';
+	const startButtonProps = {
+		variant: 'primary' as const,
+		className: PRIMARY_BUTTON_CLASS,
+		onClick: onStart,
+	};
+	const continueButtonProps = onContinue
+		? {
+				variant: 'primary' as const,
+				className: PRIMARY_BUTTON_CLASS,
+				onClick: onContinue,
+			}
+		: null;
+	const secondaryStartProps = {
+		variant: 'secondary' as const,
+		className: PRIMARY_BUTTON_CLASS,
+		onClick: onStart,
+	};
+	const devButtonProps = {
+		variant: 'dev' as const,
+		className: DEV_BUTTON_CLASS,
+		onClick: onStartDev,
+	};
+	const tutorialButtonProps = {
+		variant: 'ghost' as const,
+		className: GHOST_BUTTON_CLASS,
+		onClick: onTutorial,
+	};
+	const overviewButtonProps = {
+		variant: 'ghost' as const,
+		className: GHOST_BUTTON_CLASS,
+		onClick: onOverview,
+	};
+	const startButton = <Button {...startButtonProps}>{startLabel}</Button>;
+	const secondaryStartButton = (
+		<Button {...secondaryStartProps}>{startLabel}</Button>
+	);
+	const continueButton = continueButtonProps ? (
+		<Button {...continueButtonProps}>{continueLabel}</Button>
+	) : null;
+	const devButton = <Button {...devButtonProps}>Start Dev/Debug Game</Button>;
+	const tutorialButton = <Button {...tutorialButtonProps}>Tutorial</Button>;
+	const overviewButton = (
+		<Button {...overviewButtonProps}>Game Overview</Button>
+	);
+	const knowledgeActions = (
+		<div className={KNOWLEDGE_ACTIONS_CLASS}>
+			{tutorialButton}
+			{overviewButton}
+		</div>
+	);
+	const heroHeading = <h2 className={CTA_HEADING_CLASS}>Begin Your Reign</h2>;
+	const heroDescription = (
+		<p className={CTA_DESCRIPTION_CLASS}>{CTA_DESCRIPTION_TEXT}</p>
+	);
+	const knowledgeTitle = (
+		<div className={KNOWLEDGE_TITLE_CLASS}>Learn The Basics</div>
+	);
+	return (
+		<ShowcaseCard className="flex flex-col gap-8">
+			<div className={CTA_CONTENT_LAYOUT_CLASS}>
+				<div className="text-left">
+					{heroHeading}
+					{heroDescription}
+				</div>
+				<div className={CTA_BUTTON_COLUMN_CLASS}>
+					{hasSave && onContinue ? (
+						<>
+							{continueButton}
+							{secondaryStartButton}
+						</>
+					) : (
+						startButton
+					)}
+					{devButton}
+				</div>
+			</div>
+
+			<div className={KNOWLEDGE_CARD_CLASS}>
+				<div className={KNOWLEDGE_HEADER_LAYOUT_CLASS}>
+					{knowledgeTitle}
+					{knowledgeActions}
+				</div>
+				<p>{KNOWLEDGE_PARAGRAPH_TEXT}</p>
+			</div>
+		</ShowcaseCard>
+	);
+}

--- a/packages/web/src/components/menu/HighlightsSection.tsx
+++ b/packages/web/src/components/menu/HighlightsSection.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+
+const HIGHLIGHTS = [
+	{
+		icon: '⚔️',
+		title: 'Lead Bold Campaigns',
+		description: [
+			'Chain daring orders and spring ambushes.',
+			'Steal momentum before rivals can react.',
+		].join(' '),
+	},
+	{
+		icon: '🌱',
+		title: 'Turbocharge Your Realm',
+		description: [
+			'Spin up booming economies and trigger',
+			'population perks.',
+			'Let every turn snowball into the next.',
+		].join(' '),
+	},
+	{
+		icon: '🧠',
+		title: 'Forge Wild Combos',
+		description: [
+			'Unlock outrageous developments that bend the rules.',
+			'Stitch together synergies that reshape the map.',
+		].join(' '),
+	},
+];
+
+const HIGHLIGHT_CARD_CLASS = [
+	'group relative overflow-hidden rounded-2xl border border-white/60',
+	'bg-white/70 p-6 shadow-lg transition-transform duration-200',
+	'hover:-translate-y-1 hover:shadow-2xl',
+	'dark:border-white/5 dark:bg-slate-900/70',
+].join(' ');
+
+const HIGHLIGHT_OVERLAY_CLASS = [
+	'absolute inset-0 bg-gradient-to-br from-amber-200/0 via-white/40',
+	'to-transparent opacity-0 transition-opacity duration-200',
+	'group-hover:opacity-100 dark:via-white/5',
+].join(' ');
+
+const HIGHLIGHTS_SECTION_CLASS = [
+	'grid w-full max-w-5xl grid-cols-1 gap-6 sm:grid-cols-3',
+].join(' ');
+
+const HIGHLIGHT_CONTENT_CLASS = ['relative flex flex-col gap-3 text-left'].join(
+	' ',
+);
+
+const HIGHLIGHT_TITLE_CLASS = [
+	'text-lg font-semibold text-slate-900',
+	'dark:text-slate-100',
+].join(' ');
+
+const HIGHLIGHT_TEXT_CLASS = [
+	'text-sm text-slate-600',
+	'dark:text-slate-300/80',
+].join(' ');
+
+function HighlightCardItem({
+	icon,
+	title,
+	description,
+}: (typeof HIGHLIGHTS)[number]) {
+	return (
+		<div className={HIGHLIGHT_CARD_CLASS}>
+			<div className={HIGHLIGHT_OVERLAY_CLASS} />
+			<div className={HIGHLIGHT_CONTENT_CLASS}>
+				<div className="text-3xl">{icon}</div>
+				<h3 className={HIGHLIGHT_TITLE_CLASS}>{title}</h3>
+				<p className={HIGHLIGHT_TEXT_CLASS}>{description}</p>
+			</div>
+		</div>
+	);
+}
+
+export function HighlightsSection() {
+	return (
+		<section className={HIGHLIGHTS_SECTION_CLASS}>
+			{HIGHLIGHTS.map((highlight) => (
+				<HighlightCardItem key={highlight.title} {...highlight} />
+			))}
+		</section>
+	);
+}

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -71,11 +71,25 @@ function cloneParams(
 }
 
 function cloneEvents(events: SavedGameEvent[]): SavedGameEvent[] {
-	return events.map((event) =>
-		event.type === 'action'
-			? { ...event, params: cloneParams(event.params) }
-			: { ...event },
-	);
+	return events.map((event) => {
+		if (event.type === 'action') {
+			const clonedParams = cloneParams(event.params);
+			if (clonedParams === undefined) {
+				return {
+					type: 'action',
+					playerId: event.playerId,
+					actionId: event.actionId,
+				} satisfies SavedGameEvent;
+			}
+			return {
+				type: 'action',
+				playerId: event.playerId,
+				actionId: event.actionId,
+				params: clonedParams,
+			} satisfies SavedGameEvent;
+		}
+		return { ...event } satisfies SavedGameEvent;
+	});
 }
 
 interface Action {

--- a/packages/web/src/state/persistence.ts
+++ b/packages/web/src/state/persistence.ts
@@ -1,0 +1,123 @@
+import {
+	advance,
+	performAction,
+	type ActionParams,
+	type EngineContext,
+	type PlayerId,
+} from '@kingdom-builder/engine';
+import type { LogEntry } from './types';
+
+const STORAGE_KEY = 'kingdom-builder:save-state';
+const STORAGE_VERSION = 1;
+
+interface SavedActionEvent {
+	type: 'action';
+	playerId: PlayerId;
+	actionId: string;
+	params?: Record<string, unknown>;
+}
+
+interface SavedEndTurnEvent {
+	type: 'end-turn';
+	playerId: PlayerId;
+}
+
+export type SavedGameEvent = SavedActionEvent | SavedEndTurnEvent;
+
+export interface SavedGame {
+	version: typeof STORAGE_VERSION;
+	events: SavedGameEvent[];
+	turn: number;
+	nextPlayerId: PlayerId;
+	log: LogEntry[];
+	logOverflowed: boolean;
+	devMode: boolean;
+}
+
+export interface SavedGameMeta {
+	turn: number;
+	nextPlayerId: PlayerId;
+	devMode: boolean;
+}
+
+function parseStoredGame(value: string | null): SavedGame | null {
+	if (!value) {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse(value) as SavedGame;
+		if (!parsed || parsed.version !== STORAGE_VERSION) {
+			return null;
+		}
+		return parsed;
+	} catch (error) {
+		console.warn('Failed to parse saved game', error);
+		return null;
+	}
+}
+
+export function loadSavedGame(): SavedGame | null {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+	return parseStoredGame(window.localStorage.getItem(STORAGE_KEY));
+}
+
+export function loadSavedGameMeta(): SavedGameMeta | null {
+	const save = loadSavedGame();
+	if (!save) {
+		return null;
+	}
+	return {
+		turn: save.turn,
+		nextPlayerId: save.nextPlayerId,
+		devMode: save.devMode,
+	};
+}
+
+export function saveGame(save: SavedGame): void {
+	if (typeof window === 'undefined') {
+		return;
+	}
+	const payload = JSON.stringify(save);
+	window.localStorage.setItem(STORAGE_KEY, payload);
+}
+
+export function clearSavedGame(): void {
+	if (typeof window === 'undefined') {
+		return;
+	}
+	window.localStorage.removeItem(STORAGE_KEY);
+}
+
+export function replaySavedGame(ctx: EngineContext, save: SavedGame): void {
+	for (const event of save.events) {
+		if (event.type === 'action') {
+			const activePlayerId = ctx.activePlayer.id;
+			if (activePlayerId !== event.playerId) {
+				const message = [
+					'Saved history mismatch:',
+					`expected player ${event.playerId}`,
+					`but active player is ${activePlayerId}`,
+				].join(' ');
+				throw new Error(message);
+			}
+			const actionParams = event.params as ActionParams<string>;
+			performAction(event.actionId, ctx, actionParams);
+		} else {
+			const activePlayerId = ctx.activePlayer.id;
+			if (activePlayerId !== event.playerId) {
+				const message = [
+					'Saved history mismatch:',
+					`expected player ${event.playerId} to end turn`,
+					`but active player is ${activePlayerId}`,
+				].join(' ');
+				throw new Error(message);
+			}
+			advance(ctx);
+			while (!ctx.phases[ctx.game.phaseIndex]?.action) {
+				advance(ctx);
+			}
+		}
+	}
+}

--- a/packages/web/src/state/types.ts
+++ b/packages/web/src/state/types.ts
@@ -1,0 +1,5 @@
+export interface LogEntry {
+	time: string;
+	text: string;
+	playerId: string;
+}

--- a/packages/web/tests/App.test.tsx
+++ b/packages/web/tests/App.test.tsx
@@ -4,57 +4,57 @@ import React from 'react';
 import App from '../src/App';
 
 vi.mock('@kingdom-builder/engine', () => {
-  const phaseA = 'phaseA';
-  const phaseB = 'phaseB';
-  const phaseC = 'phaseC';
-  const resources = {
-    r1: 'r1',
-    r2: 'r2',
-    r3: 'r3',
-    r4: 'r4',
-  } as const;
+	const phaseA = 'phaseA';
+	const phaseB = 'phaseB';
+	const phaseC = 'phaseC';
+	const resources = {
+		r1: 'r1',
+		r2: 'r2',
+		r3: 'r3',
+		r4: 'r4',
+	} as const;
 
-  const player = {
-    id: 'A',
-    name: 'A',
-    resources: {} as Record<string, number>,
-    stats: { maxPopulation: 0, warWeariness: 0 } as Record<string, number>,
-    population: {} as Record<string, number>,
-    buildings: new Set<string>(),
-    lands: [] as unknown[],
-  };
-  return {
-    createEngine: () => ({
-      activePlayer: player,
-      actions: { map: new Map() },
-      developments: { map: new Map() },
-      buildings: { map: new Map(), get: () => undefined },
-      passives: { list: () => [] },
-      game: {
-        currentPhase: phaseA,
-        players: [player],
-        currentPlayerIndex: 0,
-      },
-    }),
-    performAction: () => {},
-    runEffects: () => {},
-    collectTriggerEffects: () => [],
-    getActionCosts: () => ({}),
-    Phase: { Growth: phaseA, Upkeep: phaseB, Main: phaseC },
-    PHASES: [
-      { id: phaseA, label: 'Phase A', icon: '🏗️', steps: [] },
-      { id: phaseB, label: 'Phase B', icon: '🧹', steps: [] },
-      { id: phaseC, label: 'Phase C', icon: '🎯', steps: [], action: true },
-    ],
-    Resource: resources,
-  };
+	const player = {
+		id: 'A',
+		name: 'A',
+		resources: {} as Record<string, number>,
+		stats: { maxPopulation: 0, warWeariness: 0 } as Record<string, number>,
+		population: {} as Record<string, number>,
+		buildings: new Set<string>(),
+		lands: [] as unknown[],
+	};
+	return {
+		createEngine: () => ({
+			activePlayer: player,
+			actions: { map: new Map() },
+			developments: { map: new Map() },
+			buildings: { map: new Map(), get: () => undefined },
+			passives: { list: () => [] },
+			game: {
+				currentPhase: phaseA,
+				players: [player],
+				currentPlayerIndex: 0,
+			},
+		}),
+		performAction: () => {},
+		runEffects: () => {},
+		collectTriggerEffects: () => [],
+		getActionCosts: () => ({}),
+		Phase: { Growth: phaseA, Upkeep: phaseB, Main: phaseC },
+		PHASES: [
+			{ id: phaseA, label: 'Phase A', icon: '🏗️', steps: [] },
+			{ id: phaseB, label: 'Phase B', icon: '🧹', steps: [] },
+			{ id: phaseC, label: 'Phase C', icon: '🎯', steps: [], action: true },
+		],
+		Resource: resources,
+	};
 });
 
 describe('<App />', () => {
-  it('renders main menu', () => {
-    const html = renderToString(<App />);
-    expect(html).toContain('Kingdom Builder');
-    expect(html).toContain('Start New Game');
-    expect(html).toContain('Start Dev/Debug Game');
-  });
+	it('renders main menu', () => {
+		const html = renderToString(<App />);
+		expect(html).toContain('Kingdom Builder');
+		expect(html).toContain('Start game');
+		expect(html).toContain('Start Dev/Debug Game');
+	});
 });


### PR DESCRIPTION
## Summary
- add a persistence layer that records turn history, logs, and metadata to localStorage and can hydrate saved games
- update App, Menu, and Game flows with continue/overwrite prompts, quit handling, and loading UI fragments
- extract reusable dialog, menu, and layout components to support the new menu presentation

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ded715843c8325b6f1a61310c67104