### PR TITLE
Implement Royal Decree multi-step action

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -207,24 +207,19 @@ export function createActionRegistry() {
 			.effect(
 				effect(Types.Action, ActionMethods.PERFORM).param('id', 'till').build(),
 			)
-			.effect({
-				type: Types.Resource,
-				method: ResourceMethods.REMOVE,
-				params: resourceParams().key(Resource.happiness).amount(3).build(),
-				meta: { allowShortfall: true },
-			})
 			.effectGroup(
 				actionEffectGroup('royal_decree_develop')
 					.title('Decree a development')
-					.summary('Choose what to raise on the prepared land.')
+					.summary('Choose what to raise on the newly claimed land.')
 					.description(
-						'After expanding and tilling, select one project to complete. Each option runs Develop on the chosen land.',
+						'After expanding and tilling, select one project to complete before unrest rises. Each option runs Develop on the prepared land.',
 					)
+					.layout('compact')
 					.option(
 						actionEffectGroupOption('royal_decree_house')
 							.label('Raise a House')
 							.icon('🏠')
-							.summary('Expand housing and increase the population cap by 1.')
+							.summary('Expand housing and raise the population cap by 1.')
 							.action('develop')
 							.param('landId', '$landId')
 							.param('id', 'house'),
@@ -233,7 +228,7 @@ export function createActionRegistry() {
 						actionEffectGroupOption('royal_decree_farm')
 							.label('Establish a Farm')
 							.icon('🌾')
-							.summary('Gain +2 gold during the income step each round.')
+							.summary('Gain +2 gold during each income step.')
 							.action('develop')
 							.param('landId', '$landId')
 							.param('id', 'farm'),
@@ -252,13 +247,19 @@ export function createActionRegistry() {
 							.label('Raise a Watchtower')
 							.icon('🗼')
 							.summary(
-								'Add +2 Fortification Strength and absorption after defending once.',
+								'Add +2 Fortification Strength and absorption after one defense.',
 							)
 							.action('develop')
 							.param('landId', '$landId')
 							.param('id', 'watchtower'),
 					),
 			)
+			.effect({
+				type: Types.Resource,
+				method: ResourceMethods.REMOVE,
+				params: resourceParams().key(Resource.happiness).amount(3).build(),
+				meta: { allowShortfall: true },
+			})
 			.build(),
 		category: 'development',
 		order: 2,

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -284,6 +284,11 @@ class ActionEffectGroupBuilder {
 		return this;
 	}
 
+	layout(layout: 'default' | 'compact') {
+		this.config.layout = layout;
+		return this;
+	}
+
 	option(option: ActionEffectGroupOptionBuilder | ActionEffectGroupOptionDef) {
 		const built =
 			option instanceof ActionEffectGroupOptionBuilder

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -49,6 +49,7 @@ export const actionEffectGroupSchema = z.object({
 	summary: z.string().optional(),
 	description: z.string().optional(),
 	icon: z.string().optional(),
+	layout: z.enum(['default', 'compact']).optional(),
 	options: z.array(actionEffectGroupOptionSchema).min(1),
 });
 

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -64,6 +64,9 @@ export type ActionCardOption = {
 	description?: string;
 	disabled?: boolean;
 	onSelect: () => void;
+	onMouseEnter?: (() => void) | undefined;
+	onMouseLeave?: (() => void) | undefined;
+	compact?: boolean;
 };
 
 export type ActionCardVariant = 'front' | 'back';
@@ -93,46 +96,82 @@ export interface ActionCardProps {
 	promptDescription?: string | undefined;
 	options?: ActionCardOption[] | undefined;
 	onCancel?: (() => void) | undefined;
+	multiStep?: boolean | undefined;
 }
 
 function StepBadge({
 	stepIndex,
 	stepCount,
 	stepLabel,
+	variant,
+	multiStep,
 }: {
 	stepIndex: number | undefined;
 	stepCount: number | undefined;
 	stepLabel: string | undefined;
+	variant: ActionCardVariant;
+	multiStep: boolean | undefined;
 }) {
-	if (!stepCount || stepCount <= 0) {
+	if (variant === 'back' && stepCount && stepCount > 0) {
+		const current = stepIndex && stepIndex > 0 ? stepIndex : 1;
+		const label =
+			stepLabel ?? `Step ${Math.min(current, stepCount)} of ${stepCount}`;
+		return (
+			<div className="action-card__badge">
+				<span className="action-card__badge-pill">{label}</span>
+			</div>
+		);
+	}
+	if (!multiStep || variant !== 'front') {
 		return null;
 	}
-	const current = stepIndex && stepIndex > 0 ? stepIndex : 1;
-	const label =
-		stepLabel ?? `Step ${Math.min(current, stepCount)} of ${stepCount}`;
 	return (
 		<div className="action-card__badge">
-			<span className="action-card__badge-pill">{label}</span>
+			<span
+				className="action-card__multi-step"
+				role="img"
+				aria-label="Multi-step action"
+				title="Multi-step action"
+			>
+				<svg
+					className="action-card__multi-step-icon"
+					viewBox="0 0 24 24"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<circle cx="6" cy="12" r="2.25" />
+					<circle cx="12" cy="12" r="2.25" />
+					<circle cx="18" cy="12" r="2.25" />
+					<path d="M8.25 12h3.5M14.25 12h3.5" strokeLinecap="round" />
+				</svg>
+			</span>
 		</div>
 	);
 }
 
 function OptionCard({ option }: { option: ActionCardOption }) {
 	const label = [option.icon, option.label].filter(Boolean).join(' ').trim();
+	const optionClass = [
+		'action-card__option',
+		option.compact ? 'action-card__option--compact' : '',
+		option.disabled ? 'opacity-50 cursor-not-allowed' : 'hoverable',
+	]
+		.filter(Boolean)
+		.join(' ');
 	return (
 		<button
 			type="button"
-			className={`action-card__option ${
-				option.disabled ? 'opacity-50 cursor-not-allowed' : 'hoverable'
-			}`}
+			className={optionClass}
 			onClick={option.disabled ? undefined : option.onSelect}
 			disabled={option.disabled}
+			onMouseEnter={option.onMouseEnter}
+			onMouseLeave={option.onMouseLeave}
 		>
 			<span className="action-card__option-title">{label}</span>
-			{option.summary && (
+			{!option.compact && option.summary && (
 				<p className="action-card__option-summary">{option.summary}</p>
 			)}
-			{option.description && (
+			{!option.compact && option.description && (
 				<p className="action-card__option-description">{option.description}</p>
 			)}
 		</button>
@@ -164,6 +203,7 @@ export default function ActionCard({
 	promptDescription,
 	options = [],
 	onCancel,
+	multiStep = false,
 }: ActionCardProps) {
 	const focusClass =
 		(focus && FOCUS_GRADIENTS[focus]) ?? FOCUS_GRADIENTS.default;
@@ -207,6 +247,8 @@ export default function ActionCard({
 				stepIndex={stepIndex}
 				stepCount={stepCount}
 				stepLabel={stepLabel}
+				variant={variant}
+				multiStep={multiStep}
 			/>
 			<div className="action-card__inner">
 				<button
@@ -249,8 +291,10 @@ export default function ActionCard({
 									type="button"
 									className="action-card__cancel"
 									onClick={onCancel}
+									aria-label="Cancel selection"
+									title="Cancel selection"
 								>
-									Cancel
+									×
 								</button>
 							)}
 						</div>

--- a/packages/web/src/components/actions/types.ts
+++ b/packages/web/src/components/actions/types.ts
@@ -1,0 +1,4 @@
+import type { useGameEngine } from '../../state/GameContext';
+
+export type GameEngineApi = ReturnType<typeof useGameEngine>;
+export type HoverCardData = Parameters<GameEngineApi['handleHoverCard']>[0];

--- a/packages/web/src/components/actions/useEffectGroupOptions.ts
+++ b/packages/web/src/components/actions/useEffectGroupOptions.ts
@@ -1,0 +1,161 @@
+import { useMemo } from 'react';
+import {
+	getActionCosts,
+	getActionRequirements,
+	type ActionEffectGroup,
+	type ActionEffectGroupOption,
+	type EngineContext,
+} from '@kingdom-builder/engine';
+import { describeContent, splitSummary } from '../../translation';
+import { type ActionCardOption } from './ActionCard';
+import type { HoverCardData } from './types';
+
+type ResolveParams = Record<string, unknown> | undefined;
+
+type BuildOptionsParams = {
+	currentGroup: ActionEffectGroup | undefined;
+	pendingParams: Record<string, unknown> | undefined;
+	context: EngineContext;
+	formatRequirement: (requirement: string) => string;
+	handleOptionSelect: (
+		group: ActionEffectGroup,
+		option: ActionEffectGroupOption,
+	) => void;
+	clearHoverCard: () => void;
+	handleHoverCard: (data: HoverCardData) => void;
+	hoverBackground: string;
+};
+
+function resolveOptionParams(
+	option: ActionEffectGroupOption,
+	pendingParams: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+	const base: Record<string, unknown> = {};
+	const params: ResolveParams = option.params;
+	if (!params) {
+		return base;
+	}
+	for (const [key, value] of Object.entries(params)) {
+		if (typeof value === 'string' && value.startsWith('$') && pendingParams) {
+			const placeholder = value.slice(1);
+			if (placeholder in pendingParams) {
+				base[key] = pendingParams[placeholder];
+				continue;
+			}
+		}
+		base[key] = value;
+	}
+	return base;
+}
+
+function buildHoverDetails(
+	option: ActionEffectGroupOption,
+	mergedParams: Record<string, unknown>,
+	context: EngineContext,
+	formatRequirement: (requirement: string) => string,
+	hoverBackground: string,
+): HoverCardData {
+	let optionIcon = '';
+	let optionName = option.label;
+	try {
+		const definition = context.actions.get(option.actionId);
+		const possible = definition as { icon?: unknown; name?: unknown };
+		if (possible && typeof possible.icon === 'string') {
+			optionIcon = possible.icon;
+		}
+		if (possible && typeof possible.name === 'string') {
+			optionName = possible.name;
+		}
+	} catch {
+		// ignore missing action definitions
+	}
+	const hoverTitle = `${optionIcon} ${optionName}`.trim() || optionName;
+	const hoverSummary = describeContent(
+		'action',
+		option.actionId,
+		context,
+		mergedParams,
+	);
+	const { effects, description } = splitSummary(hoverSummary);
+	const requirements = getActionRequirements(
+		option.actionId,
+		context,
+		mergedParams,
+	).map(formatRequirement);
+	const costBag = getActionCosts(option.actionId, context, mergedParams);
+	const costs: Record<string, number> = {};
+	for (const [resourceKey, cost] of Object.entries(costBag)) {
+		costs[resourceKey] = cost ?? 0;
+	}
+	return {
+		title: hoverTitle,
+		effects,
+		...(description && { description }),
+		requirements,
+		costs,
+		bgClass: hoverBackground,
+	};
+}
+
+export function useEffectGroupOptions({
+	currentGroup,
+	pendingParams,
+	context,
+	formatRequirement,
+	handleOptionSelect,
+	clearHoverCard,
+	handleHoverCard,
+	hoverBackground,
+}: BuildOptionsParams): ActionCardOption[] | undefined {
+	return useMemo(() => {
+		if (!currentGroup) {
+			return undefined;
+		}
+		return currentGroup.options.map((option) => {
+			const resolved = resolveOptionParams(option, pendingParams);
+			const mergedParams: Record<string, unknown> = {
+				...(pendingParams ?? {}),
+				...resolved,
+			};
+			const card: ActionCardOption = {
+				id: option.id,
+				label: option.label,
+				onSelect: () => {
+					clearHoverCard();
+					handleOptionSelect(currentGroup, option);
+				},
+				compact: currentGroup.layout === 'compact',
+			};
+			if (option.icon) {
+				card.icon = option.icon;
+			}
+			if (option.summary) {
+				card.summary = option.summary;
+			}
+			if (option.description) {
+				card.description = option.description;
+			}
+			card.onMouseEnter = () => {
+				const hoverDetails = buildHoverDetails(
+					option,
+					mergedParams,
+					context,
+					formatRequirement,
+					hoverBackground,
+				);
+				handleHoverCard(hoverDetails);
+			};
+			card.onMouseLeave = clearHoverCard;
+			return card;
+		});
+	}, [
+		clearHoverCard,
+		context,
+		currentGroup,
+		formatRequirement,
+		handleHoverCard,
+		handleOptionSelect,
+		hoverBackground,
+		pendingParams,
+	]);
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -151,8 +151,27 @@
   .action-card__badge-pill {
     @apply rounded-full bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-amber-600 shadow-sm shadow-amber-400/30 dark:bg-slate-800/70 dark:text-amber-300;
   }
+  .action-card__multi-step {
+    @apply flex items-center justify-center rounded-full border border-white/40 bg-white/70 p-1 text-emerald-700 shadow-sm shadow-emerald-400/30 dark:border-white/10 dark:bg-slate-900/70 dark:text-emerald-200;
+  }
+  .action-card__multi-step-icon {
+    width: 1.5rem;
+    height: 1.5rem;
+    stroke: currentColor;
+    stroke-width: 1.5;
+  }
+  .action-card__multi-step-icon circle {
+    fill: currentColor;
+    opacity: 0.85;
+  }
   .action-card__option {
     @apply panel-card cursor-pointer border border-white/40 bg-white/70 p-3 text-left text-sm text-slate-700 transition dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100;
+  }
+  .action-card__option--compact {
+    @apply flex min-h-[4.25rem] items-center justify-center gap-2 text-base font-semibold;
+  }
+  .action-card__option--compact .action-card__option-title {
+    @apply text-base font-semibold text-center;
   }
   .action-card__option-title {
     @apply text-base font-semibold;


### PR DESCRIPTION
## Summary
- add Royal Decree action flow that expands, tills, prompts for a development option, then applies unrest
- extend effect group schema/builders with compact layout metadata and reuse to hide option details
- update action card UI with multi-step badge, compact option grid, reusable selection hook, and hover previews

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e1197b5cc48325ae50a7352361f96c