### PR TITLE
feat(web): enhance happiness tier presentation

### DIFF
--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -11,6 +11,8 @@ export interface PassiveSummary {
 	id: string;
 	name?: string | undefined;
 	icon?: string | undefined;
+	detail?: string | undefined;
+	meta?: PassiveMetadata | undefined;
 }
 
 type PassiveRecord = PassiveSummary & {
@@ -443,6 +445,13 @@ export class PassiveManager {
 			}
 			if (value.icon !== undefined) {
 				summary.icon = value.icon;
+			}
+			if (value.detail !== undefined) {
+				summary.detail = value.detail;
+			}
+			const meta = clonePassiveMetadata(value.meta);
+			if (meta) {
+				summary.meta = meta;
 			}
 			return summary;
 		});

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -9,6 +9,7 @@ import {
 import { describeEffects, splitSummary } from '../../translation';
 import type {
 	EffectDef,
+	EngineContext,
 	PassiveSummary,
 	PlayerId,
 } from '@kingdom-builder/engine';
@@ -31,11 +32,7 @@ export default function PassiveDisplay({
 	const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
 	const playerId: PlayerId = player.id;
 	const summaries: PassiveSummary[] = ctx.passives.list(playerId);
-	const defs = ctx.passives.values(playerId) as Array<{
-		id: string;
-		effects?: EffectDef[];
-		onUpkeepPhase?: EffectDef[];
-	}>;
+	const defs = ctx.passives.values(playerId);
 	const defMap = new Map(defs.map((def) => [def.id, def]));
 
 	const buildingIds = Array.from(player.buildings);
@@ -52,9 +49,7 @@ export default function PassiveDisplay({
 				entry,
 			): entry is {
 				summary: PassiveSummary;
-				def: { effects?: EffectDef[]; onUpkeepPhase?: EffectDef[] } & {
-					id: string;
-				};
+				def: ReturnType<EngineContext['passives']['values']>[number];
 			} => {
 				const { summary, def } = entry;
 				if (!def) {
@@ -84,7 +79,11 @@ export default function PassiveDisplay({
 	const getIcon = (
 		summary: PassiveSummary,
 		effects: EffectDef[] | undefined,
+		meta: PassiveSummary['meta'],
 	) => {
+		if (meta?.source?.icon) {
+			return meta.source.icon;
+		}
 		if (summary.icon) {
 			return summary.icon;
 		}
@@ -92,14 +91,60 @@ export default function PassiveDisplay({
 		return ICON_MAP[first?.type as keyof typeof ICON_MAP] ?? PASSIVE_INFO.icon;
 	};
 
+	const resolveRemovalText = (meta: PassiveSummary['meta']) => {
+		if (!meta?.removal) {
+			return undefined;
+		}
+		if (
+			typeof meta.removal.text === 'string' &&
+			meta.removal.text.trim().length > 0
+		) {
+			return meta.removal.text;
+		}
+		if (
+			typeof meta.removal.token === 'string' &&
+			meta.removal.token.trim().length > 0
+		) {
+			return `Removed when ${meta.removal.token}`;
+		}
+		return undefined;
+	};
+
+	const resolveLabel = (
+		summary: PassiveSummary,
+		def: Pick<
+			ReturnType<EngineContext['passives']['values']>[number],
+			'detail' | 'meta'
+		>,
+	) => {
+		const meta = def.meta ?? summary.meta;
+		const labelToken = meta?.source?.labelToken;
+		if (labelToken && labelToken.trim().length > 0) {
+			return labelToken;
+		}
+		if (def.detail && def.detail.trim().length > 0) {
+			return def.detail;
+		}
+		if (summary.detail && summary.detail.trim().length > 0) {
+			return summary.detail;
+		}
+		if (summary.name && summary.name.trim().length > 0) {
+			return summary.name;
+		}
+		return summary.id;
+	};
+
 	const animatePassives = useAnimate<HTMLDivElement>();
 	return (
 		<div
 			ref={animatePassives}
-			className="panel-card flex w-fit items-center gap-3 px-4 py-3 text-lg"
+			className="panel-card flex w-fit flex-col gap-3 px-4 py-3 text-left text-base"
 		>
 			{entries.map(({ summary: passive, def }) => {
-				const icon = getIcon(passive, def.effects);
+				const meta = def.meta ?? passive.meta;
+				const icon = getIcon(passive, def.effects, meta);
+				const label = resolveLabel(passive, def);
+				const removalText = resolveRemovalText(meta);
 				const items = describeEffects(def.effects || [], ctx);
 				const upkeepLabel =
 					PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
@@ -108,24 +153,44 @@ export default function PassiveDisplay({
 					: items;
 				const passiveName = passive.name ?? PASSIVE_INFO.label;
 				return (
-					<span
+					<div
 						key={passive.id}
-						className="hoverable cursor-pointer"
+						className="hoverable cursor-pointer rounded-xl border border-white/50 bg-white/60 p-3 shadow-sm transition hover:border-blue-400/70 hover:bg-white/80 dark:border-white/10 dark:bg-slate-900/50 dark:hover:border-blue-300/60 dark:hover:bg-slate-900/70"
 						onMouseEnter={() => {
 							const { effects, description } = splitSummary(sections);
+							const descriptionEntries = [...(description ?? [])] as ReturnType<
+								typeof splitSummary
+							>['effects'];
+							if (removalText) {
+								descriptionEntries.push(removalText);
+							}
 							handleHoverCard({
 								title: `${icon} ${passiveName || PASSIVE_INFO.label}`,
 								effects,
 								requirements: [],
-								...(description && { description }),
+								...(descriptionEntries.length
+									? { description: descriptionEntries }
+									: {}),
 								bgClass:
 									'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
 							});
 						}}
 						onMouseLeave={clearHoverCard}
 					>
-						{icon}
-					</span>
+						<div className="flex items-start gap-3">
+							<span className="text-2xl leading-none">{icon}</span>
+							<div className="flex flex-col gap-1 text-sm leading-snug">
+								<span className="font-semibold text-slate-700 dark:text-slate-100">
+									{label}
+								</span>
+								{removalText && (
+									<span className="text-xs text-slate-600 dark:text-slate-300">
+										{removalText}
+									</span>
+								)}
+							</div>
+						</div>
+					</div>
 				);
 			})}
 		</div>

--- a/packages/web/tests/passive-display.test.tsx
+++ b/packages/web/tests/passive-display.test.tsx
@@ -1,0 +1,80 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import PassiveDisplay from '../src/components/player/PassiveDisplay';
+import { createEngine } from '@kingdom-builder/engine';
+import type { EngineContext } from '@kingdom-builder/engine';
+import {
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	type ResourceKey,
+} from '@kingdom-builder/contents';
+
+vi.mock('@kingdom-builder/engine', async () => {
+	return await import('../../engine/src');
+});
+
+type MockGame = {
+	ctx: EngineContext;
+	handleHoverCard: ReturnType<typeof vi.fn>;
+	clearHoverCard: ReturnType<typeof vi.fn>;
+};
+
+let currentGame: MockGame;
+
+vi.mock('../src/state/GameContext', () => ({
+	useGameEngine: () => currentGame,
+}));
+
+describe('<PassiveDisplay />', () => {
+	it('shows passive labels and removal text from metadata', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		const happinessKey = ctx.services.tieredResource.resourceKey as ResourceKey;
+		ctx.activePlayer.resources[happinessKey] = 6;
+		ctx.services.handleTieredResourceChange(ctx, happinessKey);
+
+		const handleHoverCard = vi.fn();
+		const clearHoverCard = vi.fn();
+		currentGame = {
+			ctx,
+			handleHoverCard,
+			clearHoverCard,
+		} as MockGame;
+
+		render(<PassiveDisplay player={ctx.activePlayer} />);
+
+		const summaryText = screen.getByText(/Income \+25%/i);
+		expect(summaryText).toBeInTheDocument();
+		expect(
+			screen.getByText(/Removed when happiness leaves the \+5 to \+7 range/i),
+		).toBeInTheDocument();
+
+		const hoverTarget = summaryText.closest('div.hoverable');
+		expect(hoverTarget).not.toBeNull();
+		fireEvent.mouseEnter(hoverTarget!);
+		expect(handleHoverCard).toHaveBeenCalled();
+		const [{ description }] = handleHoverCard.mock.calls.at(-1) ?? [{}];
+		expect(description).toEqual(
+			expect.arrayContaining([
+				expect.stringMatching(
+					/Removed when happiness leaves the \+5 to \+7 range/i,
+				),
+			]),
+		);
+	});
+});

--- a/packages/web/tests/resource-bar.test.tsx
+++ b/packages/web/tests/resource-bar.test.tsx
@@ -1,0 +1,87 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import ResourceBar from '../src/components/player/ResourceBar';
+import { createEngine } from '@kingdom-builder/engine';
+import type { EngineContext } from '@kingdom-builder/engine';
+import {
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	RESOURCES,
+	type ResourceKey,
+} from '@kingdom-builder/contents';
+
+vi.mock('@kingdom-builder/engine', async () => {
+	return await import('../../engine/src');
+});
+
+type MockGame = {
+	ctx: EngineContext;
+	handleHoverCard: ReturnType<typeof vi.fn>;
+	clearHoverCard: ReturnType<typeof vi.fn>;
+};
+
+let currentGame: MockGame;
+
+vi.mock('../src/state/GameContext', () => ({
+	useGameEngine: () => currentGame,
+}));
+
+describe('<ResourceBar /> happiness hover card', () => {
+	it('lists happiness tiers and highlights the active threshold', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		const happinessKey = ctx.services.tieredResource.resourceKey as ResourceKey;
+		ctx.activePlayer.resources[happinessKey] = 6;
+		ctx.services.handleTieredResourceChange(ctx, happinessKey);
+
+		const handleHoverCard = vi.fn();
+		const clearHoverCard = vi.fn();
+		currentGame = {
+			ctx,
+			handleHoverCard,
+			clearHoverCard,
+		} as MockGame;
+
+		render(<ResourceBar player={ctx.activePlayer} />);
+
+		const info = RESOURCES[happinessKey];
+		const value = ctx.activePlayer.resources[happinessKey] ?? 0;
+		const button = screen.getByRole('button', {
+			name: `${info.label}: ${value}`,
+		});
+		fireEvent.mouseEnter(button);
+
+		expect(handleHoverCard).toHaveBeenCalled();
+		const call = handleHoverCard.mock.calls.at(-1)?.[0];
+		expect(call).toBeTruthy();
+		expect(call?.title).toBe(`${info.icon} ${info.label}`);
+		expect(call?.description).toEqual([`Current value: ${value}`]);
+		const tiers = call?.effects ?? [];
+		expect(tiers).toHaveLength(ctx.services.rules.tierDefinitions.length);
+		const activeEntry = tiers.find(
+			(entry: unknown) =>
+				typeof entry !== 'string' &&
+				Boolean((entry as { title?: string }).title?.includes('🟢')),
+		) as { items: unknown[] } | undefined;
+		expect(activeEntry).toBeTruthy();
+		const removal = activeEntry?.items.find(
+			(item) => typeof item === 'string' && /Removed when/i.test(item),
+		);
+		expect(removal).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## Summary
- expose passive metadata in engine summaries so the UI can show source and removal context
- update the passive panel and happiness hover card to surface tier details and highlight the active threshold
- expand log formatting for tier changes and add frontend tests covering the new displays

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e0f0ef48b4832591684498ca8a36b5