### PR TITLE
Fix time scale toggle applying to ongoing transitions

### DIFF
--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -164,6 +164,7 @@ export function GameProvider({
 		clearTrackedInterval,
 		setTrackedInterval,
 		isMountedRef: mountedRef,
+		timeScaleRef,
 	} = useTimeScale({ devMode });
 
 	const actionCostResource = ctx.actionCostResource as ResourceKey;
@@ -308,7 +309,7 @@ export function GameProvider({
 	}
 
 	function runDelay(total: number) {
-		const scale = timeScale || 1;
+		const scale = timeScaleRef.current || 1;
 		const adjustedTotal = total / scale;
 		if (adjustedTotal <= 0) {
 			if (mountedRef.current) {
@@ -468,7 +469,7 @@ export function GameProvider({
 	const runUntilActionPhase = () => enqueue(runUntilActionPhaseCore);
 
 	function waitWithScale(base: number) {
-		const scale = timeScale || 1;
+		const scale = timeScaleRef.current || 1;
 		const duration = base / scale;
 		if (duration <= 0) {
 			return Promise.resolve();


### PR DESCRIPTION
## Summary
- track the active time scale in a ref so updates are visible to in-flight tasks
- read the ref when scheduling animation delays so phase and log transitions react to speed changes immediately

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e10486baac832587196ca3ff50d877