### PR TITLE
Add multi-step action effect selection flow

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -32,6 +32,7 @@ import {
 	statEvaluator,
 	attackParams,
 	transferParams,
+	actionEffectGroup,
 } from './config/builders';
 import type { Focus } from './defs';
 
@@ -157,6 +158,87 @@ export function createActionRegistry() {
 		category: 'basic',
 		order: 4,
 		focus: 'economy',
+	});
+
+	registry.add('festival_choice', {
+		...action()
+			.id('festival_choice')
+			.name('Festival of Choices')
+			.icon('🎭')
+			.cost(Resource.ap, 1)
+			.effectGroup(
+				actionEffectGroup('festival-reward')
+					.label('Select your celebration reward')
+					.option(
+						'festival-gold',
+						'Gain 3 Gold',
+						effect(Types.Resource, ResourceMethods.ADD)
+							.params(resourceParams().key(Resource.gold).amount(3))
+							.build(),
+					)
+					.option(
+						'festival-joy',
+						'Gain 2 Happiness',
+						effect(Types.Resource, ResourceMethods.ADD)
+							.params(resourceParams().key(Resource.happiness).amount(2))
+							.build(),
+					)
+					.build(),
+			)
+			.build(),
+		category: 'basic',
+		order: 5,
+		focus: 'economy',
+	});
+
+	registry.add('strategic_campaign', {
+		...action()
+			.id('strategic_campaign')
+			.name('Strategic Campaign')
+			.icon('🧭')
+			.cost(Resource.ap, 1)
+			.effectGroup(
+				actionEffectGroup('campaign-prep')
+					.label('Prepare your forces')
+					.option(
+						'campaign-train',
+						'Train the Legion (+1 Army Strength)',
+						effect(Types.Stat, StatMethods.ADD)
+							.params(statParams().key(Stat.armyStrength).amount(1))
+							.build(),
+					)
+					.option(
+						'campaign-fortify',
+						'Fortify the walls (+1 Fortification Strength)',
+						effect(Types.Stat, StatMethods.ADD)
+							.params(statParams().key(Stat.fortificationStrength).amount(1))
+							.build(),
+					)
+					.build(),
+			)
+			.effectGroup(
+				actionEffectGroup('campaign-march')
+					.label('Decide the campaign reward')
+					.option(
+						'campaign-gold',
+						'Collect 2 Gold',
+						effect(Types.Resource, ResourceMethods.ADD)
+							.params(resourceParams().key(Resource.gold).amount(2))
+							.build(),
+					)
+					.option(
+						'campaign-morale',
+						'Boost morale (+1 Happiness)',
+						effect(Types.Resource, ResourceMethods.ADD)
+							.params(resourceParams().key(Resource.happiness).amount(1))
+							.build(),
+					)
+					.build(),
+			)
+			.build(),
+		category: 'basic',
+		order: 6,
+		focus: 'aggressive',
 	});
 
 	registry.add('raise_pop', {

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 import type { EffectDef } from '../effects';
 
 const requirementSchema = z.object({
-  type: z.string(),
-  method: z.string(),
-  params: z.record(z.unknown()).optional(),
-  message: z.string().optional(),
+	type: z.string(),
+	method: z.string(),
+	params: z.record(z.unknown()).optional(),
+	message: z.string().optional(),
 });
 
 export type RequirementConfig = z.infer<typeof requirementSchema>;
@@ -14,130 +14,160 @@ export type RequirementConfig = z.infer<typeof requirementSchema>;
 const costBagSchema = z.record(z.string(), z.number());
 
 const evaluatorSchema = z.object({
-  type: z.string(),
-  params: z.record(z.unknown()).optional(),
+	type: z.string(),
+	params: z.record(z.unknown()).optional(),
 });
 
 // Effect
 export const effectSchema: z.ZodType<EffectDef> = z.lazy(() =>
-  z.object({
-    type: z.string().optional(),
-    method: z.string().optional(),
-    params: z.record(z.unknown()).optional(),
-    effects: z.array(effectSchema).optional(),
-    evaluator: evaluatorSchema.optional(),
-    round: z.enum(['up', 'down']).optional(),
-    meta: z.record(z.unknown()).optional(),
-  }),
+	z.object({
+		type: z.string().optional(),
+		method: z.string().optional(),
+		params: z.record(z.unknown()).optional(),
+		effects: z.array(effectSchema).optional(),
+		evaluator: evaluatorSchema.optional(),
+		round: z.enum(['up', 'down']).optional(),
+		meta: z.record(z.unknown()).optional(),
+	}),
 );
 
 export type EffectConfig = EffectDef;
 
 // Action
+const actionEffectOptionSchema = z.object({
+	id: z.string(),
+	label: z.string(),
+	effect: effectSchema,
+});
+
+export type ActionEffectGroupOptionConfig = z.infer<
+	typeof actionEffectOptionSchema
+>;
+
+const actionEffectGroupSchema = z
+	.object({
+		id: z.string(),
+		label: z.string(),
+		options: z.array(actionEffectOptionSchema).min(2),
+	})
+	.refine(
+		(value) => {
+			const optionIds = value.options.map((opt) => opt.id);
+			return new Set(optionIds).size === optionIds.length;
+		},
+		{
+			message: 'Action effect group option ids must be unique',
+			path: ['options'],
+		},
+	);
+
+export type ActionEffectGroupConfig = z.infer<typeof actionEffectGroupSchema>;
+
 export const actionSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  baseCosts: costBagSchema.optional(),
-  requirements: z.array(requirementSchema).optional(),
-  effects: z.array(effectSchema),
-  system: z.boolean().optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	baseCosts: costBagSchema.optional(),
+	requirements: z.array(requirementSchema).optional(),
+	effects: z.array(effectSchema),
+	effectGroups: z.array(actionEffectGroupSchema).optional(),
+	system: z.boolean().optional(),
 });
 
 export type ActionConfig = z.infer<typeof actionSchema>;
 
 // Building
 export const buildingSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  costs: costBagSchema,
