### PR TITLE
feat: add navigation history and quit confirmation

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -11,6 +11,20 @@ import ErrorToaster from './components/common/ErrorToaster';
 
 function GameLayout() {
 	const { ctx, onExit, darkMode, onToggleDark } = useGameEngine();
+	const confirmExit = () => {
+		if (!onExit) {
+			return;
+		}
+		const shouldExit =
+			typeof window === 'undefined'
+				? true
+				: window.confirm(
+						'Are you sure you want to quit the current game? This progress will be lost.',
+					);
+		if (shouldExit) {
+			onExit();
+		}
+	};
 	const [playerHeights, setPlayerHeights] = useState<Record<string, number>>(
 		{},
 	);
@@ -91,7 +105,7 @@ function GameLayout() {
 								{darkMode ? 'Light Mode' : 'Dark Mode'}
 							</Button>
 							<Button
-								onClick={onExit}
+								onClick={confirmExit}
 								variant="danger"
 								className="rounded-full px-4 py-2 text-sm font-semibold shadow-lg shadow-rose-500/30"
 							>

--- a/packages/web/src/components/common/ConfirmDialog.tsx
+++ b/packages/web/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,83 @@
+import { createPortal } from 'react-dom';
+import { useEffect } from 'react';
+import Button from './Button';
+
+interface ConfirmDialogProps {
+	open: boolean;
+	title: string;
+	description: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export default function ConfirmDialog({
+	open,
+	title,
+	description,
+	confirmLabel = 'Confirm',
+	cancelLabel = 'Cancel',
+	onConfirm,
+	onCancel,
+}: ConfirmDialogProps) {
+	useEffect(() => {
+		if (!open || typeof window === 'undefined') {
+			return;
+		}
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				onCancel();
+			}
+			if (event.key === 'Enter') {
+				event.preventDefault();
+				onConfirm();
+			}
+		};
+		window.addEventListener('keydown', handleKeyDown);
+		return () => {
+			window.removeEventListener('keydown', handleKeyDown);
+		};
+	}, [open, onCancel, onConfirm]);
+
+	if (!open || typeof document === 'undefined') {
+		return null;
+	}
+
+	return createPortal(
+		<div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8">
+			<div
+				className="absolute inset-0 bg-slate-900/70 backdrop-blur-sm"
+				onClick={onCancel}
+				aria-hidden
+			/>
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="confirm-dialog-title"
+				className="relative z-10 w-full max-w-md rounded-3xl border border-white/20 bg-gradient-to-br from-white/95 via-white/90 to-white/80 p-8 text-slate-900 shadow-2xl shadow-slate-900/30 dark:border-white/10 dark:from-slate-900/95 dark:via-slate-900/90 dark:to-slate-900/80 dark:text-slate-100"
+			>
+				<div className="absolute -top-10 left-1/2 h-20 w-20 -translate-x-1/2 rounded-full bg-rose-400/30 blur-2xl dark:bg-rose-500/30" />
+				<h2
+					id="confirm-dialog-title"
+					className="text-xl font-semibold tracking-tight"
+				>
+					{title}
+				</h2>
+				<p className="mt-4 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+					{description}
+				</p>
+				<div className="mt-8 flex flex-wrap justify-end gap-3">
+					<Button variant="ghost" onClick={onCancel} className="px-5">
+						{cancelLabel}
+					</Button>
+					<Button variant="danger" onClick={onConfirm} className="px-5">
+						{confirmLabel}
+					</Button>
+				</div>
+			</div>
+		</div>,
+		document.body,
+	);
+}


### PR DESCRIPTION
## Summary
- add browser history state management to the SPA so navigation actions push entries and popstate restores screens
- persist dark/dev mode in history state and sync the URL path while handling initialization
- show a confirmation dialog when quitting a running game session

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e0eb895ca88325992f983c92cffda3