### PR TITLE
Extract time scale utilities into dedicated hook

### DIFF
--- a/packages/web/src/state/useTimeScale.ts
+++ b/packages/web/src/state/useTimeScale.ts
@@ -1,0 +1,141 @@
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type MutableRefObject,
+} from 'react';
+
+export const TIME_SCALE_OPTIONS = [1, 2, 5, 100] as const;
+export type TimeScale = (typeof TIME_SCALE_OPTIONS)[number];
+const TIME_SCALE_STORAGE_KEY = 'kingdom-builder:time-scale';
+
+function readStoredTimeScale(): TimeScale | null {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+	const raw = window.localStorage.getItem(TIME_SCALE_STORAGE_KEY);
+	if (!raw) {
+		return null;
+	}
+	const parsed = Number(raw);
+	return (TIME_SCALE_OPTIONS as readonly number[]).includes(parsed)
+		? (parsed as TimeScale)
+		: null;
+}
+
+interface UseTimeScaleOptions {
+	devMode: boolean;
+}
+
+export interface TimeScaleControls {
+	timeScale: TimeScale;
+	setTimeScale: (value: TimeScale) => void;
+	clearTrackedTimeout: (id: number) => void;
+	setTrackedTimeout: (handler: () => void, delay: number) => number;
+	clearTrackedInterval: (id: number) => void;
+	setTrackedInterval: (handler: () => void, delay: number) => number;
+	isMountedRef: MutableRefObject<boolean>;
+}
+
+export function useTimeScale({
+	devMode,
+}: UseTimeScaleOptions): TimeScaleControls {
+	const [timeScale, setTimeScaleState] = useState<TimeScale>(() => {
+		if (devMode) {
+			return 100;
+		}
+		const stored = readStoredTimeScale();
+		return stored ?? 1;
+	});
+
+	useEffect(() => {
+		if (devMode) {
+			setTimeScaleState(100);
+			return;
+		}
+		const stored = readStoredTimeScale();
+		setTimeScaleState(stored ?? 1);
+	}, [devMode]);
+
+	const updateTimeScale = useCallback((value: TimeScale) => {
+		setTimeScaleState((prev) => {
+			if (prev === value) {
+				return prev;
+			}
+			if (typeof window !== 'undefined') {
+				const storage = window.localStorage;
+				storage.setItem(TIME_SCALE_STORAGE_KEY, String(value));
+			}
+			return value;
+		});
+	}, []);
+
+	const timeouts = useRef(new Set<number>());
+	const intervals = useRef(new Set<number>());
+	const isMountedRef = useRef(true);
+
+	useEffect(() => {
+		return () => {
+			isMountedRef.current = false;
+			timeouts.current.forEach((id) => {
+				window.clearTimeout(id);
+			});
+			intervals.current.forEach((id) => {
+				window.clearInterval(id);
+			});
+			timeouts.current.clear();
+			intervals.current.clear();
+		};
+	}, []);
+
+	const clearTrackedTimeout = useCallback((id: number) => {
+		window.clearTimeout(id);
+		timeouts.current.delete(id);
+	}, []);
+
+	const setTrackedTimeout = useCallback(
+		(handler: () => void, delay: number) => {
+			const timeoutId = window.setTimeout(() => {
+				timeouts.current.delete(timeoutId);
+				if (!isMountedRef.current) {
+					return;
+				}
+				handler();
+			}, delay);
+			timeouts.current.add(timeoutId);
+			return timeoutId;
+		},
+		[],
+	);
+
+	const clearTrackedInterval = useCallback((id: number) => {
+		window.clearInterval(id);
+		intervals.current.delete(id);
+	}, []);
+
+	const setTrackedInterval = useCallback(
+		(handler: () => void, delay: number) => {
+			const intervalId = window.setInterval(() => {
+				if (!isMountedRef.current) {
+					clearTrackedInterval(intervalId);
+					return;
+				}
+				handler();
+			}, delay);
+			intervals.current.add(intervalId);
+			return intervalId;
+		},
+		[clearTrackedInterval],
+	);
+
+	return {
+		timeScale,
+		setTimeScale: updateTimeScale,
+		clearTrackedTimeout,
+		setTrackedTimeout,
+		clearTrackedInterval,
+		setTrackedInterval,
+		isMountedRef,
+	};
+}


### PR DESCRIPTION
## Summary
- add a new useTimeScale hook that manages time scale persistence and tracked timers
- refactor GameContext to consume the hook, clean up guard clauses, and shorten long template strings

## Testing
- npm run lint packages/web/src/state/GameContext.tsx packages/web/src/state/useTimeScale.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0f6b67b508325909389c9033233a3