### PR TITLE
Fix council AP penalty for despair tier

### DIFF
--- a/packages/contents/src/populations.ts
+++ b/packages/contents/src/populations.ts
@@ -4,93 +4,118 @@ import { Resource } from './resources';
 import { Stat } from './stats';
 import { populationSchema } from '@kingdom-builder/engine/config/schema';
 import {
-  population,
-  effect,
-  Types,
-  ResourceMethods,
-  PassiveMethods,
-  StatMethods,
-  resourceParams,
-  statParams,
+	population,
+	effect,
+	Types,
+	ResourceMethods,
+	PassiveMethods,
+	StatMethods,
+	resourceParams,
+	statParams,
+	populationEvaluator,
 } from './config/builders';
 import type { PopulationDef } from './defs';
 
 export type { PopulationDef } from './defs';
 
+const COUNCIL_AP_GAIN_PARAMS = resourceParams()
+	.key(Resource.ap)
+	.amount(1)
+	.build();
+
+const LEGION_STRENGTH_GAIN_PARAMS = statParams()
+	.key(Stat.armyStrength)
+	.amount(1)
+	.build();
+
+const FORTIFIER_STRENGTH_GAIN_PARAMS = statParams()
+	.key(Stat.fortificationStrength)
+	.amount(1)
+	.build();
+
 export function createPopulationRegistry() {
-  const registry = new Registry<PopulationDef>(populationSchema);
+	const registry = new Registry<PopulationDef>(populationSchema);
 
-  registry.add(
-    PopulationRole.Council,
-    population()
-      .id(PopulationRole.Council)
-      .name('Council')
-      .icon('⚖️')
-      .upkeep(Resource.gold, 2)
-      .onGainAPStep(
-        effect(Types.Resource, ResourceMethods.ADD)
-          .params(resourceParams().key(Resource.ap).amount(1))
-          .build(),
-      )
-      .build(),
-  );
+	registry.add(
+		PopulationRole.Council,
+		population()
+			.id(PopulationRole.Council)
+			.name('Council')
+			.icon('⚖️')
+			.upkeep(Resource.gold, 2)
+			.onGainAPStep(
+				effect()
+					.evaluator(
+						populationEvaluator()
+							.param('id', PopulationRole.Council)
+							.role(PopulationRole.Council),
+					)
+					.effect(
+						effect(Types.Resource, ResourceMethods.ADD)
+							.params(COUNCIL_AP_GAIN_PARAMS)
+							.build(),
+					)
+					.build(),
+			)
+			.build(),
+	);
 
-  registry.add(
-    PopulationRole.Legion,
-    population()
-      .id(PopulationRole.Legion)
-      .name('Legion')
-      .icon('🎖️')
-      .upkeep(Resource.gold, 1)
-      .onAssigned(
-        effect(Types.Passive, PassiveMethods.ADD)
-          .param('id', 'legion_$player_$index')
-          .effect(
-            effect(Types.Stat, StatMethods.ADD)
-              .params(statParams().key(Stat.armyStrength).amount(1))
-              .build(),
-          )
-          .build(),
-      )
-      .onUnassigned(
-        effect(Types.Passive, PassiveMethods.REMOVE)
-          .param('id', 'legion_$player_$index')
-          .build(),
-      )
-      .build(),
-  );
+	registry.add(
+		PopulationRole.Legion,
+		population()
+			.id(PopulationRole.Legion)
+			.name('Legion')
+			.icon('🎖️')
+			.upkeep(Resource.gold, 1)
+			.onAssigned(
+				effect(Types.Passive, PassiveMethods.ADD)
+					.param('id', 'legion_$player_$index')
+					.effect(
+						effect(Types.Stat, StatMethods.ADD)
+							.params(LEGION_STRENGTH_GAIN_PARAMS)
+							.build(),
+					)
+					.build(),
+			)
+			.onUnassigned(
+				effect(Types.Passive, PassiveMethods.REMOVE)
+					.param('id', 'legion_$player_$index')
+					.build(),
+			)
+			.build(),
+	);
 
-  registry.add(
-    PopulationRole.Fortifier,
-    population()
-      .id(PopulationRole.Fortifier)
-      .name('Fortifier')
-      .icon('🔧')
-      .upkeep(Resource.gold, 1)
-      .onAssigned(
-        effect(Types.Passive, PassiveMethods.ADD)
-          .param('id', 'fortifier_$player_$index')
-          .effect(
-            effect(Types.Stat, StatMethods.ADD)
-              .params(statParams().key(Stat.fortificationStrength).amount(1))
-              .build(),
-          )
-          .build(),
-      )
-      .onUnassigned(
-        effect(Types.Passive, PassiveMethods.REMOVE)
-          .param('id', 'fortifier_$player_$index')
-          .build(),
-      )
-      .build(),
-  );
+	registry.add(
+		PopulationRole.Fortifier,
+		population()
+			.id(PopulationRole.Fortifier)
+			.name('Fortifier')
+			.icon('🔧')
+			.upkeep(Resource.gold, 1)
+			.onAssigned(
+				effect(Types.Passive, PassiveMethods.ADD)
+					.param('id', 'fortifier_$player_$index')
+					.effect(
+						effect(Types.Stat, StatMethods.ADD)
+							.params(FORTIFIER_STRENGTH_GAIN_PARAMS)
+							.build(),
+					)
+					.build(),
+			)
+			.onUnassigned(
+				effect(Types.Passive, PassiveMethods.REMOVE)
+					.param('id', 'fortifier_$player_$index')
+					.build(),
+			)
+			.build(),
+	);
 
-  registry.add(
-    PopulationRole.Citizen,
-    population().id(PopulationRole.Citizen).name('Citizen').icon('👤').build(),
-  );
+	registry.add(
+		PopulationRole.Citizen,
+		population().id(PopulationRole.Citizen).name('Citizen').icon('👤').build(),
+	);
 
-  return registry;
+	return registry;
 }
 
 export const POPULATIONS = createPopulationRegistry();


### PR DESCRIPTION
## Summary
- wrap council AP gain in a population evaluator so despair result modifiers adjust the awarded action points
- factor reusable parameter objects for council AP and legion/fortifier stat gains to keep the content definition lint-compliant

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e0f2b30c488325a0eed2356096c3c6