### PR TITLE
Fix action overview cards layout

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -109,7 +109,9 @@
   }
   .action-card__inner {
     position: relative;
-    height: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
     transition: transform 0.6s cubic-bezier(0.25, 0.8, 0.25, 1);
     transform-style: preserve-3d;
   }
@@ -117,13 +119,12 @@
     transform: rotateY(180deg);
   }
   .action-card__face {
-    position: absolute;
-    inset: 0;
     display: flex;
     flex-direction: column;
     backface-visibility: hidden;
     border-radius: inherit;
     background: transparent;
+    grid-area: 1 / 1;
   }
   .action-card__face--front {
     transform: rotateY(0deg);


### PR DESCRIPTION
## Summary
- update the action card layout CSS to use a grid stack so the faces establish height
- ensure action overview cards remain visible while preserving the flip animation

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e10282d3b083258bb97670d4482b4f