### PR TITLE
Rename resource add handler parameters

### DIFF
--- a/packages/engine/src/effects/resource_add.ts
+++ b/packages/engine/src/effects/resource_add.ts
@@ -1,20 +1,20 @@
 import type { EffectHandler } from '.';
 import type { ResourceKey } from '../state';
 
-export const resourceAdd: EffectHandler = (effect, ctx, mult = 1) => {
+export const resourceAdd: EffectHandler = (effect, context, multiplier = 1) => {
 	const key = effect.params!['key'] as ResourceKey;
 	const amount = effect.params!['amount'] as number;
-	let total = amount * mult;
+	let total = amount * multiplier;
 	if (effect.round === 'up') {
 		total = total >= 0 ? Math.ceil(total) : Math.floor(total);
 	} else if (effect.round === 'down') {
 		total = total >= 0 ? Math.floor(total) : Math.ceil(total);
 	}
-	const current = ctx.activePlayer.resources[key] || 0;
+	const current = context.activePlayer.resources[key] || 0;
 	const newVal = current + total;
-	ctx.activePlayer.resources[key] = newVal < 0 ? 0 : newVal;
+	context.activePlayer.resources[key] = newVal < 0 ? 0 : newVal;
 	if (total > 0) {
-		ctx.recentResourceGains.push({ key, amount: total });
+		context.recentResourceGains.push({ key, amount: total });
 	}
-	ctx.services.handleTieredResourceChange(ctx, key);
+	context.services.handleTieredResourceChange(context, key);
 };


### PR DESCRIPTION
## Summary
- rename the resource add effect handler parameters to use `context` and `multiplier`
- propagate the new identifiers through the handler and keep rounding logic wrapped in braces

## Testing
- npm run lint packages/engine/src/effects/resource_add.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0f6b1f9848325909da1c0192f9635