### PR TITLE
Add multi-step action option selection

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -159,6 +159,122 @@ export function createActionRegistry() {
 		focus: 'economy',
 	});
 
+	registry.add('festival-planning', {
+		...action()
+			.id('festival-planning')
+			.name('Festival Planning')
+			.icon('🎭')
+			.cost(Resource.ap, 1)
+			.effectGroup('festival-perk', (group) =>
+				group
+					.title('Choose a festival perk')
+					.option((option) =>
+						option
+							.id('crowd-boost')
+							.label('Invite travelling performers')
+							.description('Placeholder: Gain excitement rewards (demo).')
+							.effect(
+								effect(Types.Resource, ResourceMethods.ADD)
+									.params(resourceParams().key(Resource.happiness).amount(2))
+									.build(),
+							),
+					)
+					.option((option) =>
+						option
+							.id('market-rush')
+							.label('Open a vibrant market')
+							.description('Placeholder: Generate trade income (demo).')
+							.effect(
+								effect(Types.Resource, ResourceMethods.ADD)
+									.params(resourceParams().key(Resource.gold).amount(3))
+									.build(),
+							),
+					),
+			)
+			.build(),
+		category: 'basic',
+		order: 5,
+		focus: 'economy',
+	});
+
+	registry.add('strategic-council', {
+		...action()
+			.id('strategic-council')
+			.name('Strategic Council')
+			.icon('🗺️')
+			.cost(Resource.ap, 1)
+			.effectGroup('council-agenda', (group) =>
+				group
+					.title('Set the council agenda')
+					.option((option) =>
+						option
+							.id('fortify')
+							.label('Plan fortifications')
+							.description('Placeholder: Prepare defenses (demo).')
+							.effect(
+								effect(Types.Stat, StatMethods.ADD)
+									.params(
+										statParams().key(Stat.fortificationStrength).amount(1),
+									)
+									.build(),
+							),
+					)
+					.option((option) =>
+						option
+							.id('recruit')
+							.label('Recruit volunteers')
+							.description('Placeholder: Rally supporters (demo).')
+							.effect(
+								effect(Types.Population, PopulationMethods.ADD)
+									.param('role', PopulationRole.Citizen)
+									.param('count', 1)
+									.build(),
+							),
+					),
+			)
+			.effectGroup('council-outcome', (group) =>
+				group
+					.title('Finalize the strategy')
+					.option((option) =>
+						option
+							.id('treasury')
+							.label('Secure treasury support')
+							.description('Placeholder: Leverage savings (demo).')
+							.effect(
+								effect(Types.Resource, ResourceMethods.ADD)
+									.params(resourceParams().key(Resource.gold).amount(2))
+									.build(),
+							),
+					)
+					.option((option) =>
+						option
+							.id('morale')
+							.label('Boost morale')
+							.description('Placeholder: Encourage citizens (demo).')
+							.effect(
+								effect(Types.Resource, ResourceMethods.ADD)
+									.params(resourceParams().key(Resource.happiness).amount(1))
+									.build(),
+							),
+					)
+					.option((option) =>
+						option
+							.id('intel')
+							.label('Gather intelligence')
+							.description('Placeholder: Scout opportunities (demo).')
+							.effect(
+								effect(Types.Action, ActionMethods.ADD)
+									.params({ id: 'scout-placeholder' })
+									.build(),
+							),
+					),
+			)
+			.build(),
+		category: 'basic',
+		order: 6,
+		focus: 'other',
+	});
+
 	registry.add('raise_pop', {
 		...action()
 			.id('raise_pop')

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -5,9 +5,9 @@ export { POPULATIONS, createPopulationRegistry } from './populations';
 export { PHASES } from './phases';
 export type { PhaseDef, StepDef } from './config/builders';
 export {
-  POPULATION_ROLES,
-  PopulationRole,
-  type PopulationRoleId,
+	POPULATION_ROLES,
+	PopulationRole,
+	type PopulationRoleId,
 } from './populationRoles';
 export { Resource, type ResourceKey, RESOURCES } from './resources';
 export { Stat, type StatKey, STATS } from './stats';
@@ -19,13 +19,17 @@ export { MODIFIER_INFO } from './modifiers';
 export { GAME_START } from './game';
 export { RULES } from './rules';
 export type { ActionDef } from './actions';
+export type {
+	ActionEffectGroupConfig,
+	ActionEffectGroupOptionConfig,
+} from '@kingdom-builder/engine/config/schema';
 export type { BuildingDef } from './buildings';
 export type { DevelopmentDef } from './developments';
 export type { PopulationDef, TriggerKey, Focus } from './defs';
 export {
-  ON_PAY_UPKEEP_STEP,
-  ON_GAIN_INCOME_STEP,
-  ON_GAIN_AP_STEP,
-  BROOM_ICON,
-  RESOURCE_TRANSFER_ICON,
+	ON_PAY_UPKEEP_STEP,
+	ON_GAIN_INCOME_STEP,
+	ON_GAIN_AP_STEP,
+	BROOM_ICON,
+	RESOURCE_TRANSFER_ICON,
 } from './defs';

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 import type { EffectDef } from '../effects';
 
 const requirementSchema = z.object({
-  type: z.string(),
-  method: z.string(),
-  params: z.record(z.unknown()).optional(),
-  message: z.string().optional(),
+	type: z.string(),
+	method: z.string(),
+	params: z.record(z.unknown()).optional(),
+	message: z.string().optional(),
 });
 
 export type RequirementConfig = z.infer<typeof requirementSchema>;
@@ -14,130 +14,151 @@ export type RequirementConfig = z.infer<typeof requirementSchema>;
 const costBagSchema = z.record(z.string(), z.number());
 
 const evaluatorSchema = z.object({
-  type: z.string(),
-  params: z.record(z.unknown()).optional(),
+	type: z.string(),
+	params: z.record(z.unknown()).optional(),
 });
 
 // Effect
 export const effectSchema: z.ZodType<EffectDef> = z.lazy(() =>
-  z.object({
-    type: z.string().optional(),
-    method: z.string().optional(),
-    params: z.record(z.unknown()).optional(),
-    effects: z.array(effectSchema).optional(),
-    evaluator: evaluatorSchema.optional(),
-    round: z.enum(['up', 'down']).optional(),
-    meta: z.record(z.unknown()).optional(),
-  }),
+	z.object({
+		type: z.string().optional(),
+		method: z.string().optional(),
+		params: z.record(z.unknown()).optional(),
+		effects: z.array(effectSchema).optional(),
+		evaluator: evaluatorSchema.optional(),
+		round: z.enum(['up', 'down']).optional(),
+		meta: z.record(z.unknown()).optional(),
+	}),
 );
 
 export type EffectConfig = EffectDef;
 
+const effectGroupOptionSchema = z.object({
+	id: z.string(),
+	label: z.string(),
+	description: z.string().optional(),
+	effects: z.array(effectSchema),
+});
+
+export type ActionEffectGroupOptionConfig = z.infer<
+	typeof effectGroupOptionSchema
+>;
+
+const effectGroupSchema = z.object({
+	id: z.string(),
+	title: z.string().optional(),
+	order: z.number().optional(),
+	options: z.array(effectGroupOptionSchema).min(2),
+});
+
+export type ActionEffectGroupConfig = z.infer<typeof effectGroupSchema>;
+
 // Action
 export const actionSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  baseCosts: costBagSchema.optional(),
-  requirements: z.array(requirementSchema).optional(),
-  effects: z.array(effectSchema),
-  system: z.boolean().optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	baseCosts: costBagSchema.optional(),
+	requirements: z.array(requirementSchema).optional(),
+	effects: z.array(effectSchema),
+	effectGroups: z.array(effectGroupSchema).optional(),
+	system: z.boolean().optional(),
 });
 
 export type ActionConfig = z.infer<typeof actionSchema>;
 
 // Building
 export const buildingSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  costs: costBagSchema,
