### PR TITLE
Refactor attack effect snapshot utilities

### DIFF
--- a/packages/engine/src/effects/attack.ts
+++ b/packages/engine/src/effects/attack.ts
@@ -1,260 +1,37 @@
 import type { EffectDef, EffectHandler } from '.';
-import type { EngineContext } from '../context';
-import type { PlayerState, ResourceKey, StatKey } from '../state';
 import type { ResourceGain } from '../services';
 import { runEffects } from '.';
-import { collectTriggerEffects } from '../triggers';
-import { withStatSourceFrames } from '../stat_sources';
-import { snapshotPlayer, type PlayerSnapshot } from '../log';
-import type { AttackEvaluationTargetLog, AttackTarget } from './attack.types';
-import {
-	attackTargetHandlers,
-	type AttackTargetHandlerMeta,
-} from './attack_target_handlers';
+import { snapshotPlayer } from '../log';
+import type { AttackTarget } from './attack.types';
+import { attackTargetHandlers } from './attack_target_handlers';
+import { diffPlayerSnapshots } from './attack/snapshot_diff';
+import type {
+	AttackCalcOptions,
+	AttackLogOwner,
+	AttackOnDamageLogEntry,
+} from './attack/log.types';
+import { resolveAttack } from './attack/resolve';
+
+export type { AttackPlayerDiff } from './attack/snapshot_diff';
+export type {
+	AttackCalcOptions,
+	AttackEvaluationLog,
+	AttackLog,
+	AttackLogOwner,
+	AttackOnDamageLogEntry,
+	AttackPowerLog,
+} from './attack/log.types';
 
 export {
 	type AttackTarget,
 	type AttackEvaluationTargetLog,
 } from './attack.types';
