### PR TITLE
Ensure population effect descriptions include icons

### DIFF
--- a/packages/web/src/translation/effects/evaluators/population.ts
+++ b/packages/web/src/translation/effects/evaluators/population.ts
@@ -1,31 +1,28 @@
-import { POPULATION_ROLES, POPULATION_INFO } from '@kingdom-builder/contents';
+import type { PopulationRoleId } from '@kingdom-builder/contents';
 import { registerEvaluatorFormatter } from '../factory';
+import { resolvePopulationDisplay } from '../helpers';
 
 registerEvaluatorFormatter('population', {
-  summarize: (ev, sub) => {
-    const role = (ev.params as Record<string, string>)?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const info = role ? POPULATION_ROLES[role] : undefined;
-    const icon = info?.icon || POPULATION_INFO.icon;
-    const label = info?.label || role || POPULATION_INFO.label;
-    return sub.map((s) =>
-      typeof s === 'string'
-        ? `${s} per ${icon} ${label}`.trim()
-        : { ...s, title: `${s.title} per ${icon} ${label}`.trim() },
-    );
-  },
-  describe: (ev, sub) => {
-    const role = (ev.params as Record<string, string>)?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const info = role ? POPULATION_ROLES[role] : undefined;
-    const icon = info?.icon || '';
-    const label = info?.label || role || POPULATION_INFO.label;
-    return sub.map((s) =>
-      typeof s === 'string'
-        ? `${s} for each ${icon} ${label}`.trim()
-        : { ...s, title: `${s.title} for each ${icon} ${label}`.trim() },
-    );
-  },
+	summarize: (ev, sub) => {
+		const role = (ev.params as Record<string, string>)?.['role'] as
+			| PopulationRoleId
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return sub.map((s) =>
+			typeof s === 'string'
+				? `${s} per ${icon} ${label}`.trim()
+				: { ...s, title: `${s.title} per ${icon} ${label}`.trim() },
+		);
+	},
+	describe: (ev, sub) => {
+		const role = (ev.params as Record<string, string>)?.['role'] as
+			| PopulationRoleId
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return sub.map((s) =>
+			typeof s === 'string'
+				? `${s} for each ${icon} ${label}`.trim()
+				: { ...s, title: `${s.title} for each ${icon} ${label}`.trim() },
+		);
+	},
 });

--- a/packages/web/src/translation/effects/formatters/population.ts
+++ b/packages/web/src/translation/effects/formatters/population.ts
@@ -1,44 +1,55 @@
 import { POPULATION_ROLES, POPULATION_INFO } from '@kingdom-builder/contents';
 import { registerEffectFormatter } from '../factory';
+import { resolvePopulationDisplay } from '../helpers';
 
 registerEffectFormatter('population', 'add', {
-  summarize: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const icon = role
-      ? POPULATION_ROLES[role]?.icon || role
-      : POPULATION_INFO.icon;
-    return `${POPULATION_INFO.icon}(${icon}) +1`;
-  },
-  describe: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const info = role ? POPULATION_ROLES[role] : undefined;
-    const label = info?.label || role || POPULATION_INFO.label;
-    const icon = info?.icon || '';
-    return `Add ${icon} ${label}`;
-  },
+	summarize: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const icon = role
+			? POPULATION_ROLES[role]?.icon || role
+			: POPULATION_INFO.icon;
+		return `${POPULATION_INFO.icon}(${icon}) +1`;
+	},
+	describe: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return `Add ${icon} ${label}`;
+	},
+	log: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return `Added ${icon} ${label}`;
+	},
 });
 
 registerEffectFormatter('population', 'remove', {
-  summarize: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const icon = role
-      ? POPULATION_ROLES[role]?.icon || role
-      : POPULATION_INFO.icon;
-    return `${POPULATION_INFO.icon}(${icon}) -1`;
-  },
-  describe: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const info = role ? POPULATION_ROLES[role] : undefined;
-    const label = info?.label || role || POPULATION_INFO.label;
-    const icon = info?.icon || '';
-    return `Remove ${icon} ${label}`;
-  },
+	summarize: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const icon = role
+			? POPULATION_ROLES[role]?.icon || role
+			: POPULATION_INFO.icon;
+		return `${POPULATION_INFO.icon}(${icon}) -1`;
+	},
+	describe: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return `Remove ${icon} ${label}`;
+	},
+	log: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return `Removed ${icon} ${label}`;
+	},
 });

--- a/packages/web/src/translation/effects/helpers.ts
+++ b/packages/web/src/translation/effects/helpers.ts
@@ -1,4 +1,20 @@
+import {
+	POPULATION_INFO,
+	POPULATION_ROLES,
+	type PopulationRoleId,
+} from '@kingdom-builder/contents';
+
 export const signed = (n: number): string => (n >= 0 ? '+' : '');
 export const gainOrLose = (n: number): string => (n >= 0 ? 'Gain' : 'Lose');
 export const increaseOrDecrease = (n: number): string =>
-  n >= 0 ? 'Increase' : 'Decrease';
+	n >= 0 ? 'Increase' : 'Decrease';
+
+export function resolvePopulationDisplay(role: PopulationRoleId | undefined): {
+	icon: string;
+	label: string;
+} {
+	const info = role ? POPULATION_ROLES[role] : undefined;
+	const icon = info?.icon || POPULATION_INFO.icon;
+	const label = info?.label || role || POPULATION_INFO.label;
+	return { icon, label };
+}


### PR DESCRIPTION
## Summary
- add a shared population display helper to consistently pair role icons with labels
- update population add/remove formatters to use the helper so descriptions and logs (including Tax) show the icon next to each population label

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

## Text Updates
- Updated description of evaluator-wrapped effect in action Tax from format "Add Population for each Population" to align into format "Add 👥 Population for each 👥 Population."
- Updated description/log of population:add effect in action Hire from format "Add Council" to align into format "Add 🏛️ Council" / "Added 🏛️ Council."
- Updated description/log of population:remove effects from icon-less "Remove Council" / "Removed Council" strings to the icon-paired "Remove 🏛️ Council" / "Removed 🏛️ Council."

------
https://chatgpt.com/codex/tasks/task_e_68e0f02dfb8c83259f30e2cff3275822