-  upkeep: costBagSchema.optional(),
-  onBuild: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onUpkeepPhase: z.array(effectSchema).optional(),
-  onBeforeAttacked: z.array(effectSchema).optional(),
-  onAttackResolved: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	costs: costBagSchema,
+	upkeep: costBagSchema.optional(),
+	onBuild: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onUpkeepPhase: z.array(effectSchema).optional(),
+	onBeforeAttacked: z.array(effectSchema).optional(),
+	onAttackResolved: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type BuildingConfig = z.infer<typeof buildingSchema>;
 
 // Development
 export const developmentSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  upkeep: costBagSchema.optional(),
-  onBuild: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onBeforeAttacked: z.array(effectSchema).optional(),
-  onAttackResolved: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
-  system: z.boolean().optional(),
-  populationCap: z.number().optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	upkeep: costBagSchema.optional(),
+	onBuild: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onBeforeAttacked: z.array(effectSchema).optional(),
+	onAttackResolved: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
+	system: z.boolean().optional(),
+	populationCap: z.number().optional(),
 });
 
 export type DevelopmentConfig = z.infer<typeof developmentSchema>;
 
 // Population
 export const populationSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  upkeep: costBagSchema.optional(),
-  onAssigned: z.array(effectSchema).optional(),
-  onUnassigned: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onUpkeepPhase: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	upkeep: costBagSchema.optional(),
+	onAssigned: z.array(effectSchema).optional(),
+	onUnassigned: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onUpkeepPhase: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type PopulationConfig = z.infer<typeof populationSchema>;
 
 // Game config
 const landStartSchema = z.object({
-  developments: z.array(z.string()).optional(),
-  slotsMax: z.number().optional(),
-  slotsUsed: z.number().optional(),
-  tilled: z.boolean().optional(),
-  upkeep: costBagSchema.optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	developments: z.array(z.string()).optional(),
+	slotsMax: z.number().optional(),
+	slotsUsed: z.number().optional(),
+	tilled: z.boolean().optional(),
+	upkeep: costBagSchema.optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 const playerStartSchema = z.object({
-  resources: z.record(z.string(), z.number()).optional(),
-  stats: z.record(z.string(), z.number()).optional(),
-  population: z.record(z.string(), z.number()).optional(),
-  lands: z.array(landStartSchema).optional(),
+	resources: z.record(z.string(), z.number()).optional(),
+	stats: z.record(z.string(), z.number()).optional(),
+	population: z.record(z.string(), z.number()).optional(),
+	lands: z.array(landStartSchema).optional(),
 });
 
 export const startConfigSchema = z.object({
-  player: playerStartSchema,
-  players: z.record(z.string(), playerStartSchema).optional(),
+	player: playerStartSchema,
+	players: z.record(z.string(), playerStartSchema).optional(),
 });
 
 export type PlayerStartConfig = z.infer<typeof playerStartSchema>;
 export type StartConfig = z.infer<typeof startConfigSchema>;
 
 export const gameConfigSchema = z.object({
-  start: startConfigSchema.optional(),
-  actions: z.array(actionSchema).optional(),
-  buildings: z.array(buildingSchema).optional(),
-  developments: z.array(developmentSchema).optional(),
-  populations: z.array(populationSchema).optional(),
+	start: startConfigSchema.optional(),
+	actions: z.array(actionSchema).optional(),
+	buildings: z.array(buildingSchema).optional(),
+	developments: z.array(developmentSchema).optional(),
+	populations: z.array(populationSchema).optional(),
 });
 
 export type GameConfig = z.infer<typeof gameConfigSchema>;
 
 export function validateGameConfig(config: unknown): GameConfig {
-  return gameConfigSchema.parse(config);
+	return gameConfigSchema.parse(config);
 }

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import { type Summary } from '../../translation';
 import { renderSummary, renderCosts } from '../../translation/render';
-import type { Focus } from '@kingdom-builder/contents';
+import type { ActionEffectGroupConfig, Focus } from '@kingdom-builder/contents';
 
 const FOCUS_GRADIENTS: Record<Focus, string> & { default: string } = {
 	economy:
@@ -66,6 +72,11 @@ export type ActionCardProps = {
 	onMouseEnter?: () => void;
 	onMouseLeave?: () => void;
 	focus?: Focus | undefined;
+	multiStep?: {
+		groups: ActionEffectGroupConfig[];
+		onComplete: (selections: { groupId: string; optionId: string }[]) => void;
+		onCancel?: () => void;
+	};
 };
 
 export default function ActionCard({
@@ -84,40 +95,238 @@ export default function ActionCard({
 	onMouseEnter,
 	onMouseLeave,
 	focus,
+	multiStep,
 }: ActionCardProps) {
 	const focusClass =
 		(focus && FOCUS_GRADIENTS[focus]) ?? FOCUS_GRADIENTS.default;
+	const [activeGroupIndex, setActiveGroupIndex] = useState<number | null>(null);
+	const [selected, setSelected] = useState<
+		{ groupId: string; optionId: string }[]
+	>([]);
+	const [finalizing, setFinalizing] = useState(false);
+	const timeoutRef = useRef<number>();
+	const groups = multiStep?.groups ?? [];
+	const totalSteps = groups.length;
+	const hasMultiStep = groups.length > 0;
+	const isFlipped = hasMultiStep && activeGroupIndex !== null;
+	const FLIP_DURATION = 500;
+
+	const clearTimeoutRef = useCallback(() => {
+		if (timeoutRef.current) {
+			window.clearTimeout(timeoutRef.current);
+			timeoutRef.current = undefined;
+		}
+	}, []);
+
+	const resetMultiStep = useCallback(
+		(notifyCancel: boolean) => {
+			clearTimeoutRef();
+			setActiveGroupIndex(null);
+			setSelected([]);
+			setFinalizing(false);
+			if (notifyCancel) multiStep?.onCancel?.();
+		},
+		[clearTimeoutRef, multiStep],
+	);
+
+	useEffect(() => () => clearTimeoutRef(), [clearTimeoutRef]);
+
+	useEffect(() => {
+		if (!enabled && activeGroupIndex !== null) {
+			resetMultiStep(false);
+		}
+	}, [enabled, activeGroupIndex, resetMultiStep]);
+
+	useEffect(() => {
+		if (!hasMultiStep) {
+			resetMultiStep(false);
+		}
+	}, [hasMultiStep, resetMultiStep]);
+
+	useEffect(() => {
+		if (isFlipped) onMouseLeave?.();
+	}, [isFlipped, onMouseLeave]);
+
+	const currentGroup: ActionEffectGroupConfig | undefined = useMemo(() => {
+		if (!hasMultiStep || activeGroupIndex === null) return undefined;
+		return groups[activeGroupIndex];
+	}, [activeGroupIndex, groups, hasMultiStep]);
+
+	const optionLayoutClass = useMemo(() => {
+		const count = currentGroup?.options.length ?? 0;
+		if (count >= 3)
+			return 'grid grid-cols-1 sm:grid-cols-2 sm:grid-rows-2 gap-3';
+		return 'grid grid-cols-1 sm:grid-cols-2 gap-3';
+	}, [currentGroup]);
+
+	const stepLabel = useMemo(() => {
+		if (!hasMultiStep || totalSteps === 0) return 'Choose an option';
+		return `Step ${(activeGroupIndex ?? 0) + 1} of ${totalSteps}`;
+	}, [activeGroupIndex, hasMultiStep, totalSteps]);
+
+	const handleStart = () => {
+		if (!enabled) return;
+		if (!hasMultiStep) {
+			onClick?.();
+			return;
+		}
+		onMouseLeave?.();
+		setSelected([]);
+		setActiveGroupIndex(0);
+	};
+
+	const finalizeSelections = (
+		nextSelections: {
+			groupId: string;
+			optionId: string;
+		}[],
+	) => {
+		setFinalizing(true);
+		clearTimeoutRef();
+		timeoutRef.current = window.setTimeout(() => {
+			setActiveGroupIndex(null);
+			setSelected([]);
+			setFinalizing(false);
+			multiStep?.onComplete(nextSelections);
+		}, FLIP_DURATION);
+	};
+
+	const handleOption = (optionId: string) => {
+		if (!multiStep || !currentGroup) return;
+		if (finalizing) return;
+		const nextSelections = [
+			...selected,
+			{ groupId: currentGroup.id, optionId },
+		];
+		setSelected(nextSelections);
+		const isLast = activeGroupIndex === groups.length - 1;
+		if (isLast) {
+			finalizeSelections(nextSelections);
+		} else {
+			setActiveGroupIndex((index) => (index ?? 0) + 1);
+		}
+	};
+
+	const handleCancel = () => {
+		if (!hasMultiStep) return;
+		resetMultiStep(true);
+	};
+
+	const handleMouseEnterCard = () => {
+		if (isFlipped) return;
+		onMouseEnter?.();
+	};
+
+	const faceBaseClass = `panel-card absolute inset-0 flex h-full flex-col items-start gap-2 rounded-3xl border border-white/40 bg-gradient-to-br p-4 text-left shadow-lg shadow-amber-500/10 transition-transform duration-500 ease-out dark:border-white/10 ${focusClass}`;
+
 	return (
-		<button
-			className={`relative panel-card flex h-full flex-col items-start gap-2 border border-white/40 bg-gradient-to-br p-4 text-left shadow-lg shadow-amber-500/10 transition ${
-				enabled ? 'hoverable cursor-pointer' : 'cursor-not-allowed opacity-50'
-			} ${focusClass}`}
-			title={tooltip}
-			onClick={enabled ? onClick : undefined}
-			onMouseEnter={onMouseEnter}
+		<div
+			className="relative h-full min-h-[220px] w-full [perspective:1600px]"
+			onMouseEnter={handleMouseEnterCard}
 			onMouseLeave={onMouseLeave}
+			title={isFlipped ? undefined : tooltip}
 		>
-			<span className="text-base font-medium">{title}</span>
-			<div className="absolute top-2 right-2 flex flex-col items-end gap-1 text-right">
-				{renderCosts(costs, playerResources, actionCostResource, upkeep)}
-				{requirements.length > 0 && (
-					<div className="flex flex-col items-end gap-0.5 text-xs text-rose-500 dark:text-rose-300">
-						<div className="whitespace-nowrap">
-							Req
-							{requirementIcons.length > 0 && ` ${requirementIcons.join('')}`}
+			<div
+				className="relative h-full w-full transform-gpu transition-transform duration-500 [transform-style:preserve-3d]"
+				style={{
+					transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
+				}}
+			>
+				<div
+					className={`${faceBaseClass} ${
+						enabled
+							? 'hoverable cursor-pointer'
+							: 'cursor-not-allowed opacity-50'
+					} ${isFlipped ? 'pointer-events-none' : 'pointer-events-auto'} [backface-visibility:hidden]`}
+					onClick={handleStart}
+				>
+					{hasMultiStep && (
+						<div className="pointer-events-none absolute left-3 top-3 flex items-center gap-1 rounded-full bg-slate-900/10 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-700 shadow-sm dark:bg-white/10 dark:text-slate-100">
+							<svg
+								aria-hidden
+								className="h-3 w-3"
+								viewBox="0 0 16 16"
+								fill="none"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<path
+									d="M3 2h5l2 3h3v3h-2l2 3H8l-2-3H3V5h2L3 2z"
+									className="fill-current"
+								/>
+							</svg>
+							<span>Multi-step</span>
 						</div>
+					)}
+					<span className="text-base font-medium">{title}</span>
+					<div className="absolute right-2 top-2 flex flex-col items-end gap-1 text-right">
+						{renderCosts(costs, playerResources, actionCostResource, upkeep)}
+						{requirements.length > 0 && (
+							<div className="flex flex-col items-end gap-0.5 text-xs text-rose-500 dark:text-rose-300">
+								<div className="whitespace-nowrap">
+									Req
+									{requirementIcons.length > 0 &&
+										` ${requirementIcons.join('')}`}
+								</div>
+							</div>
+						)}
 					</div>
-				)}
+					<ul className="list-disc pl-4 text-left text-sm">
+						{implemented ? (
+							renderSummary(stripSummary(summary, requirements))
+						) : (
+							<li className="italic text-rose-500 dark:text-rose-300">
+								Not implemented yet
+							</li>
+						)}
+					</ul>
+				</div>
+				<div
+					className={`${faceBaseClass} ${
+						isFlipped ? 'pointer-events-auto' : 'pointer-events-none opacity-0'
+					} flex gap-4 [backface-visibility:hidden] [transform:rotateY(180deg)]`}
+				>
+					<button
+						type="button"
+						className="absolute right-3 top-3 rounded-full bg-gradient-to-r from-rose-500 to-red-500 px-3 py-1 text-xs font-semibold text-white shadow-lg shadow-rose-500/40 transition hover:from-rose-400 hover:to-red-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-200/70"
+						onClick={handleCancel}
+					>
+						✕
+					</button>
+					<div className="flex w-full flex-col gap-4 pr-2">
+						<div>
+							<p className="text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300">
+								{stepLabel}
+							</p>
+							<h4 className="mt-1 text-lg font-semibold text-slate-900 dark:text-slate-100">
+								{currentGroup?.title ?? 'Choose an option'}
+							</h4>
+						</div>
+						<div className={optionLayoutClass}>
+							{currentGroup?.options.map((option) => (
+								<button
+									key={option.id}
+									type="button"
+									className={`flex h-full flex-col gap-1 rounded-2xl border border-white/40 bg-white/75 p-3 text-left text-sm font-medium text-slate-800 shadow-md shadow-amber-500/10 transition hoverable dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:shadow-slate-900/40 ${
+										finalizing ? 'pointer-events-none opacity-60' : ''
+									}`}
+									onClick={() => handleOption(option.id)}
+								>
+									<span>{option.label}</span>
+									{option.description && (
+										<span className="text-xs font-normal text-slate-600 dark:text-slate-300">
+											{option.description}
+										</span>
+									)}
+								</button>
+							))}
+						</div>
+						<p className="mt-auto text-xs text-slate-500 dark:text-slate-300">
+							Pick one option to continue. Choices are placeholders for demo
+							purposes.
+						</p>
+					</div>
+				</div>
 			</div>
-			<ul className="text-sm list-disc pl-4 text-left">
-				{implemented ? (
-					renderSummary(stripSummary(summary, requirements))
-				) : (
-					<li className="italic text-rose-500 dark:text-rose-300">
-						Not implemented yet
-					</li>
-				)}
-			</ul>
-		</button>
+		</div>
 	);
 }

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -110,6 +110,7 @@ interface GameEngineContextValue {
 	onToggleDark: () => void;
 	timeScale: TimeScale;
 	setTimeScale: (value: TimeScale) => void;
+	addFrontendLog: (entry: string | string[]) => void;
 }
 
 const GameEngineContext = createContext<GameEngineContextValue | null>(null);
@@ -248,6 +249,10 @@ export function GameProvider({
 			}
 			return next;
 		});
+	};
+
+	const addFrontendLog = (entry: string | string[]) => {
+		addLog(entry);
 	};
 
 	useEffect(() => {
@@ -698,6 +703,7 @@ export function GameProvider({
 		onToggleDark,
 		timeScale,
 		setTimeScale: changeTimeScale,
+		addFrontendLog,
 		...(onExit ? { onExit } : {}),
 	};
 


### PR DESCRIPTION
## Summary
- add action effect group builders and schema support to configure multi-option actions
- create demo multi-step actions and expose effect group types from the contents package
- update the web action card and panel to drive multi-step choices with animations, cancellation, and logging

## Testing
- npm run lint
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68def72ac1b083258182eb0a158a8f85