### PR TITLE
Reword passive removal messaging

### DIFF
--- a/packages/contents/src/rules.ts
+++ b/packages/contents/src/rules.ts
@@ -56,7 +56,8 @@ const growthBonusEffect = (amount: number) =>
 		params: statParams().key(Stat.growth).amount(amount).build(),
 	}) as const;
 
-const formatRemoval = (description: string) => `Removed when ${description}`;
+const formatRemoval = (description: string) =>
+	`Active as long as ${description}`;
 
 type TierPassiveEffectOptions = {
 	tierId: string;
@@ -100,7 +101,7 @@ const TIER_CONFIGS = [
 		skipSteps: [{ phase: UPKEEP_PHASE_ID, step: WAR_RECOVERY_STEP_ID }],
 		summaryToken: happinessSummaryToken('despair'),
 		summary: '💰 Income -50%. ⏭️ Skip Growth. 🛡️ War Recovery skipped.',
-		removal: 'happiness rises to -9 or higher',
+		removal: 'happiness is -10 or lower',
 		effects: [incomeModifier('happiness:despair:income', -0.5)],
 	},
 	{
@@ -112,7 +113,7 @@ const TIER_CONFIGS = [
 		skipPhases: [GROWTH_PHASE_ID],
 		summaryToken: happinessSummaryToken('misery'),
 		summary: '💰 Income -50%. ⏭️ Skip Growth while morale is ' + 'desperate.',
-		removal: 'happiness leaves the -9 to -8 range',
+		removal: 'happiness stays between -9 and -8',
 		effects: [incomeModifier('happiness:misery:income', -0.5)],
 	},
 	{
@@ -124,7 +125,7 @@ const TIER_CONFIGS = [
 		skipPhases: [GROWTH_PHASE_ID],
 		summaryToken: happinessSummaryToken('grim'),
 		summary: '💰 Income -25%. ⏭️ Skip Growth until spirits recover.',
-		removal: 'happiness leaves the -7 to -5 range',
+		removal: 'happiness stays between -7 and -5',
 		effects: [incomeModifier('happiness:grim:income', -0.25)],
 	},
 	{
@@ -134,7 +135,7 @@ const TIER_CONFIGS = [
 		incomeMultiplier: 0.75,
 		summaryToken: happinessSummaryToken('unrest'),
 		summary: '💰 Income -25% while unrest simmers.',
-		removal: 'happiness leaves the -4 to -3 range',
+		removal: 'happiness stays between -4 and -3',
 		effects: [incomeModifier('happiness:unrest:income', -0.25)],
 	},
 	{
@@ -143,7 +144,7 @@ const TIER_CONFIGS = [
 		incomeMultiplier: 1,
 		summaryToken: happinessSummaryToken('steady'),
 		summary: 'Morale is steady. No tier bonuses are active.',
-		removal: 'happiness leaves the -2 to +2 range',
+		removal: 'happiness stays between -2 and +2',
 	},
 	{
 		id: 'happiness:tier:content',
@@ -152,7 +153,7 @@ const TIER_CONFIGS = [
 		incomeMultiplier: 1.2,
 		summaryToken: happinessSummaryToken('content'),
 		summary: '💰 Income +20% while the realm is content.',
-		removal: 'happiness leaves the +3 to +4 range',
+		removal: 'happiness stays between +3 and +4',
 		effects: [incomeModifier('happiness:content:income', 0.2)],
 	},
 	{
@@ -163,7 +164,7 @@ const TIER_CONFIGS = [
 		buildingDiscountPct: 0.2,
 		summaryToken: happinessSummaryToken('joyful'),
 		summary: '💰 Income +25%. 🏛️ Building costs reduced by 20%.',
-		removal: 'happiness leaves the +5 to +7 range',
+		removal: 'happiness stays between +5 and +7',
 		effects: [
 			incomeModifier('happiness:joyful:income', 0.25),
 			buildingDiscountModifier('happiness:joyful:build-discount'),
@@ -177,7 +178,7 @@ const TIER_CONFIGS = [
 		buildingDiscountPct: 0.2,
 		summaryToken: happinessSummaryToken('elated'),
 		summary: '💰 Income +50%. 🏛️ Building costs reduced by 20%.',
-		removal: 'happiness leaves the +8 to +9 range',
+		removal: 'happiness stays between +8 and +9',
 		effects: [
 			incomeModifier('happiness:elated:income', 0.5),
 			buildingDiscountModifier('happiness:elated:build-discount'),
@@ -193,7 +194,7 @@ const TIER_CONFIGS = [
 		summaryToken: happinessSummaryToken('ecstatic'),
 		summary:
 			'💰 Income +50%. 🏛️ Building costs reduced by 20%. ' + '📈 Growth +20%.',
-		removal: 'happiness drops below +10',
+		removal: 'happiness is +10 or higher',
 		effects: [
 			incomeModifier('happiness:ecstatic:income', 0.5),
 			buildingDiscountModifier('happiness:ecstatic:build-discount'),

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -105,7 +105,7 @@ export default function PassiveDisplay({
 			typeof meta.removal.token === 'string' &&
 			meta.removal.token.trim().length > 0
 		) {
-			return `Removed when ${meta.removal.token}`;
+			return `Active as long as ${meta.removal.token}`;
 		}
 		return undefined;
 	};

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -49,7 +49,7 @@ function buildTierEntries(
 		const removalText =
 			text?.removal ??
 			(display?.removalCondition
-				? `Removed when ${display.removalCondition}`
+				? `Active as long as ${display.removalCondition}`
 				: undefined);
 		const items = [] as ReturnType<typeof describeEffects>;
 		if (summary) {

--- a/packages/web/src/translation/log/passives.ts
+++ b/packages/web/src/translation/log/passives.ts
@@ -23,7 +23,7 @@ function describeRemoval(meta: PassiveSummary['meta']): string | undefined {
 	}
 	const removalToken = meta?.removal?.token;
 	if (removalToken && removalToken.trim().length > 0) {
-		return `Removed when ${removalToken}`;
+		return `Active as long as ${removalToken}`;
 	}
 	return undefined;
 }

--- a/packages/web/src/utils/stats/summary.ts
+++ b/packages/web/src/utils/stats/summary.ts
@@ -68,7 +68,7 @@ function buildLongevityEntries(
 			});
 		}
 		if (removal) {
-			pushSummaryEntry(items, `Removed when ${removal}`);
+			pushSummaryEntry(items, `Active as long as ${removal}`);
 		}
 		if (items.length) {
 			entries.push({
@@ -89,7 +89,7 @@ function buildLongevityEntries(
 		});
 	}
 	if (removal) {
-		pushSummaryEntry(items, `Can be removed when ${removal}`);
+		pushSummaryEntry(items, `Active as long as ${removal}`);
 	}
 	if (items.length) {
 		entries.push({ title: 'Permanent', items });

--- a/packages/web/tests/passive-display.test.tsx
+++ b/packages/web/tests/passive-display.test.tsx
@@ -61,7 +61,9 @@ describe('<PassiveDisplay />', () => {
 		const summaryText = screen.getByText(/Income \+25%/i);
 		expect(summaryText).toBeInTheDocument();
 		expect(
-			screen.getByText(/Removed when happiness leaves the \+5 to \+7 range/i),
+			screen.getByText(
+				/Active as long as happiness stays between \+5 and \+7/i,
+			),
 		).toBeInTheDocument();
 
 		const hoverTarget = summaryText.closest('div.hoverable');
@@ -72,7 +74,7 @@ describe('<PassiveDisplay />', () => {
 		expect(description).toEqual(
 			expect.arrayContaining([
 				expect.stringMatching(
-					/Removed when happiness leaves the \+5 to \+7 range/i,
+					/Active as long as happiness stays between \+5 and \+7/i,
 				),
 			]),
 		);

--- a/packages/web/tests/resource-bar.test.tsx
+++ b/packages/web/tests/resource-bar.test.tsx
@@ -80,7 +80,7 @@ describe('<ResourceBar /> happiness hover card', () => {
 		) as { items: unknown[] } | undefined;
 		expect(activeEntry).toBeTruthy();
 		const removal = activeEntry?.items.find(
-			(item) => typeof item === 'string' && /Removed when/i.test(item),
+			(item) => typeof item === 'string' && /Active as long as/i.test(item),
 		);
 		expect(removal).toBeTruthy();
 	});

--- a/packages/web/tests/stat-breakdown.test.ts
+++ b/packages/web/tests/stat-breakdown.test.ts
@@ -79,7 +79,7 @@ describe('stat breakdown summary', () => {
 					title: expect.stringContaining('Ongoing'),
 					items: expect.arrayContaining([
 						expect.stringContaining('While 🎖️ Legion'),
-						expect.stringContaining('Removed when'),
+						expect.stringContaining('Active as long as'),
 					]),
 				}),
 			]),

--- a/tests/integration/happiness-tier-content.test.ts
+++ b/tests/integration/happiness-tier-content.test.ts
@@ -57,7 +57,7 @@ describe('content happiness tiers', () => {
           "passives": [
             {
               "id": "passive:happiness:content",
-              "removalToken": "happiness leaves the +3 to +4 range",
+              "removalToken": "happiness stays between +3 and +4",
               "summary": "💰 Income +20% while the realm is content.",
               "summaryToken": "happiness.tier.summary.content",
             },
@@ -70,7 +70,7 @@ describe('content happiness tiers', () => {
           "passives": [
             {
               "id": "passive:happiness:despair",
-              "removalToken": "happiness rises to -9 or higher",
+              "removalToken": "happiness is -10 or lower",
               "summary": "💰 Income -50%. ⏭️ Skip Growth. 🛡️ War Recovery skipped.",
               "summaryToken": "happiness.tier.summary.despair",
             },
@@ -93,7 +93,7 @@ describe('content happiness tiers', () => {
           "passives": [
             {
               "id": "passive:happiness:ecstatic",
-              "removalToken": "happiness drops below +10",
+              "removalToken": "happiness is +10 or higher",
               "summary": "💰 Income +50%. 🏛️ Building costs reduced by 20%. 📈 Growth +20%.",
               "summaryToken": "happiness.tier.summary.ecstatic",
             },
@@ -106,7 +106,7 @@ describe('content happiness tiers', () => {
           "passives": [
             {
               "id": "passive:happiness:elated",
-              "removalToken": "happiness leaves the +8 to +9 range",
+              "removalToken": "happiness stays between +8 and +9",
               "summary": "💰 Income +50%. 🏛️ Building costs reduced by 20%.",
               "summaryToken": "happiness.tier.summary.elated",
             },
@@ -119,7 +119,7 @@ describe('content happiness tiers', () => {
           "passives": [
             {
               "id": "passive:happiness:grim",
-              "removalToken": "happiness leaves the -7 to -5 range",
+              "removalToken": "happiness stays between -7 and -5",
               "summary": "💰 Income -25%. ⏭️ Skip Growth until spirits recover.",
               "summaryToken": "happiness.tier.summary.grim",
             },
@@ -136,7 +136,7 @@ describe('content happiness tiers', () => {
           "passives": [
             {
               "id": "passive:happiness:joyful",
-              "removalToken": "happiness leaves the +5 to +7 range",
+              "removalToken": "happiness stays between +5 and +7",
               "summary": "💰 Income +25%. 🏛️ Building costs reduced by 20%.",
               "summaryToken": "happiness.tier.summary.joyful",
             },
@@ -149,7 +149,7 @@ describe('content happiness tiers', () => {
           "passives": [
             {
               "id": "passive:happiness:misery",
-              "removalToken": "happiness leaves the -9 to -8 range",
+              "removalToken": "happiness stays between -9 and -8",
               "summary": "💰 Income -50%. ⏭️ Skip Growth while morale is desperate.",
               "summaryToken": "happiness.tier.summary.misery",
             },
@@ -172,7 +172,7 @@ describe('content happiness tiers', () => {
           "passives": [
             {
               "id": "passive:happiness:unrest",
-              "removalToken": "happiness leaves the -4 to -3 range",
+              "removalToken": "happiness stays between -4 and -3",
               "summary": "💰 Income -25% while unrest simmers.",
               "summaryToken": "happiness.tier.summary.unrest",
             },


### PR DESCRIPTION
## Summary
- rephrased happiness tier removal descriptions to state their active conditions and emit "Active as long as …" text
- updated passive display, resource bar, stat summaries, and log translation fallbacks to reuse the new phrasing
- refreshed integration and UI tests to cover the new wording for content, passives, and summaries

## Testing
- npx vitest run packages/web/tests/passive-display.test.tsx packages/web/tests/resource-bar.test.tsx packages/web/tests/stat-breakdown.test.ts tests/integration/happiness-tier-content.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1341b8e188325b4e15db604913137