### PR TITLE
Use synthetic plow content fixtures in web translator tests

### DIFF
--- a/packages/web/tests/fixtures/syntheticPlow.ts
+++ b/packages/web/tests/fixtures/syntheticPlow.ts
@@ -1,0 +1,195 @@
+import { vi } from 'vitest';
+import {
+	createContentFactory,
+	type ContentFactory,
+} from '../../../engine/tests/factories/content';
+import type { PhaseDef } from '@kingdom-builder/engine/phases';
+import type {
+	StartConfig,
+	ActionConfig,
+	BuildingConfig,
+} from '@kingdom-builder/engine/config/schema';
+import type { RuleSet } from '@kingdom-builder/engine/services';
+import type { EffectDef } from '@kingdom-builder/engine';
+
+type SyntheticResourceKey = 'gold' | 'ap' | 'happiness';
+
+type SyntheticResourceInfo = { icon: string; label: string };
+
+const syntheticData = vi.hoisted(() => ({
+	RESOURCES: {
+		gold: { icon: '🪙', label: 'Synthetic Gold' },
+		ap: { icon: '🛠️', label: 'Synthetic Action Points' },
+		happiness: { icon: '🙂', label: 'Synthetic Happiness' },
+	} satisfies Record<SyntheticResourceKey, SyntheticResourceInfo>,
+	LAND_INFO: { icon: '🗺️', label: 'Synthetic Land' } as const,
+	SLOT_INFO: { icon: '🧱', label: 'Synthetic Slot' } as const,
+	PASSIVE_INFO: { icon: '♻️', label: 'Synthetic Passive' } as const,
+	UPKEEP_PHASE: {
+		id: 'phase:synthetic:upkeep',
+		label: 'Synthetic Upkeep',
+		icon: '🧭',
+		steps: [{ id: 'phase:synthetic:upkeep:step' }],
+	} satisfies PhaseDef,
+}));
+
+export const SYNTHETIC_RESOURCES = syntheticData.RESOURCES;
+export const SYNTHETIC_LAND_INFO = syntheticData.LAND_INFO;
+export const SYNTHETIC_SLOT_INFO = syntheticData.SLOT_INFO;
+export const SYNTHETIC_PASSIVE_INFO = syntheticData.PASSIVE_INFO;
+export const SYNTHETIC_UPKEEP_PHASE: PhaseDef = syntheticData.UPKEEP_PHASE;
+
+vi.mock('@kingdom-builder/contents', async () => {
+	const actual = (await vi.importActual('@kingdom-builder/contents')) as Record<
+		string,
+		unknown
+	>;
+	const module = actual as unknown as {
+		RESOURCES: Record<string, { icon?: string; label?: string }>;
+		LAND_INFO: { icon: string; label: string };
+		SLOT_INFO: { icon: string; label: string };
+		PASSIVE_INFO: { icon: string; label: string };
+		[key: string]: unknown;
+	};
+	return {
+		...module,
+		RESOURCES: {
+			...module.RESOURCES,
+			gold: syntheticData.RESOURCES.gold,
+			ap: syntheticData.RESOURCES.ap,
+			happiness: syntheticData.RESOURCES.happiness,
+		},
+		LAND_INFO: syntheticData.LAND_INFO,
+		SLOT_INFO: syntheticData.SLOT_INFO,
+		PASSIVE_INFO: syntheticData.PASSIVE_INFO,
+	};
+});
+
+export interface SyntheticPlowContent {
+	factory: ContentFactory;
+	expand: ActionConfig;
+	till: ActionConfig;
+	plow: ActionConfig;
+	plowPassive: EffectDef['params'];
+	building: BuildingConfig;
+	phases: PhaseDef[];
+	start: StartConfig;
+	rules: RuleSet;
+	tierResourceKey: string;
+}
+
+export function createSyntheticPlowContent(): SyntheticPlowContent {
+	const factory = createContentFactory();
+	const tierResourceKey = 'resource:synthetic:tier';
+	const expand = factory.action({
+		id: 'action:synthetic:expand',
+		name: 'Expand Fields',
+		icon: '🌾',
+		system: true,
+		baseCosts: { ap: 1, gold: 2 },
+		effects: [
+			{ type: 'land', method: 'add', params: { count: 1 } },
+			{
+				type: 'resource',
+				method: 'add',
+				params: { key: 'happiness', amount: 1 },
+			},
+		],
+	});
+	const till = factory.action({
+		id: 'action:synthetic:till',
+		name: 'Till Soil',
+		icon: '🧑\u200d🌾',
+		system: true,
+		effects: [{ type: 'land', method: 'till' }],
+	});
+	const plowPassiveParams = {
+		id: 'passive:synthetic:furrows',
+		name: 'Furrow Focus',
+		icon: '🌱',
+		durationPhaseId: SYNTHETIC_UPKEEP_PHASE.id,
+	} satisfies EffectDef['params'];
+	const plow = factory.action({
+		id: 'action:synthetic:plow',
+		name: 'Plow Furrows',
+		icon: '🚜',
+		system: true,
+		baseCosts: { ap: 1, gold: 6 },
+		effects: [
+			{ type: 'action', method: 'perform', params: { id: expand.id } },
+			{ type: 'action', method: 'perform', params: { id: till.id } },
+			{
+				type: 'passive',
+				method: 'add',
+				params: plowPassiveParams,
+				effects: [
+					{
+						type: 'cost_mod',
+						method: 'add',
+						params: {
+							id: 'cost-mod:synthetic:plow',
+							key: 'gold',
+							amount: 2,
+						},
+					},
+				],
+			},
+		],
+	});
+	const building = factory.building({
+		id: 'building:synthetic:plow-workshop',
+		name: 'Synthetic Plow Workshop',
+		icon: '🏗️',
+		onBuild: [
+			{
+				type: 'action',
+				method: 'add',
+				params: { id: plow.id },
+			},
+		],
+	});
+	const phases = [SYNTHETIC_UPKEEP_PHASE];
+	const start: StartConfig = {
+		player: {
+			resources: {
+				gold: 0,
+				ap: 0,
+				happiness: 0,
+				[tierResourceKey]: 0,
+			},
+			stats: {},
+			population: {},
+			lands: [
+				{
+					id: 'land:synthetic:home',
+					developments: [],
+					slotsMax: 1,
+					slotsUsed: 0,
+					tilled: false,
+				},
+			],
+		},
+	};
+	const rules: RuleSet = {
+		defaultActionAPCost: 1,
+		absorptionCapPct: 1,
+		absorptionRounding: 'down',
+		tieredResourceKey: tierResourceKey,
+		tierDefinitions: [],
+		slotsPerNewLand: 1,
+		maxSlotsPerLand: 2,
+		basePopulationCap: 1,
+	};
+	return {
+		factory,
+		expand,
+		till,
+		plow,
+		plowPassive: plowPassiveParams,
+		building,
+		phases,
+		start,
+		rules,
+		tierResourceKey,
+	};
+}

