### PR TITLE
Clarify Market and Mill building descriptions

### DIFF
--- a/packages/web/src/translation/effects/formatters/modifier.ts
+++ b/packages/web/src/translation/effects/formatters/modifier.ts
@@ -84,6 +84,7 @@ registerModifierEvalHandler('population', {
 			eff,
 			evaluation,
 			ctx,
+			false,
 		);
 		return toArray(summary);
 	},
@@ -93,6 +94,7 @@ registerModifierEvalHandler('population', {
 			eff,
 			evaluation,
 			ctx,
+			true,
 		);
 		return toArray(description);
 	},

--- a/packages/web/src/translation/effects/formatters/modifier_helpers.ts
+++ b/packages/web/src/translation/effects/formatters/modifier_helpers.ts
@@ -145,7 +145,7 @@ export function formatDevelopment(
 		return formatGainFrom(label, source, amount, { key, detailed });
 	}
 	const amount = Number(eff.params?.['amount'] ?? 0);
-	return formatGainFrom(label, source, amount);
+	return formatGainFrom(label, source, amount, { detailed });
 }
 
 export function formatPopulation(
@@ -153,6 +153,7 @@ export function formatPopulation(
 	eff: EffectDef,
 	evaluation: { id: string },
 	ctx: EngineContext,
+	detailed: boolean,
 ) {
 	const { icon, name } = getActionInfo(ctx, evaluation.id);
 	const amount = Number(eff.params?.['amount'] ?? 0);
@@ -161,9 +162,13 @@ export function formatPopulation(
 		{
 			summaryTargetIcon: POPULATION_INFO.icon,
 			summaryContextIcon: icon,
-			description: `${POPULATION_INFO.icon} ${POPULATION_INFO.label} through ${icon} ${name}`,
+			description: `${POPULATION_INFO.icon} ${POPULATION_INFO.label} through ${formatTargetLabel(
+				icon,
+				name,
+			)}`,
 		},
 		amount,
+		{ detailed },
 	);
 }
 

--- a/packages/web/tests/raiders-guild-translation.test.ts
+++ b/packages/web/tests/raiders-guild-translation.test.ts
@@ -34,6 +34,26 @@ function createCtx() {
 	});
 }
 
+function collectText(summary: Summary | undefined): string[] {
+	if (!summary) {
+		return [];
+	}
+	const lines: string[] = [];
+	const visit = (entries: Summary) => {
+		for (const entry of entries) {
+			if (typeof entry === 'string') {
+				lines.push(entry);
+				continue;
+			}
+			if (Array.isArray(entry.items)) {
+				visit(entry.items as Summary);
+			}
+		}
+	};
+	visit(summary);
+	return lines;
+}
+
 describe('raiders guild translation', () => {
 	it('describes plunder action', () => {
 		const ctx = createCtx();
@@ -96,5 +116,23 @@ describe('raiders guild translation', () => {
 					: [],
 		);
 		expect(lines).toContain(expected);
+	});
+
+	it('describes market modifier with detailed clause', () => {
+		const ctx = createCtx();
+		const summary = describeContent('building', 'market', ctx);
+		const lines = collectText(summary);
+		expect(lines).toContain(
+			'✨ Result Modifier on 👥 Population through 💰 Tax: Whenever it grants resources, gain 🧺+1 more of that resource',
+		);
+	});
+
+	it('describes mill modifier with detailed clause', () => {
+		const ctx = createCtx();
+		const summary = describeContent('building', 'mill', ctx);
+		const lines = collectText(summary);
+		expect(lines).toContain(
+			'✨ Result Modifier on 🌾 Farm: Whenever it grants resources, gain 🧺+1 more of that resource',
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- ensure development-based result modifiers generate detailed description clauses instead of mirroring summaries
- format population-based result modifiers with detailed descriptions and use them in building translations
- cover Market and Mill description formatting with translation tests

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e105bf519c8325bcd06ee90af33fd2