### PR TITLE
Fix Menu CTA indentation

### DIFF
--- a/packages/web/src/Menu.tsx
+++ b/packages/web/src/Menu.tsx
@@ -153,8 +153,8 @@ function CallToActionSection({
 					</h2>
 					{/* prettier-ignore */}
 					<p className={CTA_DESCRIPTION_CLASS}>
-                                        {CTA_DESCRIPTION_TEXT}
-                                </p>
+						{CTA_DESCRIPTION_TEXT}
+					</p>
 				</div>
 				<div className={CTA_BUTTON_COLUMN_CLASS}>
 					<Button
@@ -178,8 +178,8 @@ function CallToActionSection({
 				<div className={KNOWLEDGE_HEADER_LAYOUT_CLASS}>
 					{/* prettier-ignore */}
 					<div className={KNOWLEDGE_TITLE_CLASS}>
-                                        Learn The Basics
-                                </div>
+						Learn The Basics
+					</div>
 					<div className={KNOWLEDGE_ACTIONS_CLASS}>
 						<Button
 							variant="ghost"


### PR DESCRIPTION
## Summary
- replace space-indented CTA description and knowledge title lines in `Menu.tsx` with tabs to match surrounding JSX
- keep multiline JSX formatting within the 80 character guideline while preserving existing layout

## Testing
- npm run lint packages/web/src/Menu.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0f6bde6d4832587a7221ef51176db