### PR TITLE
Use tabs and clarify population evaluator formatter callbacks

### DIFF
--- a/packages/web/src/translation/effects/evaluators/population.ts
+++ b/packages/web/src/translation/effects/evaluators/population.ts
@@ -3,26 +3,32 @@ import { registerEvaluatorFormatter } from '../factory';
 import { resolvePopulationDisplay } from '../helpers';
 
 registerEvaluatorFormatter('population', {
-	summarize: (ev, sub) => {
-		const role = (ev.params as Record<string, string>)?.['role'] as
+	summarize: (evaluator, sub) => {
+		const role = (evaluator.params as Record<string, string>)?.['role'] as
 			| PopulationRoleId
 			| undefined;
 		const { icon, label } = resolvePopulationDisplay(role);
-		return sub.map((s) =>
-			typeof s === 'string'
-				? `${s} per ${icon} ${label}`.trim()
-				: { ...s, title: `${s.title} per ${icon} ${label}`.trim() },
+		return sub.map((summaryEntry) =>
+			typeof summaryEntry === 'string'
+				? `${summaryEntry} per ${icon} ${label}`.trim()
+				: {
+						...summaryEntry,
+						title: `${summaryEntry.title} per ${icon} ${label}`.trim(),
+					},
 		);
 	},
-	describe: (ev, sub) => {
-		const role = (ev.params as Record<string, string>)?.['role'] as
+	describe: (evaluator, sub) => {
+		const role = (evaluator.params as Record<string, string>)?.['role'] as
 			| PopulationRoleId
 			| undefined;
 		const { icon, label } = resolvePopulationDisplay(role);
-		return sub.map((s) =>
-			typeof s === 'string'
-				? `${s} for each ${icon} ${label}`.trim()
-				: { ...s, title: `${s.title} for each ${icon} ${label}`.trim() },
+		return sub.map((summaryEntry) =>
+			typeof summaryEntry === 'string'
+				? `${summaryEntry} for each ${icon} ${label}`.trim()
+				: {
+						...summaryEntry,
+						title: `${summaryEntry.title} for each ${icon} ${label}`.trim(),
+					},
 		);
 	},
 });


### PR DESCRIPTION
## Summary
- switch the population evaluator formatter to use tab indentation and clearer callback names
- reformat ternary branches to keep template strings within the 80 character guideline

## Testing
- npm run lint packages/web/src/translation/effects/evaluators/population.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0f6ac8ce083258524dfe0bf639f3d