--- a/packages/web/tests/plow-workshop-translation.test.ts
+++ b/packages/web/tests/plow-workshop-translation.test.ts
@@ -1,49 +1,42 @@
 import { describe, it, expect, vi } from 'vitest';
+import { createSyntheticPlowContent } from './fixtures/syntheticPlow';
 import {
-  describeContent,
-  splitSummary,
-  type Summary,
+	describeContent,
+	splitSummary,
+	type Summary,
 } from '../src/translation/content';
 import { createEngine } from '@kingdom-builder/engine';
-import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
-} from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
-  return await import('../../engine/src');
+	return await import('../../engine/src');
 });
 
-function createCtx() {
-  return createEngine({
-    actions: ACTIONS,
-    buildings: BUILDINGS,
-    developments: DEVELOPMENTS,
-    populations: POPULATIONS,
-    phases: PHASES,
-    start: GAME_START,
-    rules: RULES,
-  });
-}
-
 describe('plow workshop translation', () => {
-  it('includes action card and omits Immediately', () => {
-    const ctx = createCtx();
-    const summary = describeContent('building', 'plow_workshop', ctx);
-    const { effects, description } = splitSummary(summary);
-    expect(effects).toHaveLength(1);
-    const build = effects[0] as { title: string; items?: unknown[] };
-    expect(build.items?.[0]).toBe('Gain action 🚜 Plow');
-    expect(description).toBeDefined();
-    const actionCard = (description as Summary)[0] as { title: string };
-    expect(actionCard.title).toBe('🚜 Plow');
-    expect(JSON.stringify({ effects, description })).not.toMatch(
-      /Immediately|🎯/,
-    );
-  });
+	it('includes action card and omits Immediately', () => {
+		const synthetic = createSyntheticPlowContent();
+		const ctx = createEngine({
+			actions: synthetic.factory.actions,
+			buildings: synthetic.factory.buildings,
+			developments: synthetic.factory.developments,
+			populations: synthetic.factory.populations,
+			phases: synthetic.phases,
+			start: synthetic.start,
+			rules: synthetic.rules,
+		});
+		const summary = describeContent('building', synthetic.building.id, ctx);
+		const { effects, description } = splitSummary(summary);
+		expect(effects).toHaveLength(1);
+		const build = effects[0] as { title: string; items?: unknown[] };
+		expect(build.items?.[0]).toBe(
+			`Gain action ${synthetic.plow.icon} ${synthetic.plow.name}`,
+		);
+		expect(description).toBeDefined();
+		const actionCard = (description as Summary)[0] as { title: string };
+		expect(actionCard.title).toBe(
+			`${synthetic.plow.icon} ${synthetic.plow.name}`,
+		);
+		expect(JSON.stringify({ effects, description })).not.toMatch(
+			/Immediately|🎯/,
+		);
+	});
 });

