### PR TITLE
Allow neutral happiness tier without passive payload

### DIFF
--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -877,11 +877,6 @@ class HappinessTierBuilder {
 				'Happiness tier is missing range(). Call range(min, max?) before build().',
 			);
 		}
-		if (!this.passiveSet) {
-			throw new Error(
-				'Happiness tier is missing passive(). Call passive(...) with a passive:add effect before build().',
-			);
-		}
 		const definition: HappinessTierDefinition = {
 			id: this.config.id!,
 			range: this.config.range!,

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -223,10 +223,11 @@ describe('content builder safeguards', () => {
 		);
 	});
 
-	it('demands happiness tiers to define a passive payload', () => {
-		expect(() => happinessTier('tier:test').range(0, 1).build()).toThrowError(
-			'Happiness tier is missing passive(). Call passive(...) with a passive:add effect before build().',
-		);
+	it('allows happiness tiers to omit a passive payload', () => {
+		const tier = happinessTier('tier:test').range(0, 1).build();
+		expect(tier.enterEffects).toBeUndefined();
+		expect(tier.exitEffects).toBeUndefined();
+		expect(tier.preview).toBeUndefined();
 	});
 
 	it('requires tier passives to provide an id', () => {

--- a/packages/engine/src/services/services.ts
+++ b/packages/engine/src/services/services.ts
@@ -36,14 +36,16 @@ export class Services {
 			return;
 		}
 		if (currentTier) {
-			if (currentTier.exitEffects?.length) {
-				runEffects(currentTier.exitEffects, context);
+			const exitEffects = currentTier.exitEffects ?? [];
+			if (exitEffects.length) {
+				runEffects(exitEffects, context);
 			}
 			this.activeTiers.delete(player.id);
 		}
 		if (nextTier) {
-			if (nextTier.enterEffects?.length) {
-				runEffects(nextTier.enterEffects, context);
+			const enterEffects = nextTier.enterEffects ?? [];
+			if (enterEffects.length) {
+				runEffects(enterEffects, context);
 			}
 			this.activeTiers.set(player.id, nextTier);
 		} else {

--- a/packages/web/tests/passive-display.test.tsx
+++ b/packages/web/tests/passive-display.test.tsx
@@ -77,4 +77,31 @@ describe('<PassiveDisplay />', () => {
 			]),
 		);
 	});
+
+	it('renders no passive cards when the active tier has no passive effects', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		const happinessKey = ctx.services.tieredResource.resourceKey as ResourceKey;
+		ctx.activePlayer.resources[happinessKey] = 0;
+		ctx.services.handleTieredResourceChange(ctx, happinessKey);
+
+		const handleHoverCard = vi.fn();
+		const clearHoverCard = vi.fn();
+		currentGame = {
+			ctx,
+			handleHoverCard,
+			clearHoverCard,
+		} as MockGame;
+
+		const { container } = render(<PassiveDisplay player={ctx.activePlayer} />);
+
+		expect(container).toBeEmptyDOMElement();
+	});
 });

--- a/tests/integration/happiness-tier-content.test.ts
+++ b/tests/integration/happiness-tier-content.test.ts
@@ -207,22 +207,7 @@ describe('content happiness tiers', () => {
         },
         "steady": {
           "happiness": 0,
-          "passives": [
-            {
-              "detail": "Morale is steady. No tier bonuses are active.",
-              "id": "passive:happiness:steady",
-              "meta": {
-                "removal": {
-                  "text": "Removed when happiness leaves the -2 to +2 range",
-                  "token": "happiness leaves the -2 to +2 range",
-                },
-                "source": {
-                  "id": "happiness:tier:steady",
-                  "type": "tiered-resource",
-                },
-              },
-            },
-          ],
+          "passives": [],
           "skipPhases": {},
           "skipSteps": {},
         },


### PR DESCRIPTION
## Summary
- let happiness tier builders produce definitions without a passive payload and skip installing a steady-tier passive in the default ruleset
- ensure tier service gracefully handles tiers that only provide multiplier metadata and retain other bonuses
- update integration and UI tests to expect no passive card in the neutral happiness range and cover the new scenario

## Testing
- npm test -- packages/contents/tests/builder-validations.test.ts packages/web/tests/passive-display.test.tsx tests/integration/happiness-tier-content.test.ts
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e12bcb64d48325bb64b8af57107302