-  upkeep: costBagSchema.optional(),
-  onBuild: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onUpkeepPhase: z.array(effectSchema).optional(),
-  onBeforeAttacked: z.array(effectSchema).optional(),
-  onAttackResolved: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	costs: costBagSchema,
+	upkeep: costBagSchema.optional(),
+	onBuild: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onUpkeepPhase: z.array(effectSchema).optional(),
+	onBeforeAttacked: z.array(effectSchema).optional(),
+	onAttackResolved: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type BuildingConfig = z.infer<typeof buildingSchema>;
 
 // Development
 export const developmentSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  upkeep: costBagSchema.optional(),
-  onBuild: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onBeforeAttacked: z.array(effectSchema).optional(),
-  onAttackResolved: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
-  system: z.boolean().optional(),
-  populationCap: z.number().optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	upkeep: costBagSchema.optional(),
+	onBuild: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onBeforeAttacked: z.array(effectSchema).optional(),
+	onAttackResolved: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
+	system: z.boolean().optional(),
+	populationCap: z.number().optional(),
 });
 
 export type DevelopmentConfig = z.infer<typeof developmentSchema>;
 
 // Population
 export const populationSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  upkeep: costBagSchema.optional(),
-  onAssigned: z.array(effectSchema).optional(),
-  onUnassigned: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onUpkeepPhase: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	upkeep: costBagSchema.optional(),
+	onAssigned: z.array(effectSchema).optional(),
+	onUnassigned: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onUpkeepPhase: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type PopulationConfig = z.infer<typeof populationSchema>;
 
 // Game config
 const landStartSchema = z.object({
-  developments: z.array(z.string()).optional(),
-  slotsMax: z.number().optional(),
-  slotsUsed: z.number().optional(),
-  tilled: z.boolean().optional(),
-  upkeep: costBagSchema.optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	developments: z.array(z.string()).optional(),
+	slotsMax: z.number().optional(),
+	slotsUsed: z.number().optional(),
+	tilled: z.boolean().optional(),
+	upkeep: costBagSchema.optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 const playerStartSchema = z.object({
-  resources: z.record(z.string(), z.number()).optional(),
-  stats: z.record(z.string(), z.number()).optional(),
-  population: z.record(z.string(), z.number()).optional(),
-  lands: z.array(landStartSchema).optional(),
+	resources: z.record(z.string(), z.number()).optional(),
+	stats: z.record(z.string(), z.number()).optional(),
+	population: z.record(z.string(), z.number()).optional(),
+	lands: z.array(landStartSchema).optional(),
 });
 
 export const startConfigSchema = z.object({
-  player: playerStartSchema,
-  players: z.record(z.string(), playerStartSchema).optional(),
+	player: playerStartSchema,
+	players: z.record(z.string(), playerStartSchema).optional(),
 });
 
 export type PlayerStartConfig = z.infer<typeof playerStartSchema>;
 export type StartConfig = z.infer<typeof startConfigSchema>;
 
 export const gameConfigSchema = z.object({
-  start: startConfigSchema.optional(),
-  actions: z.array(actionSchema).optional(),
-  buildings: z.array(buildingSchema).optional(),
-  developments: z.array(developmentSchema).optional(),
-  populations: z.array(populationSchema).optional(),
+	start: startConfigSchema.optional(),
+	actions: z.array(actionSchema).optional(),
+	buildings: z.array(buildingSchema).optional(),
+	developments: z.array(developmentSchema).optional(),
+	populations: z.array(populationSchema).optional(),
 });
 
 export type GameConfig = z.infer<typeof gameConfigSchema>;
 
 export function validateGameConfig(config: unknown): GameConfig {
-  return gameConfigSchema.parse(config);
+	return gameConfigSchema.parse(config);
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -38,7 +38,12 @@ export type { EvaluatorHandler, EvaluatorDef } from './evaluators';
 export { registerCoreRequirements, RequirementRegistry } from './requirements';
 export type { RequirementHandler, RequirementDef } from './requirements';
 export { validateGameConfig } from './config/schema';
-export type { GameConfig } from './config/schema';
+export type {
+	GameConfig,
+	ActionConfig,
+	ActionEffectGroupConfig,
+	ActionEffectGroupOptionConfig,
+} from './config/schema';
 export { resolveAttack } from './effects/attack';
 export type {
 	AttackLog,

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -50,6 +50,30 @@ function stripSummary(
 	return filtered.length > 0 ? filtered : undefined;
 }
 
+type MultiStepOption = {
+	id: string;
+	label: string;
+};
+
+type MultiStepOptionsFace = {
+	kind: 'options';
+	groupId: string;
+	label: string;
+	step: number;
+	total: number;
+	options: MultiStepOption[];
+};
+
+type MultiStepFaceContent = { kind: 'default' } | MultiStepOptionsFace;
+
+type MultiStepStateProps = {
+	front: MultiStepFaceContent;
+	back: MultiStepFaceContent;
+	flipped: boolean;
+	visibleFace: 'front' | 'back';
+	interactive: boolean;
+};
+
 export type ActionCardProps = {
 	title: React.ReactNode;
 	costs: Record<string, number>;
@@ -66,7 +90,153 @@ export type ActionCardProps = {
 	onMouseEnter?: () => void;
 	onMouseLeave?: () => void;
 	focus?: Focus | undefined;
+	isMultiStep?: boolean;
+	multiStepState?: MultiStepStateProps;
+	onSelectMultiStepOption?: (groupId: string, optionId: string) => void;
+	onCancelMultiStep?: () => void;
 };
+
+function MultiStepIcon() {
+	return (
+		<div className="absolute left-3 top-3 flex h-8 w-8 items-center justify-center rounded-full bg-amber-500/80 text-sm font-semibold text-white shadow shadow-amber-500/30">
+			⇄
+		</div>
+	);
+}
+
+function DefaultCardFace({
+	title,
+	costs,
+	playerResources,
+	actionCostResource,
+	summary,
+	implemented,
+	enabled,
+	tooltip,
+	requirements,
+	requirementIcons,
+	focusClass,
+	onClick,
+	onMouseEnter,
+	onMouseLeave,
+	isMultiStep,
+	upkeep,
+}: {
+	title: React.ReactNode;
+	costs: Record<string, number>;
+	playerResources: Record<string, number>;
+	actionCostResource: string;
+	summary?: Summary | undefined;
+	implemented: boolean;
+	enabled: boolean;
+	tooltip?: string | undefined;
+	requirements: string[];
+	requirementIcons: string[];
+	focusClass: string;
+	onClick?: () => void;
+	onMouseEnter?: () => void;
+	onMouseLeave?: () => void;
+	isMultiStep: boolean;
+	upkeep?: Record<string, number> | undefined;
+}) {
+	return (
+		<button
+			className={`panel-card flex h-full min-h-[220px] w-full flex-col items-start gap-2 border border-white/40 bg-gradient-to-br p-4 text-left shadow-lg shadow-amber-500/10 transition ${
+				enabled ? 'hoverable cursor-pointer' : 'cursor-not-allowed opacity-50'
+			} ${focusClass}`}
+			title={tooltip}
+			onClick={enabled ? onClick : undefined}
+			onMouseEnter={onMouseEnter}
+			onMouseLeave={onMouseLeave}
+		>
+			{isMultiStep && <MultiStepIcon />}
+			<span className="text-base font-medium">{title}</span>
+			<div className="pointer-events-none absolute right-2 top-2 flex flex-col items-end gap-1 text-right">
+				{renderCosts(costs, playerResources, actionCostResource, upkeep)}
+				{requirements.length > 0 && (
+					<div className="flex flex-col items-end gap-0.5 text-xs text-rose-500 dark:text-rose-300">
+						<div className="whitespace-nowrap">
+							Req
+							{requirementIcons.length > 0 && ` ${requirementIcons.join('')}`}
+						</div>
+					</div>
+				)}
+			</div>
+			<ul className="list-disc pl-4 text-left text-sm">
+				{implemented ? (
+					renderSummary(summary)
+				) : (
+					<li className="italic text-rose-500 dark:text-rose-300">
+						Not implemented yet
+					</li>
+				)}
+			</ul>
+		</button>
+	);
+}
+
+function OptionsCardFace({
+	face,
+	focusClass,
+	onSelect,
+	onCancel,
+	interactive,
+}: {
+	face: MultiStepOptionsFace;
+	focusClass: string;
+	onSelect?: (optionId: string) => void;
+	onCancel?: () => void;
+	interactive: boolean;
+}) {
+	const layoutClass =
+		face.options.length >= 3
+			? 'grid grid-cols-2 gap-3 auto-rows-fr'
+			: 'flex flex-col gap-3';
+	return (
+		<div
+			className={`panel-card flex h-full min-h-[220px] w-full flex-col gap-4 border border-white/40 bg-gradient-to-br p-4 text-left shadow-lg shadow-amber-500/10 ${focusClass}`}
+		>
+			<div className="flex items-start justify-between gap-4">
+				<div className="flex flex-col gap-1">
+					<span className="text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300">
+						Step {face.step} of {face.total}
+					</span>
+					<h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+						{face.label}
+					</h3>
+				</div>
+				<button
+					type="button"
+					aria-label="Cancel multi-step action"
+					onClick={interactive ? onCancel : undefined}
+					className={`flex h-9 w-9 items-center justify-center rounded-full text-base font-bold text-white shadow-lg shadow-rose-500/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-200/70 ${
+						interactive
+							? 'hoverable cursor-pointer'
+							: 'cursor-not-allowed opacity-60'
+					} bg-gradient-to-r from-rose-500 to-red-500 hover:from-rose-400 hover:to-red-400`}
+				>
+					×
+				</button>
+			</div>
+			<div className={layoutClass}>
+				{face.options.map((option) => (
+					<button
+						key={option.id}
+						type="button"
+						onClick={interactive ? () => onSelect?.(option.id) : undefined}
+						className={`group flex h-full flex-col gap-2 rounded-2xl border border-white/50 bg-white/80 p-4 text-left font-semibold text-slate-800 shadow-md shadow-amber-500/10 transition dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 ${
+							interactive
+								? 'hoverable cursor-pointer'
+								: 'cursor-not-allowed opacity-60'
+						}`}
+					>
+						<span className="text-base font-semibold">{option.label}</span>
+					</button>
+				))}
+			</div>
+		</div>
+	);
+}
 
 export default function ActionCard({
 	title,
@@ -84,40 +254,102 @@ export default function ActionCard({
 	onMouseEnter,
 	onMouseLeave,
 	focus,
+	isMultiStep = false,
+	multiStepState,
+	onSelectMultiStepOption,
+	onCancelMultiStep,
 }: ActionCardProps) {
 	const focusClass =
 		(focus && FOCUS_GRADIENTS[focus]) ?? FOCUS_GRADIENTS.default;
+	const strippedSummary = stripSummary(summary, requirements);
+	const frontFace = multiStepState?.front ?? { kind: 'default' };
+	const backFace = multiStepState?.back ?? { kind: 'default' };
+	const flipped = multiStepState?.flipped ?? false;
+	const visibleFace = multiStepState?.visibleFace ?? 'front';
+	const interactive = multiStepState?.interactive ?? false;
+	const enableFrontInteractions = !multiStepState && enabled;
+
 	return (
-		<button
-			className={`relative panel-card flex h-full flex-col items-start gap-2 border border-white/40 bg-gradient-to-br p-4 text-left shadow-lg shadow-amber-500/10 transition ${
-				enabled ? 'hoverable cursor-pointer' : 'cursor-not-allowed opacity-50'
-			} ${focusClass}`}
-			title={tooltip}
-			onClick={enabled ? onClick : undefined}
-			onMouseEnter={onMouseEnter}
-			onMouseLeave={onMouseLeave}
-		>
-			<span className="text-base font-medium">{title}</span>
-			<div className="absolute top-2 right-2 flex flex-col items-end gap-1 text-right">
-				{renderCosts(costs, playerResources, actionCostResource, upkeep)}
-				{requirements.length > 0 && (
-					<div className="flex flex-col items-end gap-0.5 text-xs text-rose-500 dark:text-rose-300">
-						<div className="whitespace-nowrap">
-							Req
-							{requirementIcons.length > 0 && ` ${requirementIcons.join('')}`}
-						</div>
-					</div>
-				)}
+		<div className="relative h-full w-full [perspective:1600px]">
+			<div
+				className={`relative h-full w-full transition-transform duration-500 ease-out [transform-style:preserve-3d] ${
+					flipped ? '[transform:rotateY(180deg)]' : ''
+				}`}
+			>
+				<div
+					className={`absolute inset-0 [backface-visibility:hidden] ${
+						visibleFace === 'front'
+							? 'pointer-events-auto'
+							: 'pointer-events-none'
+					}`}
+				>
+					{frontFace.kind === 'options' ? (
+						<OptionsCardFace
+							face={frontFace}
+							focusClass={focusClass}
+							onSelect={(optionId) =>
+								onSelectMultiStepOption?.(frontFace.groupId, optionId)
+							}
+							onCancel={onCancelMultiStep}
+							interactive={interactive && visibleFace === 'front'}
+						/>
+					) : (
+						<DefaultCardFace
+							title={title}
+							costs={costs}
+							playerResources={playerResources}
+							actionCostResource={actionCostResource}
+							summary={strippedSummary}
+							implemented={implemented}
+							enabled={enableFrontInteractions}
+							tooltip={tooltip}
+							requirements={requirements}
+							requirementIcons={requirementIcons}
+							focusClass={focusClass}
+							onClick={onClick}
+							onMouseEnter={onMouseEnter}
+							onMouseLeave={onMouseLeave}
+							isMultiStep={isMultiStep && !multiStepState}
+							upkeep={upkeep}
+						/>
+					)}
+				</div>
+				<div
+					className={`absolute inset-0 [backface-visibility:hidden] [transform:rotateY(180deg)] ${
+						visibleFace === 'back'
+							? 'pointer-events-auto'
+							: 'pointer-events-none'
+					}`}
+				>
+					{backFace.kind === 'options' ? (
+						<OptionsCardFace
+							face={backFace}
+							focusClass={focusClass}
+							onSelect={(optionId) =>
+								onSelectMultiStepOption?.(backFace.groupId, optionId)
+							}
+							onCancel={onCancelMultiStep}
+							interactive={interactive && visibleFace === 'back'}
+						/>
+					) : (
+						<DefaultCardFace
+							title={title}
+							costs={costs}
+							playerResources={playerResources}
+							actionCostResource={actionCostResource}
+							summary={strippedSummary}
+							implemented={implemented}
+							enabled={false}
+							tooltip={tooltip}
+							requirements={requirements}
+							requirementIcons={requirementIcons}
+							focusClass={focusClass}
+							isMultiStep={false}
+							upkeep={upkeep}
+						/>
+					)}
+				</div>
 			</div>
-			<ul className="text-sm list-disc pl-4 text-left">
-				{implemented ? (
-					renderSummary(stripSummary(summary, requirements))
-				) : (
-					<li className="italic text-rose-500 dark:text-rose-300">
-						Not implemented yet
-					</li>
-				)}
-			</ul>
-		</button>
+		</div>
 	);
 }

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -110,6 +110,10 @@ interface GameEngineContextValue {
 	onToggleDark: () => void;
 	timeScale: TimeScale;
 	setTimeScale: (value: TimeScale) => void;
+	addLogEntry: (
+		entry: string | string[],
+		player?: EngineContext['activePlayer'],
+	) => void;
 }
 
 const GameEngineContext = createContext<GameEngineContextValue | null>(null);
@@ -698,6 +702,7 @@ export function GameProvider({
 		onToggleDark,
 		timeScale,
 		setTimeScale: changeTimeScale,
+		addLogEntry: addLog,
 		...(onExit ? { onExit } : {}),
 	};
 

--- a/packages/web/src/translation/content/action.ts
+++ b/packages/web/src/translation/content/action.ts
@@ -1,4 +1,7 @@
-import type { EngineContext } from '@kingdom-builder/engine';
+import type {
+	EngineContext,
+	ActionEffectGroupConfig,
+} from '@kingdom-builder/engine';
 import { summarizeEffects, describeEffects, logEffects } from '../effects';
 import { applyParamsToEffects } from '@kingdom-builder/engine';
 import { registerContentTranslator } from './factory';
@@ -8,6 +11,14 @@ import { getActionLogHook } from './actionLogHooks';
 class ActionTranslator
 	implements ContentTranslator<string, Record<string, unknown>>
 {
+	private summarizeGroups(groups: ActionEffectGroupConfig[] | undefined) {
+		if (!groups?.length) return [];
+		return groups.map((group, index) => ({
+			title: `Choice ${index + 1}: ${group.label}`,
+			items: group.options.map((option) => option.label),
+		}));
+	}
+
 	summarize(
 		id: string,
 		ctx: EngineContext,
@@ -18,7 +29,9 @@ class ActionTranslator
 			? applyParamsToEffects(def.effects, opts)
 			: def.effects;
 		const eff = summarizeEffects(effects, ctx);
-		return eff.length ? eff : [];
+		const choices = this.summarizeGroups(def.effectGroups);
+		const combined: Summary = [...choices, ...eff];
+		return combined.length ? combined : [];
 	}
 	describe(
 		id: string,
@@ -30,7 +43,9 @@ class ActionTranslator
 			? applyParamsToEffects(def.effects, opts)
 			: def.effects;
 		const eff = describeEffects(effects, ctx);
-		return eff.length ? eff : [];
+		const choices = this.summarizeGroups(def.effectGroups);
+		const combined: Summary = [...choices, ...eff];
+		return combined.length ? combined : [];
 	}
 	log(
 		id: string,

--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -56,12 +56,12 @@ beforeEach(() => {
 describe('<ActionsPanel />', () => {
 	it('renders hire options for available population roles with derived requirement icons', () => {
 		render(<ActionsPanel />);
-		expect(screen.getByText('👶⚖️ Hire: Council')).toBeInTheDocument();
-		expect(screen.getByText('👶🎖️ Hire: Legion')).toBeInTheDocument();
+		expect(screen.getAllByText('👶⚖️ Hire: Council')).not.toHaveLength(0);
+		expect(screen.getAllByText('👶🎖️ Hire: Legion')).not.toHaveLength(0);
 		expect(screen.queryByText(/Fortifier/)).not.toBeInTheDocument();
 		expect(screen.queryByText(/Citizen/)).not.toBeInTheDocument();
-		expect(screen.getByText('Req 📈👥⚖️')).toBeInTheDocument();
-		expect(screen.getByText('Req 📈👥🎖️')).toBeInTheDocument();
+		expect(screen.getAllByText('Req 📈👥⚖️')).not.toHaveLength(0);
+		expect(screen.getAllByText('Req 📈👥🎖️')).not.toHaveLength(0);
 	});
 
 	it('falls back to requirement helper icons for building cards', () => {
@@ -71,6 +71,6 @@ describe('<ActionsPanel />', () => {
 			'build',
 			expect.anything(),
 		);
-		expect(screen.getByText('Req 🛠️')).toBeInTheDocument();
+		expect(screen.getAllByText('Req 🛠️')).not.toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## Summary
- extend the engine schema and content builders to describe action effect choice groups
- add demo actions using effect groups and surface placeholder summaries in translations
- rebuild the web action card and panel to handle multi-step selections, flipping UI, and demo logging

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0e72db9f88325807c6b00d053641f