-
-export interface AttackCalcOptions {
-	ignoreAbsorption?: boolean;
-	ignoreFortification?: boolean;
-}
-
-export type AttackLogOwner = 'attacker' | 'defender';
-
-export interface AttackPowerLog {
-	base: number;
-	modified: number;
-}
-
-export interface AttackEvaluationLog {
-	power: AttackPowerLog;
-	absorption: {
-		ignored: boolean;
-		before: number;
-		damageAfter: number;
-	};
-	fortification: {
-		ignored: boolean;
-		before: number;
-		damage: number;
-		after: number;
-	};
-	target: AttackEvaluationTargetLog;
-}
-
-interface AttackResourceDiff {
-	type: 'resource';
-	key: ResourceKey;
-	before: number;
-	after: number;
-}
-
-interface AttackStatDiff {
-	type: 'stat';
-	key: StatKey;
-	before: number;
-	after: number;
-}
-
-export type AttackPlayerDiff = AttackResourceDiff | AttackStatDiff;
-
-export interface AttackOnDamageLogEntry {
-	owner: AttackLogOwner;
-	effect: EffectDef;
-	attacker: AttackPlayerDiff[];
-	defender: AttackPlayerDiff[];
-}
-
-export interface AttackLog {
-	evaluation: AttackEvaluationLog;
-	onDamage: AttackOnDamageLogEntry[];
-}
-
-interface AttackResolution {
-	damageDealt: number;
-	evaluation: AttackEvaluationLog;
-}
-
-function diffPlayerSnapshots(
-	before: PlayerSnapshot,
-	after: PlayerSnapshot,
-): AttackPlayerDiff[] {
-	const diffs: AttackPlayerDiff[] = [];
-	const resourceKeys = new Set<ResourceKey>(
-		// Cast snapshot keys to ResourceKey so downstream consumers can rely on
-		// resource metadata lookups during logging.
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-		Object.keys({ ...before.resources, ...after.resources }) as ResourceKey[],
-	);
-	for (const key of resourceKeys) {
-		const beforeVal = before.resources[key] ?? 0;
-		const afterVal = after.resources[key] ?? 0;
-		if (beforeVal !== afterVal) {
-			diffs.push({
-				type: 'resource',
-				key,
-				before: beforeVal,
-				after: afterVal,
-			});
-		}
-	}
-	const statKeys = new Set<StatKey>(
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-		Object.keys({ ...before.stats, ...after.stats }) as StatKey[],
-	);
-	for (const key of statKeys) {
-		const beforeVal = before.stats[key] ?? 0;
-		const afterVal = after.stats[key] ?? 0;
-		if (beforeVal !== afterVal) {
-			diffs.push({
-				type: 'stat',
-				key,
-				before: beforeVal,
-				after: afterVal,
-			});
-		}
-	}
-	return diffs;
-}
-
-function applyAbsorption(
-	damage: number,
-	absorption: number,
-	rounding: 'up' | 'down' | 'nearest',
-): number {
-	if (absorption <= 0) {
-		return damage;
-	}
-	const reduced = damage * (1 - absorption);
-	if (rounding === 'down') {
-		return Math.floor(reduced);
-	}
-	if (rounding === 'up') {
-		return Math.ceil(reduced);
-	}
-	return Math.round(reduced);
-}
-
-export function resolveAttack(
-	defender: PlayerState,
-	damage: number,
-	ctx: EngineContext,
-	target: AttackTarget,
-	opts: AttackCalcOptions = {},
-	baseDamage = damage,
-): AttackResolution {
-	const original = ctx.game.currentPlayerIndex;
-	const defenderIndex = ctx.game.players.indexOf(defender);
-
-	ctx.game.currentPlayerIndex = defenderIndex;
-	const pre = collectTriggerEffects('onBeforeAttacked', ctx, defender);
-
-	for (const bundle of pre) {
-		withStatSourceFrames(ctx, bundle.frames, () =>
-			runEffects(bundle.effects, ctx),
-		);
-	}
-
-	if (pre.length) {
-		runEffects(pre, ctx);
-	}
-
-	ctx.game.currentPlayerIndex = original;
-
-	const absorption = opts.ignoreAbsorption
-		? 0
-		: Math.min(
-				(defender.absorption as number) || 0,
-				ctx.services.rules.absorptionCapPct,
-			);
-	const damageAfterAbsorption = opts.ignoreAbsorption
-		? damage
-		: applyAbsorption(
-				damage,
-				absorption,
-				ctx.services.rules.absorptionRounding,
-			);
-
-	const fortBefore = (defender.fortificationStrength as number) || 0;
-	const fortDamage = opts.ignoreFortification
-		? 0
-		: Math.min(fortBefore, damageAfterAbsorption);
-	const fortAfter = opts.ignoreFortification
-		? fortBefore
-		: Math.max(0, fortBefore - fortDamage);
-	if (!opts.ignoreFortification) {
-		defender.fortificationStrength = fortAfter;
-	}
-
-	const targetDamage = Math.max(0, damageAfterAbsorption - fortDamage);
-	const handlerMeta: AttackTargetHandlerMeta = {
-		defenderIndex,
-		originalIndex: original,
-	};
-	const handler = attackTargetHandlers[target.type];
-	const mutation = handler.applyDamage(
-		target as never,
-		targetDamage,
-		ctx,
-		defender,
-		handlerMeta,
-	);
-	const targetLog = handler.buildLog(
-		target as never,
-		targetDamage,
-		ctx,
-		defender,
-		handlerMeta,
-		mutation as never,
-	);
-
-	ctx.game.currentPlayerIndex = defenderIndex;
-	const post = collectTriggerEffects('onAttackResolved', ctx, defender);
-
-	for (const bundle of post) {
-		withStatSourceFrames(ctx, bundle.frames, () =>
-			runEffects(bundle.effects, ctx),
-		);
-	}
-
-	if ((defender.fortificationStrength || 0) < 0) {
-		defender.fortificationStrength = 0;
-	}
-
-	if (post.length) {
-		runEffects(post, ctx);
-	}
-
-	ctx.game.currentPlayerIndex = original;
-
-	return {
-		damageDealt: targetDamage,
-		evaluation: {
-			power: { base: baseDamage, modified: damage },
-			absorption: {
-				ignored: Boolean(opts.ignoreAbsorption),
-				before: absorption,
-				damageAfter: damageAfterAbsorption,
-			},
-			fortification: {
-				ignored: Boolean(opts.ignoreFortification),
-				before: fortBefore,
-				damage: fortDamage,
-				after: fortAfter,
-			},
-			target: targetLog,
-		},
-	};
-}
-
-export const attackPerform: EffectHandler = (effect, ctx) => {
-	const attacker = ctx.activePlayer;
-	const defender = ctx.opponent;
-	const params = effect.params || {};
-	const target = params['target'] as AttackTarget | undefined;
+export { resolveAttack } from './attack/resolve';
+export const attackPerform: EffectHandler = (effectDefinition, context) => {
+	const attacker = context.activePlayer;
+	const defender = context.opponent;
+	const effectParams = effectDefinition.params || {};
+	const target = effectParams['target'] as AttackTarget | undefined;
 	if (!target) {
 		return;
 	}
@@ -262,52 +39,57 @@ export const attackPerform: EffectHandler = (effect, ctx) => {
 	const baseDamage = (attacker.armyStrength as number) || 0;
 	const targetHandler = attackTargetHandlers[target.type];
 	const evaluationKey = targetHandler.getEvaluationModifierKey(target as never);
-	const mods: ResourceGain[] = [{ key: evaluationKey, amount: baseDamage }];
-	ctx.passives.runEvaluationMods('attack:power', ctx, mods);
-	const modifiedDamage = mods[0]!.amount;
+	const powerModifiers: ResourceGain[] = [
+		{ key: evaluationKey, amount: baseDamage },
+	];
+	context.passives.runEvaluationMods('attack:power', context, powerModifiers);
+	const modifiedDamage = powerModifiers[0]!.amount;
 
-	const { onDamage, ...calcOpts } = params as {
+	const { onDamage, ...calcOptions } = effectParams as {
 		onDamage?: { attacker?: EffectDef[]; defender?: EffectDef[] };
 	} & AttackCalcOptions;
 
 	const result = resolveAttack(
 		defender,
 		modifiedDamage,
-		ctx,
+		context,
 		target,
-		calcOpts,
+		calcOptions,
 		baseDamage,
 	);
 
 	const onDamageLogs: AttackOnDamageLogEntry[] = [];
 
 	if (result.damageDealt > 0 && onDamage) {
-		const runList = (owner: AttackLogOwner, defs: EffectDef[] | undefined) => {
-			if (!defs?.length) {
+		const runList = (
+			owner: AttackLogOwner,
+			effectDefinitions: EffectDef[] | undefined,
+		) => {
+			if (!effectDefinitions?.length) {
 				return;
 			}
-			const defenderIndex = ctx.game.players.indexOf(defender);
-			const original = ctx.game.currentPlayerIndex;
+			const defenderIndex = context.game.players.indexOf(defender);
+			const originalIndex = context.game.currentPlayerIndex;
 			if (owner === 'defender') {
-				ctx.game.currentPlayerIndex = defenderIndex;
+				context.game.currentPlayerIndex = defenderIndex;
 			}
 			try {
-				for (const def of defs) {
-					const beforeAttacker = snapshotPlayer(attacker, ctx);
-					const beforeDefender = snapshotPlayer(defender, ctx);
-					runEffects([def], ctx);
-					const afterAttacker = snapshotPlayer(attacker, ctx);
-					const afterDefender = snapshotPlayer(defender, ctx);
+				for (const effectDef of effectDefinitions) {
+					const beforeAttacker = snapshotPlayer(attacker, context);
+					const beforeDefender = snapshotPlayer(defender, context);
+					runEffects([effectDef], context);
+					const afterAttacker = snapshotPlayer(attacker, context);
+					const afterDefender = snapshotPlayer(defender, context);
 					onDamageLogs.push({
 						owner,
-						effect: def,
+						effect: effectDef,
 						attacker: diffPlayerSnapshots(beforeAttacker, afterAttacker),
 						defender: diffPlayerSnapshots(beforeDefender, afterDefender),
 					});
 				}
 			} finally {
 				if (owner === 'defender') {
-					ctx.game.currentPlayerIndex = original;
+					context.game.currentPlayerIndex = originalIndex;
 				}
 			}
 		};
@@ -316,7 +98,7 @@ export const attackPerform: EffectHandler = (effect, ctx) => {
 		runList('attacker', onDamage.attacker);
 	}
 
-	ctx.pushEffectLog('attack:perform', {
+	context.pushEffectLog('attack:perform', {
 		evaluation: result.evaluation,
 		onDamage: onDamageLogs,
 	});

--- a/packages/engine/src/effects/attack/log.types.ts
+++ b/packages/engine/src/effects/attack/log.types.ts
@@ -1,0 +1,43 @@
+import type { EffectDef } from '..';
+import type { AttackEvaluationTargetLog } from '../attack.types';
+import type { AttackPlayerDiff } from './snapshot_diff';
+
+export interface AttackCalcOptions {
+	ignoreAbsorption?: boolean;
+	ignoreFortification?: boolean;
+}
+
+export type AttackLogOwner = 'attacker' | 'defender';
+
+export interface AttackPowerLog {
+	base: number;
+	modified: number;
+}
+
+export interface AttackEvaluationLog {
+	power: AttackPowerLog;
+	absorption: {
+		ignored: boolean;
+		before: number;
+		damageAfter: number;
+	};
+	fortification: {
+		ignored: boolean;
+		before: number;
+		damage: number;
+		after: number;
+	};
+	target: AttackEvaluationTargetLog;
+}
+
+export interface AttackOnDamageLogEntry {
+	owner: AttackLogOwner;
+	effect: EffectDef;
+	attacker: AttackPlayerDiff[];
+	defender: AttackPlayerDiff[];
+}
+
+export interface AttackLog {
+	evaluation: AttackEvaluationLog;
+	onDamage: AttackOnDamageLogEntry[];
+}

--- a/packages/engine/src/effects/attack/resolve.ts
+++ b/packages/engine/src/effects/attack/resolve.ts
@@ -1,0 +1,160 @@
+import { runEffects } from '..';
+import type { EngineContext } from '../../context';
+import { withStatSourceFrames } from '../../stat_sources';
+import { collectTriggerEffects } from '../../triggers';
+import type { PlayerState } from '../../state';
+import type { AttackTarget } from '../attack.types';
+import {
+	attackTargetHandlers,
+	type AttackTargetHandlerMeta,
+} from '../attack_target_handlers';
+import type { AttackCalcOptions, AttackEvaluationLog } from './log.types';
+
+interface AttackResolution {
+	damageDealt: number;
+	evaluation: AttackEvaluationLog;
+}
+
+function applyAbsorption(
+	damage: number,
+	absorption: number,
+	rounding: 'up' | 'down' | 'nearest',
+): number {
+	if (absorption <= 0) {
+		return damage;
+	}
+
+	const reduced = damage * (1 - absorption);
+
+	if (rounding === 'down') {
+		return Math.floor(reduced);
+	}
+
+	if (rounding === 'up') {
+		return Math.ceil(reduced);
+	}
+
+	return Math.round(reduced);
+}
+
+export function resolveAttack(
+	defender: PlayerState,
+	damage: number,
+	context: EngineContext,
+	target: AttackTarget,
+	options: AttackCalcOptions = {},
+	baseDamage = damage,
+): AttackResolution {
+	const originalIndex = context.game.currentPlayerIndex;
+	const defenderIndex = context.game.players.indexOf(defender);
+
+	context.game.currentPlayerIndex = defenderIndex;
+	const beforeAttackTriggers = collectTriggerEffects(
+		'onBeforeAttacked',
+		context,
+		defender,
+	);
+
+	for (const triggerBundle of beforeAttackTriggers) {
+		withStatSourceFrames(context, triggerBundle.frames, () =>
+			runEffects(triggerBundle.effects, context),
+		);
+	}
+
+	if (beforeAttackTriggers.length > 0) {
+		runEffects(beforeAttackTriggers, context);
+	}
+
+	context.game.currentPlayerIndex = originalIndex;
+
+	const absorption = options.ignoreAbsorption
+		? 0
+		: Math.min(
+				(defender.absorption as number) || 0,
+				context.services.rules.absorptionCapPct,
+			);
+	const damageAfterAbsorption = options.ignoreAbsorption
+		? damage
+		: applyAbsorption(
+				damage,
+				absorption,
+				context.services.rules.absorptionRounding,
+			);
+
+	const fortBefore = (defender.fortificationStrength as number) || 0;
+	const fortDamage = options.ignoreFortification
+		? 0
+		: Math.min(fortBefore, damageAfterAbsorption);
+	const fortAfter = options.ignoreFortification
+		? fortBefore
+		: Math.max(0, fortBefore - fortDamage);
+	if (!options.ignoreFortification) {
+		defender.fortificationStrength = fortAfter;
+	}
+
+	const targetDamage = Math.max(0, damageAfterAbsorption - fortDamage);
+	const handlerMeta: AttackTargetHandlerMeta = {
+		defenderIndex,
+		originalIndex,
+	};
+	const handler = attackTargetHandlers[target.type];
+	const mutation = handler.applyDamage(
+		target as never,
+		targetDamage,
+		context,
+		defender,
+		handlerMeta,
+	);
+	const targetLog = handler.buildLog(
+		target as never,
+		targetDamage,
+		context,
+		defender,
+		handlerMeta,
+		mutation as never,
+	);
+
+	context.game.currentPlayerIndex = defenderIndex;
+	const afterAttackTriggers = collectTriggerEffects(
+		'onAttackResolved',
+		context,
+		defender,
+	);
+
+	for (const triggerBundle of afterAttackTriggers) {
+		withStatSourceFrames(context, triggerBundle.frames, () =>
+			runEffects(triggerBundle.effects, context),
+		);
+	}
+
+	if ((defender.fortificationStrength || 0) < 0) {
+		defender.fortificationStrength = 0;
+	}
+
+	if (afterAttackTriggers.length > 0) {
+		runEffects(afterAttackTriggers, context);
+	}
+
+	context.game.currentPlayerIndex = originalIndex;
+
+	return {
+		damageDealt: targetDamage,
+		evaluation: {
+			power: { base: baseDamage, modified: damage },
+			absorption: {
+				ignored: Boolean(options.ignoreAbsorption),
+				before: absorption,
+				damageAfter: damageAfterAbsorption,
+			},
+			fortification: {
+				ignored: Boolean(options.ignoreFortification),
+				before: fortBefore,
+				damage: fortDamage,
+				after: fortAfter,
+			},
+			target: targetLog,
+		} satisfies AttackEvaluationLog,
+	};
+}
+
+export type { AttackResolution };

--- a/packages/engine/src/effects/attack/snapshot_diff.ts
+++ b/packages/engine/src/effects/attack/snapshot_diff.ts
@@ -1,0 +1,66 @@
+import type { PlayerSnapshot } from '../../log';
+import type { ResourceKey, StatKey } from '../../state';
+
+export interface AttackResourceDiff {
+	type: 'resource';
+	key: ResourceKey;
+	before: number;
+	after: number;
+}
+
+export interface AttackStatDiff {
+	type: 'stat';
+	key: StatKey;
+	before: number;
+	after: number;
+}
+
+export type AttackPlayerDiff = AttackResourceDiff | AttackStatDiff;
+
+export function diffPlayerSnapshots(
+	before: PlayerSnapshot,
+	after: PlayerSnapshot,
+): AttackPlayerDiff[] {
+	const diffs: AttackPlayerDiff[] = [];
+	const resourceKeys = new Set(
+		Object.keys({
+			...before.resources,
+			...after.resources,
+		}),
+	);
+	for (const key of resourceKeys) {
+		const typedKey: ResourceKey = key;
+		const beforeValue = before.resources[typedKey] ?? 0;
+		const afterValue = after.resources[typedKey] ?? 0;
+		if (beforeValue !== afterValue) {
+			diffs.push({
+				type: 'resource',
+				key: typedKey,
+				before: beforeValue,
+				after: afterValue,
+			});
+		}
+	}
+
+	const statKeys = new Set(
+		Object.keys({
+			...before.stats,
+			...after.stats,
+		}),
+	);
+	for (const key of statKeys) {
+		const typedKey: StatKey = key;
+		const beforeValue = before.stats[typedKey] ?? 0;
+		const afterValue = after.stats[typedKey] ?? 0;
+		if (beforeValue !== afterValue) {
+			diffs.push({
+				type: 'stat',
+				key: typedKey,
+				before: beforeValue,
+				after: afterValue,
+			});
+		}
+	}
+
+	return diffs;
+}


### PR DESCRIPTION
## Summary
- extract attack snapshot diff and logging types into dedicated modules
- move resolveAttack implementation to a focused helper and simplify attack.ts
- rename guard variables for clarity while keeping attack effect exports intact

## Testing
- npm run lint packages/engine/src/effects/attack*


------
https://chatgpt.com/codex/tasks/task_e_68e0f6bf18f48325924b6cef596cf6dd