### PR TITLE
Support resolving action effect groups

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -34,7 +34,6 @@ import {
 	transferParams,
 	actionEffectGroup,
 	actionEffectGroupOption,
-	type ActionEffectGroupDef,
 } from './config/builders';
 import type { Focus } from './defs';
 
@@ -42,7 +41,6 @@ export interface ActionDef extends ActionConfig {
 	category?: string;
 	order?: number;
 	focus?: Focus;
-	effectGroups?: ActionEffectGroupDef[];
 }
 
 export function createActionRegistry() {

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -1,5 +1,8 @@
 import type {
 	ActionConfig,
+	ActionEffect,
+	ActionEffectGroup,
+	ActionEffectGroupOption,
 	BuildingConfig,
 	DevelopmentConfig,
 	PopulationConfig,
@@ -126,24 +129,16 @@ function resolveEffectConfig(effect: EffectConfig | EffectBuilder) {
 	return effect instanceof EffectBuilder ? effect.build() : effect;
 }
 
-export interface ActionEffectGroupOptionDef {
-	id: string;
-	label: string;
-	icon?: string;
-	summary?: string;
-	description?: string;
-	actionId: string;
-	params?: Record<string, unknown>;
-}
+export type ActionEffectGroupOptionDef = ActionEffectGroupOption;
 
 class ActionEffectGroupOptionBuilder extends ParamsBuilder<{
 	id?: string;
 	label?: string;
-	icon?: string;
-	summary?: string;
-	description?: string;
+	icon?: string | undefined;
+	summary?: string | undefined;
+	description?: string | undefined;
 	actionId?: string;
-	params?: Record<string, unknown>;
+	params?: Record<string, unknown> | undefined;
 }> {
 	constructor(id?: string) {
 		super();
@@ -211,7 +206,7 @@ class ActionEffectGroupOptionBuilder extends ParamsBuilder<{
 		return this;
 	}
 
-	override build() {
+	override build(): ActionEffectGroupOptionDef {
 		if (!this.wasSet('id')) {
 			throw new Error(
 				'Action effect group option is missing id(). Call id("your-option-id") before build().',
@@ -235,14 +230,7 @@ export function actionEffectGroupOption(id?: string) {
 	return new ActionEffectGroupOptionBuilder(id);
 }
 
-export interface ActionEffectGroupDef {
-	id: string;
-	title: string;
-	summary?: string;
-	description?: string;
-	icon?: string;
-	options: ActionEffectGroupOptionDef[];
-}
+export type ActionEffectGroupDef = ActionEffectGroup;
 
 class ActionEffectGroupBuilder {
 	private config: Partial<ActionEffectGroupDef> & {
@@ -1531,9 +1519,7 @@ class BaseBuilder<T extends { id: string; name: string }> {
 	}
 }
 
-type ActionBuilderConfig = ActionConfig & {
-	effectGroups?: ActionEffectGroupDef[];
-};
+type ActionBuilderConfig = ActionConfig;
 
 export class ActionBuilder extends BaseBuilder<ActionBuilderConfig> {
 	private readonly effectGroupIds = new Set<string>();
@@ -1570,8 +1556,7 @@ export class ActionBuilder extends BaseBuilder<ActionBuilderConfig> {
 			);
 		}
 		this.effectGroupIds.add(built.id);
-		this.config.effectGroups = this.config.effectGroups || [];
-		this.config.effectGroups.push(built);
+		this.config.effects.push(built as ActionEffect);
 		return this;
 	}
 	system(flag = true) {

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -14,6 +14,7 @@ import {
 	happinessTier,
 	tierPassive,
 } from '../src/config/builders';
+import type { ActionEffectGroupDef } from '../src/config/builders';
 import { RESOURCES, type ResourceKey } from '../src/resources';
 import { STATS, type StatKey } from '../src/stats';
 import { describe, expect, it } from 'vitest';
@@ -120,21 +121,22 @@ describe('content builder safeguards', () => {
 			)
 			.build();
 
-		expect(built.effectGroups).toEqual([
-			{
-				id: 'choose',
-				title: 'Pick a project',
-				summary: 'Choose one follow-up action to resolve immediately.',
-				options: [
-					{
-						id: 'farm',
-						label: 'Farm',
-						actionId: 'develop',
-						params: { id: 'farm', landId: '$landId' },
-					},
-				],
-			},
-		]);
+		expect(built.effects).toHaveLength(1);
+		expect('options' in built.effects[0]).toBe(true);
+		const group = built.effects[0] as ActionEffectGroupDef;
+		expect(group).toEqual({
+			id: 'choose',
+			title: 'Pick a project',
+			summary: 'Choose one follow-up action to resolve immediately.',
+			options: [
+				{
+					id: 'farm',
+					label: 'Farm',
+					actionId: 'develop',
+					params: { id: 'farm', landId: '$landId' },
+				},
+			],
+		});
 	});
 
 	it('prevents mixing amount and percent for resource changes', () => {

--- a/packages/engine/src/actions/costs.ts
+++ b/packages/engine/src/actions/costs.ts
@@ -1,4 +1,3 @@
-import { applyParamsToEffects } from '../utils';
 import { EFFECT_COST_COLLECTORS } from '../effects';
 import { runRequirement } from '../requirements';
 import type { EffectDef } from '../effects';
@@ -6,6 +5,7 @@ import type { EngineContext } from '../context';
 import type { CostBag } from '../services';
 import type { PlayerState } from '../state';
 import type { ActionParameters } from './action_parameters';
+import { resolveActionEffects } from './effect_groups';
 
 function cloneCostBag(costBag: CostBag): CostBag {
 	return { ...costBag };
@@ -56,11 +56,17 @@ export function getActionCosts<T extends string>(
 ): CostBag {
 	const actionDefinition = engineContext.actions.get(actionId);
 	const baseCosts = cloneCostBag(actionDefinition.baseCosts || {});
-	const resolvedEffects = applyParamsToEffects(
-		actionDefinition.effects,
-		params || {},
-	);
-	applyEffectCostCollectors(resolvedEffects, baseCosts, engineContext);
+	const resolved = resolveActionEffects(actionDefinition, params);
+	if (resolved.missingSelections.length > 0) {
+		const formatted = resolved.missingSelections
+			.map((id) => `"${id}"`)
+			.join(', ');
+		const suffix = resolved.missingSelections.length > 1 ? 'groups' : 'group';
+		throw new Error(
+			`Action ${actionDefinition.id} requires a selection for effect ${suffix} ${formatted}`,
+		);
+	}
+	applyEffectCostCollectors(resolved.effects, baseCosts, engineContext);
 	const finalCosts = applyCostsWithPassives(
 		actionDefinition.id,
 		baseCosts,

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 import type { EffectDef } from '../effects';
 
 const requirementSchema = z.object({
-  type: z.string(),
-  method: z.string(),
-  params: z.record(z.unknown()).optional(),
-  message: z.string().optional(),
+	type: z.string(),
+	method: z.string(),
+	params: z.record(z.unknown()).optional(),
+	message: z.string().optional(),
 });
 
 export type RequirementConfig = z.infer<typeof requirementSchema>;
@@ -14,130 +14,160 @@ export type RequirementConfig = z.infer<typeof requirementSchema>;
 const costBagSchema = z.record(z.string(), z.number());
 
 const evaluatorSchema = z.object({
-  type: z.string(),
-  params: z.record(z.unknown()).optional(),
+	type: z.string(),
+	params: z.record(z.unknown()).optional(),
 });
 
 // Effect
 export const effectSchema: z.ZodType<EffectDef> = z.lazy(() =>
-  z.object({
-    type: z.string().optional(),
-    method: z.string().optional(),
-    params: z.record(z.unknown()).optional(),
-    effects: z.array(effectSchema).optional(),
-    evaluator: evaluatorSchema.optional(),
-    round: z.enum(['up', 'down']).optional(),
-    meta: z.record(z.unknown()).optional(),
-  }),
+	z.object({
+		type: z.string().optional(),
+		method: z.string().optional(),
+		params: z.record(z.unknown()).optional(),
+		effects: z.array(effectSchema).optional(),
+		evaluator: evaluatorSchema.optional(),
+		round: z.enum(['up', 'down']).optional(),
+		meta: z.record(z.unknown()).optional(),
+	}),
 );
 
 export type EffectConfig = EffectDef;
 
+const actionEffectGroupOptionSchema = z.object({
+	id: z.string(),
+	label: z.string(),
+	icon: z.string().optional(),
+	summary: z.string().optional(),
+	description: z.string().optional(),
+	actionId: z.string(),
+	params: z.record(z.unknown()).optional(),
+});
+
+export const actionEffectGroupSchema = z.object({
+	id: z.string(),
+	title: z.string(),
+	summary: z.string().optional(),
+	description: z.string().optional(),
+	icon: z.string().optional(),
+	options: z.array(actionEffectGroupOptionSchema).min(1),
+});
+
+export const actionEffectSchema = z.union([
+	effectSchema,
+	actionEffectGroupSchema,
+]);
+
+export type ActionEffectGroupOption = z.infer<
+	typeof actionEffectGroupOptionSchema
+>;
+export type ActionEffectGroup = z.infer<typeof actionEffectGroupSchema>;
+export type ActionEffect = z.infer<typeof actionEffectSchema>;
+
 // Action
 export const actionSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  baseCosts: costBagSchema.optional(),
-  requirements: z.array(requirementSchema).optional(),
-  effects: z.array(effectSchema),
-  system: z.boolean().optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	baseCosts: costBagSchema.optional(),
+	requirements: z.array(requirementSchema).optional(),
+	effects: z.array(actionEffectSchema),
+	system: z.boolean().optional(),
 });
 
 export type ActionConfig = z.infer<typeof actionSchema>;
 
 // Building
 export const buildingSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  costs: costBagSchema,
-  upkeep: costBagSchema.optional(),
-  onBuild: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onUpkeepPhase: z.array(effectSchema).optional(),
-  onBeforeAttacked: z.array(effectSchema).optional(),
-  onAttackResolved: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	costs: costBagSchema,
+	upkeep: costBagSchema.optional(),
+	onBuild: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onUpkeepPhase: z.array(effectSchema).optional(),
+	onBeforeAttacked: z.array(effectSchema).optional(),
+	onAttackResolved: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type BuildingConfig = z.infer<typeof buildingSchema>;
 
 // Development
 export const developmentSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  upkeep: costBagSchema.optional(),
-  onBuild: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onBeforeAttacked: z.array(effectSchema).optional(),
-  onAttackResolved: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
-  system: z.boolean().optional(),
-  populationCap: z.number().optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	upkeep: costBagSchema.optional(),
+	onBuild: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onBeforeAttacked: z.array(effectSchema).optional(),
+	onAttackResolved: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
+	system: z.boolean().optional(),
+	populationCap: z.number().optional(),
 });
 
 export type DevelopmentConfig = z.infer<typeof developmentSchema>;
 
 // Population
 export const populationSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  icon: z.string().optional(),
-  upkeep: costBagSchema.optional(),
-  onAssigned: z.array(effectSchema).optional(),
-  onUnassigned: z.array(effectSchema).optional(),
-  onGrowthPhase: z.array(effectSchema).optional(),
-  onUpkeepPhase: z.array(effectSchema).optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	id: z.string(),
+	name: z.string(),
+	icon: z.string().optional(),
+	upkeep: costBagSchema.optional(),
+	onAssigned: z.array(effectSchema).optional(),
+	onUnassigned: z.array(effectSchema).optional(),
+	onGrowthPhase: z.array(effectSchema).optional(),
+	onUpkeepPhase: z.array(effectSchema).optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 export type PopulationConfig = z.infer<typeof populationSchema>;
 
 // Game config
 const landStartSchema = z.object({
-  developments: z.array(z.string()).optional(),
-  slotsMax: z.number().optional(),
-  slotsUsed: z.number().optional(),
-  tilled: z.boolean().optional(),
-  upkeep: costBagSchema.optional(),
-  onPayUpkeepStep: z.array(effectSchema).optional(),
-  onGainIncomeStep: z.array(effectSchema).optional(),
-  onGainAPStep: z.array(effectSchema).optional(),
+	developments: z.array(z.string()).optional(),
+	slotsMax: z.number().optional(),
+	slotsUsed: z.number().optional(),
+	tilled: z.boolean().optional(),
+	upkeep: costBagSchema.optional(),
+	onPayUpkeepStep: z.array(effectSchema).optional(),
+	onGainIncomeStep: z.array(effectSchema).optional(),
+	onGainAPStep: z.array(effectSchema).optional(),
 });
 
 const playerStartSchema = z.object({
-  resources: z.record(z.string(), z.number()).optional(),
-  stats: z.record(z.string(), z.number()).optional(),
-  population: z.record(z.string(), z.number()).optional(),
-  lands: z.array(landStartSchema).optional(),
+	resources: z.record(z.string(), z.number()).optional(),
+	stats: z.record(z.string(), z.number()).optional(),
+	population: z.record(z.string(), z.number()).optional(),
+	lands: z.array(landStartSchema).optional(),
 });
 
 export const startConfigSchema = z.object({
-  player: playerStartSchema,
-  players: z.record(z.string(), playerStartSchema).optional(),
+	player: playerStartSchema,
+	players: z.record(z.string(), playerStartSchema).optional(),
 });
 
 export type PlayerStartConfig = z.infer<typeof playerStartSchema>;
 export type StartConfig = z.infer<typeof startConfigSchema>;
 
 export const gameConfigSchema = z.object({
-  start: startConfigSchema.optional(),
-  actions: z.array(actionSchema).optional(),
-  buildings: z.array(buildingSchema).optional(),
-  developments: z.array(developmentSchema).optional(),
-  populations: z.array(populationSchema).optional(),
+	start: startConfigSchema.optional(),
+	actions: z.array(actionSchema).optional(),
+	buildings: z.array(buildingSchema).optional(),
+	developments: z.array(developmentSchema).optional(),
+	populations: z.array(populationSchema).optional(),
 });
 
 export type GameConfig = z.infer<typeof gameConfigSchema>;
 
 export function validateGameConfig(config: unknown): GameConfig {
-  return gameConfigSchema.parse(config);
+	return gameConfigSchema.parse(config);
 }

--- a/packages/engine/src/effects/action_perform.ts
+++ b/packages/engine/src/effects/action_perform.ts
@@ -1,19 +1,29 @@
 import type { EffectHandler } from '.';
-import { applyParamsToEffects } from '../utils';
 import { runEffects } from '.';
 import { snapshotPlayer } from '../log';
 import { withStatSourceFrames } from '../stat_sources';
+import { resolveActionEffects } from '../actions/effect_groups';
+import type { ActionParameters } from '../actions/action_parameters';
 
 export const actionPerform: EffectHandler = (effect, ctx, mult = 1) => {
 	const id = effect.params?.['id'] as string;
 	if (!id) {
 		throw new Error('action:perform requires id');
 	}
-	const params = effect.params as Record<string, unknown>;
+	const params = effect.params as ActionParameters<string> | undefined;
 	for (let i = 0; i < Math.floor(mult); i++) {
 		const def = ctx.actions.get(id);
 		const before = snapshotPlayer(ctx.activePlayer, ctx);
-		const resolved = applyParamsToEffects(def.effects, params);
+		const resolved = resolveActionEffects(def, params);
+		if (resolved.missingSelections.length > 0) {
+			const formatted = resolved.missingSelections
+				.map((selection) => `"${selection}"`)
+				.join(', ');
+			const suffix = resolved.missingSelections.length > 1 ? 'groups' : 'group';
+			throw new Error(
+				`Action ${def.id} requires a selection for effect ${suffix} ${formatted}`,
+			);
+		}
 		withStatSourceFrames(
 			ctx,
 			(_effect, _ctx, statKey) => ({
@@ -24,7 +34,7 @@ export const actionPerform: EffectHandler = (effect, ctx, mult = 1) => {
 				longevity: 'permanent',
 			}),
 			() => {
-				runEffects(resolved, ctx);
+				runEffects(resolved.effects, ctx);
 				ctx.passives.runResultMods(def.id, ctx);
 			},
 		);

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -19,10 +19,14 @@ export { performAction, simulateAction } from './actions/action_execution';
 export {
 	getActionEffectGroups,
 	coerceActionEffectGroupChoices,
+	resolveActionEffects,
 	type ActionEffectGroup,
 	type ActionEffectGroupOption,
 	type ActionEffectGroupChoice,
 	type ActionEffectGroupChoiceMap,
+	type ResolvedActionEffects,
+	type ResolvedActionEffectGroup,
+	type ResolvedActionEffectGroupOption,
 } from './actions/effect_groups';
 export { advance } from './phases/advance';
 export { EngineContext } from './context';
@@ -46,7 +50,11 @@ export type { EvaluatorHandler, EvaluatorDef } from './evaluators';
 export { registerCoreRequirements, RequirementRegistry } from './requirements';
 export type { RequirementHandler, RequirementDef } from './requirements';
 export { validateGameConfig } from './config/schema';
-export type { GameConfig } from './config/schema';
+export type {
+	GameConfig,
+	ActionEffect,
+	ActionEffectGroup as ActionEffectGroupConfig,
+} from './config/schema';
 export { resolveAttack } from './effects/attack';
 export type {
 	AttackLog,

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -12,6 +12,7 @@ import {
 	simulateAction,
 	advance,
 	getActionCosts,
+	resolveActionEffects,
 	type EngineContext,
 	type ActionParams,
 } from '@kingdom-builder/engine';
@@ -515,10 +516,11 @@ export function GameProvider({
 
 			const after = snapshotPlayer(player, ctx);
 			const stepDef = ctx.actions.get(action.id);
+			const resolvedStep = resolveActionEffects(stepDef, params);
 			const changes = diffStepSnapshots(
 				before,
 				after,
-				stepDef,
+				resolvedStep,
 				ctx,
 				RESOURCE_KEYS,
 			);
@@ -546,10 +548,11 @@ export function GameProvider({
 			const subLines: string[] = [];
 			for (const trace of traces) {
 				const subStep = ctx.actions.get(trace.id);
+				const subResolved = resolveActionEffects(subStep);
 				const subChanges = diffStepSnapshots(
 					trace.before,
 					trace.after,
-					subStep,
+					subResolved,
 					ctx,
 					RESOURCE_KEYS,
 				);

--- a/packages/web/src/translation/content/actionLogHooks.ts
+++ b/packages/web/src/translation/content/actionLogHooks.ts
@@ -1,4 +1,9 @@
-import type { EngineContext, EffectDef } from '@kingdom-builder/engine';
+import type {
+	EngineContext,
+	EffectDef,
+	ActionEffect,
+	ActionEffectGroup,
+} from '@kingdom-builder/engine';
 import type { ActionConfig } from '@kingdom-builder/engine/config/schema';
 import { logContent } from './factory';
 
@@ -25,14 +30,24 @@ export function registerActionLogHookResolver(
 	derivedCache.clear();
 }
 
+function isEffectGroup(effect: ActionEffect): effect is ActionEffectGroup {
+	return Boolean(effect && typeof effect === 'object' && 'options' in effect);
+}
+
 function findEffect(
-	effects: EffectDef[] | undefined,
+	effects: ActionEffect[] | undefined,
 	predicate: (effect: EffectDef) => boolean,
 ): EffectDef | undefined {
 	if (!effects) {
 		return undefined;
 	}
 	for (const effect of effects) {
+		if (!effect || typeof effect !== 'object') {
+			continue;
+		}
+		if (isEffectGroup(effect)) {
+			continue;
+		}
 		if (predicate(effect)) {
 			return effect;
 		}

--- a/packages/web/src/translation/effects/formatters/action.ts
+++ b/packages/web/src/translation/effects/formatters/action.ts
@@ -1,4 +1,7 @@
-import type { EngineContext } from '@kingdom-builder/engine';
+import {
+	resolveActionEffects,
+	type EngineContext,
+} from '@kingdom-builder/engine';
 import { describeContent } from '../../content';
 import { registerEffectFormatter, logEffects } from '../factory';
 
@@ -114,7 +117,8 @@ registerEffectFormatter('action', 'perform', {
 		}
 		const { icon, name } = getActionLabel(id, ctx);
 		const def = ctx.actions.get(id);
-		const sub = logEffects(def.effects, ctx);
+		const resolved = resolveActionEffects(def);
+		const sub = logEffects(resolved.effects, ctx);
 		return [{ title: `${icon} ${name}`, items: sub }];
 	},
 });

--- a/tests/integration/action-effect-groups.test.ts
+++ b/tests/integration/action-effect-groups.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import {
+	advance,
+	getActionCosts,
+	performAction,
+	resolveActionEffects,
+} from '@kingdom-builder/engine';
+import { logContent } from '@kingdom-builder/web/translation/content';
+import { Resource } from '@kingdom-builder/contents';
+import { createTestEngine } from '../../packages/engine/tests/helpers';
+import { Registry } from '@kingdom-builder/engine/registry';
+import type { ActionConfig } from '@kingdom-builder/engine/config/schema';
+import {
+	actionEffectGroup,
+	actionEffectGroupOption,
+} from '../../packages/contents/src/config/builders';
+import type { ActionEffectGroup } from '@kingdom-builder/engine';
+
+describe('action effect groups integration', () => {
+	function setup() {
+		const rewardAmount = 4;
+		const rewardAction: ActionConfig = {
+			id: 'reward_action',
+			name: 'Grant Gold',
+			baseCosts: { [Resource.ap]: 0 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: Resource.gold, amount: rewardAmount },
+				},
+			],
+		};
+		const alternateAction: ActionConfig = {
+			id: 'mood_action',
+			name: 'Lift Morale',
+			baseCosts: { [Resource.ap]: 0 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: Resource.happiness, amount: 1 },
+				},
+			],
+		};
+		const group: ActionEffectGroup = actionEffectGroup('reward_group')
+			.title('Select decree')
+			.option(
+				actionEffectGroupOption('gold_reward')
+					.label('Grant gold')
+					.action(rewardAction.id),
+			)
+			.option(
+				actionEffectGroupOption('mood_reward')
+					.label('Lift morale')
+					.action(alternateAction.id),
+			)
+			.build();
+		const chooser: ActionConfig = {
+			id: 'royal_directive',
+			name: 'Royal directive',
+			baseCosts: { [Resource.ap]: 0 },
+			effects: [group],
+		};
+		const actions = new Registry<ActionConfig>();
+		actions.add(rewardAction.id, rewardAction);
+		actions.add(alternateAction.id, alternateAction);
+		actions.add(chooser.id, chooser);
+		const ctx = createTestEngine({ actions });
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		const stored = ctx.actions.get(chooser.id);
+		if (!stored.effects.some((effect) => 'options' in (effect as object))) {
+			throw new Error('Test setup failed: action lacks effect group entry');
+		}
+		const unresolved = resolveActionEffects(stored);
+		if (unresolved.missingSelections.length === 0) {
+			throw new Error(
+				'Test setup failed: effect group should require a choice',
+			);
+		}
+		ctx.activePlayer.resources[Resource.ap] = 5;
+		ctx.activePlayer.resources[Resource.gold] = 0;
+		ctx.activePlayer.resources[Resource.happiness] = 0;
+		return { ctx, chooser, group, rewardAmount };
+	}
+
+	it('requires explicit selections for effect groups', () => {
+		const { ctx, chooser, group } = setup();
+		expect(() => getActionCosts(chooser.id, ctx)).toThrowError(
+			new RegExp(`requires a selection for effect group`),
+		);
+		expect(() => performAction(chooser.id, ctx)).toThrowError(
+			new RegExp(group.id),
+		);
+	});
+
+	it('applies chosen option effects and preserves action traces', () => {
+		const { ctx, chooser, group, rewardAmount } = setup();
+		const params = {
+			choices: {
+				[group.id]: { optionId: 'gold_reward' },
+			},
+		} as const;
+		const beforeGold = ctx.activePlayer.resources[Resource.gold];
+		const traces = performAction(chooser.id, ctx, params);
+		expect(ctx.activePlayer.resources[Resource.gold]).toBe(
+			beforeGold + rewardAmount,
+		);
+		expect(traces).toHaveLength(1);
+		const trace = traces[0];
+		const delta =
+			(trace.after.resources[Resource.gold] ?? 0) -
+			(trace.before.resources[Resource.gold] ?? 0);
+		expect(delta).toBe(rewardAmount);
+	});
+
+	it('exposes effect groups for logging and summaries', () => {
+		const { ctx, chooser, group } = setup();
+		const resolved = resolveActionEffects(chooser, {
+			choices: { [group.id]: { optionId: 'mood_reward' } },
+		});
+		expect(resolved.groups).toHaveLength(1);
+		expect(resolved.groups[0]?.group.id).toBe(group.id);
+		const lines = logContent('action', chooser.id, ctx, {
+			choices: { [group.id]: { optionId: 'mood_reward' } },
+		});
+		const serialized = lines.join('\n');
+		expect(serialized).toContain('Lift morale');
+	});
+});

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -1,183 +1,184 @@
-import { createEngine, getActionCosts } from '@kingdom-builder/engine';
 import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
-  RESOURCES,
+	createEngine,
+	getActionCosts,
+	resolveActionEffects,
+} from '@kingdom-builder/engine';
+import {
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	RESOURCES,
 } from '@kingdom-builder/contents';
 import type { EngineContext, EffectDef } from '@kingdom-builder/engine';
 import { PlayerState, Land } from '@kingdom-builder/engine/state';
 import { runEffects } from '@kingdom-builder/engine/effects';
 
 function deepClone<T>(value: T): T {
-  return structuredClone(value);
+	return structuredClone(value);
 }
 
 function clonePlayer(player: PlayerState) {
-  const copy = new PlayerState(player.id, player.name);
-  copy.resources = deepClone(player.resources);
-  copy.stats = deepClone(player.stats);
-  copy.population = deepClone(player.population);
-  copy.lands = player.lands.map((landState) => {
-    const newLand = new Land(landState.id, landState.slotsMax);
-    newLand.slotsUsed = landState.slotsUsed;
-    newLand.developments = [...landState.developments];
-    return newLand;
-  });
-  copy.buildings = new Set([...player.buildings]);
-  return copy;
+	const copy = new PlayerState(player.id, player.name);
+	copy.resources = deepClone(player.resources);
+	copy.stats = deepClone(player.stats);
+	copy.population = deepClone(player.population);
+	copy.lands = player.lands.map((landState) => {
+		const newLand = new Land(landState.id, landState.slotsMax);
+		newLand.slotsUsed = landState.slotsUsed;
+		newLand.developments = [...landState.developments];
+		return newLand;
+	});
+	copy.buildings = new Set([...player.buildings]);
+	return copy;
 }
 
 export function createTestContext(
-  overrides?: Partial<Record<keyof typeof RESOURCES, number>>,
+	overrides?: Partial<Record<keyof typeof RESOURCES, number>>,
 ) {
-  const ctx = createEngine({
-    actions: ACTIONS,
-    buildings: BUILDINGS,
-    developments: DEVELOPMENTS,
-    populations: POPULATIONS,
-    phases: PHASES,
-    start: GAME_START,
-    rules: RULES,
-  });
-  if (overrides) {
-    for (const key of Object.keys(RESOURCES) as (keyof typeof RESOURCES)[]) {
-      const value = overrides[key];
-      if (value !== undefined) ctx.activePlayer.resources[key] = value;
-    }
-  }
-  return ctx;
+	const ctx = createEngine({
+		actions: ACTIONS,
+		buildings: BUILDINGS,
+		developments: DEVELOPMENTS,
+		populations: POPULATIONS,
+		phases: PHASES,
+		start: GAME_START,
+		rules: RULES,
+	});
+	if (overrides) {
+		for (const key of Object.keys(RESOURCES) as (keyof typeof RESOURCES)[]) {
+			const value = overrides[key];
+			if (value !== undefined) ctx.activePlayer.resources[key] = value;
+		}
+	}
+	return ctx;
 }
 
 export function simulateEffects(
-  effects: EffectDef[],
-  ctx: EngineContext,
-  actionId?: string,
+	effects: EffectDef[],
+	ctx: EngineContext,
+	actionId?: string,
 ) {
-  const before = clonePlayer(ctx.activePlayer);
-  const dummy = clonePlayer(ctx.activePlayer);
-  const dummyCtx = { ...ctx, activePlayer: dummy } as EngineContext;
-  runEffects(effects, dummyCtx);
-  if (actionId) ctx.passives.runResultMods(actionId, dummyCtx);
+	const before = clonePlayer(ctx.activePlayer);
+	const dummy = clonePlayer(ctx.activePlayer);
+	const dummyCtx = { ...ctx, activePlayer: dummy } as EngineContext;
+	runEffects(effects, dummyCtx);
+	if (actionId) ctx.passives.runResultMods(actionId, dummyCtx);
 
-  const resources: Record<string, number> = {};
-  for (const key of Object.keys(before.resources)) {
-    const delta =
-      dummy.resources[key as keyof typeof dummy.resources] -
-      before.resources[key as keyof typeof before.resources];
-    if (delta !== 0) resources[key] = delta;
-  }
+	const resources: Record<string, number> = {};
+	for (const key of Object.keys(before.resources)) {
+		const delta =
+			dummy.resources[key as keyof typeof dummy.resources] -
+			before.resources[key as keyof typeof before.resources];
+		if (delta !== 0) resources[key] = delta;
+	}
 
-  const stats: Record<string, number> = {};
-  for (const key of Object.keys(before.stats)) {
-    const delta =
-      dummy.stats[key as keyof typeof dummy.stats] -
-      before.stats[key as keyof typeof before.stats];
-    if (delta !== 0) stats[key] = delta;
-  }
+	const stats: Record<string, number> = {};
+	for (const key of Object.keys(before.stats)) {
+		const delta =
+			dummy.stats[key as keyof typeof dummy.stats] -
+			before.stats[key as keyof typeof before.stats];
+		if (delta !== 0) stats[key] = delta;
+	}
 
-  const land = dummy.lands.length - before.lands.length;
-  return { resources, stats, land };
+	const land = dummy.lands.length - before.lands.length;
+	return { resources, stats, land };
 }
 
 export function getActionOutcome(id: string, ctx: EngineContext) {
-  const actionDefinition = ctx.actions.get(id);
-  const costs = getActionCosts(id, ctx);
-  const results = simulateEffects(
-    actionDefinition.effects,
-    ctx,
-    actionDefinition.id,
-  );
-  return { costs, results };
+	const actionDefinition = ctx.actions.get(id);
+	const resolved = resolveActionEffects(actionDefinition);
+	const costs = getActionCosts(id, ctx);
+	const results = simulateEffects(resolved.effects, ctx, actionDefinition.id);
+	return { costs, results };
 }
 
 function findEffect(
-  effects: EffectDef[],
-  predicate: (e: EffectDef) => boolean,
+	effects: EffectDef[],
+	predicate: (e: EffectDef) => boolean,
 ): EffectDef | undefined {
-  for (const effect of effects) {
-    if (predicate(effect)) return effect;
-    const nested =
-      (effect as { effects?: EffectDef[] }).effects &&
-      findEffect((effect as { effects?: EffectDef[] }).effects!, predicate);
-    if (nested) return nested;
-  }
-  return undefined;
+	for (const effect of effects) {
+		if (predicate(effect)) return effect;
+		const nested =
+			(effect as { effects?: EffectDef[] }).effects &&
+			findEffect((effect as { effects?: EffectDef[] }).effects!, predicate);
+		if (nested) return nested;
+	}
+	return undefined;
 }
 
 export function getBuildActionId(ctx: EngineContext) {
-  for (const [id, def] of ctx.actions.entries()) {
-    if (
-      findEffect(
-        def.effects,
-        (e) => e.type === 'building' && e.method === 'add',
-      )
-    ) {
-      return id;
-    }
-  }
-  throw new Error('No build action found');
+	for (const [id, def] of ctx.actions.entries()) {
+		if (
+			findEffect(
+				def.effects,
+				(e) => e.type === 'building' && e.method === 'add',
+			)
+		) {
+			return id;
+		}
+	}
+	throw new Error('No build action found');
 }
 
 export function getBuildingWithActionMods() {
-  for (const [id, def] of BUILDINGS.entries()) {
-    const mod = findEffect(
-      def.onBuild ?? [],
-      (e) =>
-        (e.type === 'cost_mod' || e.type === 'result_mod') &&
-        typeof (e.params as { actionId?: unknown }).actionId === 'string',
-    );
-    if (mod) {
-      return {
-        buildingId: id,
-        actionId: (mod.params as { actionId: string }).actionId,
-      };
-    }
-  }
-  throw new Error('No building with action mods found');
+	for (const [id, def] of BUILDINGS.entries()) {
+		const mod = findEffect(
+			def.onBuild ?? [],
+			(e) =>
+				(e.type === 'cost_mod' || e.type === 'result_mod') &&
+				typeof (e.params as { actionId?: unknown }).actionId === 'string',
+		);
+		if (mod) {
+			return {
+				buildingId: id,
+				actionId: (mod.params as { actionId: string }).actionId,
+			};
+		}
+	}
+	throw new Error('No building with action mods found');
 }
 
 export function getBuildingWithStatBonuses() {
-  for (const [id, def] of BUILDINGS.entries()) {
-    const passive = findEffect(
-      def.onBuild ?? [],
-      (e) => e.type === 'passive' && e.method === 'add',
-    );
-    if (passive) {
-      const stats = ((passive as { effects?: EffectDef[] }).effects || [])
-        .filter(
-          (e): e is EffectDef<{ key: string; amount: number }> =>
-            e.type === 'stat' &&
-            e.method === 'add' &&
-            typeof (e.params as { key?: unknown }).key === 'string' &&
-            typeof (e.params as { amount?: unknown }).amount === 'number',
-        )
-        .map((e) => ({
-          key: (e.params as { key: string }).key,
-          amount: (e.params as { amount: number }).amount,
-        }));
-      if (stats.length > 0) return { buildingId: id, stats };
-    }
-  }
-  throw new Error('No building with stat bonuses found');
+	for (const [id, def] of BUILDINGS.entries()) {
+		const passive = findEffect(
+			def.onBuild ?? [],
+			(e) => e.type === 'passive' && e.method === 'add',
+		);
+		if (passive) {
+			const stats = ((passive as { effects?: EffectDef[] }).effects || [])
+				.filter(
+					(e): e is EffectDef<{ key: string; amount: number }> =>
+						e.type === 'stat' &&
+						e.method === 'add' &&
+						typeof (e.params as { key?: unknown }).key === 'string' &&
+						typeof (e.params as { amount?: unknown }).amount === 'number',
+				)
+				.map((e) => ({
+					key: (e.params as { key: string }).key,
+					amount: (e.params as { amount: number }).amount,
+				}));
+			if (stats.length > 0) return { buildingId: id, stats };
+		}
+	}
+	throw new Error('No building with stat bonuses found');
 }
 
 export function getActionWithMultipleCosts(ctx: EngineContext) {
-  for (const [id] of ctx.actions.entries()) {
-    const costs = getActionCosts(id, ctx);
-    if (Object.keys(costs).length > 1) return { actionId: id, costs };
-  }
-  throw new Error('No action with multiple costs found');
+	for (const [id] of ctx.actions.entries()) {
+		const costs = getActionCosts(id, ctx);
+		if (Object.keys(costs).length > 1) return { actionId: id, costs };
+	}
+	throw new Error('No action with multiple costs found');
 }
 
 export function getActionWithCost(ctx: EngineContext) {
-  for (const [id] of ctx.actions.entries()) {
-    const costs = getActionCosts(id, ctx);
-    if (Object.keys(costs).length > 0) return { actionId: id, costs };
-  }
-  throw new Error('No action with costs found');
+	for (const [id] of ctx.actions.entries()) {
+		const costs = getActionCosts(id, ctx);
+		if (Object.keys(costs).length > 0) return { actionId: id, costs };
+	}
+	throw new Error('No action with costs found');
 }


### PR DESCRIPTION
## Summary
- adjust action effect group utilities to avoid lint errors and support optional choice params cleanly
- update engine and web consumers to resolve action effects before execution, logging, and diffing
- align content builders and formatters with action effect groups and keep tests covering new flows

## Testing
- npm run typecheck -- --pretty false
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e10ba140448325b95aa86ff882ff7f