### PR TITLE
Refactor attack formatter utilities

### DIFF
--- a/packages/web/src/translation/effects/formatters/attack.ts
+++ b/packages/web/src/translation/effects/formatters/attack.ts
@@ -6,18 +6,18 @@ import type {
 	EffectDef,
 } from '@kingdom-builder/engine';
 import type { SummaryEntry } from '../../content';
+import { registerEffectFormatter } from '../factory';
 import {
-	registerEffectFormatter,
-	summarizeEffects,
-	describeEffects,
-} from '../factory';
+	buildBaseEntry,
+	summarizeOnDamage,
+	formatDiffEntries,
+	ownerLabel,
+	collectTransferPercents,
+} from './attackFormatterUtils';
 import {
 	resolveAttackTargetFormatter,
 	resolveAttackTargetFormatterFromLogTarget,
-	type AttackTarget,
 	type AttackTargetFormatter,
-	type TargetInfo,
-	type Mode,
 } from './attack/target-formatter';
 
 type AttackOnDamageFormatterArgs = {
@@ -48,141 +48,18 @@ function resolveAttackOnDamageFormatter(
 	);
 }
 
-const DAMAGE_EFFECT_CATEGORIES: Record<
-	string,
-	(item: SummaryEntry, mode: Mode) => SummaryEntry[]
-> = {
-	'action:perform': (item, mode) => [
-		mode === 'summarize' && typeof item !== 'string'
-			? (item as { title: string }).title
-			: item,
-	],
-};
-
-type BaseEntryResult = {
-	entry: SummaryEntry;
-	formatter: AttackTargetFormatter;
-	info: TargetInfo;
-	target: AttackTarget;
-	targetLabel: string;
-};
-
-function categorizeDamageEffects(
-	def: EffectDef,
-	item: SummaryEntry,
-	mode: Mode,
-): { actions: SummaryEntry[]; others: SummaryEntry[] } {
-	const key = `${def.type}:${def.method}`;
-	const handler = DAMAGE_EFFECT_CATEGORIES[key];
-	if (handler) {
-		return { actions: handler(item, mode), others: [] };
-	}
-	return { actions: [], others: [item] };
-}
-
-function ownerLabel(owner: 'attacker' | 'defender') {
-	return owner === 'attacker' ? 'You' : 'Opponent';
-}
-
-function formatDiffEntries(
-	entry: AttackOnDamageLogEntry,
-	formatter: AttackTargetFormatter,
-): SummaryEntry[] {
-	const parts: SummaryEntry[] = [];
-	entry.defender.forEach((diff) =>
-		parts.push(formatter.formatDiff(ownerLabel('defender'), diff)),
-	);
-	entry.attacker.forEach((diff) =>
-		parts.push(formatter.formatDiff(ownerLabel('attacker'), diff)),
-	);
-	return parts;
-}
-
-function buildBaseEntry(
-	eff: EffectDef<Record<string, unknown>>,
-	mode: Mode,
-): BaseEntryResult {
-	const army = STATS[Stat.armyStrength];
-	const absorption = STATS[Stat.absorption];
-	const fort = STATS[Stat.fortificationStrength];
-	const { formatter, target, info, targetLabel } =
-		resolveAttackTargetFormatter(eff);
-	const ignoreAbsorption = Boolean(eff.params?.['ignoreAbsorption']);
-	const ignoreFortification = Boolean(eff.params?.['ignoreFortification']);
-	const entry = formatter.buildBaseEntry({
-		mode,
-		army,
-		absorption,
-		fort,
-		info,
-		target,
-		targetLabel,
-		ignoreAbsorption,
-		ignoreFortification,
-	});
-	return { entry, formatter, info, target, targetLabel };
-}
-
-function summarizeOnDamage(
-	eff: EffectDef<Record<string, unknown>>,
-	ctx: EngineContext,
-	mode: Mode,
-	base: BaseEntryResult,
-): SummaryEntry | null {
-	const onDamage = eff.params?.['onDamage'] as
-		| { attacker?: EffectDef[]; defender?: EffectDef[] }
-		| undefined;
-	if (!onDamage) {
-		return null;
-	}
-	const { formatter, info, target, targetLabel } = base;
-	const format = mode === 'summarize' ? summarizeEffects : describeEffects;
-	const attackerDefs = onDamage.attacker ?? [];
-	const defenderDefs = onDamage.defender ?? [];
-	const attackerEntries = format(attackerDefs, ctx);
-	const defenderEntries = format(defenderDefs, ctx);
-	const items: SummaryEntry[] = [];
-	const actionItems: SummaryEntry[] = [];
-
-	const collect = (
-		defs: EffectDef[],
-		entries: SummaryEntry[],
-		suffix: string,
-	) => {
-		entries.forEach((entry, index) => {
-			const def = defs[index]!;
-			const { actions, others } = categorizeDamageEffects(def, entry, mode);
-			actionItems.push(...actions);
-			others.forEach((other) => {
-				if (typeof other === 'string') {
-					items.push(`${other} ${suffix}`);
-				} else {
-					items.push({ ...other, title: `${other.title} ${suffix}` });
-				}
-			});
-		});
-	};
-
-	collect(defenderDefs, defenderEntries, 'for opponent');
-	collect(attackerDefs, attackerEntries, 'for you');
-
-	const combined = items.concat(actionItems);
-	if (!combined.length) {
-		return null;
-	}
-	return {
-		title: formatter.buildOnDamageTitle(mode, { info, target, targetLabel }),
-		items: combined,
-	};
-}
-
 function fallbackLog(
-	eff: EffectDef<Record<string, unknown>>,
+	effectDefinition: EffectDef<Record<string, unknown>>,
 	ctx: EngineContext,
 ): SummaryEntry[] {
-	const base = buildBaseEntry(eff, 'describe');
-	const onDamage = summarizeOnDamage(eff, ctx, 'describe', base);
-	const parts: SummaryEntry[] = [base.entry];
+	const baseEntry = buildBaseEntry(effectDefinition, 'describe');
+	const onDamage = summarizeOnDamage(
+		effectDefinition,
+		ctx,
+		'describe',
+		baseEntry,
+	);
+	const parts: SummaryEntry[] = [baseEntry.entry];
 	if (onDamage) {
 		parts.push(onDamage);
 	}
@@ -216,32 +93,13 @@ function buildActionLog(
 	const transferPercents = new Map<ResourceKey, number>();
 	if (id) {
 		try {
-			const def = ctx.actions.get(id);
-			icon = def.icon || '';
-			name = def.name;
-			const walk = (effects: EffectDef[] | undefined) => {
-				if (!effects) {
-					return;
-				}
-				for (const eff of effects) {
-					if (
-						eff.type === 'resource' &&
-						eff.method === 'transfer' &&
-						eff.params
-					) {
-						const key =
-							(eff.params['key'] as ResourceKey | undefined) ?? undefined;
-						const pct = eff.params['percent'] as number | undefined;
-						if (key && pct !== undefined && !transferPercents.has(key)) {
-							transferPercents.set(key, pct);
-						}
-					}
-					if (Array.isArray(eff.effects)) {
-						walk(eff.effects as EffectDef[] | undefined);
-					}
-				}
-			};
-			walk(def.effects as EffectDef[] | undefined);
+			const definition = ctx.actions.get(id);
+			icon = definition.icon || '';
+			name = definition.name;
+			collectTransferPercents(
+				definition.effects as EffectDef[] | undefined,
+				transferPercents,
+			);
 		} catch {
 			/* ignore missing action */
 		}
@@ -260,21 +118,22 @@ function buildActionLog(
 			),
 		);
 	});
