### PR TITLE
Add action effect group builder and define Royal Decree flow

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -32,6 +32,9 @@ import {
 	statEvaluator,
 	attackParams,
 	transferParams,
+	actionEffectGroup,
+	actionEffectGroupOption,
+	type ActionEffectGroupDef,
 } from './config/builders';
 import type { Focus } from './defs';
 
@@ -39,6 +42,7 @@ export interface ActionDef extends ActionConfig {
 	category?: string;
 	order?: number;
 	focus?: Focus;
+	effectGroups?: ActionEffectGroupDef[];
 }
 
 export function createActionRegistry() {
@@ -197,10 +201,70 @@ export function createActionRegistry() {
 			.icon('📜')
 			.cost(Resource.ap, 1)
 			.cost(Resource.gold, 12)
+			.effect(
+				effect(Types.Action, ActionMethods.PERFORM)
+					.param('id', 'expand')
+					.build(),
+			)
+			.effect(
+				effect(Types.Action, ActionMethods.PERFORM).param('id', 'till').build(),
+			)
+			.effect({
+				type: Types.Resource,
+				method: ResourceMethods.REMOVE,
+				params: resourceParams().key(Resource.happiness).amount(3).build(),
+				meta: { allowShortfall: true },
+			})
+			.effectGroup(
+				actionEffectGroup('royal_decree_develop')
+					.title('Decree a development')
+					.summary('Choose what to raise on the prepared land.')
+					.description(
+						'After expanding and tilling, select one project to complete. Each option runs Develop on the chosen land.',
+					)
+					.option(
+						actionEffectGroupOption('royal_decree_house')
+							.label('Raise a House')
+							.icon('🏠')
+							.summary('Expand housing and increase the population cap by 1.')
+							.action('develop')
+							.param('landId', '$landId')
+							.param('id', 'house'),
+					)
+					.option(
+						actionEffectGroupOption('royal_decree_farm')
+							.label('Establish a Farm')
+							.icon('🌾')
+							.summary('Gain +2 gold during the income step each round.')
+							.action('develop')
+							.param('landId', '$landId')
+							.param('id', 'farm'),
+					)
+					.option(
+						actionEffectGroupOption('royal_decree_outpost')
+							.label('Fortify with an Outpost')
+							.icon('🏹')
+							.summary('Gain +1 Army Strength and +1 Fortification Strength.')
+							.action('develop')
+							.param('landId', '$landId')
+							.param('id', 'outpost'),
+					)
+					.option(
+						actionEffectGroupOption('royal_decree_watchtower')
+							.label('Raise a Watchtower')
+							.icon('🗼')
+							.summary(
+								'Add +2 Fortification Strength and absorption after defending once.',
+							)
+							.action('develop')
+							.param('landId', '$landId')
+							.param('id', 'watchtower'),
+					),
+			)
 			.build(),
-		category: 'basic',
-		order: 5,
-		focus: 'other',
+		category: 'development',
+		order: 2,
+		focus: 'economy',
 	});
 
 	registry.add('army_attack', {

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -5,9 +5,9 @@ export { POPULATIONS, createPopulationRegistry } from './populations';
 export { PHASES } from './phases';
 export type { PhaseDef, StepDef } from './config/builders';
 export {
-  POPULATION_ROLES,
-  PopulationRole,
-  type PopulationRoleId,
+	POPULATION_ROLES,
+	PopulationRole,
+	type PopulationRoleId,
 } from './populationRoles';
 export { Resource, type ResourceKey, RESOURCES } from './resources';
 export { Stat, type StatKey, STATS } from './stats';
@@ -22,10 +22,14 @@ export type { ActionDef } from './actions';
 export type { BuildingDef } from './buildings';
 export type { DevelopmentDef } from './developments';
 export type { PopulationDef, TriggerKey, Focus } from './defs';
+export type {
+	ActionEffectGroupDef,
+	ActionEffectGroupOptionDef,
+} from './config/builders';
 export {
-  ON_PAY_UPKEEP_STEP,
-  ON_GAIN_INCOME_STEP,
-  ON_GAIN_AP_STEP,
-  BROOM_ICON,
-  RESOURCE_TRANSFER_ICON,
+	ON_PAY_UPKEEP_STEP,
+	ON_GAIN_INCOME_STEP,
+	ON_GAIN_AP_STEP,
+	BROOM_ICON,
+	RESOURCE_TRANSFER_ICON,
 } from './defs';

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -1,5 +1,9 @@
 import {
+	ActionBuilder,
 	action,
+	actionEffectGroup,
+	actionEffectGroupOption,
+	building,
 	resourceParams,
 	statParams,
 	effect,
@@ -34,6 +38,103 @@ describe('content builder safeguards', () => {
 		expect(() => action().id('example').build()).toThrowError(
 			"Action is missing name(). Call name('Readable name') before build().",
 		);
+	});
+
+	it('requires action effect groups to include options', () => {
+		const group = actionEffectGroup('choose').title('Pick a project');
+		expect(() => group.build()).toThrowError(
+			'Action effect group needs at least one option(). Add option(...) before build().',
+		);
+	});
+
+	it('prevents duplicate option ids within an effect group', () => {
+		const group = actionEffectGroup('choose')
+			.title('Pick a project')
+			.option(actionEffectGroupOption('farm').label('Farm').action('develop'));
+
+		expect(() =>
+			group.option(
+				actionEffectGroupOption('farm').label('House').action('develop'),
+			),
+		).toThrowError(
+			'Action effect group option id "farm" already exists. Use unique option ids within a group.',
+		);
+	});
+
+	it('prevents duplicate effect group ids on an action', () => {
+		const builder = action().id('has_group').name('Has Group');
+		builder.effectGroup(
+			actionEffectGroup('choose')
+				.title('Pick a project')
+				.option(
+					actionEffectGroupOption('farm').label('Farm').action('develop'),
+				),
+		);
+
+		expect(() =>
+			builder.effectGroup(
+				actionEffectGroup('choose')
+					.title('Pick again')
+					.option(
+						actionEffectGroupOption('house').label('House').action('develop'),
+					),
+			),
+		).toThrowError(
+			'Action effect group id "choose" already exists on this action. Use unique group ids.',
+		);
+	});
+
+	it('blocks attaching effect groups to non-action builders', () => {
+		const buildingBuilder = building();
+		const group = actionEffectGroup('choose')
+			.title('Pick a project')
+			.option(actionEffectGroupOption('farm').label('Farm').action('develop'));
+
+		expect(() =>
+			(
+				ActionBuilder.prototype.effectGroup as (
+					this: ActionBuilder,
+					group: unknown,
+				) => ActionBuilder
+			).call(buildingBuilder as unknown as ActionBuilder, group),
+		).toThrowError(
+			'Action effect groups can only be used on actions. Use action().effectGroup(...).',
+		);
+	});
+
+	it('builds actions with effect groups', () => {
+		const built = action()
+			.id('group_action')
+			.name('Group Action')
+			.effectGroup(
+				actionEffectGroup('choose')
+					.title('Pick a project')
+					.summary('Choose one follow-up action to resolve immediately.')
+					.option(
+						actionEffectGroupOption('farm')
+							.label('Farm')
+							.action('develop')
+							.param('id', 'farm')
+							.param('landId', '$landId'),
+					),
+			)
+			.build();
+
+		expect(built.effectGroups).toEqual([
+			{
+				id: 'choose',
+				title: 'Pick a project',
+				summary: 'Choose one follow-up action to resolve immediately.',
+				options: [
+					{
+						id: 'farm',
+						label: 'Farm',
+						actionId: 'develop',
+						params: { id: 'farm', landId: '$landId' },
+					},
+				],
+			},
+		]);
 	});
 
 	it('prevents mixing amount and percent for resource changes', () => {


### PR DESCRIPTION
## Summary
- add action effect group and option builders with validation, and wire them into ActionBuilder while exporting the new metadata types
- define the Royal Decree action with its expand, till, happiness penalty effects and development-choice group metadata
- extend builder validation tests for effect group misuse cases and happy paths

## Testing
- npm run test -- packages/contents/tests/builder-validations.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0f1e369f48325b28aa33c9d386b26