### PR TITLE
Implement happiness threshold content passives

### DIFF
--- a/packages/contents/src/rules.ts
+++ b/packages/contents/src/rules.ts
@@ -1,6 +1,61 @@
 import type { RuleSet } from '@kingdom-builder/engine/services';
 import { Resource } from './resources';
-import { happinessTier, tierPassive } from './config/builders';
+import { PopulationRole } from './populationRoles';
+import {
+	Types,
+	CostModMethods,
+	ResultModMethods,
+	costModParams,
+	evaluationTarget,
+	happinessTier,
+	resultModParams,
+	tierPassive,
+} from './config/builders';
+
+const GROWTH_PHASE_ID = 'growth';
+const RAISE_STRENGTH_STEP_ID = 'raise-strength';
+const BUILD_ACTION_ID = 'build';
+
+const DEVELOPMENT_EVALUATION = evaluationTarget('development');
+const COUNCIL_EVALUATION = evaluationTarget('population').id(
+	PopulationRole.Council,
+);
+
+const incomeModifier = (id: string, percent: number) =>
+	({
+		type: Types.ResultMod,
+		method: ResultModMethods.ADD,
+		params: resultModParams()
+			.id(id)
+			.evaluation(DEVELOPMENT_EVALUATION)
+			.percent(percent)
+			.build(),
+	}) as const;
+
+const buildingDiscountModifier = (id: string) =>
+	({
+		type: Types.CostMod,
+		method: CostModMethods.ADD,
+		params: costModParams()
+			.id(id)
+			.actionId(BUILD_ACTION_ID)
+			.key(Resource.gold)
+			.percent(-0.2)
+			.build(),
+	}) as const;
+
+const councilApPenaltyModifier = (id: string) =>
+	({
+		type: Types.ResultMod,
+		method: ResultModMethods.ADD,
+		params: resultModParams()
+			.id(id)
+			.evaluation(COUNCIL_EVALUATION)
+			.percent(-0.5)
+			.build(),
+	}) as const;
+
+const formatRemoval = (description: string) => `Removed when ${description}`;
 
 export const RULES: RuleSet = {
 	defaultActionAPCost: 1,
@@ -8,32 +63,120 @@ export const RULES: RuleSet = {
 	absorptionRounding: 'down',
 	tieredResourceKey: Resource.happiness,
 	tierDefinitions: [
+		happinessTier('happiness:tier:despair')
+			.range(-10, -9)
+			.incomeMultiplier(0.5)
+			.passive(
+				tierPassive('passive:happiness:despair')
+					.effect(incomeModifier('happiness:despair:income', -0.5))
+					.effect(councilApPenaltyModifier('happiness:despair:council-ap'))
+					.skipStep(GROWTH_PHASE_ID, RAISE_STRENGTH_STEP_ID)
+					.text((text) => {
+						const removalDetail = 'happiness rises to -9 or higher';
+						text
+							.summary(
+								'💰 Income -50%. 📉 Skip Raise Strength. ⚖️ Councils grant half ⚡.',
+							)
+							.removal(formatRemoval(removalDetail));
+						return text;
+					}),
+			)
+			.display((display) =>
+				display.removalCondition('happiness rises to -9 or higher'),
+			)
+			.build(),
+		happinessTier('happiness:tier:misery')
+			.range(-8, -6)
+			.incomeMultiplier(0.5)
+			.passive(
+				tierPassive('passive:happiness:misery')
+					.effect(incomeModifier('happiness:misery:income', -0.5))
+					.skipStep(GROWTH_PHASE_ID, RAISE_STRENGTH_STEP_ID)
+					.text((text) => {
+						const removalDetail = 'happiness leaves the -8 to -6 range';
+						text
+							.summary(
+								'💰 Income -50%. 📉 Skip Raise Strength while morale is desperate.',
+							)
+							.removal(formatRemoval(removalDetail));
+						return text;
+					}),
+			)
+			.display((display) =>
+				display.removalCondition('happiness leaves the -8 to -6 range'),
+			)
+			.build(),
+		happinessTier('happiness:tier:grim')
+			.range(-5, -4)
+			.incomeMultiplier(0.75)
+			.passive(
+				tierPassive('passive:happiness:grim')
+					.effect(incomeModifier('happiness:grim:income', -0.25))
+					.skipStep(GROWTH_PHASE_ID, RAISE_STRENGTH_STEP_ID)
+					.text((text) => {
+						const removalDetail = 'happiness leaves the -5 to -4 range';
+						text
+							.summary(
+								'💰 Income -25%. 📉 Skip Raise Strength until spirits recover.',
+							)
+							.removal(formatRemoval(removalDetail));
+						return text;
+					}),
+			)
+			.display((display) =>
+				display.removalCondition('happiness leaves the -5 to -4 range'),
+			)
+			.build(),
+		happinessTier('happiness:tier:unrest')
+			.range(-3, -1)
+			.incomeMultiplier(0.75)
+			.passive(
+				tierPassive('passive:happiness:unrest')
+					.effect(incomeModifier('happiness:unrest:income', -0.25))
+					.text((text) => {
+						const removalDetail = 'happiness leaves the -3 to -1 range';
+						text
+							.summary('💰 Income -25% while unrest simmers.')
+							.removal(formatRemoval(removalDetail));
+						return text;
+					}),
+			)
+			.display((display) =>
+				display.removalCondition('happiness leaves the -3 to -1 range'),
+			)
+			.build(),
 		happinessTier('happiness:tier:steady')
 			.range(0, 2)
 			.incomeMultiplier(1)
 			.passive(
-				tierPassive('passive:happiness:steady').text((text) =>
+				tierPassive('passive:happiness:steady').text((text) => {
+					const removalDetail = 'happiness leaves the 0 to 2 range';
 					text
-						.summary('passive.happiness.steady.summary')
-						.removal('passive.happiness.steady.removal'),
-				),
+						.summary('Morale is steady. No tier bonuses are active.')
+						.removal(formatRemoval(removalDetail));
+					return text;
+				}),
 			)
 			.display((display) =>
-				display.removalCondition('passive.happiness.steady.removal'),
+				display.removalCondition('happiness leaves the 0 to 2 range'),
 			)
 			.build(),
 		happinessTier('happiness:tier:content')
 			.range(3, 4)
 			.incomeMultiplier(1.25)
 			.passive(
-				tierPassive('passive:happiness:content').text((text) =>
-					text
-						.summary('passive.happiness.content.summary')
-						.removal('passive.happiness.content.removal'),
-				),
+				tierPassive('passive:happiness:content')
+					.effect(incomeModifier('happiness:content:income', 0.25))
+					.text((text) => {
+						const removalDetail = 'happiness leaves the +3 to +4 range';
+						text
+							.summary('💰 Income +25% while the realm is content.')
+							.removal(formatRemoval(removalDetail));
+						return text;
+					}),
 			)
 			.display((display) =>
-				display.removalCondition('passive.happiness.content.removal'),
+				display.removalCondition('happiness leaves the +3 to +4 range'),
 			)
 			.build(),
 		happinessTier('happiness:tier:joyful')
@@ -41,29 +184,59 @@ export const RULES: RuleSet = {
 			.incomeMultiplier(1.25)
 			.buildingDiscountPct(0.2)
 			.passive(
-				tierPassive('passive:happiness:joyful').text((text) =>
-					text
-						.summary('passive.happiness.joyful.summary')
-						.removal('passive.happiness.joyful.removal'),
-				),
+				tierPassive('passive:happiness:joyful')
+					.effect(incomeModifier('happiness:joyful:income', 0.25))
+					.effect(buildingDiscountModifier('happiness:joyful:build-discount'))
+					.text((text) => {
+						const removalDetail = 'happiness leaves the +5 to +7 range';
+						text
+							.summary('💰 Income +25%. 🏛️ Building costs reduced by 20%.')
+							.removal(formatRemoval(removalDetail));
+						return text;
+					}),
 			)
 			.display((display) =>
-				display.removalCondition('passive.happiness.joyful.removal'),
+				display.removalCondition('happiness leaves the +5 to +7 range'),
 			)
 			.build(),
 		happinessTier('happiness:tier:elated')
-			.range(8)
+			.range(8, 9)
 			.incomeMultiplier(1.5)
 			.buildingDiscountPct(0.2)
 			.passive(
-				tierPassive('passive:happiness:elated').text((text) =>
-					text
-						.summary('passive.happiness.elated.summary')
-						.removal('passive.happiness.elated.removal'),
-				),
+				tierPassive('passive:happiness:elated')
+					.effect(incomeModifier('happiness:elated:income', 0.5))
+					.effect(buildingDiscountModifier('happiness:elated:build-discount'))
+					.text((text) => {
+						const removalDetail = 'happiness leaves the +8 to +9 range';
+						text
+							.summary('💰 Income +50%. 🏛️ Building costs reduced by 20%.')
+							.removal(formatRemoval(removalDetail));
+						return text;
+					}),
 			)
 			.display((display) =>
-				display.removalCondition('passive.happiness.elated.removal'),
+				display.removalCondition('happiness leaves the +8 to +9 range'),
+			)
+			.build(),
+		happinessTier('happiness:tier:ecstatic')
+			.range(10)
+			.incomeMultiplier(1.5)
+			.buildingDiscountPct(0.2)
+			.passive(
+				tierPassive('passive:happiness:ecstatic')
+					.effect(incomeModifier('happiness:ecstatic:income', 0.5))
+					.effect(buildingDiscountModifier('happiness:ecstatic:build-discount'))
+					.text((text) => {
+						const removalDetail = 'happiness drops below +10';
+						text
+							.summary('💰 Income +50%. 🏛️ Building costs reduced by 20%.')
+							.removal(formatRemoval(removalDetail));
+						return text;
+					}),
+			)
+			.display((display) =>
+				display.removalCondition('happiness drops below +10'),
 			)
 			.build(),
 	],

--- a/tests/integration/happiness-tier-content.test.ts
+++ b/tests/integration/happiness-tier-content.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest';
+import { Resource } from '@kingdom-builder/contents';
+import { createTestContext } from './fixtures';
+
+describe('content happiness tiers', () => {
+	it('exposes tier passive metadata for web presentation', () => {
+		const ctx = createTestContext();
+		const player = ctx.activePlayer;
+		const samples = [
+			{ value: -10, label: 'despair' },
+			{ value: -8, label: 'misery' },
+			{ value: -5, label: 'grim' },
+			{ value: -3, label: 'unrest' },
+			{ value: 0, label: 'steady' },
+			{ value: 3, label: 'content' },
+			{ value: 5, label: 'joyful' },
+			{ value: 8, label: 'elated' },
+			{ value: 10, label: 'ecstatic' },
+		] as const;
+
+		const snapshot: Record<string, unknown> = {};
+
+		for (const sample of samples) {
+			player.resources[Resource.happiness] = sample.value;
+			ctx.services.handleTieredResourceChange(ctx, Resource.happiness);
+
+			const passives = ctx.passives.values(player.id).map((passive) => ({
+				id: passive.id,
+				detail: passive.detail,
+				meta: passive.meta,
+			}));
+
+			snapshot[sample.label] = {
+				happiness: sample.value,
+				passives,
+				skipPhases: JSON.parse(JSON.stringify(player.skipPhases)),
+				skipSteps: JSON.parse(JSON.stringify(player.skipSteps)),
+			};
+		}
+
+		expect(snapshot).toMatchInlineSnapshot(`
+      {
+        "content": {
+          "happiness": 3,
+          "passives": [
+            {
+              "detail": "💰 Income +25% while the realm is content.",
+              "id": "passive:happiness:content",
+              "meta": {
+                "removal": {
+                  "text": "Removed when happiness leaves the +3 to +4 range",
+                  "token": "happiness leaves the +3 to +4 range",
+                },
+                "source": {
+                  "id": "happiness:tier:content",
+                  "type": "tiered-resource",
+                },
+              },
+            },
+          ],
+          "skipPhases": {},
+          "skipSteps": {},
+        },
+        "despair": {
+          "happiness": -10,
+          "passives": [
+            {
+              "detail": "💰 Income -50%. 📉 Skip Raise Strength. ⚖️ Councils grant half ⚡.",
+              "id": "passive:happiness:despair",
+              "meta": {
+                "removal": {
+                  "text": "Removed when happiness rises to -9 or higher",
+                  "token": "happiness rises to -9 or higher",
+                },
+                "source": {
+                  "id": "happiness:tier:despair",
+                  "type": "tiered-resource",
+                },
+              },
+            },
+          ],
+          "skipPhases": {},
+          "skipSteps": {
+            "growth": {
+              "raise-strength": {
+                "passive:happiness:despair": true,
+              },
+            },
+          },
+        },
+        "ecstatic": {
+          "happiness": 10,
+          "passives": [
+            {
+              "detail": "💰 Income +50%. 🏛️ Building costs reduced by 20%.",
+              "id": "passive:happiness:ecstatic",
+              "meta": {
+                "removal": {
+                  "text": "Removed when happiness drops below +10",
+                  "token": "happiness drops below +10",
+                },
+                "source": {
+                  "id": "happiness:tier:ecstatic",
+                  "type": "tiered-resource",
+                },
+              },
+            },
+          ],
+          "skipPhases": {},
+          "skipSteps": {},
+        },
+        "elated": {
+          "happiness": 8,
+          "passives": [
+            {
+              "detail": "💰 Income +50%. 🏛️ Building costs reduced by 20%.",
+              "id": "passive:happiness:elated",
+              "meta": {
+                "removal": {
+                  "text": "Removed when happiness leaves the +8 to +9 range",
+                  "token": "happiness leaves the +8 to +9 range",
+                },
+                "source": {
+                  "id": "happiness:tier:elated",
+                  "type": "tiered-resource",
+                },
+              },
+            },
+          ],
+          "skipPhases": {},
+          "skipSteps": {},
+        },
+        "grim": {
+          "happiness": -5,
+          "passives": [
+            {
+              "detail": "💰 Income -25%. 📉 Skip Raise Strength until spirits recover.",
+              "id": "passive:happiness:grim",
+              "meta": {
+                "removal": {
+                  "text": "Removed when happiness leaves the -5 to -4 range",
+                  "token": "happiness leaves the -5 to -4 range",
+                },
+                "source": {
+                  "id": "happiness:tier:grim",
+                  "type": "tiered-resource",
+                },
+              },
+            },
+          ],
+          "skipPhases": {},
+          "skipSteps": {
+            "growth": {
+              "raise-strength": {
+                "passive:happiness:grim": true,
+              },
+            },
+          },
+        },
+        "joyful": {
+          "happiness": 5,
+          "passives": [
+            {
+              "detail": "💰 Income +25%. 🏛️ Building costs reduced by 20%.",
+              "id": "passive:happiness:joyful",
+              "meta": {
+                "removal": {
+                  "text": "Removed when happiness leaves the +5 to +7 range",
+                  "token": "happiness leaves the +5 to +7 range",
+                },
+                "source": {
+                  "id": "happiness:tier:joyful",
+                  "type": "tiered-resource",
+                },
+              },
+            },
+          ],
+          "skipPhases": {},
+          "skipSteps": {},
+        },
+        "misery": {
+          "happiness": -8,
+          "passives": [
+            {
+              "detail": "💰 Income -50%. 📉 Skip Raise Strength while morale is desperate.",
+              "id": "passive:happiness:misery",
+              "meta": {
+                "removal": {
+                  "text": "Removed when happiness leaves the -8 to -6 range",
+                  "token": "happiness leaves the -8 to -6 range",
+                },
+                "source": {
+                  "id": "happiness:tier:misery",
+                  "type": "tiered-resource",
+                },
+              },
+            },
+          ],
+          "skipPhases": {},
+          "skipSteps": {
+            "growth": {
+              "raise-strength": {
+                "passive:happiness:misery": true,
+              },
+            },
+          },
+        },
+        "steady": {
+          "happiness": 0,
+          "passives": [
+            {
+              "detail": "Morale is steady. No tier bonuses are active.",
+              "id": "passive:happiness:steady",
+              "meta": {
+                "removal": {
+                  "text": "Removed when happiness leaves the 0 to 2 range",
+                  "token": "happiness leaves the 0 to 2 range",
+                },
+                "source": {
+                  "id": "happiness:tier:steady",
+                  "type": "tiered-resource",
+                },
+              },
+            },
+          ],
+          "skipPhases": {},
+          "skipSteps": {},
+        },
+        "unrest": {
+          "happiness": -3,
+          "passives": [
+            {
+              "detail": "💰 Income -25% while unrest simmers.",
+              "id": "passive:happiness:unrest",
+              "meta": {
+                "removal": {
+                  "text": "Removed when happiness leaves the -3 to -1 range",
+                  "token": "happiness leaves the -3 to -1 range",
+                },
+                "source": {
+                  "id": "happiness:tier:unrest",
+                  "type": "tiered-resource",
+                },
+              },
+            },
+          ],
+          "skipPhases": {},
+          "skipSteps": {},
+        },
+      }
+    `);
+	});
+});


### PR DESCRIPTION
## Summary
- implement the full happiness threshold content definitions with passive effects, skip markers, and tier metadata
- add an integration snapshot test to confirm the engine emits the expected passive metadata for each happiness tier

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e0ec02d2e48325ab4700dcbe6f5b73