-	entry.attacker.forEach((diff) =>
-		items.push(formatter.formatDiff(ownerLabel('attacker'), diff)),
-	);
+	entry.attacker.forEach((diff) => {
+		items.push(formatter.formatDiff(ownerLabel('attacker'), diff));
+	});
 	return { title: `Triggered ${icon} ${name}`.trim(), items };
 }
 
 export function buildOnDamageEntry(
 	logEntries: AttackLog['onDamage'],
 	ctx: EngineContext,
-	eff: EffectDef<Record<string, unknown>>,
+	effectDefinition: EffectDef<Record<string, unknown>>,
 ): SummaryEntry | null {
 	if (!logEntries.length) {
 		return null;
 	}
-	const { formatter, info, target } = resolveAttackTargetFormatter(eff);
+	const { formatter, info, target } =
+		resolveAttackTargetFormatter(effectDefinition);
 	const items: SummaryEntry[] = [];
 	const defenderEntries = logEntries.filter(
 		(entry) => entry.owner === 'defender',
@@ -316,44 +175,44 @@ registerAttackOnDamageFormatter(
 			return formatDiffEntries(entry, formatter);
 		}
 		const parts: SummaryEntry[] = [];
-		entry.defender.forEach((diff) =>
+		entry.defender.forEach((diff) => {
 			parts.push(
 				formatter.formatDiff(ownerLabel('defender'), diff, { percent }),
-			),
-		);
-		entry.attacker.forEach((diff) =>
-			parts.push(formatter.formatDiff(ownerLabel('attacker'), diff)),
-		);
+			);
+		});
+		entry.attacker.forEach((diff) => {
+			parts.push(formatter.formatDiff(ownerLabel('attacker'), diff));
+		});
 		return parts;
 	},
 );
 
 registerEffectFormatter('attack', 'perform', {
-	summarize: (eff, ctx) => {
-		const base = buildBaseEntry(eff, 'summarize');
-		const parts: SummaryEntry[] = [base.entry];
-		const onDamage = summarizeOnDamage(eff, ctx, 'summarize', base);
+	summarize: (effect, ctx) => {
+		const baseEntry = buildBaseEntry(effect, 'summarize');
+		const parts: SummaryEntry[] = [baseEntry.entry];
+		const onDamage = summarizeOnDamage(effect, ctx, 'summarize', baseEntry);
 		if (onDamage) {
 			parts.push(onDamage);
 		}
 		return parts;
 	},
-	describe: (eff, ctx) => {
-		const base = buildBaseEntry(eff, 'describe');
-		const parts: SummaryEntry[] = [base.entry];
-		const onDamage = summarizeOnDamage(eff, ctx, 'describe', base);
+	describe: (effect, ctx) => {
+		const baseEntry = buildBaseEntry(effect, 'describe');
+		const parts: SummaryEntry[] = [baseEntry.entry];
+		const onDamage = summarizeOnDamage(effect, ctx, 'describe', baseEntry);
 		if (onDamage) {
 			parts.push(onDamage);
 		}
 		return parts;
 	},
-	log: (eff, ctx) => {
+	log: (effect, ctx) => {
 		const log = ctx.pullEffectLog<AttackLog>('attack:perform');
 		if (!log) {
-			return fallbackLog(eff, ctx);
+			return fallbackLog(effect, ctx);
 		}
 		const entries: SummaryEntry[] = [buildEvaluationEntry(log.evaluation)];
-		const onDamage = buildOnDamageEntry(log.onDamage, ctx, eff);
+		const onDamage = buildOnDamageEntry(log.onDamage, ctx, effect);
 		if (onDamage) {
 			entries.push(onDamage);
 		}

--- a/packages/web/src/translation/effects/formatters/attackFormatterUtils.ts
+++ b/packages/web/src/translation/effects/formatters/attackFormatterUtils.ts
@@ -1,0 +1,188 @@
+import { STATS, Stat, type ResourceKey } from '@kingdom-builder/contents';
+import type {
+	EngineContext,
+	EffectDef,
+	AttackOnDamageLogEntry,
+} from '@kingdom-builder/engine';
+import type { SummaryEntry } from '../../content';
+import { summarizeEffects, describeEffects } from '../factory';
+import {
+	resolveAttackTargetFormatter,
+	type AttackTargetFormatter,
+	type TargetInfo,
+	type AttackTarget,
+	type Mode,
+} from './attack/target-formatter';
+
+type DamageEffectCategorizer = (
+	item: SummaryEntry,
+	mode: Mode,
+) => SummaryEntry[];
+
+const DAMAGE_EFFECT_CATEGORIES: Record<string, DamageEffectCategorizer> = {
+	'action:perform': (item, mode) => [
+		mode === 'summarize' && typeof item !== 'string'
+			? (item as { title: string }).title
+			: item,
+	],
+};
+
+export type BaseEntryResult = {
+	entry: SummaryEntry;
+	formatter: AttackTargetFormatter;
+	info: TargetInfo;
+	target: AttackTarget;
+	targetLabel: string;
+};
+
+export function categorizeDamageEffects(
+	effectDefinition: EffectDef,
+	item: SummaryEntry,
+	mode: Mode,
+): { actions: SummaryEntry[]; others: SummaryEntry[] } {
+	const key = `${effectDefinition.type}:${effectDefinition.method}`;
+	const handler = DAMAGE_EFFECT_CATEGORIES[key];
+	if (handler) {
+		return { actions: handler(item, mode), others: [] };
+	}
+	return { actions: [], others: [item] };
+}
+
+export function ownerLabel(owner: 'attacker' | 'defender'): string {
+	return owner === 'attacker' ? 'You' : 'Opponent';
+}
+
+export function buildBaseEntry(
+	effectDefinition: EffectDef<Record<string, unknown>>,
+	mode: Mode,
+): BaseEntryResult {
+	const army = STATS[Stat.armyStrength];
+	const absorption = STATS[Stat.absorption];
+	const fort = STATS[Stat.fortificationStrength];
+	const { formatter, target, info, targetLabel } =
+		resolveAttackTargetFormatter(effectDefinition);
+	const ignoreAbsorption = Boolean(
+		effectDefinition.params?.['ignoreAbsorption'],
+	);
+	const ignoreFortification = Boolean(
+		effectDefinition.params?.['ignoreFortification'],
+	);
+	const entry = formatter.buildBaseEntry({
+		mode,
+		army,
+		absorption,
+		fort,
+		info,
+		target,
+		targetLabel,
+		ignoreAbsorption,
+		ignoreFortification,
+	});
+	return { entry, formatter, info, target, targetLabel };
+}
+
+export function summarizeOnDamage(
+	effectDefinition: EffectDef<Record<string, unknown>>,
+	ctx: EngineContext,
+	mode: Mode,
+	baseEntry: BaseEntryResult,
+): SummaryEntry | null {
+	const onDamage = effectDefinition.params?.['onDamage'] as
+		| { attacker?: EffectDef[]; defender?: EffectDef[] }
+		| undefined;
+	if (!onDamage) {
+		return null;
+	}
+	const { formatter, info, target, targetLabel } = baseEntry;
+	const format = mode === 'summarize' ? summarizeEffects : describeEffects;
+	const attackerDefs = onDamage.attacker ?? [];
+	const defenderDefs = onDamage.defender ?? [];
+	const attackerEntries = format(attackerDefs, ctx);
+	const defenderEntries = format(defenderDefs, ctx);
+	const items: SummaryEntry[] = [];
+	const actionItems: SummaryEntry[] = [];
+
+	const collect = (
+		defs: EffectDef[],
+		entries: SummaryEntry[],
+		suffix: string,
+	) => {
+		entries.forEach((entry, index) => {
+			const definition = defs[index]!;
+			const { actions, others } = categorizeDamageEffects(
+				definition,
+				entry,
+				mode,
+			);
+			actionItems.push(...actions);
+			others.forEach((other) => {
+				if (typeof other === 'string') {
+					items.push(`${other} ${suffix}`);
+				} else {
+					items.push({
+						...other,
+						title: `${other.title} ${suffix}`,
+					});
+				}
+			});
+		});
+	};
+
+	collect(defenderDefs, defenderEntries, 'for opponent');
+	collect(attackerDefs, attackerEntries, 'for you');
+
+	const combined = items.concat(actionItems);
+	if (!combined.length) {
+		return null;
+	}
+	return {
+		title: formatter.buildOnDamageTitle(mode, {
+			info,
+			target,
+			targetLabel,
+		}),
+		items: combined,
+	};
+}
+
+export function formatDiffEntries(
+	entry: AttackOnDamageLogEntry,
+	formatter: AttackTargetFormatter,
+): SummaryEntry[] {
+	const parts: SummaryEntry[] = [];
+	entry.defender.forEach((diff) =>
+		parts.push(formatter.formatDiff(ownerLabel('defender'), diff)),
+	);
+	entry.attacker.forEach((diff) =>
+		parts.push(formatter.formatDiff(ownerLabel('attacker'), diff)),
+	);
+	return parts;
+}
+
+export function collectTransferPercents(
+	effects: EffectDef[] | undefined,
+	transferPercents: Map<ResourceKey, number>,
+): void {
+	if (!effects) {
+		return;
+	}
+	for (const effectDefinition of effects) {
+		if (
+			effectDefinition.type === 'resource' &&
+			effectDefinition.method === 'transfer' &&
+			effectDefinition.params
+		) {
+			const key =
+				(effectDefinition.params['key'] as ResourceKey | undefined) ??
+				undefined;
+			const percent = effectDefinition.params['percent'] as number | undefined;
+			if (key && percent !== undefined && !transferPercents.has(key)) {
+				transferPercents.set(key, percent);
+			}
+		}
+		if (Array.isArray(effectDefinition.effects)) {
+			const nestedEffects = effectDefinition.effects;
+			collectTransferPercents(nestedEffects, transferPercents);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- extract shared attack formatter helpers into a dedicated module for reuse
- update the attack formatter to consume the shared helpers and use clearer naming

## Testing
- npm run lint packages/web/src/translation/effects/formatters/attack.ts packages/web/src/translation/effects/formatters/attackFormatterUtils.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0f6be2c4c8325b7ed48724e89225d