### PR TITLE
Refactor tier passives to run via effects

### DIFF
--- a/packages/contents/src/rules.ts
+++ b/packages/contents/src/rules.ts
@@ -1,4 +1,8 @@
-import type { RuleSet } from '@kingdom-builder/engine/services';
+import type {
+	RuleSet,
+	HappinessTierDefinition,
+} from '@kingdom-builder/engine/services';
+import type { EffectConfig } from '@kingdom-builder/engine/config/schema';
 import { Resource } from './resources';
 import { Stat } from './stats';
 import {
@@ -11,7 +15,9 @@ import {
 	happinessTier,
 	resultModParams,
 	statParams,
-	tierPassive,
+	effect,
+	passiveParams,
+	PassiveMethods,
 } from './config/builders';
 
 const GROWTH_PHASE_ID = 'growth';
@@ -52,194 +58,198 @@ const growthBonusEffect = (amount: number) =>
 
 const formatRemoval = (description: string) => `Removed when ${description}`;
 
+type TierPassiveEffectOptions = {
+	tierId: string;
+	summary: string;
+	removalDetail: string;
+	params: ReturnType<typeof passiveParams>;
+	effects?: EffectConfig[];
+};
+
+function createTierPassiveEffect({
+	tierId,
+	summary,
+	removalDetail,
+	params,
+	effects = [],
+}: TierPassiveEffectOptions) {
+	params.detail(summary);
+	params.meta({
+		source: { type: 'tiered-resource', id: tierId },
+		removal: { token: removalDetail, text: formatRemoval(removalDetail) },
+	});
+	const builder = effect()
+		.type(Types.Passive)
+		.method(PassiveMethods.ADD)
+		.params(params);
+	effects.forEach((entry) => builder.effect(entry));
+	return builder;
+}
+
+type TierConfig = {
+	id: string;
+	passiveId: string;
+	range: { min: number; max?: number };
+	incomeMultiplier: number;
+	buildingDiscountPct?: number;
+	growthBonusPct?: number;
+	disableGrowth?: boolean;
+	skipPhases?: string[];
+	skipSteps?: Array<{ phase: string; step: string }>;
+	summary: string;
+	removal: string;
+	effects?: EffectConfig[];
+};
+
+const TIER_CONFIGS: TierConfig[] = [
+	{
+		id: 'happiness:tier:despair',
+		passiveId: 'passive:happiness:despair',
+		range: { min: -10 },
+		incomeMultiplier: 0.5,
+		disableGrowth: true,
+		skipPhases: [GROWTH_PHASE_ID],
+		skipSteps: [{ phase: UPKEEP_PHASE_ID, step: WAR_RECOVERY_STEP_ID }],
+		summary: '💰 Income -50%. ⏭️ Skip Growth. 🛡️ War Recovery skipped.',
+		removal: 'happiness rises to -9 or higher',
+		effects: [incomeModifier('happiness:despair:income', -0.5)],
+	},
+	{
+		id: 'happiness:tier:misery',
+		passiveId: 'passive:happiness:misery',
+		range: { min: -9, max: -8 },
+		incomeMultiplier: 0.5,
+		disableGrowth: true,
+		skipPhases: [GROWTH_PHASE_ID],
+		summary: '💰 Income -50%. ⏭️ Skip Growth while morale is ' + 'desperate.',
+		removal: 'happiness leaves the -9 to -8 range',
+		effects: [incomeModifier('happiness:misery:income', -0.5)],
+	},
+	{
+		id: 'happiness:tier:grim',
+		passiveId: 'passive:happiness:grim',
+		range: { min: -7, max: -5 },
+		incomeMultiplier: 0.75,
+		disableGrowth: true,
+		skipPhases: [GROWTH_PHASE_ID],
+		summary: '💰 Income -25%. ⏭️ Skip Growth until spirits recover.',
+		removal: 'happiness leaves the -7 to -5 range',
+		effects: [incomeModifier('happiness:grim:income', -0.25)],
+	},
+	{
+		id: 'happiness:tier:unrest',
+		passiveId: 'passive:happiness:unrest',
+		range: { min: -4, max: -3 },
+		incomeMultiplier: 0.75,
+		summary: '💰 Income -25% while unrest simmers.',
+		removal: 'happiness leaves the -4 to -3 range',
+		effects: [incomeModifier('happiness:unrest:income', -0.25)],
+	},
+	{
+		id: 'happiness:tier:steady',
+		passiveId: 'passive:happiness:steady',
+		range: { min: -2, max: 2 },
+		incomeMultiplier: 1,
+		summary: 'Morale is steady. No tier bonuses are active.',
+		removal: 'happiness leaves the -2 to +2 range',
+	},
+	{
+		id: 'happiness:tier:content',
+		passiveId: 'passive:happiness:content',
+		range: { min: 3, max: 4 },
+		incomeMultiplier: 1.2,
+		summary: '💰 Income +20% while the realm is content.',
+		removal: 'happiness leaves the +3 to +4 range',
+		effects: [incomeModifier('happiness:content:income', 0.2)],
+	},
+	{
+		id: 'happiness:tier:joyful',
+		passiveId: 'passive:happiness:joyful',
+		range: { min: 5, max: 7 },
+		incomeMultiplier: 1.25,
+		buildingDiscountPct: 0.2,
+		summary: '💰 Income +25%. 🏛️ Building costs reduced by 20%.',
+		removal: 'happiness leaves the +5 to +7 range',
+		effects: [
+			incomeModifier('happiness:joyful:income', 0.25),
+			buildingDiscountModifier('happiness:joyful:build-discount'),
+		],
+	},
+	{
+		id: 'happiness:tier:elated',
+		passiveId: 'passive:happiness:elated',
+		range: { min: 8, max: 9 },
+		incomeMultiplier: 1.5,
+		buildingDiscountPct: 0.2,
+		summary: '💰 Income +50%. 🏛️ Building costs reduced by 20%.',
+		removal: 'happiness leaves the +8 to +9 range',
+		effects: [
+			incomeModifier('happiness:elated:income', 0.5),
+			buildingDiscountModifier('happiness:elated:build-discount'),
+		],
+	},
+	{
+		id: 'happiness:tier:ecstatic',
+		passiveId: 'passive:happiness:ecstatic',
+		range: { min: 10 },
+		incomeMultiplier: 1.5,
+		buildingDiscountPct: 0.2,
+		growthBonusPct: 0.2,
+		summary:
+			'💰 Income +50%. 🏛️ Building costs reduced by 20%. ' + '📈 Growth +20%.',
+		removal: 'happiness drops below +10',
+		effects: [
+			incomeModifier('happiness:ecstatic:income', 0.5),
+			buildingDiscountModifier('happiness:ecstatic:build-discount'),
+			growthBonusEffect(0.2),
+		],
+	},
+];
+
+function buildTierDefinition(config: TierConfig): HappinessTierDefinition {
+	const params = passiveParams().id(config.passiveId);
+	config.skipPhases?.forEach((phaseId) => params.skipPhase(phaseId));
+	config.skipSteps?.forEach(({ phase, step }) => {
+		params.skipStep(phase, step);
+	});
+	const passive = createTierPassiveEffect({
+		tierId: config.id,
+		summary: config.summary,
+		removalDetail: config.removal,
+		params,
+		...(config.effects ? { effects: config.effects } : {}),
+	});
+	const builder = happinessTier(config.id)
+		.range(config.range.min, config.range.max)
+		.incomeMultiplier(config.incomeMultiplier)
+		.passive(passive)
+		.text((text) => {
+			text.summary(config.summary).removal(formatRemoval(config.removal));
+			return text;
+		})
+		.display((display) => display.removalCondition(config.removal));
+	if (config.disableGrowth) {
+		builder.disableGrowth();
+	}
+	if (config.buildingDiscountPct) {
+		builder.buildingDiscountPct(config.buildingDiscountPct);
+	}
+	if (config.growthBonusPct) {
+		builder.growthBonusPct(config.growthBonusPct);
+	}
+	return builder.build();
+}
+
+const tierDefinitions: HappinessTierDefinition[] = TIER_CONFIGS.map((config) =>
+	buildTierDefinition(config),
+);
+
 export const RULES: RuleSet = {
 	defaultActionAPCost: 1,
 	absorptionCapPct: 1,
 	absorptionRounding: 'down',
 	tieredResourceKey: Resource.happiness,
-	tierDefinitions: [
-		happinessTier('happiness:tier:despair')
-			.range(-10)
-			.incomeMultiplier(0.5)
-			.disableGrowth()
-			.passive(
-				tierPassive('passive:happiness:despair')
-					.effect(incomeModifier('happiness:despair:income', -0.5))
-					.skipPhase(GROWTH_PHASE_ID)
-					.skipStep(UPKEEP_PHASE_ID, WAR_RECOVERY_STEP_ID)
-					.text((text) => {
-						const removalDetail = 'happiness rises to -9 or higher';
-						text
-							.summary(
-								'💰 Income -50%. ⏭️ Skip Growth. 🛡️ War Recovery skipped.',
-							)
-							.removal(formatRemoval(removalDetail));
-						return text;
-					}),
-			)
-			.display((display) =>
-				display.removalCondition('happiness rises to -9 or higher'),
-			)
-			.build(),
-		happinessTier('happiness:tier:misery')
-			.range(-9, -8)
-			.incomeMultiplier(0.5)
-			.disableGrowth()
-			.passive(
-				tierPassive('passive:happiness:misery')
-					.effect(incomeModifier('happiness:misery:income', -0.5))
-					.skipPhase(GROWTH_PHASE_ID)
-					.text((text) => {
-						const removalDetail = 'happiness leaves the -9 to -8 range';
-						text
-							.summary(
-								'💰 Income -50%. ⏭️ Skip Growth while morale is desperate.',
-							)
-							.removal(formatRemoval(removalDetail));
-						return text;
-					}),
-			)
-			.display((display) =>
-				display.removalCondition('happiness leaves the -9 to -8 range'),
-			)
-			.build(),
-		happinessTier('happiness:tier:grim')
-			.range(-7, -5)
-			.incomeMultiplier(0.75)
-			.disableGrowth()
-			.passive(
-				tierPassive('passive:happiness:grim')
-					.effect(incomeModifier('happiness:grim:income', -0.25))
-					.skipPhase(GROWTH_PHASE_ID)
-					.text((text) => {
-						const removalDetail = 'happiness leaves the -7 to -5 range';
-						text
-							.summary('💰 Income -25%. ⏭️ Skip Growth until spirits recover.')
-							.removal(formatRemoval(removalDetail));
-						return text;
-					}),
-			)
-			.display((display) =>
-				display.removalCondition('happiness leaves the -7 to -5 range'),
-			)
-			.build(),
-		happinessTier('happiness:tier:unrest')
-			.range(-4, -3)
-			.incomeMultiplier(0.75)
-			.passive(
-				tierPassive('passive:happiness:unrest')
-					.effect(incomeModifier('happiness:unrest:income', -0.25))
-					.text((text) => {
-						const removalDetail = 'happiness leaves the -4 to -3 range';
-						text
-							.summary('💰 Income -25% while unrest simmers.')
-							.removal(formatRemoval(removalDetail));
-						return text;
-					}),
-			)
-			.display((display) =>
-				display.removalCondition('happiness leaves the -4 to -3 range'),
-			)
-			.build(),
-		happinessTier('happiness:tier:steady')
-			.range(-2, 2)
-			.incomeMultiplier(1)
-			.passive(
-				tierPassive('passive:happiness:steady').text((text) => {
-					const removalDetail = 'happiness leaves the -2 to +2 range';
-					text
-						.summary('Morale is steady. No tier bonuses are active.')
-						.removal(formatRemoval(removalDetail));
-					return text;
-				}),
-			)
-			.display((display) =>
-				display.removalCondition('happiness leaves the -2 to +2 range'),
-			)
-			.build(),
-		happinessTier('happiness:tier:content')
-			.range(3, 4)
-			.incomeMultiplier(1.2)
-			.passive(
-				tierPassive('passive:happiness:content')
-					.effect(incomeModifier('happiness:content:income', 0.2))
-					.text((text) => {
-						const removalDetail = 'happiness leaves the +3 to +4 range';
-						text
-							.summary('💰 Income +20% while the realm is content.')
-							.removal(formatRemoval(removalDetail));
-						return text;
-					}),
-			)
-			.display((display) =>
-				display.removalCondition('happiness leaves the +3 to +4 range'),
-			)
-			.build(),
-		happinessTier('happiness:tier:joyful')
-			.range(5, 7)
-			.incomeMultiplier(1.25)
-			.buildingDiscountPct(0.2)
-			.passive(
-				tierPassive('passive:happiness:joyful')
-					.effect(incomeModifier('happiness:joyful:income', 0.25))
-					.effect(buildingDiscountModifier('happiness:joyful:build-discount'))
-					.text((text) => {
-						const removalDetail = 'happiness leaves the +5 to +7 range';
-						text
-							.summary('💰 Income +25%. 🏛️ Building costs reduced by 20%.')
-							.removal(formatRemoval(removalDetail));
-						return text;
-					}),
-			)
-			.display((display) =>
-				display.removalCondition('happiness leaves the +5 to +7 range'),
-			)
-			.build(),
-		happinessTier('happiness:tier:elated')
-			.range(8, 9)
-			.incomeMultiplier(1.5)
-			.buildingDiscountPct(0.2)
-			.passive(
-				tierPassive('passive:happiness:elated')
-					.effect(incomeModifier('happiness:elated:income', 0.5))
-					.effect(buildingDiscountModifier('happiness:elated:build-discount'))
-					.text((text) => {
-						const removalDetail = 'happiness leaves the +8 to +9 range';
-						text
-							.summary('💰 Income +50%. 🏛️ Building costs reduced by 20%.')
-							.removal(formatRemoval(removalDetail));
-						return text;
-					}),
-			)
-			.display((display) =>
-				display.removalCondition('happiness leaves the +8 to +9 range'),
-			)
-			.build(),
-		happinessTier('happiness:tier:ecstatic')
-			.range(10)
-			.incomeMultiplier(1.5)
-			.buildingDiscountPct(0.2)
-			.growthBonusPct(0.2)
-			.passive(
-				tierPassive('passive:happiness:ecstatic')
-					.effect(incomeModifier('happiness:ecstatic:income', 0.5))
-					.effect(buildingDiscountModifier('happiness:ecstatic:build-discount'))
-					.effect(growthBonusEffect(0.2))
-					.text((text) => {
-						const removalDetail = 'happiness drops below +10';
-						text
-							.summary(
-								'💰 Income +50%. 🏛️ Building costs reduced by 20%. 📈 Growth +20%.',
-							)
-							.removal(formatRemoval(removalDetail));
-						return text;
-					}),
-			)
-			.display((display) =>
-				display.removalCondition('happiness drops below +10'),
-			)
-			.build(),
-	],
+	tierDefinitions,
 	slotsPerNewLand: 1,
 	maxSlotsPerLand: 2,
 	basePopulationCap: 1,

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -12,7 +12,8 @@ import {
 	attackParams,
 	transferParams,
 	happinessTier,
-	tierPassive,
+	Types,
+	PassiveMethods,
 } from '../src/config/builders';
 import type { ActionEffectGroupDef } from '../src/config/builders';
 import { RESOURCES, type ResourceKey } from '../src/resources';
@@ -21,6 +22,13 @@ import { describe, expect, it } from 'vitest';
 
 const firstResourceKey = Object.keys(RESOURCES)[0] as ResourceKey;
 const firstStatKey = Object.keys(STATS)[0] as StatKey;
+
+const buildTierPassiveEffect = () =>
+	effect()
+		.type(Types.Passive)
+		.method(PassiveMethods.ADD)
+		.params(passiveParams().id('passive:test').build())
+		.build();
 
 describe('content builder safeguards', () => {
 	it('explains when an action id is missing', () => {
@@ -198,7 +206,7 @@ describe('content builder safeguards', () => {
 
 	it('requires happiness tiers to declare an id', () => {
 		expect(() =>
-			happinessTier().range(0, 1).passive(tierPassive('passive:test')).build(),
+			happinessTier().range(0, 1).passive(buildTierPassiveEffect()).build(),
 		).toThrowError(
 			"Happiness tier is missing id(). Call id('your-tier-id') before build().",
 		);
@@ -208,7 +216,7 @@ describe('content builder safeguards', () => {
 		expect(() =>
 			happinessTier('tier:test')
 				.range(5, 3)
-				.passive(tierPassive('passive:test'))
+				.passive(buildTierPassiveEffect())
 				.build(),
 		).toThrowError(
 			'Happiness tier range(min, max?) requires max to be greater than or equal to min.',
@@ -217,21 +225,26 @@ describe('content builder safeguards', () => {
 
 	it('demands happiness tiers to define a passive payload', () => {
 		expect(() => happinessTier('tier:test').range(0, 1).build()).toThrowError(
-			'Happiness tier is missing passive(). Call passive(...) with tierPassive(...) before build().',
+			'Happiness tier is missing passive(). Call passive(...) with a passive:add effect before build().',
 		);
 	});
 
 	it('requires tier passives to provide an id', () => {
 		expect(() =>
-			happinessTier('tier:test').range(0, 1).passive(tierPassive()).build(),
+			happinessTier('tier:test')
+				.range(0, 1)
+				.passive(effect().type(Types.Passive).method(PassiveMethods.ADD))
+				.build(),
 		).toThrowError(
-			'Happiness tier passive is missing id(). Call id("your-passive-id") before build().',
+			'Happiness tier passive(...) requires the passive:add effect to include params.id.',
 		);
 	});
 
 	it('verifies skipStep receives both identifiers', () => {
-		expect(() => tierPassive('passive:test').skipStep('', 'step')).toThrowError(
-			'Happiness tier passive skipStep(...) requires both phaseId and stepId. Provide both values when calling skipStep().',
+		expect(() =>
+			passiveParams().id('passive:test').skipStep('', 'step'),
+		).toThrowError(
+			'Passive params skipStep(...) requires both phaseId and stepId. Provide both values when calling skipStep().',
 		);
 	});
 });

--- a/packages/engine/src/effects/passive_add.ts
+++ b/packages/engine/src/effects/passive_add.ts
@@ -1,9 +1,16 @@
 import type { EffectHandler, EffectDef } from '.';
+import type {
+	PassiveMetadata,
+	PhaseSkipConfig,
+} from '../services/passive_types';
 
 interface PassiveParams {
 	id: string;
 	name?: string;
 	icon?: string;
+	detail?: string;
+	meta?: PassiveMetadata;
+	skip?: PhaseSkipConfig;
 	onGrowthPhase?: EffectDef[];
 	onUpkeepPhase?: EffectDef[];
 	onBeforeAttacked?: EffectDef[];
@@ -21,6 +28,9 @@ export const passiveAdd: EffectHandler<PassiveParams> = (
 		id,
 		name,
 		icon,
+		detail,
+		meta,
+		skip,
 		onGrowthPhase,
 		onUpkeepPhase,
 		onBeforeAttacked,
@@ -33,6 +43,9 @@ export const passiveAdd: EffectHandler<PassiveParams> = (
 		id: string;
 		name?: string | undefined;
 		icon?: string | undefined;
+		detail?: string | undefined;
+		meta?: PassiveMetadata | undefined;
+		skip?: PhaseSkipConfig;
 		effects: EffectDef[];
 		onGrowthPhase?: EffectDef[];
 		onUpkeepPhase?: EffectDef[];
@@ -47,6 +60,15 @@ export const passiveAdd: EffectHandler<PassiveParams> = (
 	}
 	if (icon !== undefined) {
 		passive.icon = icon;
+	}
+	if (detail !== undefined) {
+		passive.detail = detail;
+	}
+	if (meta !== undefined) {
+		passive.meta = meta;
+	}
+	if (skip !== undefined) {
+		passive.skip = skip;
 	}
 	if (onGrowthPhase) {
 		passive.onGrowthPhase = onGrowthPhase;

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -21,14 +21,13 @@ export { EvaluationModifierService } from './evaluation_modifier_service';
 export { TieredResourceService } from './tiered_resource_service';
 export type {
 	TierRange,
-	TierPassiveSkipStep,
-	TierPassiveSkipConfig,
 	TierPassiveTextTokens,
-	TierPassivePayload,
 	TierDisplayMetadata,
 	TierEffect,
 	HappinessTierDefinition,
+	TierPassivePreview,
 } from './tiered_resource_types';
+export type { PhaseSkipConfig, PhaseSkipStep } from './passive_types';
 export { PopCapService } from './pop_cap_service';
 export { Services } from './services';
 export type { RuleSet } from './services_types';

--- a/packages/engine/src/services/passive_manager.ts
+++ b/packages/engine/src/services/passive_manager.ts
@@ -15,11 +15,14 @@ import {
 	type EvaluationModifier,
 	type ResourceGain,
 	type ResultModifier,
+	type PhaseSkipConfig,
 } from './passive_types';
 import {
 	clonePassiveMetadata,
 	clonePassiveRecord,
 	reverseEffect,
+	registerSkipFlags,
+	clearSkipFlags,
 } from './passive_helpers';
 
 type PassivePayload = {
@@ -33,6 +36,7 @@ type PassivePayload = {
 	onUpkeepPhase?: PassiveRecord['onUpkeepPhase'];
 	onBeforeAttacked?: PassiveRecord['onBeforeAttacked'];
 	onAttackResolved?: PassiveRecord['onAttackResolved'];
+	skip?: PhaseSkipConfig;
 	[trigger: string]: unknown;
 };
 
@@ -156,6 +160,7 @@ export class PassiveManager {
 		if (options?.meta !== undefined) {
 			record.meta = options.meta;
 		}
+		registerSkipFlags(context.activePlayer, record.id, record.skip);
 		this.passives.set(key, record);
 		const setupEffects = record.effects;
 		if (setupEffects && setupEffects.length > 0) {
@@ -171,6 +176,7 @@ export class PassiveManager {
 		if (!passive) {
 			return;
 		}
+		clearSkipFlags(context.activePlayer, passive.id, passive.skip);
 		const teardownEffects = passive.effects;
 		if (teardownEffects && teardownEffects.length > 0) {
 			withStatSourceFrames(context, passive.frames, () =>

--- a/packages/engine/src/services/passive_types.ts
+++ b/packages/engine/src/services/passive_types.ts
@@ -3,6 +3,16 @@ import type { EngineContext } from '../context';
 import type { EffectDef } from '../effects';
 import type { StatSourceFrame } from '../stat_sources';
 
+export type PhaseSkipStep = {
+	phaseId: string;
+	stepId: string;
+};
+
+export type PhaseSkipConfig = {
+	phases?: string[];
+	steps?: PhaseSkipStep[];
+};
+
 export interface PassiveSummary {
 	id: string;
 	name?: string | undefined;
@@ -38,6 +48,7 @@ export type PassiveRecord = PassiveSummary & {
 	frames: StatSourceFrame[];
 	detail?: string;
 	meta?: PassiveMetadata;
+	skip?: PhaseSkipConfig;
 	[trigger: string]: unknown;
 };
 

--- a/packages/engine/src/services/services.ts
+++ b/packages/engine/src/services/services.ts
@@ -1,22 +1,13 @@
-import type { ResourceKey, PlayerState, PlayerId } from '../state';
+import type { ResourceKey, PlayerId } from '../state';
 import type { EngineContext } from '../context';
 import type { DevelopmentConfig } from '../config/schema';
 import type { Registry } from '../registry';
+import { runEffects } from '../effects';
 import { TieredResourceService } from './tiered_resource_service';
 import { PopCapService } from './pop_cap_service';
-import type {
-	HappinessTierDefinition,
-	TierPassivePayload,
-} from './tiered_resource_types';
-import type {
-	PassiveMetadata,
-	PassiveRemovalMetadata,
-	PassiveSourceMetadata,
-} from './passive_types';
+import type { HappinessTierDefinition } from './tiered_resource_types';
 import type { RuleSet } from './services_types';
 
-type Passive = TierPassivePayload;
-type Player = PlayerState;
 type Context = EngineContext;
 type TierResource = ResourceKey;
 
@@ -33,69 +24,6 @@ export class Services {
 		this.popcap = new PopCapService(rules, developments);
 	}
 
-	private registerSkipFlags(player: Player, passive: Passive) {
-		const skip = passive.skip;
-		if (!skip) {
-			return;
-		}
-		const sourceId = passive.id;
-		if (skip.phases) {
-			for (const phaseId of skip.phases) {
-				const phaseBucket = player.skipPhases[phaseId] ?? {};
-				phaseBucket[sourceId] = true;
-				player.skipPhases[phaseId] = phaseBucket;
-			}
-		}
-		if (skip.steps) {
-			for (const { phaseId, stepId } of skip.steps) {
-				const phaseBucket = player.skipSteps[phaseId] ?? {};
-				const stepBucket = phaseBucket[stepId] ?? {};
-				stepBucket[sourceId] = true;
-				phaseBucket[stepId] = stepBucket;
-				player.skipSteps[phaseId] = phaseBucket;
-			}
-		}
-	}
-
-	private clearSkipFlags(player: Player, passive: Passive) {
-		const skip = passive.skip;
-		if (!skip) {
-			return;
-		}
-		const sourceId = passive.id;
-		if (skip.phases) {
-			for (const phaseId of skip.phases) {
-				const bucket = player.skipPhases[phaseId];
-				if (!bucket) {
-					continue;
-				}
-				delete bucket[sourceId];
-				if (Object.keys(bucket).length === 0) {
-					delete player.skipPhases[phaseId];
-				}
-			}
-		}
-		if (skip.steps) {
-			for (const { phaseId, stepId } of skip.steps) {
-				const phaseBucket = player.skipSteps[phaseId];
-				if (!phaseBucket) {
-					continue;
-				}
-				const stepBucket = phaseBucket[stepId];
-				if (!stepBucket) {
-					continue;
-				}
-				delete stepBucket[sourceId];
-				if (Object.keys(stepBucket).length === 0) {
-					delete phaseBucket[stepId];
-				}
-				if (Object.keys(phaseBucket).length === 0) {
-					delete player.skipSteps[phaseId];
-				}
-			}
-		}
-	}
-
 	handleTieredResourceChange(context: Context, tierKey: TierResource) {
 		if (tierKey !== this.tieredResource.resourceKey) {
 			return;
@@ -108,41 +36,18 @@ export class Services {
 			return;
 		}
 		if (currentTier) {
-			this.clearSkipFlags(player, currentTier.passive);
-			context.passives.removePassive(currentTier.passive.id, context);
+			if (currentTier.exitEffects?.length) {
+				runEffects(currentTier.exitEffects, context);
+			}
 			this.activeTiers.delete(player.id);
 		}
 		if (nextTier) {
-			const sourceMeta: PassiveSourceMetadata = {
-				type: 'tiered-resource',
-				id: nextTier.id,
-			};
-			if (nextTier.display?.icon) {
-				sourceMeta.icon = nextTier.display.icon;
+			if (nextTier.enterEffects?.length) {
+				runEffects(nextTier.enterEffects, context);
 			}
-			if (nextTier.display?.summaryToken) {
-				sourceMeta.labelToken = nextTier.display.summaryToken;
-			}
-			const removalMeta: PassiveRemovalMetadata = {};
-			if (nextTier.display?.removalCondition) {
-				removalMeta.token = nextTier.display.removalCondition;
-			}
-			if (nextTier.passive.text?.removal) {
-				removalMeta.text = nextTier.passive.text.removal;
-			}
-			const metadata: PassiveMetadata = {
-				source: sourceMeta,
-			};
-			if (Object.keys(removalMeta).length > 0) {
-				metadata.removal = removalMeta;
-			}
-			const detailText = nextTier.passive.text?.summary ?? nextTier.id;
-			context.passives.addPassive(nextTier.passive, context, {
-				detail: detailText,
-				meta: metadata,
-			});
-			this.registerSkipFlags(player, nextTier.passive);
 			this.activeTiers.set(player.id, nextTier);
+		} else {
+			this.activeTiers.delete(player.id);
 		}
 	}
 

--- a/packages/engine/src/services/tiered_resource_types.ts
+++ b/packages/engine/src/services/tiered_resource_types.ts
@@ -5,34 +5,15 @@ export type TierRange = {
 	max?: number;
 };
 
-export type TierPassiveSkipStep = {
-	phaseId: string;
-	stepId: string;
-};
-
-export type TierPassiveSkipConfig = {
-	phases?: string[];
-	steps?: TierPassiveSkipStep[];
-};
-
 export type TierPassiveTextTokens = {
 	summary?: string;
 	description?: string;
 	removal?: string;
 };
 
-export type TierPassivePayload = {
+export type TierPassivePreview = {
 	id: string;
 	effects?: EffectDef[];
-	onGrowthPhase?: EffectDef[];
-	onUpkeepPhase?: EffectDef[];
-	onBeforeAttacked?: EffectDef[];
-	onAttackResolved?: EffectDef[];
-	onPayUpkeepStep?: EffectDef[];
-	onGainIncomeStep?: EffectDef[];
-	onGainAPStep?: EffectDef[];
-	skip?: TierPassiveSkipConfig;
-	text?: TierPassiveTextTokens;
 };
 
 export type TierDisplayMetadata = {
@@ -54,6 +35,9 @@ export type HappinessTierDefinition = {
 	id: string;
 	range: TierRange;
 	effect: TierEffect;
-	passive: TierPassivePayload;
+	enterEffects?: EffectDef[];
+	exitEffects?: EffectDef[];
+	preview?: TierPassivePreview;
+	text?: TierPassiveTextTokens;
 	display?: TierDisplayMetadata;
 };

--- a/packages/engine/tests/advance-skip.test.ts
+++ b/packages/engine/tests/advance-skip.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { RULES, PHASES } from '@kingdom-builder/contents';
 import {
 	happinessTier,
-	tierPassive,
+	effect,
+	passiveParams,
+	Types,
+	PassiveMethods,
 } from '@kingdom-builder/contents/config/builders';
 import { advance } from '../src';
 import { createTestEngine } from './helpers';
@@ -31,10 +34,24 @@ describe('advance skip handling', () => {
 				happinessTier('test:tier:skip-phase')
 					.range(0, 5)
 					.passive(
-						tierPassive('test:passive:skip-phase')
-							.skipPhase(growthPhaseId)
-							.text((text) => text.summary(phaseSummary)),
+						effect()
+							.type(Types.Passive)
+							.method(PassiveMethods.ADD)
+							.params(
+								passiveParams()
+									.id('test:passive:skip-phase')
+									.detail(phaseSummary)
+									.meta({
+										source: {
+											type: 'tiered-resource',
+											id: 'test:tier:skip-phase',
+										},
+									})
+									.skipPhase(growthPhaseId)
+									.build(),
+							),
 					)
+					.text((text) => text.summary(phaseSummary))
 					.build(),
 			],
 		};
@@ -47,7 +64,7 @@ describe('advance skip handling', () => {
 		expect(result.skipped?.type).toBe('phase');
 		expect(result.skipped?.phaseId).toBe(growthPhaseId);
 		expect(result.skipped?.sources[0]?.id).toBe(
-			customRules.tierDefinitions[0]?.passive.id,
+			customRules.tierDefinitions[0]?.preview?.id,
 		);
 		expect(result.skipped?.sources[0]?.detail).toBe(phaseSummary);
 
@@ -64,10 +81,24 @@ describe('advance skip handling', () => {
 				happinessTier('test:tier:skip-step')
 					.range(0, 5)
 					.passive(
-						tierPassive('test:passive:skip-step')
-							.skipStep(upkeepPhaseId, warRecoveryStepId)
-							.text((text) => text.summary(stepSummary)),
+						effect()
+							.type(Types.Passive)
+							.method(PassiveMethods.ADD)
+							.params(
+								passiveParams()
+									.id('test:passive:skip-step')
+									.detail(stepSummary)
+									.meta({
+										source: {
+											type: 'tiered-resource',
+											id: 'test:tier:skip-step',
+										},
+									})
+									.skipStep(upkeepPhaseId, warRecoveryStepId)
+									.build(),
+							),
 					)
+					.text((text) => text.summary(stepSummary))
 					.build(),
 			],
 		};
@@ -105,10 +136,24 @@ describe('advance skip handling', () => {
 				happinessTier('test:tier:skip-phase')
 					.range(0, 5)
 					.passive(
-						tierPassive('test:passive:skip-phase')
-							.skipPhase(growthPhaseId)
-							.text((text) => text.summary(phaseSummary)),
+						effect()
+							.type(Types.Passive)
+							.method(PassiveMethods.ADD)
+							.params(
+								passiveParams()
+									.id('test:passive:skip-phase')
+									.detail(phaseSummary)
+									.meta({
+										source: {
+											type: 'tiered-resource',
+											id: 'test:tier:skip-phase',
+										},
+									})
+									.skipPhase(growthPhaseId)
+									.build(),
+							),
 					)
+					.text((text) => text.summary(phaseSummary))
 					.build(),
 			],
 		};
@@ -136,7 +181,7 @@ describe('advance skip handling', () => {
 		const byId = Object.fromEntries(
 			sources.map((source) => [source.id, source]),
 		);
-		const tierPassiveId = customRules.tierDefinitions[0]?.passive.id ?? '';
+		const tierPassiveId = customRules.tierDefinitions[0]?.preview?.id ?? '';
 		expect(byId[tierPassiveId]?.detail).toBe(phaseSummary);
 		expect(byId['test:passive:extra']?.detail).toBe('Extra skip detail');
 		expect(byId['test:passive:extra']?.meta?.source?.icon).toBe('🔥');

--- a/packages/engine/tests/services/rules.test.ts
+++ b/packages/engine/tests/services/rules.test.ts
@@ -5,7 +5,10 @@ import { createTestEngine } from '../helpers';
 import { RULES, Resource as CResource } from '@kingdom-builder/contents';
 import {
 	happinessTier,
-	tierPassive,
+	effect,
+	passiveParams,
+	Types,
+	PassiveMethods,
 } from '@kingdom-builder/contents/config/builders';
 import { getActionCosts } from '../../src';
 import { createContentFactory } from '../factories/content';
@@ -44,12 +47,22 @@ describe('Services', () => {
 					happinessTier('test:tier:low')
 						.range(0, 5)
 						.incomeMultiplier(1)
-						.passive(tierPassive('test:passive:low'))
+						.passive(
+							effect()
+								.type(Types.Passive)
+								.method(PassiveMethods.ADD)
+								.params(passiveParams().id('test:passive:low').build()),
+						)
 						.build(),
 					happinessTier('test:tier:high')
 						.range(6)
 						.incomeMultiplier(2)
-						.passive(tierPassive('test:passive:high'))
+						.passive(
+							effect()
+								.type(Types.Passive)
+								.method(PassiveMethods.ADD)
+								.params(passiveParams().id('test:passive:high').build()),
+						)
 						.build(),
 				],
 			},

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -36,7 +36,7 @@ function buildTierEntries(
 		active: tier.id === activeId,
 	}));
 	return entries.map((entry) => {
-		const { passive, display, active } = entry;
+		const { preview, display, text, active } = entry;
 		const rangeLabel = formatTierRange(entry);
 		const statusIcon = active ? '🟢' : '⚪';
 		const icon = display?.icon ?? PASSIVE_INFO.icon ?? '';
@@ -44,9 +44,9 @@ function buildTierEntries(
 			(part) => part && String(part).trim().length > 0,
 		);
 		const title = titleParts.join(' ').trim();
-		const summary = passive.text?.summary;
+		const summary = text?.summary;
 		const removalText =
-			passive.text?.removal ??
+			text?.removal ??
 			(display?.removalCondition
 				? `Removed when ${display.removalCondition}`
 				: undefined);
@@ -54,7 +54,7 @@ function buildTierEntries(
 		if (summary) {
 			items.push(summary);
 		}
-		const described = describeEffects(passive.effects || [], ctx);
+		const described = describeEffects(preview?.effects || [], ctx);
 		described.forEach((item) => items.push(item));
 		if (removalText) {
 			items.push(removalText);

--- a/tests/integration/synthetic.ts
+++ b/tests/integration/synthetic.ts
@@ -15,7 +15,10 @@ import type { PhaseDef } from '@kingdom-builder/engine';
 import type { RuleSet } from '@kingdom-builder/engine/services';
 import {
 	happinessTier,
-	tierPassive,
+	effect,
+	passiveParams,
+	Types,
+	PassiveMethods,
 } from '@kingdom-builder/contents/config/builders';
 
 export function createSyntheticContext() {
@@ -105,7 +108,17 @@ export function createSyntheticContext() {
 			happinessTier('synthetic:happiness:baseline')
 				.range(0)
 				.incomeMultiplier(1)
-				.passive(tierPassive('synthetic:passive:baseline'))
+				.passive(
+					effect()
+						.type(Types.Passive)
+						.method(PassiveMethods.ADD)
+						.params(
+							passiveParams()
+								.id('synthetic:passive:baseline')
+								.detail('synthetic:happiness:baseline')
+								.build(),
+						),
+				)
 				.build(),
 		],
 		slotsPerNewLand: 1,


### PR DESCRIPTION
## Summary
- replace happiness tier passive payloads with effect-driven entry and exit lists that rely on passive:add/passive:remove
- simplify the tier service to run those effects, centralizing skip flag registration inside the PassiveManager
- regenerate content builders, rules, UI, and tests to describe tier previews and copy via effect metadata

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e12379b99883259559350f9d11a8c5