--- a/packages/web/tests/subaction-log.test.ts
+++ b/packages/web/tests/subaction-log.test.ts
@@ -1,137 +1,141 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
-  createEngine,
-  performAction,
-  getActionCosts,
-  Resource,
-  type ActionTrace,
+	createEngine,
+	performAction,
+	getActionCosts,
+	type ActionTrace,
 } from '@kingdom-builder/engine';
 import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
-  RESOURCES,
-  SLOT_INFO,
-  type ResourceKey,
-} from '@kingdom-builder/contents';
+	createSyntheticPlowContent,
+	SYNTHETIC_RESOURCES,
+	SYNTHETIC_SLOT_INFO,
+} from './fixtures/syntheticPlow';
 import {
-  snapshotPlayer,
-  diffStepSnapshots,
-  logContent,
+	snapshotPlayer,
+	diffStepSnapshots,
+	logContent,
 } from '../src/translation';
 
-const RESOURCE_KEYS = Object.keys(RESOURCES) as ResourceKey[];
+const RESOURCE_KEYS = Object.keys(
+	SYNTHETIC_RESOURCES,
+) as (keyof typeof SYNTHETIC_RESOURCES)[];
 
 vi.mock('@kingdom-builder/engine', async () => {
-  return await import('../../engine/src');
+	return await import('../../engine/src');
 });
 
 describe('sub-action logging', () => {
-  it('nests sub-action effects under the triggering action', () => {
-    const ctx = createEngine({
-      actions: ACTIONS,
-      buildings: BUILDINGS,
-      developments: DEVELOPMENTS,
-      populations: POPULATIONS,
-      phases: PHASES,
-      start: GAME_START,
-      rules: RULES,
-    });
-    ctx.activePlayer.actions.add('plow');
-    ctx.activePlayer.resources[Resource.gold] = 10;
-    ctx.activePlayer.resources[Resource.ap] = 1;
-    const before = snapshotPlayer(ctx.activePlayer, ctx);
-    const costs = getActionCosts('plow', ctx);
-    const traces = performAction('plow', ctx);
-    const after = snapshotPlayer(ctx.activePlayer, ctx);
-    const changes = diffStepSnapshots(
-      before,
-      after,
-      ctx.actions.get('plow'),
-      ctx,
-      RESOURCE_KEYS,
-    );
-    const messages = logContent('action', 'plow', ctx);
-    const costLines: string[] = [];
-    for (const key of Object.keys(costs) as (keyof typeof RESOURCES)[]) {
-      const amt = costs[key] ?? 0;
-      if (!amt) continue;
-      const info = RESOURCES[key];
-      const icon = info?.icon ? `${info.icon} ` : '';
-      const label = info?.label ?? key;
-      const b = before.resources[key] ?? 0;
-      const a = b - amt;
-      costLines.push(`    ${icon}${label} -${amt} (${b}→${a})`);
-    }
-    if (costLines.length)
-      messages.splice(1, 0, '  💲 Action cost', ...costLines);
+	it('nests sub-action effects under the triggering action', () => {
+		const synthetic = createSyntheticPlowContent();
+		const ctx = createEngine({
+			actions: synthetic.factory.actions,
+			buildings: synthetic.factory.buildings,
+			developments: synthetic.factory.developments,
+			populations: synthetic.factory.populations,
+			phases: synthetic.phases,
+			start: synthetic.start,
+			rules: synthetic.rules,
+		});
+		ctx.activePlayer.actions.add(synthetic.plow.id);
+		ctx.activePlayer.resources.gold = 10;
+		ctx.activePlayer.resources.ap = 1;
+		const before = snapshotPlayer(ctx.activePlayer, ctx);
+		const costs = getActionCosts(synthetic.plow.id, ctx);
+		const traces = performAction(synthetic.plow.id, ctx);
+		const after = snapshotPlayer(ctx.activePlayer, ctx);
+		const changes = diffStepSnapshots(
+			before,
+			after,
+			ctx.actions.get(synthetic.plow.id),
+			ctx,
+			RESOURCE_KEYS,
+		);
+		const messages = logContent('action', synthetic.plow.id, ctx);
+		const costLines: string[] = [];
+		for (const key of Object.keys(
+			costs,
+		) as (keyof typeof SYNTHETIC_RESOURCES)[]) {
+			const amt = costs[key] ?? 0;
+			if (!amt) continue;
+			const info = SYNTHETIC_RESOURCES[key];
+			const icon = info?.icon ? `${info.icon} ` : '';
+			const label = info?.label ?? key;
+			const b = before.resources[key] ?? 0;
+			const a = b - amt;
+			costLines.push(`    ${icon}${label} -${amt} (${b}→${a})`);
+		}
+		if (costLines.length)
+			messages.splice(1, 0, '  💲 Action cost', ...costLines);
 
-    const subLines: string[] = [];
-    for (const trace of traces) {
-      const subChanges = diffStepSnapshots(
-        trace.before,
-        trace.after,
-        ctx.actions.get(trace.id),
-        ctx,
-        RESOURCE_KEYS,
-      );
-      if (!subChanges.length) continue;
-      subLines.push(...subChanges);
-      const icon = ctx.actions.get(trace.id)?.icon || '';
-      const name = ctx.actions.get(trace.id).name;
-      const line = `  ${icon} ${name}`;
-      const idx = messages.indexOf(line);
-      if (idx !== -1)
-        messages.splice(idx + 1, 0, ...subChanges.map((c) => `    ${c}`));
-    }
+		const subLines: string[] = [];
+		for (const trace of traces) {
+			const subChanges = diffStepSnapshots(
+				trace.before,
+				trace.after,
+				ctx.actions.get(trace.id),
+				ctx,
+				RESOURCE_KEYS,
+			);
+			if (!subChanges.length) continue;
+			subLines.push(...subChanges);
+			const action = ctx.actions.get(trace.id);
+			const icon = action?.icon || '';
+			const name = action?.name || trace.id;
+			const line = `  ${icon} ${name}`;
+			const idx = messages.indexOf(line);
+			if (idx !== -1)
+				messages.splice(idx + 1, 0, ...subChanges.map((c) => `    ${c}`));
+		}
 
-    const costLabels = new Set(
-      Object.keys(costs) as (keyof typeof RESOURCES)[],
-    );
-    const filtered = changes.filter((line) => {
-      if (subLines.includes(line)) return false;
-      for (const key of costLabels) {
-        const info = RESOURCES[key];
-        const prefix = info?.icon ? `${info.icon} ${info.label}` : info.label;
-        if (line.startsWith(prefix)) return false;
-      }
-      return true;
-    });
-    const logLines = [...messages, ...filtered.map((c) => `  ${c}`)];
+		const costLabels = new Set(
+			Object.keys(costs) as (keyof typeof SYNTHETIC_RESOURCES)[],
+		);
+		const filtered = changes.filter((line) => {
+			if (subLines.includes(line)) return false;
+			for (const key of costLabels) {
+				const info = SYNTHETIC_RESOURCES[key];
+				const prefix = info?.icon ? `${info.icon} ${info.label}` : info.label;
+				if (line.startsWith(prefix)) return false;
+			}
+			return true;
+		});
+		const logLines = [...messages, ...filtered.map((c) => `  ${c}`)];
 
-    const expandTrace = traces.find((t) => t.id === 'expand') as ActionTrace;
-    const expandDiff = diffStepSnapshots(
-      expandTrace.before,
-      expandTrace.after,
-      ctx.actions.get('expand'),
-      ctx,
-      RESOURCE_KEYS,
-    );
-    expandDiff.forEach((line) => {
-      expect(logLines).toContain(`    ${line}`);
-      expect(logLines).not.toContain(`  ${line}`);
-    });
-    const tillTrace = traces.find((t) => t.id === 'till') as ActionTrace;
-    const tillDiff = diffStepSnapshots(
-      tillTrace.before,
-      tillTrace.after,
-      ctx.actions.get('till'),
-      ctx,
-      RESOURCE_KEYS,
-    );
-    expect(tillDiff.length).toBeGreaterThan(0);
-    expect(
-      tillDiff.some((line) =>
-        line.startsWith(`${SLOT_INFO.icon} Development Slot`),
-      ),
-    ).toBe(true);
-    tillDiff.forEach((line) => {
-      expect(logLines).toContain(`    ${line}`);
-      expect(logLines).not.toContain(`  ${line}`);
-    });
-  });
+		const expandTrace = traces.find(
+			(t) => t.id === synthetic.expand.id,
+		) as ActionTrace;
+		const expandDiff = diffStepSnapshots(
+			expandTrace.before,
+			expandTrace.after,
+			ctx.actions.get(synthetic.expand.id),
+			ctx,
+			RESOURCE_KEYS,
+		);
+		expandDiff.forEach((line) => {
+			expect(logLines).toContain(`    ${line}`);
+			expect(logLines).not.toContain(`  ${line}`);
+		});
+		const tillTrace = traces.find(
+			(t) => t.id === synthetic.till.id,
+		) as ActionTrace;
+		const tillDiff = diffStepSnapshots(
+			tillTrace.before,
+			tillTrace.after,
+			ctx.actions.get(synthetic.till.id),
+			ctx,
+			RESOURCE_KEYS,
+		);
+		expect(tillDiff.length).toBeGreaterThan(0);
+		expect(
+			tillDiff.some((line) =>
+				line.startsWith(
+					`${SYNTHETIC_SLOT_INFO.icon} ${SYNTHETIC_SLOT_INFO.label}`,
+				),
+			),
+		).toBe(true);
+		tillDiff.forEach((line) => {
+			expect(logLines).toContain(`    ${line}`);
+			expect(logLines).not.toContain(`  ${line}`);
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- add a synthetic plow content fixture that mocks @kingdom-builder/contents metadata for tests
- update plow translation and log tests to build engines from the synthetic registries instead of shipped content
- adjust expectations to read icons and labels from the synthetic definitions

## Testing
- npm run test -- packages/web/tests/plow-action-translation.test.ts packages/web/tests/subaction-log.test.ts packages/web/tests/plow-workshop-translation.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1183df4648325a5308e14a7515fce