### PR TITLE
Add action effect group resolution and expose selection metadata

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -32,6 +32,9 @@ import {
 	statEvaluator,
 	attackParams,
 	transferParams,
+	actionEffectGroup,
+	actionEffectGroupOption,
+	type ActionEffectGroupDef,
 } from './config/builders';
 import type { Focus } from './defs';
 
@@ -39,6 +42,7 @@ export interface ActionDef extends ActionConfig {
 	category?: string;
 	order?: number;
 	focus?: Focus;
+	effectGroups?: ActionEffectGroupDef[];
 }
 
 export function createActionRegistry() {
@@ -197,10 +201,70 @@ export function createActionRegistry() {
 			.icon('📜')
 			.cost(Resource.ap, 1)
 			.cost(Resource.gold, 12)
+			.effect(
+				effect(Types.Action, ActionMethods.PERFORM)
+					.param('id', 'expand')
+					.build(),
+			)
+			.effect(
+				effect(Types.Action, ActionMethods.PERFORM).param('id', 'till').build(),
+			)
+			.effect({
+				type: Types.Resource,
+				method: ResourceMethods.REMOVE,
+				params: resourceParams().key(Resource.happiness).amount(3).build(),
+				meta: { allowShortfall: true },
+			})
+			.effectGroup(
+				actionEffectGroup('royal_decree_develop')
+					.title('Decree a development')
+					.summary('Choose what to raise on the prepared land.')
+					.description(
+						'After expanding and tilling, select one project to complete. Each option runs Develop on the chosen land.',
+					)
+					.option(
+						actionEffectGroupOption('royal_decree_house')
+							.label('Raise a House')
+							.icon('🏠')
+							.summary('Expand housing and increase the population cap by 1.')
+							.action('develop')
+							.param('landId', '$landId')
+							.param('id', 'house'),
+					)
+					.option(
+						actionEffectGroupOption('royal_decree_farm')
+							.label('Establish a Farm')
+							.icon('🌾')
+							.summary('Gain +2 gold during the income step each round.')
+							.action('develop')
+							.param('landId', '$landId')
+							.param('id', 'farm'),
+					)
+					.option(
+						actionEffectGroupOption('royal_decree_outpost')
+							.label('Fortify with an Outpost')
+							.icon('🏹')
+							.summary('Gain +1 Army Strength and +1 Fortification Strength.')
+							.action('develop')
+							.param('landId', '$landId')
+							.param('id', 'outpost'),
+					)
+					.option(
+						actionEffectGroupOption('royal_decree_watchtower')
+							.label('Raise a Watchtower')
+							.icon('🗼')
+							.summary(
+								'Add +2 Fortification Strength and absorption after defending once.',
+							)
+							.action('develop')
+							.param('landId', '$landId')
+							.param('id', 'watchtower'),
+					),
+			)
 			.build(),
-		category: 'basic',
-		order: 5,
-		focus: 'other',
+		category: 'development',
+		order: 2,
+		focus: 'economy',
 	});
 
 	registry.add('army_attack', {

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -5,9 +5,9 @@ export { POPULATIONS, createPopulationRegistry } from './populations';
 export { PHASES } from './phases';
 export type { PhaseDef, StepDef } from './config/builders';
 export {
-  POPULATION_ROLES,
-  PopulationRole,
-  type PopulationRoleId,
+	POPULATION_ROLES,
+	PopulationRole,
+	type PopulationRoleId,
 } from './populationRoles';
 export { Resource, type ResourceKey, RESOURCES } from './resources';
 export { Stat, type StatKey, STATS } from './stats';
@@ -22,10 +22,14 @@ export type { ActionDef } from './actions';
 export type { BuildingDef } from './buildings';
 export type { DevelopmentDef } from './developments';
 export type { PopulationDef, TriggerKey, Focus } from './defs';
+export type {
+	ActionEffectGroupDef,
+	ActionEffectGroupOptionDef,
+} from './config/builders';
 export {
-  ON_PAY_UPKEEP_STEP,
-  ON_GAIN_INCOME_STEP,
-  ON_GAIN_AP_STEP,
-  BROOM_ICON,
-  RESOURCE_TRANSFER_ICON,
+	ON_PAY_UPKEEP_STEP,
+	ON_GAIN_INCOME_STEP,
+	ON_GAIN_AP_STEP,
+	BROOM_ICON,
+	RESOURCE_TRANSFER_ICON,
 } from './defs';

--- a/packages/contents/src/populations.ts
+++ b/packages/contents/src/populations.ts
@@ -4,93 +4,118 @@ import { Resource } from './resources';
 import { Stat } from './stats';
 import { populationSchema } from '@kingdom-builder/engine/config/schema';
 import {
-  population,
-  effect,
-  Types,
-  ResourceMethods,
-  PassiveMethods,
-  StatMethods,
-  resourceParams,
-  statParams,
+	population,
+	effect,
+	Types,
+	ResourceMethods,
+	PassiveMethods,
+	StatMethods,
+	resourceParams,
+	statParams,
+	populationEvaluator,
 } from './config/builders';
 import type { PopulationDef } from './defs';
 
 export type { PopulationDef } from './defs';
 
+const COUNCIL_AP_GAIN_PARAMS = resourceParams()
+	.key(Resource.ap)
+	.amount(1)
+	.build();
+
+const LEGION_STRENGTH_GAIN_PARAMS = statParams()
+	.key(Stat.armyStrength)
+	.amount(1)
+	.build();
+
+const FORTIFIER_STRENGTH_GAIN_PARAMS = statParams()
+	.key(Stat.fortificationStrength)
+	.amount(1)
+	.build();
+
 export function createPopulationRegistry() {
-  const registry = new Registry<PopulationDef>(populationSchema);
+	const registry = new Registry<PopulationDef>(populationSchema);
 
-  registry.add(
-    PopulationRole.Council,
-    population()
-      .id(PopulationRole.Council)
-      .name('Council')
-      .icon('⚖️')
-      .upkeep(Resource.gold, 2)
-      .onGainAPStep(
-        effect(Types.Resource, ResourceMethods.ADD)
-          .params(resourceParams().key(Resource.ap).amount(1))
-          .build(),
-      )
-      .build(),
-  );
+	registry.add(
+		PopulationRole.Council,
+		population()
+			.id(PopulationRole.Council)
+			.name('Council')
+			.icon('⚖️')
+			.upkeep(Resource.gold, 2)
+			.onGainAPStep(
+				effect()
+					.evaluator(
+						populationEvaluator()
+							.param('id', PopulationRole.Council)
+							.role(PopulationRole.Council),
+					)
+					.effect(
+						effect(Types.Resource, ResourceMethods.ADD)
+							.params(COUNCIL_AP_GAIN_PARAMS)
+							.build(),
+					)
+					.build(),
+			)
+			.build(),
+	);
 
-  registry.add(
-    PopulationRole.Legion,
-    population()
-      .id(PopulationRole.Legion)
-      .name('Legion')
-      .icon('🎖️')
-      .upkeep(Resource.gold, 1)
-      .onAssigned(
-        effect(Types.Passive, PassiveMethods.ADD)
-          .param('id', 'legion_$player_$index')
-          .effect(
-            effect(Types.Stat, StatMethods.ADD)
-              .params(statParams().key(Stat.armyStrength).amount(1))
-              .build(),
-          )
-          .build(),
-      )
-      .onUnassigned(
-        effect(Types.Passive, PassiveMethods.REMOVE)
-          .param('id', 'legion_$player_$index')
-          .build(),
-      )
-      .build(),
-  );
+	registry.add(
+		PopulationRole.Legion,
+		population()
+			.id(PopulationRole.Legion)
+			.name('Legion')
+			.icon('🎖️')
+			.upkeep(Resource.gold, 1)
+			.onAssigned(
+				effect(Types.Passive, PassiveMethods.ADD)
+					.param('id', 'legion_$player_$index')
+					.effect(
+						effect(Types.Stat, StatMethods.ADD)
+							.params(LEGION_STRENGTH_GAIN_PARAMS)
+							.build(),
+					)
+					.build(),
+			)
+			.onUnassigned(
+				effect(Types.Passive, PassiveMethods.REMOVE)
+					.param('id', 'legion_$player_$index')
+					.build(),
+			)
+			.build(),
+	);
 
-  registry.add(
-    PopulationRole.Fortifier,
-    population()
-      .id(PopulationRole.Fortifier)
-      .name('Fortifier')
-      .icon('🔧')
-      .upkeep(Resource.gold, 1)
-      .onAssigned(
-        effect(Types.Passive, PassiveMethods.ADD)
-          .param('id', 'fortifier_$player_$index')
-          .effect(
-            effect(Types.Stat, StatMethods.ADD)
-              .params(statParams().key(Stat.fortificationStrength).amount(1))
-              .build(),
-          )
-          .build(),
-      )
-      .onUnassigned(
-        effect(Types.Passive, PassiveMethods.REMOVE)
-          .param('id', 'fortifier_$player_$index')
-          .build(),
-      )
-      .build(),
-  );
+	registry.add(
+		PopulationRole.Fortifier,
+		population()
+			.id(PopulationRole.Fortifier)
+			.name('Fortifier')
+			.icon('🔧')
+			.upkeep(Resource.gold, 1)
+			.onAssigned(
+				effect(Types.Passive, PassiveMethods.ADD)
+					.param('id', 'fortifier_$player_$index')
+					.effect(
+						effect(Types.Stat, StatMethods.ADD)
+							.params(FORTIFIER_STRENGTH_GAIN_PARAMS)
+							.build(),
+					)
+					.build(),
+			)
+			.onUnassigned(
+				effect(Types.Passive, PassiveMethods.REMOVE)
+					.param('id', 'fortifier_$player_$index')
+					.build(),
+			)
+			.build(),
+	);
 
-  registry.add(
-    PopulationRole.Citizen,
-    population().id(PopulationRole.Citizen).name('Citizen').icon('👤').build(),
-  );
+	registry.add(
+		PopulationRole.Citizen,
+		population().id(PopulationRole.Citizen).name('Citizen').icon('👤').build(),
+	);
 
-  return registry;
+	return registry;
 }
 
 export const POPULATIONS = createPopulationRegistry();

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -1,5 +1,9 @@
 import {
+	ActionBuilder,
 	action,
+	actionEffectGroup,
+	actionEffectGroupOption,
+	building,
 	resourceParams,
 	statParams,
 	effect,
@@ -34,6 +38,103 @@ describe('content builder safeguards', () => {
 		expect(() => action().id('example').build()).toThrowError(
 			"Action is missing name(). Call name('Readable name') before build().",
 		);
+	});
+
+	it('requires action effect groups to include options', () => {
+		const group = actionEffectGroup('choose').title('Pick a project');
+		expect(() => group.build()).toThrowError(
+			'Action effect group needs at least one option(). Add option(...) before build().',
+		);
+	});
+
+	it('prevents duplicate option ids within an effect group', () => {
+		const group = actionEffectGroup('choose')
+			.title('Pick a project')
+			.option(actionEffectGroupOption('farm').label('Farm').action('develop'));
+
+		expect(() =>
+			group.option(
+				actionEffectGroupOption('farm').label('House').action('develop'),
+			),
+		).toThrowError(
+			'Action effect group option id "farm" already exists. Use unique option ids within a group.',
+		);
+	});
+
+	it('prevents duplicate effect group ids on an action', () => {
+		const builder = action().id('has_group').name('Has Group');
+		builder.effectGroup(
+			actionEffectGroup('choose')
+				.title('Pick a project')
+				.option(
+					actionEffectGroupOption('farm').label('Farm').action('develop'),
+				),
+		);
+
+		expect(() =>
+			builder.effectGroup(
+				actionEffectGroup('choose')
+					.title('Pick again')
+					.option(
+						actionEffectGroupOption('house').label('House').action('develop'),
+					),
+			),
+		).toThrowError(
+			'Action effect group id "choose" already exists on this action. Use unique group ids.',
+		);
+	});
+
+	it('blocks attaching effect groups to non-action builders', () => {
+		const buildingBuilder = building();
+		const group = actionEffectGroup('choose')
+			.title('Pick a project')
+			.option(actionEffectGroupOption('farm').label('Farm').action('develop'));
+
+		expect(() =>
+			(
+				ActionBuilder.prototype.effectGroup as (
+					this: ActionBuilder,
+					group: unknown,
+				) => ActionBuilder
+			).call(buildingBuilder as unknown as ActionBuilder, group),
+		).toThrowError(
+			'Action effect groups can only be used on actions. Use action().effectGroup(...).',
+		);
+	});
+
+	it('builds actions with effect groups', () => {
+		const built = action()
+			.id('group_action')
+			.name('Group Action')
+			.effectGroup(
+				actionEffectGroup('choose')
+					.title('Pick a project')
+					.summary('Choose one follow-up action to resolve immediately.')
+					.option(
+						actionEffectGroupOption('farm')
+							.label('Farm')
+							.action('develop')
+							.param('id', 'farm')
+							.param('landId', '$landId'),
+					),
+			)
+			.build();
+
+		expect(built.effectGroups).toEqual([
+			{
+				id: 'choose',
+				title: 'Pick a project',
+				summary: 'Choose one follow-up action to resolve immediately.',
+				options: [
+					{
+						id: 'farm',
+						label: 'Farm',
+						actionId: 'develop',
+						params: { id: 'farm', landId: '$landId' },
+					},
+				],
+			},
+		]);
 	});
 
 	it('prevents mixing amount and percent for resource changes', () => {

--- a/packages/engine/src/actions/action_effects.ts
+++ b/packages/engine/src/actions/action_effects.ts
@@ -1,0 +1,251 @@
+import { applyParamsToEffects } from '../utils';
+import type { EffectDef } from '../effects';
+import type {
+	ActionEffect,
+	ActionEffectGroup,
+	ActionEffectGroupOption,
+	EffectConfig,
+} from '../config/schema';
+import type { ActionParameters } from './action_parameters';
+import type { EngineContext } from '../context';
+interface NormalizedChoiceSelection {
+	option: string;
+	params: Record<string, unknown>;
+}
+interface NormalizedActionParameters {
+	values: Record<string, unknown>;
+	choices: Record<string, NormalizedChoiceSelection>;
+}
+export interface ResolvedActionEffectGroupOption {
+	id: string;
+	label?: string | undefined;
+	meta?: Record<string, unknown> | undefined;
+	groups: ResolvedActionEffectGroup[];
+}
+export interface ResolvedActionEffectGroup {
+	id: string;
+	label?: string | undefined;
+	required: boolean;
+	meta?: Record<string, unknown> | undefined;
+	options: ResolvedActionEffectGroupOption[];
+}
+export interface ResolvedActionEffectChoice {
+	groupId: string;
+	optionId: string;
+	group: ResolvedActionEffectGroup;
+	option: ResolvedActionEffectGroupOption;
+	params: Record<string, unknown>;
+}
+export interface ResolvedActionEffects {
+	effects: EffectDef[];
+	groups: ResolvedActionEffectGroup[];
+	choices: ResolvedActionEffectChoice[];
+}
+const isActionEffectGroup = (
+	effect: ActionEffect,
+): effect is ActionEffectGroup =>
+	typeof (effect as ActionEffectGroup).group === 'string';
+
+function replaceValue(
+	value: unknown,
+	params: Record<string, unknown>,
+): unknown {
+	if (typeof value === 'string' && value.startsWith('$')) {
+		return params[value.slice(1)];
+	}
+	if (Array.isArray(value)) {
+		return value.map((entry) => replaceValue(entry, params));
+	}
+	if (value && typeof value === 'object') {
+		const entries = Object.entries(value as Record<string, unknown>);
+		return Object.fromEntries(
+			entries.map(([key, entry]) => [key, replaceValue(entry, params)]),
+		);
+	}
+	return value;
+}
+function resolveGroupOptionDefinition(
+	option: ActionEffectGroupOption,
+	params: Record<string, unknown>,
+): ResolvedActionEffectGroupOption {
+	return {
+		id: option.id,
+		label: option.label
+			? (replaceValue(option.label, params) as string)
+			: undefined,
+		meta: option.meta
+			? (replaceValue(option.meta, params) as Record<string, unknown>)
+			: undefined,
+		groups: collectActionEffectGroups(option.effects, params),
+	};
+}
+function resolveGroupDefinition(
+	group: ActionEffectGroup,
+	params: Record<string, unknown>,
+): ResolvedActionEffectGroup {
+	return {
+		id: group.group,
+		label: group.label
+			? (replaceValue(group.label, params) as string)
+			: undefined,
+		required: group.required !== false,
+		meta: group.meta
+			? (replaceValue(group.meta, params) as Record<string, unknown>)
+			: undefined,
+		options: group.options.map((option) =>
+			resolveGroupOptionDefinition(option, params),
+		),
+	};
+}
+function collectActionEffectGroups(
+	effects: ActionEffect[],
+	params: Record<string, unknown>,
+): ResolvedActionEffectGroup[] {
+	return effects
+		.filter(isActionEffectGroup)
+		.map((group) => resolveGroupDefinition(group, params));
+}
+function normalizeActionParameters<T extends string>(
+	params?: ActionParameters<T>,
+): NormalizedActionParameters {
+	if (!params) {
+		return { values: {}, choices: {} };
+	}
+	const base: Record<string, unknown> = {},
+		choices: Record<string, NormalizedChoiceSelection> = {};
+	const entries = params as Record<string, unknown>;
+	for (const [key, value] of Object.entries(entries)) {
+		if (key === 'choices') {
+			continue;
+		}
+		if (key === 'values' && value && typeof value === 'object') {
+			Object.assign(base, value as Record<string, unknown>);
+			continue;
+		}
+		base[key] = value;
+	}
+	const rawChoices = (entries['choices'] ?? {}) as Record<string, unknown>;
+	for (const [groupId, choiceValue] of Object.entries(rawChoices)) {
+		if (choiceValue == null) {
+			continue;
+		}
+		if (typeof choiceValue === 'string') {
+			choices[groupId] = { option: choiceValue, params: {} };
+			continue;
+		}
+		if (
+			typeof choiceValue === 'object' &&
+			choiceValue !== null &&
+			'option' in (choiceValue as Record<string, unknown>) &&
+			typeof (choiceValue as { option: unknown }).option === 'string'
+		) {
+			const detail = choiceValue as {
+				option: string;
+				params?: Record<string, unknown>;
+			};
+			choices[groupId] = {
+				option: detail.option,
+				params: detail.params ? { ...detail.params } : {},
+			};
+			continue;
+		}
+		throw new Error(`Invalid choice payload for group ${groupId}`);
+	}
+	return { values: base, choices };
+}
+interface ResolveState {
+	effects: EffectDef[];
+	groups: ResolvedActionEffectGroup[];
+	choices: ResolvedActionEffectChoice[];
+	usedChoiceIds: Set<string>;
+}
+function resolveEffectsRecursive(
+	effects: ActionEffect[],
+	params: Record<string, unknown>,
+	choices: NormalizedActionParameters['choices'],
+	state: ResolveState,
+): void {
+	for (const effect of effects) {
+		if (!isActionEffectGroup(effect)) {
+			const effectConfig: EffectConfig = effect;
+			const effectList: EffectConfig[] = [effectConfig];
+			const [applied] = applyParamsToEffects(effectList, params);
+			if (!applied) {
+				continue;
+			}
+			state.effects.push(applied);
+			continue;
+		}
+		const resolvedGroup = resolveGroupDefinition(effect, params);
+		state.groups.push(resolvedGroup);
+		const selection = choices[resolvedGroup.id];
+		if (!selection) {
+			if (resolvedGroup.required) {
+				const detail = resolvedGroup.label ?? resolvedGroup.id;
+				throw new Error(`Missing choice for action effect group "${detail}"`);
+			}
+			continue;
+		}
+		state.usedChoiceIds.add(resolvedGroup.id);
+		const optionDef = effect.options.find(
+			(option) => option.id === selection.option,
+		);
+		if (!optionDef) {
+			throw new Error(
+				`Invalid option "${selection.option}"` +
+					` for effect group "${resolvedGroup.id}"`,
+			);
+		}
+		const optionParams = { ...params, ...selection.params };
+		const resolvedOption = resolveGroupOptionDefinition(
+			optionDef,
+			optionParams,
+		);
+		const optionEffects = optionDef.effects;
+		state.choices.push({
+			groupId: resolvedGroup.id,
+			optionId: resolvedOption.id,
+			group: resolvedGroup,
+			option: resolvedOption,
+			params: selection.params,
+		});
+		resolveEffectsRecursive(optionEffects, optionParams, choices, state);
+	}
+}
+export function resolveActionEffects<T extends string>(
+	effects: ActionEffect[],
+	params?: ActionParameters<T>,
+): ResolvedActionEffects {
+	const normalized = normalizeActionParameters(params),
+		state: ResolveState = {
+			effects: [],
+			groups: [],
+			choices: [],
+			usedChoiceIds: new Set<string>(),
+		};
+	resolveEffectsRecursive(
+		effects,
+		normalized.values,
+		normalized.choices,
+		state,
+	);
+	for (const groupId of Object.keys(normalized.choices)) {
+		if (!state.usedChoiceIds.has(groupId)) {
+			throw new Error(`Unknown effect group choice "${groupId}"`);
+		}
+	}
+	return {
+		effects: state.effects,
+		groups: state.groups,
+		choices: state.choices,
+	};
+}
+export function getActionEffectGroups<T extends string>(
+	actionId: T,
+	ctx: EngineContext,
+	params?: ActionParameters<T>,
+): ResolvedActionEffectGroup[] {
+	const def = ctx.actions.get(actionId);
+	const normalized = normalizeActionParameters(params);
+	return collectActionEffectGroups(def.effects, normalized.values);
+}

--- a/packages/engine/src/actions/action_execution.ts
+++ b/packages/engine/src/actions/action_execution.ts
@@ -1,5 +1,4 @@
 import { runEffects } from '../effects';
-import { applyParamsToEffects } from '../utils';
 import { withStatSourceFrames } from '../stat_sources';
 import { runRequirement } from '../requirements';
 import type { EngineContext } from '../context';
@@ -12,6 +11,7 @@ import {
 	verifyCostAffordability,
 } from './costs';
 import { cloneEngineContext } from './context_clone';
+import { resolveActionEffects } from './action_effects';
 
 function assertSystemActionUnlocked(
 	actionId: string,
@@ -82,9 +82,9 @@ function executeAction<T extends string>(
 	assertSystemActionUnlocked(actionId, engineContext);
 	evaluateRequirements(actionId, engineContext);
 	const baseCosts = { ...(actionDefinition.baseCosts || {}) };
-	const resolvedEffects = applyParamsToEffects(
+	const { effects: resolvedEffects } = resolveActionEffects(
 		actionDefinition.effects,
-		params || {},
+		params,
 	);
 	const pendingBuildingIds = collectPendingBuildingAdds(resolvedEffects);
 	assertBuildingsNotYetConstructed(pendingBuildingIds, engineContext);

--- a/packages/engine/src/actions/action_parameters.ts
+++ b/packages/engine/src/actions/action_parameters.ts
@@ -8,7 +8,20 @@ type ActionParameterMap = {
 	[key: string]: Record<string, unknown>;
 };
 
-export type ActionParameters<T extends string> =
-	T extends keyof ActionParameterMap
-		? ActionParameterMap[T]
-		: Record<string, unknown>;
+type ActionParameterBase<T extends string> = T extends keyof ActionParameterMap
+	? ActionParameterMap[T]
+	: Record<string, unknown>;
+
+export type ActionChoiceDetail = {
+	option: string;
+	params?: Record<string, unknown>;
+};
+
+export type ActionChoiceValue = string | ActionChoiceDetail | null | undefined;
+
+export type ActionChoiceMap = Record<string, ActionChoiceValue>;
+
+export type ActionParameters<T extends string> = ActionParameterBase<T> & {
+	choices?: ActionChoiceMap;
+	values?: ActionParameterBase<T>;
+};

--- a/packages/engine/src/actions/costs.ts
+++ b/packages/engine/src/actions/costs.ts
@@ -1,4 +1,3 @@
-import { applyParamsToEffects } from '../utils';
 import { EFFECT_COST_COLLECTORS } from '../effects';
 import { runRequirement } from '../requirements';
 import type { EffectDef } from '../effects';
@@ -6,6 +5,7 @@ import type { EngineContext } from '../context';
 import type { CostBag } from '../services';
 import type { PlayerState } from '../state';
 import type { ActionParameters } from './action_parameters';
+import { resolveActionEffects } from './action_effects';
 
 function cloneCostBag(costBag: CostBag): CostBag {
 	return { ...costBag };
@@ -56,11 +56,8 @@ export function getActionCosts<T extends string>(
 ): CostBag {
 	const actionDefinition = engineContext.actions.get(actionId);
 	const baseCosts = cloneCostBag(actionDefinition.baseCosts || {});
-	const resolvedEffects = applyParamsToEffects(
-		actionDefinition.effects,
-		params || {},
-	);
-	applyEffectCostCollectors(resolvedEffects, baseCosts, engineContext);
+	const { effects } = resolveActionEffects(actionDefinition.effects, params);
+	applyEffectCostCollectors(effects, baseCosts, engineContext);
 	const finalCosts = applyCostsWithPassives(
 		actionDefinition.id,
 		baseCosts,

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 import type { EffectDef } from '../effects';
 
 const requirementSchema = z.object({
-  type: z.string(),
-  method: z.string(),
-  params: z.record(z.unknown()).optional(),
-  message: z.string().optional(),
+	type: z.string(),
+	method: z.string(),
+	params: z.record(z.unknown()).optional(),
+	message: z.string().optional(),
 });
 
 export type RequirementConfig = z.infer<typeof requirementSchema>;
@@ -14,130 +14,172 @@ export type RequirementConfig = z.infer<typeof requirementSchema>;
 const costBagSchema = z.record(z.string(), z.number());
 
 const evaluatorSchema = z.object({
-  type: z.string(),
-  params: z.record(z.unknown()).optional(),
+	type: z.string(),
+	params: z.record(z.unknown()).optional(),
 });
 
 // Effect
 export const effectSchema: z.ZodType<EffectDef> = z.lazy(() =>
-  z.object({
-    type: z.string().optional(),
-    method: z.string().optional(),
-    params: z.record(z.unknown()).optional(),
-    effects: z.array(effectSchema).optional(),
-    evaluator: evaluatorSchema.optional(),
-    round: z.enum(['up', 'down']).optional(),
-    meta: z.record(z.unknown()).optional(),
-  }),
+	z.object({
+		type: z.string().optional(),
+		method: z.string().optional(),
+		params: z.record(z.unknown()).optional(),
+		effects: z.array(effectSchema).optional(),
+		evaluator: evaluatorSchema.optional(),
+		round: z.enum(['up', 'down']).optional(),
+		meta: z.record(z.unknown()).optional(),
+	}),
 );
 
 export type EffectConfig = EffectDef;
 
+export interface ActionEffectGroupOptionConfig {
+	id: string;
+	label?: string | undefined;
+	effects: ActionEffectConfig[];
+	meta?: Record<string, unknown> | undefined;
+}
+
+export interface ActionEffectGroupConfig {
+	group: string;
+	label?: string | undefined;
+	required?: boolean | undefined;
+	options: ActionEffectGroupOptionConfig[];
+	meta?: Record<string, unknown> | undefined;
+}
+
+export type ActionEffectConfig = EffectConfig | ActionEffectGroupConfig;
+
+const actionEffectSchema: z.ZodType<ActionEffectConfig> = z.lazy(() =>
+	z.union([effectGroupSchema, effectSchema]),
+);
+
+const effectGroupSchema: z.ZodType<ActionEffectGroupConfig> = z.lazy(() =>
+	z.object({
+		group: z.string(),
+		label: z.string().optional(),
+		required: z.boolean().optional(),
+		options: z.array(
+			z.object({
+				id: z.string(),
+				label: z.string().optional(),
+				effects: z.array(actionEffectSchema),
+				meta: z.record(z.unknown()).optional(),
+			}),
+		),
+		meta: z.record(z.unknown()).optional(),
+	}),
+);
+
+export type ActionEffectGroup = ActionEffectGroupConfig;
+export type ActionEffect = ActionEffectConfig;
+export type ActionEffectGroupOption = ActionEffectGroupOptionConfig;
+
 // Action
 export const actionSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  baseCosts: costBagSchema.optional(),
-  requirements: z.array(requirementSchema).optional(),
-  effects: z.array(effectSchema),
-  system: z.boolean().optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	baseCosts: costBagSchema.optional(),
+	requirements: z.array(requirementSchema).optional(),
+	effects: z.array(actionEffectSchema),
+	system: z.boolean().optional(),
 });
 
 export type ActionConfig = z.infer<typeof actionSchema>;
 
 // Building
 export const buildingSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  costs: costBagSchema,
-  upkeep: costBagSchema.optional(),
-  onBuild: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onUpkeepPhase: z.array(effectSchema).optional(),
-  onBeforeAttacked: z.array(effectSchema).optional(),
-  onAttackResolved: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	costs: costBagSchema,
+	upkeep: costBagSchema.optional(),
+	onBuild: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onUpkeepPhase: z.array(effectSchema).optional(),
+	onBeforeAttacked: z.array(effectSchema).optional(),
+	onAttackResolved: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type BuildingConfig = z.infer<typeof buildingSchema>;
 
 // Development
 export const developmentSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  upkeep: costBagSchema.optional(),
-  onBuild: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onBeforeAttacked: z.array(effectSchema).optional(),
-  onAttackResolved: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
-  system: z.boolean().optional(),
-  populationCap: z.number().optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	upkeep: costBagSchema.optional(),
+	onBuild: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onBeforeAttacked: z.array(effectSchema).optional(),
+	onAttackResolved: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
+	system: z.boolean().optional(),
+	populationCap: z.number().optional(),
 });
 
 export type DevelopmentConfig = z.infer<typeof developmentSchema>;
 
 // Population
 export const populationSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  upkeep: costBagSchema.optional(),
-  onAssigned: z.array(effectSchema).optional(),
-  onUnassigned: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onUpkeepPhase: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	upkeep: costBagSchema.optional(),
+	onAssigned: z.array(effectSchema).optional(),
+	onUnassigned: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onUpkeepPhase: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type PopulationConfig = z.infer<typeof populationSchema>;
 
 // Game config
 const landStartSchema = z.object({
-  developments: z.array(z.string()).optional(),
-  slotsMax: z.number().optional(),
-  slotsUsed: z.number().optional(),
-  tilled: z.boolean().optional(),
-  upkeep: costBagSchema.optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	developments: z.array(z.string()).optional(),
+	slotsMax: z.number().optional(),
+	slotsUsed: z.number().optional(),
+	tilled: z.boolean().optional(),
+	upkeep: costBagSchema.optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 const playerStartSchema = z.object({
-  resources: z.record(z.string(), z.number()).optional(),
-  stats: z.record(z.string(), z.number()).optional(),
-  population: z.record(z.string(), z.number()).optional(),
-  lands: z.array(landStartSchema).optional(),
+	resources: z.record(z.string(), z.number()).optional(),
+	stats: z.record(z.string(), z.number()).optional(),
+	population: z.record(z.string(), z.number()).optional(),
+	lands: z.array(landStartSchema).optional(),
 });
 
 export const startConfigSchema = z.object({
-  player: playerStartSchema,
-  players: z.record(z.string(), playerStartSchema).optional(),
+	player: playerStartSchema,
+	players: z.record(z.string(), playerStartSchema).optional(),
 });
 
 export type PlayerStartConfig = z.infer<typeof playerStartSchema>;
 export type StartConfig = z.infer<typeof startConfigSchema>;
 
 export const gameConfigSchema = z.object({
-  start: startConfigSchema.optional(),
-  actions: z.array(actionSchema).optional(),
-  buildings: z.array(buildingSchema).optional(),
-  developments: z.array(developmentSchema).optional(),
-  populations: z.array(populationSchema).optional(),
+	start: startConfigSchema.optional(),
+	actions: z.array(actionSchema).optional(),
+	buildings: z.array(buildingSchema).optional(),
+	developments: z.array(developmentSchema).optional(),
+	populations: z.array(populationSchema).optional(),
 });
 
 export type GameConfig = z.infer<typeof gameConfigSchema>;
 
 export function validateGameConfig(config: unknown): GameConfig {
-  return gameConfigSchema.parse(config);
+	return gameConfigSchema.parse(config);
 }

--- a/packages/engine/src/effects/action_perform.ts
+++ b/packages/engine/src/effects/action_perform.ts
@@ -1,8 +1,8 @@
 import type { EffectHandler } from '.';
-import { applyParamsToEffects } from '../utils';
 import { runEffects } from '.';
 import { snapshotPlayer } from '../log';
 import { withStatSourceFrames } from '../stat_sources';
+import { resolveActionEffects } from '../actions/action_effects';
 
 export const actionPerform: EffectHandler = (effect, ctx, mult = 1) => {
 	const id = effect.params?.['id'] as string;
@@ -13,7 +13,7 @@ export const actionPerform: EffectHandler = (effect, ctx, mult = 1) => {
 	for (let i = 0; i < Math.floor(mult); i++) {
 		const def = ctx.actions.get(id);
 		const before = snapshotPlayer(ctx.activePlayer, ctx);
-		const resolved = applyParamsToEffects(def.effects, params);
+		const { effects } = resolveActionEffects(def.effects, params);
 		withStatSourceFrames(
 			ctx,
 			(_effect, _ctx, statKey) => ({
@@ -24,7 +24,7 @@ export const actionPerform: EffectHandler = (effect, ctx, mult = 1) => {
 				longevity: 'permanent',
 			}),
 			() => {
-				runEffects(resolved, ctx);
+				runEffects(effects, ctx);
 				ctx.passives.runResultMods(def.id, ctx);
 			},
 		);

--- a/packages/engine/src/effects/attack.ts
+++ b/packages/engine/src/effects/attack.ts
@@ -1,260 +1,37 @@
 import type { EffectDef, EffectHandler } from '.';
-import type { EngineContext } from '../context';
-import type { PlayerState, ResourceKey, StatKey } from '../state';
 import type { ResourceGain } from '../services';
 import { runEffects } from '.';
-import { collectTriggerEffects } from '../triggers';
-import { withStatSourceFrames } from '../stat_sources';
-import { snapshotPlayer, type PlayerSnapshot } from '../log';
-import type { AttackEvaluationTargetLog, AttackTarget } from './attack.types';
-import {
-	attackTargetHandlers,
-	type AttackTargetHandlerMeta,
-} from './attack_target_handlers';
+import { snapshotPlayer } from '../log';
+import type { AttackTarget } from './attack.types';
+import { attackTargetHandlers } from './attack_target_handlers';
+import { diffPlayerSnapshots } from './attack/snapshot_diff';
+import type {
+	AttackCalcOptions,
+	AttackLogOwner,
+	AttackOnDamageLogEntry,
+} from './attack/log.types';
+import { resolveAttack } from './attack/resolve';
+
+export type { AttackPlayerDiff } from './attack/snapshot_diff';
+export type {
+	AttackCalcOptions,
+	AttackEvaluationLog,
+	AttackLog,
+	AttackLogOwner,
+	AttackOnDamageLogEntry,
+	AttackPowerLog,
+} from './attack/log.types';
 
 export {
 	type AttackTarget,
 	type AttackEvaluationTargetLog,
 } from './attack.types';
-
-export interface AttackCalcOptions {
-	ignoreAbsorption?: boolean;
-	ignoreFortification?: boolean;
-}
-
-export type AttackLogOwner = 'attacker' | 'defender';
-
-export interface AttackPowerLog {
-	base: number;
-	modified: number;
-}
-
-export interface AttackEvaluationLog {
-	power: AttackPowerLog;
-	absorption: {
-		ignored: boolean;
-		before: number;
-		damageAfter: number;
-	};
-	fortification: {
-		ignored: boolean;
-		before: number;
-		damage: number;
-		after: number;
-	};
-	target: AttackEvaluationTargetLog;
-}
-
-interface AttackResourceDiff {
-	type: 'resource';
-	key: ResourceKey;
-	before: number;
-	after: number;
-}
-
-interface AttackStatDiff {
-	type: 'stat';
-	key: StatKey;
-	before: number;
-	after: number;
-}
-
-export type AttackPlayerDiff = AttackResourceDiff | AttackStatDiff;
-
-export interface AttackOnDamageLogEntry {
-	owner: AttackLogOwner;
-	effect: EffectDef;
-	attacker: AttackPlayerDiff[];
-	defender: AttackPlayerDiff[];
-}
-
-export interface AttackLog {
-	evaluation: AttackEvaluationLog;
-	onDamage: AttackOnDamageLogEntry[];
-}
-
-interface AttackResolution {
-	damageDealt: number;
-	evaluation: AttackEvaluationLog;
-}
-
-function diffPlayerSnapshots(
-	before: PlayerSnapshot,
-	after: PlayerSnapshot,
-): AttackPlayerDiff[] {
-	const diffs: AttackPlayerDiff[] = [];
-	const resourceKeys = new Set<ResourceKey>(
-		// Cast snapshot keys to ResourceKey so downstream consumers can rely on
-		// resource metadata lookups during logging.
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-		Object.keys({ ...before.resources, ...after.resources }) as ResourceKey[],
-	);
-	for (const key of resourceKeys) {
-		const beforeVal = before.resources[key] ?? 0;
-		const afterVal = after.resources[key] ?? 0;
-		if (beforeVal !== afterVal) {
-			diffs.push({
-				type: 'resource',
-				key,
-				before: beforeVal,
-				after: afterVal,
-			});
-		}
-	}
-	const statKeys = new Set<StatKey>(
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-		Object.keys({ ...before.stats, ...after.stats }) as StatKey[],
-	);
-	for (const key of statKeys) {
-		const beforeVal = before.stats[key] ?? 0;
-		const afterVal = after.stats[key] ?? 0;
-		if (beforeVal !== afterVal) {
-			diffs.push({
-				type: 'stat',
-				key,
-				before: beforeVal,
-				after: afterVal,
-			});
-		}
-	}
-	return diffs;
-}
-
-function applyAbsorption(
-	damage: number,
-	absorption: number,
-	rounding: 'up' | 'down' | 'nearest',
-): number {
-	if (absorption <= 0) {
-		return damage;
-	}
-	const reduced = damage * (1 - absorption);
-	if (rounding === 'down') {
-		return Math.floor(reduced);
-	}
-	if (rounding === 'up') {
-		return Math.ceil(reduced);
-	}
-	return Math.round(reduced);
-}
-
-export function resolveAttack(
-	defender: PlayerState,
-	damage: number,
-	ctx: EngineContext,
-	target: AttackTarget,
-	opts: AttackCalcOptions = {},
-	baseDamage = damage,
-): AttackResolution {
-	const original = ctx.game.currentPlayerIndex;
-	const defenderIndex = ctx.game.players.indexOf(defender);
-
-	ctx.game.currentPlayerIndex = defenderIndex;
-	const pre = collectTriggerEffects('onBeforeAttacked', ctx, defender);
-
-	for (const bundle of pre) {
-		withStatSourceFrames(ctx, bundle.frames, () =>
-			runEffects(bundle.effects, ctx),
-		);
-	}
-
-	if (pre.length) {
-		runEffects(pre, ctx);
-	}
-
-	ctx.game.currentPlayerIndex = original;
-
-	const absorption = opts.ignoreAbsorption
-		? 0
-		: Math.min(
-				(defender.absorption as number) || 0,
-				ctx.services.rules.absorptionCapPct,
-			);
-	const damageAfterAbsorption = opts.ignoreAbsorption
-		? damage
-		: applyAbsorption(
-				damage,
-				absorption,
-				ctx.services.rules.absorptionRounding,
-			);
-
-	const fortBefore = (defender.fortificationStrength as number) || 0;
-	const fortDamage = opts.ignoreFortification
-		? 0
-		: Math.min(fortBefore, damageAfterAbsorption);
-	const fortAfter = opts.ignoreFortification
-		? fortBefore
-		: Math.max(0, fortBefore - fortDamage);
-	if (!opts.ignoreFortification) {
-		defender.fortificationStrength = fortAfter;
-	}
-
-	const targetDamage = Math.max(0, damageAfterAbsorption - fortDamage);
-	const handlerMeta: AttackTargetHandlerMeta = {
-		defenderIndex,
-		originalIndex: original,
-	};
-	const handler = attackTargetHandlers[target.type];
-	const mutation = handler.applyDamage(
-		target as never,
-		targetDamage,
-		ctx,
-		defender,
-		handlerMeta,
-	);
-	const targetLog = handler.buildLog(
-		target as never,
-		targetDamage,
-		ctx,
-		defender,
-		handlerMeta,
-		mutation as never,
-	);
-
-	ctx.game.currentPlayerIndex = defenderIndex;
-	const post = collectTriggerEffects('onAttackResolved', ctx, defender);
-
-	for (const bundle of post) {
-		withStatSourceFrames(ctx, bundle.frames, () =>
-			runEffects(bundle.effects, ctx),
-		);
-	}
-
-	if ((defender.fortificationStrength || 0) < 0) {
-		defender.fortificationStrength = 0;
-	}
-
-	if (post.length) {
-		runEffects(post, ctx);
-	}
-
-	ctx.game.currentPlayerIndex = original;
-
-	return {
-		damageDealt: targetDamage,
-		evaluation: {
-			power: { base: baseDamage, modified: damage },
-			absorption: {
-				ignored: Boolean(opts.ignoreAbsorption),
-				before: absorption,
-				damageAfter: damageAfterAbsorption,
-			},
-			fortification: {
-				ignored: Boolean(opts.ignoreFortification),
-				before: fortBefore,
-				damage: fortDamage,
-				after: fortAfter,
-			},
-			target: targetLog,
-		},
-	};
-}
-
-export const attackPerform: EffectHandler = (effect, ctx) => {
-	const attacker = ctx.activePlayer;
-	const defender = ctx.opponent;
-	const params = effect.params || {};
-	const target = params['target'] as AttackTarget | undefined;
+export { resolveAttack } from './attack/resolve';
+export const attackPerform: EffectHandler = (effectDefinition, context) => {
+	const attacker = context.activePlayer;
+	const defender = context.opponent;
+	const effectParams = effectDefinition.params || {};
+	const target = effectParams['target'] as AttackTarget | undefined;
 	if (!target) {
 		return;
 	}
@@ -262,52 +39,57 @@ export const attackPerform: EffectHandler = (effect, ctx) => {
 	const baseDamage = (attacker.armyStrength as number) || 0;
 	const targetHandler = attackTargetHandlers[target.type];
 	const evaluationKey = targetHandler.getEvaluationModifierKey(target as never);
-	const mods: ResourceGain[] = [{ key: evaluationKey, amount: baseDamage }];
-	ctx.passives.runEvaluationMods('attack:power', ctx, mods);
-	const modifiedDamage = mods[0]!.amount;
+	const powerModifiers: ResourceGain[] = [
+		{ key: evaluationKey, amount: baseDamage },
+	];
+	context.passives.runEvaluationMods('attack:power', context, powerModifiers);
+	const modifiedDamage = powerModifiers[0]!.amount;
 
-	const { onDamage, ...calcOpts } = params as {
+	const { onDamage, ...calcOptions } = effectParams as {
 		onDamage?: { attacker?: EffectDef[]; defender?: EffectDef[] };
 	} & AttackCalcOptions;
 
 	const result = resolveAttack(
 		defender,
 		modifiedDamage,
-		ctx,
+		context,
 		target,
-		calcOpts,
+		calcOptions,
 		baseDamage,
 	);
 
 	const onDamageLogs: AttackOnDamageLogEntry[] = [];
 
 	if (result.damageDealt > 0 && onDamage) {
-		const runList = (owner: AttackLogOwner, defs: EffectDef[] | undefined) => {
-			if (!defs?.length) {
+		const runList = (
+			owner: AttackLogOwner,
+			effectDefinitions: EffectDef[] | undefined,
+		) => {
+			if (!effectDefinitions?.length) {
 				return;
 			}
-			const defenderIndex = ctx.game.players.indexOf(defender);
-			const original = ctx.game.currentPlayerIndex;
+			const defenderIndex = context.game.players.indexOf(defender);
+			const originalIndex = context.game.currentPlayerIndex;
 			if (owner === 'defender') {
-				ctx.game.currentPlayerIndex = defenderIndex;
+				context.game.currentPlayerIndex = defenderIndex;
 			}
 			try {
-				for (const def of defs) {
-					const beforeAttacker = snapshotPlayer(attacker, ctx);
-					const beforeDefender = snapshotPlayer(defender, ctx);
-					runEffects([def], ctx);
-					const afterAttacker = snapshotPlayer(attacker, ctx);
-					const afterDefender = snapshotPlayer(defender, ctx);
+				for (const effectDef of effectDefinitions) {
+					const beforeAttacker = snapshotPlayer(attacker, context);
+					const beforeDefender = snapshotPlayer(defender, context);
+					runEffects([effectDef], context);
+					const afterAttacker = snapshotPlayer(attacker, context);
+					const afterDefender = snapshotPlayer(defender, context);
 					onDamageLogs.push({
 						owner,
-						effect: def,
+						effect: effectDef,
 						attacker: diffPlayerSnapshots(beforeAttacker, afterAttacker),
 						defender: diffPlayerSnapshots(beforeDefender, afterDefender),
 					});
 				}
 			} finally {
 				if (owner === 'defender') {
-					ctx.game.currentPlayerIndex = original;
+					context.game.currentPlayerIndex = originalIndex;
 				}
 			}
 		};
@@ -316,7 +98,7 @@ export const attackPerform: EffectHandler = (effect, ctx) => {
 		runList('attacker', onDamage.attacker);
 	}
 
-	ctx.pushEffectLog('attack:perform', {
+	context.pushEffectLog('attack:perform', {
 		evaluation: result.evaluation,
 		onDamage: onDamageLogs,
 	});

--- a/packages/engine/src/effects/attack/log.types.ts
+++ b/packages/engine/src/effects/attack/log.types.ts
@@ -1,0 +1,43 @@
+import type { EffectDef } from '..';
+import type { AttackEvaluationTargetLog } from '../attack.types';
+import type { AttackPlayerDiff } from './snapshot_diff';
+
+export interface AttackCalcOptions {
+	ignoreAbsorption?: boolean;
+	ignoreFortification?: boolean;
+}
+
+export type AttackLogOwner = 'attacker' | 'defender';
+
+export interface AttackPowerLog {
+	base: number;
+	modified: number;
+}
+
+export interface AttackEvaluationLog {
+	power: AttackPowerLog;
+	absorption: {
+		ignored: boolean;
+		before: number;
+		damageAfter: number;
+	};
+	fortification: {
+		ignored: boolean;
+		before: number;
+		damage: number;
+		after: number;
+	};
+	target: AttackEvaluationTargetLog;
+}
+
+export interface AttackOnDamageLogEntry {
+	owner: AttackLogOwner;
+	effect: EffectDef;
+	attacker: AttackPlayerDiff[];
+	defender: AttackPlayerDiff[];
+}
+
+export interface AttackLog {
+	evaluation: AttackEvaluationLog;
+	onDamage: AttackOnDamageLogEntry[];
+}

--- a/packages/engine/src/effects/attack/resolve.ts
+++ b/packages/engine/src/effects/attack/resolve.ts
@@ -1,0 +1,160 @@
+import { runEffects } from '..';
+import type { EngineContext } from '../../context';
+import { withStatSourceFrames } from '../../stat_sources';
+import { collectTriggerEffects } from '../../triggers';
+import type { PlayerState } from '../../state';
+import type { AttackTarget } from '../attack.types';
+import {
+	attackTargetHandlers,
+	type AttackTargetHandlerMeta,
+} from '../attack_target_handlers';
+import type { AttackCalcOptions, AttackEvaluationLog } from './log.types';
+
+interface AttackResolution {
+	damageDealt: number;
+	evaluation: AttackEvaluationLog;
+}
+
+function applyAbsorption(
+	damage: number,
+	absorption: number,
+	rounding: 'up' | 'down' | 'nearest',
+): number {
+	if (absorption <= 0) {
+		return damage;
+	}
+
+	const reduced = damage * (1 - absorption);
+
+	if (rounding === 'down') {
+		return Math.floor(reduced);
+	}
+
+	if (rounding === 'up') {
+		return Math.ceil(reduced);
+	}
+
+	return Math.round(reduced);
+}
+
+export function resolveAttack(
+	defender: PlayerState,
+	damage: number,
+	context: EngineContext,
+	target: AttackTarget,
+	options: AttackCalcOptions = {},
+	baseDamage = damage,
+): AttackResolution {
+	const originalIndex = context.game.currentPlayerIndex;
+	const defenderIndex = context.game.players.indexOf(defender);
+
+	context.game.currentPlayerIndex = defenderIndex;
+	const beforeAttackTriggers = collectTriggerEffects(
+		'onBeforeAttacked',
+		context,
+		defender,
+	);
+
+	for (const triggerBundle of beforeAttackTriggers) {
+		withStatSourceFrames(context, triggerBundle.frames, () =>
+			runEffects(triggerBundle.effects, context),
+		);
+	}
+
+	if (beforeAttackTriggers.length > 0) {
+		runEffects(beforeAttackTriggers, context);
+	}
+
+	context.game.currentPlayerIndex = originalIndex;
+
+	const absorption = options.ignoreAbsorption
+		? 0
+		: Math.min(
+				(defender.absorption as number) || 0,
+				context.services.rules.absorptionCapPct,
+			);
+	const damageAfterAbsorption = options.ignoreAbsorption
+		? damage
+		: applyAbsorption(
+				damage,
+				absorption,
+				context.services.rules.absorptionRounding,
+			);
+
+	const fortBefore = (defender.fortificationStrength as number) || 0;
+	const fortDamage = options.ignoreFortification
+		? 0
+		: Math.min(fortBefore, damageAfterAbsorption);
+	const fortAfter = options.ignoreFortification
+		? fortBefore
+		: Math.max(0, fortBefore - fortDamage);
+	if (!options.ignoreFortification) {
+		defender.fortificationStrength = fortAfter;
+	}
+
+	const targetDamage = Math.max(0, damageAfterAbsorption - fortDamage);
+	const handlerMeta: AttackTargetHandlerMeta = {
+		defenderIndex,
+		originalIndex,
+	};
+	const handler = attackTargetHandlers[target.type];
+	const mutation = handler.applyDamage(
+		target as never,
+		targetDamage,
+		context,
+		defender,
+		handlerMeta,
+	);
+	const targetLog = handler.buildLog(
+		target as never,
+		targetDamage,
+		context,
+		defender,
+		handlerMeta,
+		mutation as never,
+	);
+
+	context.game.currentPlayerIndex = defenderIndex;
+	const afterAttackTriggers = collectTriggerEffects(
+		'onAttackResolved',
+		context,
+		defender,
+	);
+
+	for (const triggerBundle of afterAttackTriggers) {
+		withStatSourceFrames(context, triggerBundle.frames, () =>
+			runEffects(triggerBundle.effects, context),
+		);
+	}
+
+	if ((defender.fortificationStrength || 0) < 0) {
+		defender.fortificationStrength = 0;
+	}
+
+	if (afterAttackTriggers.length > 0) {
+		runEffects(afterAttackTriggers, context);
+	}
+
+	context.game.currentPlayerIndex = originalIndex;
+
+	return {
+		damageDealt: targetDamage,
+		evaluation: {
+			power: { base: baseDamage, modified: damage },
+			absorption: {
+				ignored: Boolean(options.ignoreAbsorption),
+				before: absorption,
+				damageAfter: damageAfterAbsorption,
+			},
+			fortification: {
+				ignored: Boolean(options.ignoreFortification),
+				before: fortBefore,
+				damage: fortDamage,
+				after: fortAfter,
+			},
+			target: targetLog,
+		} satisfies AttackEvaluationLog,
+	};
+}
+
+export type { AttackResolution };

--- a/packages/engine/src/effects/attack/snapshot_diff.ts
+++ b/packages/engine/src/effects/attack/snapshot_diff.ts
@@ -1,0 +1,66 @@
+import type { PlayerSnapshot } from '../../log';
+import type { ResourceKey, StatKey } from '../../state';
+
+export interface AttackResourceDiff {
+	type: 'resource';
+	key: ResourceKey;
+	before: number;
+	after: number;
+}
+
+export interface AttackStatDiff {
+	type: 'stat';
+	key: StatKey;
+	before: number;
+	after: number;
+}
+
+export type AttackPlayerDiff = AttackResourceDiff | AttackStatDiff;
+
+export function diffPlayerSnapshots(
+	before: PlayerSnapshot,
+	after: PlayerSnapshot,
+): AttackPlayerDiff[] {
+	const diffs: AttackPlayerDiff[] = [];
+	const resourceKeys = new Set(
+		Object.keys({
+			...before.resources,
+			...after.resources,
+		}),
+	);
+	for (const key of resourceKeys) {
+		const typedKey: ResourceKey = key;
+		const beforeValue = before.resources[typedKey] ?? 0;
+		const afterValue = after.resources[typedKey] ?? 0;
+		if (beforeValue !== afterValue) {
+			diffs.push({
+				type: 'resource',
+				key: typedKey,
+				before: beforeValue,
+				after: afterValue,
+			});
+		}
+	}
+
+	const statKeys = new Set(
+		Object.keys({
+			...before.stats,
+			...after.stats,
+		}),
+	);
+	for (const key of statKeys) {
+		const typedKey: StatKey = key;
+		const beforeValue = before.stats[typedKey] ?? 0;
+		const afterValue = after.stats[typedKey] ?? 0;
+		if (beforeValue !== afterValue) {
+			diffs.push({
+				type: 'stat',
+				key: typedKey,
+				before: beforeValue,
+				after: afterValue,
+			});
+		}
+	}
+
+	return diffs;
+}

--- a/packages/engine/src/effects/resource_add.ts
+++ b/packages/engine/src/effects/resource_add.ts
@@ -1,20 +1,20 @@
 import type { EffectHandler } from '.';
 import type { ResourceKey } from '../state';
 
-export const resourceAdd: EffectHandler = (effect, ctx, mult = 1) => {
+export const resourceAdd: EffectHandler = (effect, context, multiplier = 1) => {
 	const key = effect.params!['key'] as ResourceKey;
 	const amount = effect.params!['amount'] as number;
-	let total = amount * mult;
+	let total = amount * multiplier;
 	if (effect.round === 'up') {
 		total = total >= 0 ? Math.ceil(total) : Math.floor(total);
 	} else if (effect.round === 'down') {
 		total = total >= 0 ? Math.floor(total) : Math.ceil(total);
 	}
-	const current = ctx.activePlayer.resources[key] || 0;
+	const current = context.activePlayer.resources[key] || 0;
 	const newVal = current + total;
-	ctx.activePlayer.resources[key] = newVal < 0 ? 0 : newVal;
+	context.activePlayer.resources[key] = newVal < 0 ? 0 : newVal;
 	if (total > 0) {
-		ctx.recentResourceGains.push({ key, amount: total });
+		context.recentResourceGains.push({ key, amount: total });
 	}
-	ctx.services.handleTieredResourceChange(ctx, key);
+	context.services.handleTieredResourceChange(context, key);
 };

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -16,6 +16,10 @@ export type {
 } from './setup/create_engine';
 export { getActionCosts, getActionRequirements } from './actions/costs';
 export { performAction, simulateAction } from './actions/action_execution';
+export {
+	resolveActionEffects,
+	getActionEffectGroups,
+} from './actions/action_effects';
 export { advance } from './phases/advance';
 export { EngineContext } from './context';
 export { Services, PassiveManager } from './services';
@@ -38,7 +42,12 @@ export type { EvaluatorHandler, EvaluatorDef } from './evaluators';
 export { registerCoreRequirements, RequirementRegistry } from './requirements';
 export type { RequirementHandler, RequirementDef } from './requirements';
 export { validateGameConfig } from './config/schema';
-export type { GameConfig } from './config/schema';
+export type {
+	GameConfig,
+	ActionEffect,
+	ActionEffectGroup,
+	ActionEffectGroupOption,
+} from './config/schema';
 export { resolveAttack } from './effects/attack';
 export type {
 	AttackLog,
@@ -52,7 +61,18 @@ export { applyParamsToEffects } from './utils';
 export { snapshotPlayer } from './log';
 export type { PlayerSnapshot, ActionTrace } from './log';
 export type { PlayerId } from './state';
-export type { ActionParameters as ActionParams } from './actions/action_parameters';
+export type {
+	ActionParameters as ActionParams,
+	ActionChoiceDetail,
+	ActionChoiceMap,
+	ActionChoiceValue,
+} from './actions/action_parameters';
+export type {
+	ResolvedActionEffects,
+	ResolvedActionEffectGroup,
+	ResolvedActionEffectGroupOption,
+	ResolvedActionEffectChoice,
+} from './actions/action_effects';
 export type {
 	AdvanceResult,
 	AdvanceSkip,

--- a/packages/engine/src/registry.ts
+++ b/packages/engine/src/registry.ts
@@ -2,27 +2,37 @@ import type { ZodType } from 'zod';
 
 export class Registry<T> {
 	private map = new Map<string, T>();
+
 	constructor(private schema?: ZodType<T>) {}
+
 	add(id: string, rawValue: unknown) {
 		const value = this.schema ? this.schema.parse(rawValue) : (rawValue as T);
+
 		this.map.set(id, value);
 	}
+
 	get(id: string): T {
 		const value = this.map.get(id);
+
 		if (!value) {
 			throw new Error(`Unknown id: ${id}`);
 		}
+
 		return value;
 	}
+
 	has(id: string): boolean {
 		return this.map.has(id);
 	}
+
 	entries(): [string, T][] {
 		return Array.from(this.map.entries());
 	}
+
 	values(): T[] {
 		return Array.from(this.map.values());
 	}
+
 	keys(): string[] {
 		return Array.from(this.map.keys());
 	}

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -11,6 +11,8 @@ export interface PassiveSummary {
 	id: string;
 	name?: string | undefined;
 	icon?: string | undefined;
+	detail?: string | undefined;
+	meta?: PassiveMetadata | undefined;
 }
 
 type PassiveRecord = PassiveSummary & {
@@ -443,6 +445,13 @@ export class PassiveManager {
 			}
 			if (value.icon !== undefined) {
 				summary.icon = value.icon;
+			}
+			if (value.detail !== undefined) {
+				summary.detail = value.detail;
+			}
+			const meta = clonePassiveMetadata(value.meta);
+			if (meta) {
+				summary.meta = meta;
 			}
 			return summary;
 		});

--- a/packages/engine/tests/actions/effect-groups.test.ts
+++ b/packages/engine/tests/actions/effect-groups.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { performAction, getActionEffectGroups } from '../../src';
+import { createTestEngine } from '../helpers';
+import { createContentFactory } from '../factories/content';
+
+describe('action effect groups', () => {
+	it('throws when required group choice is missing', () => {
+		const content = createContentFactory();
+		const action = content.action({
+			effects: [
+				{
+					group: 'target',
+					label: 'Target resource',
+					options: [
+						{
+							id: 'gain',
+							label: 'Gain resource',
+							effects: [
+								{
+									type: 'resource',
+									method: 'add',
+									params: { key: 'custom-resource', amount: 1 },
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		expect(() => performAction(action.id, ctx)).toThrowError(
+			/Missing choice for action effect group/,
+		);
+	});
+
+	it('applies the selected branch and records action traces', () => {
+		const content = createContentFactory();
+		const action = content.action({
+			effects: [
+				{
+					group: 'target',
+					label: 'Target resource',
+					options: [
+						{
+							id: 'gain',
+							label: 'Gain resource',
+							effects: [
+								{
+									type: 'resource',
+									method: 'add',
+									params: { key: '$resource', amount: '$amount' },
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		const resourceKey = 'custom-resource';
+		ctx.activePlayer.resources[resourceKey] = 0;
+		ctx.activePlayer.ap = 1;
+		const traces = performAction(action.id, ctx, {
+			resource: resourceKey,
+			choices: { target: { option: 'gain', params: { amount: 3 } } },
+		});
+		expect(ctx.activePlayer.resources[resourceKey]).toBe(3);
+		expect(traces).toEqual([]);
+	});
+
+	it('exposes action effect groups for discovery', () => {
+		const content = createContentFactory();
+		const action = content.action({
+			effects: [
+				{
+					group: 'target',
+					label: 'Target resource',
+					options: [
+						{
+							id: 'gain',
+							label: 'Gain resource',
+							effects: [
+								{
+									type: 'resource',
+									method: 'add',
+									params: { key: '$resource', amount: 1 },
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		ctx.activePlayer.ap = 1;
+		const groups = getActionEffectGroups(action.id, ctx, {
+			resource: 'custom-resource',
+		});
+		expect(groups).toHaveLength(1);
+		expect(groups[0]?.id).toBe('target');
+		expect(groups[0]?.options).toHaveLength(1);
+		expect(groups[0]?.options[0]?.id).toBe('gain');
+	});
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import Game from './Game';
 import Menu from './Menu';
 import Overview from './Overview';
@@ -11,52 +11,202 @@ enum Screen {
 	Game = 'game',
 }
 
+const SCREEN_PATHS: Record<Screen, string> = {
+	[Screen.Menu]: '/',
+	[Screen.Overview]: '/overview',
+	[Screen.Tutorial]: '/tutorial',
+	[Screen.Game]: '/game',
+};
+
+const getScreenFromPath = (pathname: string): Screen => {
+	const normalizedPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
+	const screenEntry = Object.entries(SCREEN_PATHS).find(
+		([, path]) => path === normalizedPath,
+	);
+	if (!screenEntry) {
+		return Screen.Menu;
+	}
+	return screenEntry[0] as Screen;
+};
+
+interface HistoryState {
+	screen: Screen;
+	gameKey: number;
+	isDarkModeEnabled: boolean;
+	isDevModeEnabled: boolean;
+}
+
 export default function App() {
 	const [currentScreen, setCurrentScreen] = useState<Screen>(Screen.Menu);
 	const [currentGameKey, setCurrentGameKey] = useState(0);
-	const [isDarkModeEnabled, setIsDarkModeEnabled] = useState(true);
-	const [isDevModeEnabled, setIsDevModeEnabled] = useState(false);
+	const [isDarkMode, setIsDarkMode] = useState(true);
+	const [isDevMode, setIsDevMode] = useState(false);
+
+	const buildHistoryState = useCallback(
+		(overrides?: Partial<HistoryState>): HistoryState => {
+			const {
+				screen: nextScreen = currentScreen,
+				gameKey: nextGameKey = currentGameKey,
+				isDarkModeEnabled: overrideDark,
+				isDevModeEnabled: overrideDev,
+			} = overrides ?? {};
+			const nextDarkMode = overrideDark ?? isDarkMode;
+			const nextDevMode = overrideDev ?? isDevMode;
+
+			return {
+				screen: nextScreen,
+				gameKey: nextGameKey,
+				isDarkModeEnabled: nextDarkMode,
+				isDevModeEnabled: nextDevMode,
+			};
+		},
+		[currentScreen, currentGameKey, isDarkMode, isDevMode],
+	);
+
+	const pushHistoryState = useCallback(
+		(nextState: HistoryState, path: string) => {
+			if (typeof window === 'undefined') {
+				return;
+			}
+			const { history } = window;
+			history.pushState(nextState, '', path);
+		},
+		[],
+	);
+
+	const replaceHistoryState = useCallback(
+		(nextState: HistoryState, path?: string) => {
+			if (typeof window === 'undefined') {
+				return;
+			}
+			const { history, location } = window;
+			history.replaceState(nextState, '', path ?? location.pathname);
+		},
+		[],
+	);
 
 	useEffect(() => {
-		document.documentElement.classList.toggle('dark', isDarkModeEnabled);
-	}, [isDarkModeEnabled]);
+		document.documentElement.classList.toggle('dark', isDarkMode);
+	}, [isDarkMode]);
 
 	useEffect(() => {
-		if (window.location.pathname !== '/') {
-			window.history.replaceState(null, '', '/');
+		if (typeof window === 'undefined') {
+			return;
 		}
+		const { history, location } = window;
+		const initialScreenFromPath = getScreenFromPath(location.pathname);
+		const historyState = history.state as HistoryState | null;
+		const {
+			screen: historyScreen,
+			gameKey: savedGameKey = 0,
+			isDarkModeEnabled: savedDark = true,
+			isDevModeEnabled: savedDev = false,
+		} = historyState ?? {};
+
+		const nextScreen = historyScreen ?? initialScreenFromPath;
+		const derivedState: HistoryState = {
+			screen: nextScreen,
+			gameKey: savedGameKey,
+			isDarkModeEnabled: savedDark,
+			isDevModeEnabled: savedDev,
+		};
+
+		setCurrentScreen(nextScreen);
+		setCurrentGameKey(savedGameKey);
+		setIsDarkMode(savedDark);
+		setIsDevMode(savedDev);
+
+		const targetPath = SCREEN_PATHS[nextScreen];
+		replaceHistoryState(derivedState, targetPath);
+	}, [replaceHistoryState]);
+
+	useEffect(() => {
+		if (typeof window === 'undefined') {
+			return;
+		}
+		const handlePopState = (event: PopStateEvent) => {
+			const state = event.state as HistoryState | null;
+			if (state?.screen) {
+				setCurrentScreen(state.screen);
+				setCurrentGameKey(state.gameKey ?? 0);
+				setIsDarkMode(state.isDarkModeEnabled ?? true);
+				setIsDevMode(state.isDevModeEnabled ?? false);
+			} else {
+				setCurrentScreen(Screen.Menu);
+				setCurrentGameKey(0);
+				setIsDarkMode(true);
+				setIsDevMode(false);
+			}
+		};
+
+		window.addEventListener('popstate', handlePopState);
+		return () => {
+			window.removeEventListener('popstate', handlePopState);
+		};
 	}, []);
 
 	const returnToMenu = () => {
+		const nextState = buildHistoryState({ screen: Screen.Menu });
 		setCurrentScreen(Screen.Menu);
+		pushHistoryState(nextState, SCREEN_PATHS[Screen.Menu]);
 	};
 
 	const toggleDarkMode = () => {
-		setIsDarkModeEnabled((previousDarkMode) => !previousDarkMode);
-	};
-
-	const incrementGameKey = () => {
-		setCurrentGameKey((previousGameKey) => previousGameKey + 1);
+		setIsDarkMode((previousDarkMode) => {
+			const nextDarkMode = !previousDarkMode;
+			replaceHistoryState(
+				buildHistoryState({
+					isDarkModeEnabled: nextDarkMode,
+				}),
+			);
+			return nextDarkMode;
+		});
 	};
 
 	const startStandardGame = () => {
-		setIsDevModeEnabled(false);
-		incrementGameKey();
+		const nextGameKey = currentGameKey + 1;
+		setIsDevMode(false);
+		setCurrentGameKey(nextGameKey);
 		setCurrentScreen(Screen.Game);
+		pushHistoryState(
+			buildHistoryState({
+				screen: Screen.Game,
+				gameKey: nextGameKey,
+				isDevModeEnabled: false,
+			}),
+			SCREEN_PATHS[Screen.Game],
+		);
 	};
 
 	const startDeveloperGame = () => {
-		setIsDevModeEnabled(true);
-		incrementGameKey();
+		const nextGameKey = currentGameKey + 1;
+		setIsDevMode(true);
+		setCurrentGameKey(nextGameKey);
 		setCurrentScreen(Screen.Game);
+		pushHistoryState(
+			buildHistoryState({
+				screen: Screen.Game,
+				gameKey: nextGameKey,
+				isDevModeEnabled: true,
+			}),
+			SCREEN_PATHS[Screen.Game],
+		);
 	};
 
 	const openOverview = () => {
 		setCurrentScreen(Screen.Overview);
+		const overviewState = buildHistoryState({
+			screen: Screen.Overview,
+		});
+		pushHistoryState(overviewState, SCREEN_PATHS[Screen.Overview]);
 	};
 
 	const openTutorial = () => {
 		setCurrentScreen(Screen.Tutorial);
+		const tutorialState = buildHistoryState({
+			screen: Screen.Tutorial,
+		});
+		pushHistoryState(tutorialState, SCREEN_PATHS[Screen.Tutorial]);
 	};
 
 	switch (currentScreen) {
@@ -69,9 +219,9 @@ export default function App() {
 				<Game
 					key={currentGameKey}
 					onExit={returnToMenu}
-					darkMode={isDarkModeEnabled}
+					darkMode={isDarkMode}
 					onToggleDark={toggleDarkMode}
-					devMode={isDevModeEnabled}
+					devMode={isDevMode}
 				/>
 			);
 		case Screen.Menu:

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { GameProvider, useGameEngine } from './state/GameContext';
 import PlayerPanel from './components/player/PlayerPanel';
 import HoverCard from './components/HoverCard';
@@ -8,9 +8,27 @@ import LogPanel from './components/LogPanel';
 import Button from './components/common/Button';
 import TimeControl from './components/common/TimeControl';
 import ErrorToaster from './components/common/ErrorToaster';
+import ConfirmDialog from './components/common/ConfirmDialog';
 
 function GameLayout() {
 	const { ctx, onExit, darkMode, onToggleDark } = useGameEngine();
+	const [isQuitDialogOpen, setQuitDialogOpen] = useState(false);
+	const requestQuit = useCallback(() => {
+		if (!onExit) {
+			return;
+		}
+		setQuitDialogOpen(true);
+	}, [onExit]);
+	const closeDialog = useCallback(() => {
+		setQuitDialogOpen(false);
+	}, []);
+	const confirmExit = useCallback(() => {
+		if (!onExit) {
+			return;
+		}
+		setQuitDialogOpen(false);
+		onExit();
+	}, [onExit]);
 	const [playerHeights, setPlayerHeights] = useState<Record<string, number>>(
 		{},
 	);
@@ -52,7 +70,7 @@ function GameLayout() {
 			<PlayerPanel
 				key={p.id}
 				player={p}
-				className={`flex-1 p-4 ${bgClass}`}
+				className={`grow basis-[calc(50%-1rem)] max-w-[calc(50%-1rem)] p-4 ${bgClass}`}
 				isActive={isActive}
 				onHeightChange={(height) => {
 					handlePlayerHeight(p.id, height);
@@ -67,6 +85,15 @@ function GameLayout() {
 	);
 	return (
 		<div className="relative min-h-screen w-full overflow-hidden bg-gradient-to-br from-amber-100 via-rose-100 to-sky-100 text-slate-900 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 dark:text-slate-100">
+			<ConfirmDialog
+				open={isQuitDialogOpen}
+				title="Leave the battlefield?"
+				description="If you quit now, the current game will end and any progress will be lost. Are you sure you want to retreat?"
+				confirmLabel="Quit game"
+				cancelLabel="Continue playing"
+				onCancel={closeDialog}
+				onConfirm={confirmExit}
+			/>
 			<ErrorToaster />
 			<div className="pointer-events-none absolute inset-0">
 				<div className="absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-amber-300/30 blur-3xl dark:bg-amber-500/20" />
@@ -91,7 +118,7 @@ function GameLayout() {
 								{darkMode ? 'Light Mode' : 'Dark Mode'}
 							</Button>
 							<Button
-								onClick={onExit}
+								onClick={requestQuit}
 								variant="danger"
 								className="rounded-full px-4 py-2 text-sm font-semibold shadow-lg shadow-rose-500/30"
 							>
@@ -103,7 +130,7 @@ function GameLayout() {
 
 				<div className="grid grid-cols-1 gap-y-6 gap-x-6 lg:grid-cols-[minmax(0,1fr)_30rem]">
 					<section className="relative flex min-h-[275px] items-stretch rounded-3xl bg-white/70 shadow-2xl dark:bg-slate-900/70 dark:shadow-slate-900/50 frosted-surface">
-						<div className="flex flex-1 items-stretch overflow-hidden rounded-3xl divide-x divide-white/50 dark:divide-white/10">
+						<div className="flex flex-1 items-stretch gap-6 overflow-hidden rounded-3xl px-6 py-6">
 							{playerPanels}
 						</div>
 					</section>

--- a/packages/web/src/Menu.tsx
+++ b/packages/web/src/Menu.tsx
@@ -153,8 +153,8 @@ function CallToActionSection({
 					</h2>
 					{/* prettier-ignore */}
 					<p className={CTA_DESCRIPTION_CLASS}>
-                                        {CTA_DESCRIPTION_TEXT}
-                                </p>
+						{CTA_DESCRIPTION_TEXT}
+					</p>
 				</div>
 				<div className={CTA_BUTTON_COLUMN_CLASS}>
 					<Button
@@ -178,8 +178,8 @@ function CallToActionSection({
 				<div className={KNOWLEDGE_HEADER_LAYOUT_CLASS}>
 					{/* prettier-ignore */}
 					<div className={KNOWLEDGE_TITLE_CLASS}>
-                                        Learn The Basics
-                                </div>
+						Learn The Basics
+					</div>
 					<div className={KNOWLEDGE_ACTIONS_CLASS}>
 						<Button
 							variant="ghost"

--- a/packages/web/src/components/common/ConfirmDialog.tsx
+++ b/packages/web/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,83 @@
+import { createPortal } from 'react-dom';
+import { useEffect } from 'react';
+import Button from './Button';
+
+interface ConfirmDialogProps {
+	open: boolean;
+	title: string;
+	description: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export default function ConfirmDialog({
+	open,
+	title,
+	description,
+	confirmLabel = 'Confirm',
+	cancelLabel = 'Cancel',
+	onConfirm,
+	onCancel,
+}: ConfirmDialogProps) {
+	useEffect(() => {
+		if (!open || typeof window === 'undefined') {
+			return;
+		}
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				onCancel();
+			}
+			if (event.key === 'Enter') {
+				event.preventDefault();
+				onConfirm();
+			}
+		};
+		window.addEventListener('keydown', handleKeyDown);
+		return () => {
+			window.removeEventListener('keydown', handleKeyDown);
+		};
+	}, [open, onCancel, onConfirm]);
+
+	if (!open || typeof document === 'undefined') {
+		return null;
+	}
+
+	return createPortal(
+		<div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8">
+			<div
+				className="absolute inset-0 bg-slate-900/70 backdrop-blur-sm"
+				onClick={onCancel}
+				aria-hidden
+			/>
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="confirm-dialog-title"
+				className="relative z-10 w-full max-w-md rounded-3xl border border-white/20 bg-gradient-to-br from-white/95 via-white/90 to-white/80 p-8 text-slate-900 shadow-2xl shadow-slate-900/30 dark:border-white/10 dark:from-slate-900/95 dark:via-slate-900/90 dark:to-slate-900/80 dark:text-slate-100"
+			>
+				<div className="absolute -top-10 left-1/2 h-20 w-20 -translate-x-1/2 rounded-full bg-rose-400/30 blur-2xl dark:bg-rose-500/30" />
+				<h2
+					id="confirm-dialog-title"
+					className="text-xl font-semibold tracking-tight"
+				>
+					{title}
+				</h2>
+				<p className="mt-4 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+					{description}
+				</p>
+				<div className="mt-8 flex flex-wrap justify-end gap-3">
+					<Button variant="ghost" onClick={onCancel} className="px-5">
+						{cancelLabel}
+					</Button>
+					<Button variant="danger" onClick={onConfirm} className="px-5">
+						{confirmLabel}
+					</Button>
+				</div>
+			</div>
+		</div>,
+		document.body,
+	);
+}

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -9,6 +9,7 @@ import {
 import { describeEffects, splitSummary } from '../../translation';
 import type {
 	EffectDef,
+	EngineContext,
 	PassiveSummary,
 	PlayerId,
 } from '@kingdom-builder/engine';
@@ -31,11 +32,7 @@ export default function PassiveDisplay({
 	const { ctx, handleHoverCard, clearHoverCard } = useGameEngine();
 	const playerId: PlayerId = player.id;
 	const summaries: PassiveSummary[] = ctx.passives.list(playerId);
-	const defs = ctx.passives.values(playerId) as Array<{
-		id: string;
-		effects?: EffectDef[];
-		onUpkeepPhase?: EffectDef[];
-	}>;
+	const defs = ctx.passives.values(playerId);
 	const defMap = new Map(defs.map((def) => [def.id, def]));
 
 	const buildingIds = Array.from(player.buildings);
@@ -52,9 +49,7 @@ export default function PassiveDisplay({
 				entry,
 			): entry is {
 				summary: PassiveSummary;
-				def: { effects?: EffectDef[]; onUpkeepPhase?: EffectDef[] } & {
-					id: string;
-				};
+				def: ReturnType<EngineContext['passives']['values']>[number];
 			} => {
 				const { summary, def } = entry;
 				if (!def) {
@@ -84,7 +79,11 @@ export default function PassiveDisplay({
 	const getIcon = (
 		summary: PassiveSummary,
 		effects: EffectDef[] | undefined,
+		meta: PassiveSummary['meta'],
 	) => {
+		if (meta?.source?.icon) {
+			return meta.source.icon;
+		}
 		if (summary.icon) {
 			return summary.icon;
 		}
@@ -92,14 +91,60 @@ export default function PassiveDisplay({
 		return ICON_MAP[first?.type as keyof typeof ICON_MAP] ?? PASSIVE_INFO.icon;
 	};
 
+	const resolveRemovalText = (meta: PassiveSummary['meta']) => {
+		if (!meta?.removal) {
+			return undefined;
+		}
+		if (
+			typeof meta.removal.text === 'string' &&
+			meta.removal.text.trim().length > 0
+		) {
+			return meta.removal.text;
+		}
+		if (
+			typeof meta.removal.token === 'string' &&
+			meta.removal.token.trim().length > 0
+		) {
+			return `Removed when ${meta.removal.token}`;
+		}
+		return undefined;
+	};
+
+	const resolveLabel = (
+		summary: PassiveSummary,
+		def: Pick<
+			ReturnType<EngineContext['passives']['values']>[number],
+			'detail' | 'meta'
+		>,
+	) => {
+		const meta = def.meta ?? summary.meta;
+		const labelToken = meta?.source?.labelToken;
+		if (labelToken && labelToken.trim().length > 0) {
+			return labelToken;
+		}
+		if (def.detail && def.detail.trim().length > 0) {
+			return def.detail;
+		}
+		if (summary.detail && summary.detail.trim().length > 0) {
+			return summary.detail;
+		}
+		if (summary.name && summary.name.trim().length > 0) {
+			return summary.name;
+		}
+		return summary.id;
+	};
+
 	const animatePassives = useAnimate<HTMLDivElement>();
 	return (
 		<div
 			ref={animatePassives}
-			className="panel-card flex w-fit items-center gap-3 px-4 py-3 text-lg"
+			className="panel-card flex w-fit flex-col gap-3 px-4 py-3 text-left text-base"
 		>
 			{entries.map(({ summary: passive, def }) => {
-				const icon = getIcon(passive, def.effects);
+				const meta = def.meta ?? passive.meta;
+				const icon = getIcon(passive, def.effects, meta);
+				const label = resolveLabel(passive, def);
+				const removalText = resolveRemovalText(meta);
 				const items = describeEffects(def.effects || [], ctx);
 				const upkeepLabel =
 					PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
@@ -108,24 +153,44 @@ export default function PassiveDisplay({
 					: items;
 				const passiveName = passive.name ?? PASSIVE_INFO.label;
 				return (
-					<span
+					<div
 						key={passive.id}
-						className="hoverable cursor-pointer"
+						className="hoverable cursor-pointer rounded-xl border border-white/50 bg-white/60 p-3 shadow-sm transition hover:border-blue-400/70 hover:bg-white/80 dark:border-white/10 dark:bg-slate-900/50 dark:hover:border-blue-300/60 dark:hover:bg-slate-900/70"
 						onMouseEnter={() => {
 							const { effects, description } = splitSummary(sections);
+							const descriptionEntries = [...(description ?? [])] as ReturnType<
+								typeof splitSummary
+							>['effects'];
+							if (removalText) {
+								descriptionEntries.push(removalText);
+							}
 							handleHoverCard({
 								title: `${icon} ${passiveName || PASSIVE_INFO.label}`,
 								effects,
 								requirements: [],
-								...(description && { description }),
+								...(descriptionEntries.length
+									? { description: descriptionEntries }
+									: {}),
 								bgClass:
 									'bg-gradient-to-br from-white/80 to-white/60 dark:from-slate-900/80 dark:to-slate-900/60',
 							});
 						}}
 						onMouseLeave={clearHoverCard}
 					>
-						{icon}
-					</span>
+						<div className="flex items-start gap-3">
+							<span className="text-2xl leading-none">{icon}</span>
+							<div className="flex flex-col gap-1 text-sm leading-snug">
+								<span className="font-semibold text-slate-700 dark:text-slate-100">
+									{label}
+								</span>
+								{removalText && (
+									<span className="text-xs text-slate-600 dark:text-slate-300">
+										{removalText}
+									</span>
+								)}
+							</div>
+						</div>
+					</div>
 				);
 			})}
 		</div>

--- a/packages/web/src/state/useTimeScale.ts
+++ b/packages/web/src/state/useTimeScale.ts
@@ -1,0 +1,141 @@
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type MutableRefObject,
+} from 'react';
+
+export const TIME_SCALE_OPTIONS = [1, 2, 5, 100] as const;
+export type TimeScale = (typeof TIME_SCALE_OPTIONS)[number];
+const TIME_SCALE_STORAGE_KEY = 'kingdom-builder:time-scale';
+
+function readStoredTimeScale(): TimeScale | null {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+	const raw = window.localStorage.getItem(TIME_SCALE_STORAGE_KEY);
+	if (!raw) {
+		return null;
+	}
+	const parsed = Number(raw);
+	return (TIME_SCALE_OPTIONS as readonly number[]).includes(parsed)
+		? (parsed as TimeScale)
+		: null;
+}
+
+interface UseTimeScaleOptions {
+	devMode: boolean;
+}
+
+export interface TimeScaleControls {
+	timeScale: TimeScale;
+	setTimeScale: (value: TimeScale) => void;
+	clearTrackedTimeout: (id: number) => void;
+	setTrackedTimeout: (handler: () => void, delay: number) => number;
+	clearTrackedInterval: (id: number) => void;
+	setTrackedInterval: (handler: () => void, delay: number) => number;
+	isMountedRef: MutableRefObject<boolean>;
+}
+
+export function useTimeScale({
+	devMode,
+}: UseTimeScaleOptions): TimeScaleControls {
+	const [timeScale, setTimeScaleState] = useState<TimeScale>(() => {
+		if (devMode) {
+			return 100;
+		}
+		const stored = readStoredTimeScale();
+		return stored ?? 1;
+	});
+
+	useEffect(() => {
+		if (devMode) {
+			setTimeScaleState(100);
+			return;
+		}
+		const stored = readStoredTimeScale();
+		setTimeScaleState(stored ?? 1);
+	}, [devMode]);
+
+	const updateTimeScale = useCallback((value: TimeScale) => {
+		setTimeScaleState((prev) => {
+			if (prev === value) {
+				return prev;
+			}
+			if (typeof window !== 'undefined') {
+				const storage = window.localStorage;
+				storage.setItem(TIME_SCALE_STORAGE_KEY, String(value));
+			}
+			return value;
+		});
+	}, []);
+
+	const timeouts = useRef(new Set<number>());
+	const intervals = useRef(new Set<number>());
+	const isMountedRef = useRef(true);
+
+	useEffect(() => {
+		return () => {
+			isMountedRef.current = false;
+			timeouts.current.forEach((id) => {
+				window.clearTimeout(id);
+			});
+			intervals.current.forEach((id) => {
+				window.clearInterval(id);
+			});
+			timeouts.current.clear();
+			intervals.current.clear();
+		};
+	}, []);
+
+	const clearTrackedTimeout = useCallback((id: number) => {
+		window.clearTimeout(id);
+		timeouts.current.delete(id);
+	}, []);
+
+	const setTrackedTimeout = useCallback(
+		(handler: () => void, delay: number) => {
+			const timeoutId = window.setTimeout(() => {
+				timeouts.current.delete(timeoutId);
+				if (!isMountedRef.current) {
+					return;
+				}
+				handler();
+			}, delay);
+			timeouts.current.add(timeoutId);
+			return timeoutId;
+		},
+		[],
+	);
+
+	const clearTrackedInterval = useCallback((id: number) => {
+		window.clearInterval(id);
+		intervals.current.delete(id);
+	}, []);
+
+	const setTrackedInterval = useCallback(
+		(handler: () => void, delay: number) => {
+			const intervalId = window.setInterval(() => {
+				if (!isMountedRef.current) {
+					clearTrackedInterval(intervalId);
+					return;
+				}
+				handler();
+			}, delay);
+			intervals.current.add(intervalId);
+			return intervalId;
+		},
+		[clearTrackedInterval],
+	);
+
+	return {
+		timeScale,
+		setTimeScale: updateTimeScale,
+		clearTrackedTimeout,
+		setTrackedTimeout,
+		clearTrackedInterval,
+		setTrackedInterval,
+		isMountedRef,
+	};
+}

--- a/packages/web/src/translation/effects/evaluators/population.ts
+++ b/packages/web/src/translation/effects/evaluators/population.ts
@@ -1,31 +1,34 @@
-import { POPULATION_ROLES, POPULATION_INFO } from '@kingdom-builder/contents';
+import type { PopulationRoleId } from '@kingdom-builder/contents';
 import { registerEvaluatorFormatter } from '../factory';
+import { resolvePopulationDisplay } from '../helpers';
 
 registerEvaluatorFormatter('population', {
-  summarize: (ev, sub) => {
-    const role = (ev.params as Record<string, string>)?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const info = role ? POPULATION_ROLES[role] : undefined;
-    const icon = info?.icon || POPULATION_INFO.icon;
-    const label = info?.label || role || POPULATION_INFO.label;
-    return sub.map((s) =>
-      typeof s === 'string'
-        ? `${s} per ${icon} ${label}`.trim()
-        : { ...s, title: `${s.title} per ${icon} ${label}`.trim() },
-    );
-  },
-  describe: (ev, sub) => {
-    const role = (ev.params as Record<string, string>)?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const info = role ? POPULATION_ROLES[role] : undefined;
-    const icon = info?.icon || '';
-    const label = info?.label || role || POPULATION_INFO.label;
-    return sub.map((s) =>
-      typeof s === 'string'
-        ? `${s} for each ${icon} ${label}`.trim()
-        : { ...s, title: `${s.title} for each ${icon} ${label}`.trim() },
-    );
-  },
+	summarize: (evaluator, sub) => {
+		const role = (evaluator.params as Record<string, string>)?.['role'] as
+			| PopulationRoleId
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return sub.map((summaryEntry) =>
+			typeof summaryEntry === 'string'
+				? `${summaryEntry} per ${icon} ${label}`.trim()
+				: {
+						...summaryEntry,
+						title: `${summaryEntry.title} per ${icon} ${label}`.trim(),
+					},
+		);
+	},
+	describe: (evaluator, sub) => {
+		const role = (evaluator.params as Record<string, string>)?.['role'] as
+			| PopulationRoleId
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return sub.map((summaryEntry) =>
+			typeof summaryEntry === 'string'
+				? `${summaryEntry} for each ${icon} ${label}`.trim()
+				: {
+						...summaryEntry,
+						title: `${summaryEntry.title} for each ${icon} ${label}`.trim(),
+					},
+		);
+	},
 });

--- a/packages/web/src/translation/effects/formatters/attack.ts
+++ b/packages/web/src/translation/effects/formatters/attack.ts
@@ -6,18 +6,18 @@ import type {
 	EffectDef,
 } from '@kingdom-builder/engine';
 import type { SummaryEntry } from '../../content';
+import { registerEffectFormatter } from '../factory';
 import {
-	registerEffectFormatter,
-	summarizeEffects,
-	describeEffects,
-} from '../factory';
+	buildBaseEntry,
+	summarizeOnDamage,
+	formatDiffEntries,
+	ownerLabel,
+	collectTransferPercents,
+} from './attackFormatterUtils';
 import {
 	resolveAttackTargetFormatter,
 	resolveAttackTargetFormatterFromLogTarget,
-	type AttackTarget,
 	type AttackTargetFormatter,
-	type TargetInfo,
-	type Mode,
 } from './attack/target-formatter';
 
 type AttackOnDamageFormatterArgs = {
@@ -48,141 +48,18 @@ function resolveAttackOnDamageFormatter(
 	);
 }
 
-const DAMAGE_EFFECT_CATEGORIES: Record<
-	string,
-	(item: SummaryEntry, mode: Mode) => SummaryEntry[]
-> = {
-	'action:perform': (item, mode) => [
-		mode === 'summarize' && typeof item !== 'string'
-			? (item as { title: string }).title
-			: item,
-	],
-};
-
-type BaseEntryResult = {
-	entry: SummaryEntry;
-	formatter: AttackTargetFormatter;
-	info: TargetInfo;
-	target: AttackTarget;
-	targetLabel: string;
-};
-
-function categorizeDamageEffects(
-	def: EffectDef,
-	item: SummaryEntry,
-	mode: Mode,
-): { actions: SummaryEntry[]; others: SummaryEntry[] } {
-	const key = `${def.type}:${def.method}`;
-	const handler = DAMAGE_EFFECT_CATEGORIES[key];
-	if (handler) {
-		return { actions: handler(item, mode), others: [] };
-	}
-	return { actions: [], others: [item] };
-}
-
-function ownerLabel(owner: 'attacker' | 'defender') {
-	return owner === 'attacker' ? 'You' : 'Opponent';
-}
-
-function formatDiffEntries(
-	entry: AttackOnDamageLogEntry,
-	formatter: AttackTargetFormatter,
-): SummaryEntry[] {
-	const parts: SummaryEntry[] = [];
-	entry.defender.forEach((diff) =>
-		parts.push(formatter.formatDiff(ownerLabel('defender'), diff)),
-	);
-	entry.attacker.forEach((diff) =>
-		parts.push(formatter.formatDiff(ownerLabel('attacker'), diff)),
-	);
-	return parts;
-}
-
-function buildBaseEntry(
-	eff: EffectDef<Record<string, unknown>>,
-	mode: Mode,
-): BaseEntryResult {
-	const army = STATS[Stat.armyStrength];
-	const absorption = STATS[Stat.absorption];
-	const fort = STATS[Stat.fortificationStrength];
-	const { formatter, target, info, targetLabel } =
-		resolveAttackTargetFormatter(eff);
-	const ignoreAbsorption = Boolean(eff.params?.['ignoreAbsorption']);
-	const ignoreFortification = Boolean(eff.params?.['ignoreFortification']);
-	const entry = formatter.buildBaseEntry({
-		mode,
-		army,
-		absorption,
-		fort,
-		info,
-		target,
-		targetLabel,
-		ignoreAbsorption,
-		ignoreFortification,
-	});
-	return { entry, formatter, info, target, targetLabel };
-}
-
-function summarizeOnDamage(
-	eff: EffectDef<Record<string, unknown>>,
-	ctx: EngineContext,
-	mode: Mode,
-	base: BaseEntryResult,
-): SummaryEntry | null {
-	const onDamage = eff.params?.['onDamage'] as
-		| { attacker?: EffectDef[]; defender?: EffectDef[] }
-		| undefined;
-	if (!onDamage) {
-		return null;
-	}
-	const { formatter, info, target, targetLabel } = base;
-	const format = mode === 'summarize' ? summarizeEffects : describeEffects;
-	const attackerDefs = onDamage.attacker ?? [];
-	const defenderDefs = onDamage.defender ?? [];
-	const attackerEntries = format(attackerDefs, ctx);
-	const defenderEntries = format(defenderDefs, ctx);
-	const items: SummaryEntry[] = [];
-	const actionItems: SummaryEntry[] = [];
-
-	const collect = (
-		defs: EffectDef[],
-		entries: SummaryEntry[],
-		suffix: string,
-	) => {
-		entries.forEach((entry, index) => {
-			const def = defs[index]!;
-			const { actions, others } = categorizeDamageEffects(def, entry, mode);
-			actionItems.push(...actions);
-			others.forEach((other) => {
-				if (typeof other === 'string') {
-					items.push(`${other} ${suffix}`);
-				} else {
-					items.push({ ...other, title: `${other.title} ${suffix}` });
-				}
-			});
-		});
-	};
-
-	collect(defenderDefs, defenderEntries, 'for opponent');
-	collect(attackerDefs, attackerEntries, 'for you');
-
-	const combined = items.concat(actionItems);
-	if (!combined.length) {
-		return null;
-	}
-	return {
-		title: formatter.buildOnDamageTitle(mode, { info, target, targetLabel }),
-		items: combined,
-	};
-}
-
 function fallbackLog(
-	eff: EffectDef<Record<string, unknown>>,
+	effectDefinition: EffectDef<Record<string, unknown>>,
 	ctx: EngineContext,
 ): SummaryEntry[] {
-	const base = buildBaseEntry(eff, 'describe');
-	const onDamage = summarizeOnDamage(eff, ctx, 'describe', base);
-	const parts: SummaryEntry[] = [base.entry];
+	const baseEntry = buildBaseEntry(effectDefinition, 'describe');
+	const onDamage = summarizeOnDamage(
+		effectDefinition,
+		ctx,
+		'describe',
+		baseEntry,
+	);
+	const parts: SummaryEntry[] = [baseEntry.entry];
 	if (onDamage) {
 		parts.push(onDamage);
 	}
@@ -216,32 +93,13 @@ function buildActionLog(
 	const transferPercents = new Map<ResourceKey, number>();
 	if (id) {
 		try {
-			const def = ctx.actions.get(id);
-			icon = def.icon || '';
-			name = def.name;
-			const walk = (effects: EffectDef[] | undefined) => {
-				if (!effects) {
-					return;
-				}
-				for (const eff of effects) {
-					if (
-						eff.type === 'resource' &&
-						eff.method === 'transfer' &&
-						eff.params
-					) {
-						const key =
-							(eff.params['key'] as ResourceKey | undefined) ?? undefined;
-						const pct = eff.params['percent'] as number | undefined;
-						if (key && pct !== undefined && !transferPercents.has(key)) {
-							transferPercents.set(key, pct);
-						}
-					}
-					if (Array.isArray(eff.effects)) {
-						walk(eff.effects as EffectDef[] | undefined);
-					}
-				}
-			};
-			walk(def.effects as EffectDef[] | undefined);
+			const definition = ctx.actions.get(id);
+			icon = definition.icon || '';
+			name = definition.name;
+			collectTransferPercents(
+				definition.effects as EffectDef[] | undefined,
+				transferPercents,
+			);
 		} catch {
 			/* ignore missing action */
 		}
@@ -260,21 +118,22 @@ function buildActionLog(
 			),
 		);
 	});
-	entry.attacker.forEach((diff) =>
-		items.push(formatter.formatDiff(ownerLabel('attacker'), diff)),
-	);
+	entry.attacker.forEach((diff) => {
+		items.push(formatter.formatDiff(ownerLabel('attacker'), diff));
+	});
 	return { title: `Triggered ${icon} ${name}`.trim(), items };
 }
 
 export function buildOnDamageEntry(
 	logEntries: AttackLog['onDamage'],
 	ctx: EngineContext,
-	eff: EffectDef<Record<string, unknown>>,
+	effectDefinition: EffectDef<Record<string, unknown>>,
 ): SummaryEntry | null {
 	if (!logEntries.length) {
 		return null;
 	}
-	const { formatter, info, target } = resolveAttackTargetFormatter(eff);
+	const { formatter, info, target } =
+		resolveAttackTargetFormatter(effectDefinition);
 	const items: SummaryEntry[] = [];
 	const defenderEntries = logEntries.filter(
 		(entry) => entry.owner === 'defender',
@@ -316,44 +175,44 @@ registerAttackOnDamageFormatter(
 			return formatDiffEntries(entry, formatter);
 		}
 		const parts: SummaryEntry[] = [];
-		entry.defender.forEach((diff) =>
+		entry.defender.forEach((diff) => {
 			parts.push(
 				formatter.formatDiff(ownerLabel('defender'), diff, { percent }),
-			),
-		);
-		entry.attacker.forEach((diff) =>
-			parts.push(formatter.formatDiff(ownerLabel('attacker'), diff)),
-		);
+			);
+		});
+		entry.attacker.forEach((diff) => {
+			parts.push(formatter.formatDiff(ownerLabel('attacker'), diff));
+		});
 		return parts;
 	},
 );
 
 registerEffectFormatter('attack', 'perform', {
-	summarize: (eff, ctx) => {
-		const base = buildBaseEntry(eff, 'summarize');
-		const parts: SummaryEntry[] = [base.entry];
-		const onDamage = summarizeOnDamage(eff, ctx, 'summarize', base);
+	summarize: (effect, ctx) => {
+		const baseEntry = buildBaseEntry(effect, 'summarize');
+		const parts: SummaryEntry[] = [baseEntry.entry];
+		const onDamage = summarizeOnDamage(effect, ctx, 'summarize', baseEntry);
 		if (onDamage) {
 			parts.push(onDamage);
 		}
 		return parts;
 	},
-	describe: (eff, ctx) => {
-		const base = buildBaseEntry(eff, 'describe');
-		const parts: SummaryEntry[] = [base.entry];
-		const onDamage = summarizeOnDamage(eff, ctx, 'describe', base);
+	describe: (effect, ctx) => {
+		const baseEntry = buildBaseEntry(effect, 'describe');
+		const parts: SummaryEntry[] = [baseEntry.entry];
+		const onDamage = summarizeOnDamage(effect, ctx, 'describe', baseEntry);
 		if (onDamage) {
 			parts.push(onDamage);
 		}
 		return parts;
 	},
-	log: (eff, ctx) => {
+	log: (effect, ctx) => {
 		const log = ctx.pullEffectLog<AttackLog>('attack:perform');
 		if (!log) {
-			return fallbackLog(eff, ctx);
+			return fallbackLog(effect, ctx);
 		}
 		const entries: SummaryEntry[] = [buildEvaluationEntry(log.evaluation)];
-		const onDamage = buildOnDamageEntry(log.onDamage, ctx, eff);
+		const onDamage = buildOnDamageEntry(log.onDamage, ctx, effect);
 		if (onDamage) {
 			entries.push(onDamage);
 		}

--- a/packages/web/src/translation/effects/formatters/attackFormatterUtils.ts
+++ b/packages/web/src/translation/effects/formatters/attackFormatterUtils.ts
@@ -1,0 +1,188 @@
+import { STATS, Stat, type ResourceKey } from '@kingdom-builder/contents';
+import type {
+	EngineContext,
+	EffectDef,
+	AttackOnDamageLogEntry,
+} from '@kingdom-builder/engine';
+import type { SummaryEntry } from '../../content';
+import { summarizeEffects, describeEffects } from '../factory';
+import {
+	resolveAttackTargetFormatter,
+	type AttackTargetFormatter,
+	type TargetInfo,
+	type AttackTarget,
+	type Mode,
+} from './attack/target-formatter';
+
+type DamageEffectCategorizer = (
+	item: SummaryEntry,
+	mode: Mode,
+) => SummaryEntry[];
+
+const DAMAGE_EFFECT_CATEGORIES: Record<string, DamageEffectCategorizer> = {
+	'action:perform': (item, mode) => [
+		mode === 'summarize' && typeof item !== 'string'
+			? (item as { title: string }).title
+			: item,
+	],
+};
+
+export type BaseEntryResult = {
+	entry: SummaryEntry;
+	formatter: AttackTargetFormatter;
+	info: TargetInfo;
+	target: AttackTarget;
+	targetLabel: string;
+};
+
+export function categorizeDamageEffects(
+	effectDefinition: EffectDef,
+	item: SummaryEntry,
+	mode: Mode,
+): { actions: SummaryEntry[]; others: SummaryEntry[] } {
+	const key = `${effectDefinition.type}:${effectDefinition.method}`;
+	const handler = DAMAGE_EFFECT_CATEGORIES[key];
+	if (handler) {
+		return { actions: handler(item, mode), others: [] };
+	}
+	return { actions: [], others: [item] };
+}
+
+export function ownerLabel(owner: 'attacker' | 'defender'): string {
+	return owner === 'attacker' ? 'You' : 'Opponent';
+}
+
+export function buildBaseEntry(
+	effectDefinition: EffectDef<Record<string, unknown>>,
+	mode: Mode,
+): BaseEntryResult {
+	const army = STATS[Stat.armyStrength];
+	const absorption = STATS[Stat.absorption];
+	const fort = STATS[Stat.fortificationStrength];
+	const { formatter, target, info, targetLabel } =
+		resolveAttackTargetFormatter(effectDefinition);
+	const ignoreAbsorption = Boolean(
+		effectDefinition.params?.['ignoreAbsorption'],
+	);
+	const ignoreFortification = Boolean(
+		effectDefinition.params?.['ignoreFortification'],
+	);
+	const entry = formatter.buildBaseEntry({
+		mode,
+		army,
+		absorption,
+		fort,
+		info,
+		target,
+		targetLabel,
+		ignoreAbsorption,
+		ignoreFortification,
+	});
+	return { entry, formatter, info, target, targetLabel };
+}
+
+export function summarizeOnDamage(
+	effectDefinition: EffectDef<Record<string, unknown>>,
+	ctx: EngineContext,
+	mode: Mode,
+	baseEntry: BaseEntryResult,
+): SummaryEntry | null {
+	const onDamage = effectDefinition.params?.['onDamage'] as
+		| { attacker?: EffectDef[]; defender?: EffectDef[] }
+		| undefined;
+	if (!onDamage) {
+		return null;
+	}
+	const { formatter, info, target, targetLabel } = baseEntry;
+	const format = mode === 'summarize' ? summarizeEffects : describeEffects;
+	const attackerDefs = onDamage.attacker ?? [];
+	const defenderDefs = onDamage.defender ?? [];
+	const attackerEntries = format(attackerDefs, ctx);
+	const defenderEntries = format(defenderDefs, ctx);
+	const items: SummaryEntry[] = [];
+	const actionItems: SummaryEntry[] = [];
+
+	const collect = (
+		defs: EffectDef[],
+		entries: SummaryEntry[],
+		suffix: string,
+	) => {
+		entries.forEach((entry, index) => {
+			const definition = defs[index]!;
+			const { actions, others } = categorizeDamageEffects(
+				definition,
+				entry,
+				mode,
+			);
+			actionItems.push(...actions);
+			others.forEach((other) => {
+				if (typeof other === 'string') {
+					items.push(`${other} ${suffix}`);
+				} else {
+					items.push({
+						...other,
+						title: `${other.title} ${suffix}`,
+					});
+				}
+			});
+		});
+	};
+
+	collect(defenderDefs, defenderEntries, 'for opponent');
+	collect(attackerDefs, attackerEntries, 'for you');
+
+	const combined = items.concat(actionItems);
+	if (!combined.length) {
+		return null;
+	}
+	return {
+		title: formatter.buildOnDamageTitle(mode, {
+			info,
+			target,
+			targetLabel,
+		}),
+		items: combined,
+	};
+}
+
+export function formatDiffEntries(
+	entry: AttackOnDamageLogEntry,
+	formatter: AttackTargetFormatter,
+): SummaryEntry[] {
+	const parts: SummaryEntry[] = [];
+	entry.defender.forEach((diff) =>
+		parts.push(formatter.formatDiff(ownerLabel('defender'), diff)),
+	);
+	entry.attacker.forEach((diff) =>
+		parts.push(formatter.formatDiff(ownerLabel('attacker'), diff)),
+	);
+	return parts;
+}
+
+export function collectTransferPercents(
+	effects: EffectDef[] | undefined,
+	transferPercents: Map<ResourceKey, number>,
+): void {
+	if (!effects) {
+		return;
+	}
+	for (const effectDefinition of effects) {
+		if (
+			effectDefinition.type === 'resource' &&
+			effectDefinition.method === 'transfer' &&
+			effectDefinition.params
+		) {
+			const key =
+				(effectDefinition.params['key'] as ResourceKey | undefined) ??
+				undefined;
+			const percent = effectDefinition.params['percent'] as number | undefined;
+			if (key && percent !== undefined && !transferPercents.has(key)) {
+				transferPercents.set(key, percent);
+			}
+		}
+		if (Array.isArray(effectDefinition.effects)) {
+			const nestedEffects = effectDefinition.effects;
+			collectTransferPercents(nestedEffects, transferPercents);
+		}
+	}
+}

--- a/packages/web/src/translation/effects/formatters/population.ts
+++ b/packages/web/src/translation/effects/formatters/population.ts
@@ -1,44 +1,55 @@
 import { POPULATION_ROLES, POPULATION_INFO } from '@kingdom-builder/contents';
 import { registerEffectFormatter } from '../factory';
+import { resolvePopulationDisplay } from '../helpers';
 
 registerEffectFormatter('population', 'add', {
-  summarize: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const icon = role
-      ? POPULATION_ROLES[role]?.icon || role
-      : POPULATION_INFO.icon;
-    return `${POPULATION_INFO.icon}(${icon}) +1`;
-  },
-  describe: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const info = role ? POPULATION_ROLES[role] : undefined;
-    const label = info?.label || role || POPULATION_INFO.label;
-    const icon = info?.icon || '';
-    return `Add ${icon} ${label}`;
-  },
+	summarize: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const icon = role
+			? POPULATION_ROLES[role]?.icon || role
+			: POPULATION_INFO.icon;
+		return `${POPULATION_INFO.icon}(${icon}) +1`;
+	},
+	describe: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return `Add ${icon} ${label}`;
+	},
+	log: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return `Added ${icon} ${label}`;
+	},
 });
 
 registerEffectFormatter('population', 'remove', {
-  summarize: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const icon = role
-      ? POPULATION_ROLES[role]?.icon || role
-      : POPULATION_INFO.icon;
-    return `${POPULATION_INFO.icon}(${icon}) -1`;
-  },
-  describe: (eff) => {
-    const role = eff.params?.['role'] as
-      | keyof typeof POPULATION_ROLES
-      | undefined;
-    const info = role ? POPULATION_ROLES[role] : undefined;
-    const label = info?.label || role || POPULATION_INFO.label;
-    const icon = info?.icon || '';
-    return `Remove ${icon} ${label}`;
-  },
+	summarize: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const icon = role
+			? POPULATION_ROLES[role]?.icon || role
+			: POPULATION_INFO.icon;
+		return `${POPULATION_INFO.icon}(${icon}) -1`;
+	},
+	describe: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return `Remove ${icon} ${label}`;
+	},
+	log: (eff) => {
+		const role = eff.params?.['role'] as
+			| keyof typeof POPULATION_ROLES
+			| undefined;
+		const { icon, label } = resolvePopulationDisplay(role);
+		return `Removed ${icon} ${label}`;
+	},
 });

--- a/packages/web/src/translation/effects/helpers.ts
+++ b/packages/web/src/translation/effects/helpers.ts
@@ -1,4 +1,20 @@
+import {
+	POPULATION_INFO,
+	POPULATION_ROLES,
+	type PopulationRoleId,
+} from '@kingdom-builder/contents';
+
 export const signed = (n: number): string => (n >= 0 ? '+' : '');
 export const gainOrLose = (n: number): string => (n >= 0 ? 'Gain' : 'Lose');
 export const increaseOrDecrease = (n: number): string =>
-  n >= 0 ? 'Increase' : 'Decrease';
+	n >= 0 ? 'Increase' : 'Decrease';
+
+export function resolvePopulationDisplay(role: PopulationRoleId | undefined): {
+	icon: string;
+	label: string;
+} {
+	const info = role ? POPULATION_ROLES[role] : undefined;
+	const icon = info?.icon || POPULATION_INFO.icon;
+	const label = info?.label || role || POPULATION_INFO.label;
+	return { icon, label };
+}

--- a/packages/web/tests/passive-display.test.tsx
+++ b/packages/web/tests/passive-display.test.tsx
@@ -1,0 +1,80 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import PassiveDisplay from '../src/components/player/PassiveDisplay';
+import { createEngine } from '@kingdom-builder/engine';
+import type { EngineContext } from '@kingdom-builder/engine';
+import {
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	type ResourceKey,
+} from '@kingdom-builder/contents';
+
+vi.mock('@kingdom-builder/engine', async () => {
+	return await import('../../engine/src');
+});
+
+type MockGame = {
+	ctx: EngineContext;
+	handleHoverCard: ReturnType<typeof vi.fn>;
+	clearHoverCard: ReturnType<typeof vi.fn>;
+};
+
+let currentGame: MockGame;
+
+vi.mock('../src/state/GameContext', () => ({
+	useGameEngine: () => currentGame,
+}));
+
+describe('<PassiveDisplay />', () => {
+	it('shows passive labels and removal text from metadata', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		const happinessKey = ctx.services.tieredResource.resourceKey as ResourceKey;
+		ctx.activePlayer.resources[happinessKey] = 6;
+		ctx.services.handleTieredResourceChange(ctx, happinessKey);
+
+		const handleHoverCard = vi.fn();
+		const clearHoverCard = vi.fn();
+		currentGame = {
+			ctx,
+			handleHoverCard,
+			clearHoverCard,
+		} as MockGame;
+
+		render(<PassiveDisplay player={ctx.activePlayer} />);
+
+		const summaryText = screen.getByText(/Income \+25%/i);
+		expect(summaryText).toBeInTheDocument();
+		expect(
+			screen.getByText(/Removed when happiness leaves the \+5 to \+7 range/i),
+		).toBeInTheDocument();
+
+		const hoverTarget = summaryText.closest('div.hoverable');
+		expect(hoverTarget).not.toBeNull();
+		fireEvent.mouseEnter(hoverTarget!);
+		expect(handleHoverCard).toHaveBeenCalled();
+		const [{ description }] = handleHoverCard.mock.calls.at(-1) ?? [{}];
+		expect(description).toEqual(
+			expect.arrayContaining([
+				expect.stringMatching(
+					/Removed when happiness leaves the \+5 to \+7 range/i,
+				),
+			]),
+		);
+	});
+});

--- a/packages/web/tests/resource-bar.test.tsx
+++ b/packages/web/tests/resource-bar.test.tsx
@@ -1,0 +1,87 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import ResourceBar from '../src/components/player/ResourceBar';
+import { createEngine } from '@kingdom-builder/engine';
+import type { EngineContext } from '@kingdom-builder/engine';
+import {
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	RESOURCES,
+	type ResourceKey,
+} from '@kingdom-builder/contents';
+
+vi.mock('@kingdom-builder/engine', async () => {
+	return await import('../../engine/src');
+});
+
+type MockGame = {
+	ctx: EngineContext;
+	handleHoverCard: ReturnType<typeof vi.fn>;
+	clearHoverCard: ReturnType<typeof vi.fn>;
+};
+
+let currentGame: MockGame;
+
+vi.mock('../src/state/GameContext', () => ({
+	useGameEngine: () => currentGame,
+}));
+
+describe('<ResourceBar /> happiness hover card', () => {
+	it('lists happiness tiers and highlights the active threshold', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		const happinessKey = ctx.services.tieredResource.resourceKey as ResourceKey;
+		ctx.activePlayer.resources[happinessKey] = 6;
+		ctx.services.handleTieredResourceChange(ctx, happinessKey);
+
+		const handleHoverCard = vi.fn();
+		const clearHoverCard = vi.fn();
+		currentGame = {
+			ctx,
+			handleHoverCard,
+			clearHoverCard,
+		} as MockGame;
+
+		render(<ResourceBar player={ctx.activePlayer} />);
+
+		const info = RESOURCES[happinessKey];
+		const value = ctx.activePlayer.resources[happinessKey] ?? 0;
+		const button = screen.getByRole('button', {
+			name: `${info.label}: ${value}`,
+		});
+		fireEvent.mouseEnter(button);
+
+		expect(handleHoverCard).toHaveBeenCalled();
+		const call = handleHoverCard.mock.calls.at(-1)?.[0];
+		expect(call).toBeTruthy();
+		expect(call?.title).toBe(`${info.icon} ${info.label}`);
+		expect(call?.description).toEqual([`Current value: ${value}`]);
+		const tiers = call?.effects ?? [];
+		expect(tiers).toHaveLength(ctx.services.rules.tierDefinitions.length);
+		const activeEntry = tiers.find(
+			(entry: unknown) =>
+				typeof entry !== 'string' &&
+				Boolean((entry as { title?: string }).title?.includes('🟢')),
+		) as { items: unknown[] } | undefined;
+		expect(activeEntry).toBeTruthy();
+		const removal = activeEntry?.items.find(
+			(item) => typeof item === 'string' && /Removed when/i.test(item),
+		);
+		expect(removal).toBeTruthy();
+	});
+});

--- a/tests/integration/action-effect-groups.test.ts
+++ b/tests/integration/action-effect-groups.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+	createEngine,
+	performAction,
+	getActionEffectGroups,
+} from '@kingdom-builder/engine';
+import {
+	PHASES,
+	POPULATIONS,
+	GAME_START,
+	RULES,
+	BUILDINGS,
+	DEVELOPMENTS,
+	createBuildingRegistry,
+	createDevelopmentRegistry,
+} from '@kingdom-builder/contents';
+import { logContent } from '@kingdom-builder/web/translation/content';
+import { createContentFactory } from '../../packages/engine/tests/factories/content';
+
+describe('integration: action effect groups', () => {
+	it('requires explicit choices and logs the selected branch', () => {
+		const content = createContentFactory();
+		const action = content.action({
+			name: 'Choose Reward',
+			effects: [
+				{
+					group: 'reward',
+					label: 'Reward',
+					options: [
+						{
+							id: 'gain',
+							label: 'Gain resource',
+							effects: [
+								{
+									type: 'resource',
+									method: 'add',
+									params: { key: '$resource', amount: '$amount' },
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+		const delegate = content.action({
+			name: 'Delegate Reward',
+			effects: [
+				{
+					type: 'action',
+					method: 'perform',
+					params: {
+						id: action.id,
+						resource: '$resource',
+						amount: '$amount',
+						choices: {
+							reward: { option: 'gain', params: { amount: '$amount' } },
+						},
+					},
+				},
+			],
+		});
+
+		const buildings = createBuildingRegistry();
+		for (const [id, def] of BUILDINGS.entries()) buildings.add(id, def);
+		const developments = createDevelopmentRegistry();
+		for (const [id, def] of DEVELOPMENTS.entries()) developments.add(id, def);
+
+		const ctx = createEngine({
+			actions: content.actions,
+			buildings,
+			developments,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+
+		const resourceKey = 'integration-resource';
+		expect(() =>
+			performAction(action.id, ctx, { resource: resourceKey }),
+		).toThrowError(/Missing choice for action effect group/);
+
+		ctx.activePlayer.resources[resourceKey] = 0;
+		ctx.activePlayer.ap = 1;
+		const traces = performAction(action.id, ctx, {
+			resource: resourceKey,
+			choices: { reward: { option: 'gain', params: { amount: 4 } } },
+		});
+		expect(ctx.activePlayer.resources[resourceKey]).toBe(4);
+		expect(Array.isArray(traces)).toBe(true);
+		expect(traces).toEqual([]);
+
+		const groups = getActionEffectGroups(action.id, ctx, {
+			resource: resourceKey,
+		});
+		expect(groups).toHaveLength(1);
+
+		const log = logContent('action', action.id, ctx, {
+			resource: resourceKey,
+			choices: { reward: { option: 'gain', params: { amount: 4 } } },
+		});
+		expect(log.some((line) => line.includes('Chose'))).toBe(true);
+
+		ctx.activePlayer.resources[resourceKey] = 0;
+		ctx.activePlayer.ap = 1;
+		const nestedTraces = performAction(delegate.id, ctx, {
+			resource: resourceKey,
+			amount: 2,
+		});
+		expect(ctx.activePlayer.resources[resourceKey]).toBe(2);
+		expect(nestedTraces).toHaveLength(1);
+		expect(nestedTraces[0]?.id).toBe(action.id);
+	});
+});


### PR DESCRIPTION
## Summary
- add a resolver for action effect groups that parameterizes branches, flattens the chosen effects, and surfaces selection metadata for logging and consumers
- extend engine APIs to validate required action-effect choices, return group definitions, and update cost/validation flows to work on the resolved effect list
- update web translation logging and add integration/unit coverage for effect-group discovery, choice handling, and missing-choice failures

## Testing
- npm run lint
- npm run typecheck
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e0f1e8574883259f420795bd9dd0e5