### PR TITLE
Use tier summary tokens in passive logs

### DIFF
--- a/packages/engine/src/services/services.ts
+++ b/packages/engine/src/services/services.ts
@@ -47,6 +47,27 @@ export class Services {
 			if (enterEffects.length) {
 				runEffects(enterEffects, context);
 			}
+			const passiveId = nextTier.preview?.id;
+			const summaryToken =
+				nextTier.display?.summaryToken ?? nextTier.text?.summary;
+			if (passiveId && summaryToken) {
+				const passive = context.passives.get(passiveId, player.id);
+				if (passive) {
+					passive.detail = summaryToken;
+					const existingMeta = passive.meta ?? {};
+					const baseSource = existingMeta.source ?? {
+						type: 'tiered-resource',
+						id: nextTier.id,
+					};
+					passive.meta = {
+						...existingMeta,
+						source: {
+							...baseSource,
+							labelToken: summaryToken,
+						},
+					};
+				}
+			}
 			this.activeTiers.set(player.id, nextTier);
 		} else {
 			this.activeTiers.delete(player.id);

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -6,7 +6,12 @@ import {
 	PASSIVE_INFO,
 	POPULATIONS,
 } from '@kingdom-builder/contents';
-import { describeEffects, splitSummary } from '../../translation';
+import {
+	describeEffects,
+	splitSummary,
+	hasTierSummaryTranslation,
+	translateTierSummary,
+} from '../../translation';
 import type {
 	EffectDef,
 	EngineContext,
@@ -118,20 +123,33 @@ export default function PassiveDisplay({
 		>,
 	) => {
 		const meta = def.meta ?? summary.meta;
-		const labelToken = meta?.source?.labelToken;
-		if (labelToken && labelToken.trim().length > 0) {
-			return labelToken;
-		}
-		if (def.detail && def.detail.trim().length > 0) {
-			return def.detail;
-		}
-		if (summary.detail && summary.detail.trim().length > 0) {
-			return summary.detail;
-		}
-		if (summary.name && summary.name.trim().length > 0) {
-			return summary.name;
-		}
-		return summary.id;
+		const normalize = (value: string | undefined) => {
+			if (!value) {
+				return undefined;
+			}
+			const trimmed = value.trim();
+			return trimmed.length > 0 ? trimmed : undefined;
+		};
+		const translateToken = (value: string | undefined) => {
+			const token = normalize(value);
+			if (!token) {
+				return undefined;
+			}
+			if (!hasTierSummaryTranslation(token)) {
+				return undefined;
+			}
+			return translateTierSummary(token) ?? token;
+		};
+		return (
+			translateToken(meta?.source?.labelToken) ||
+			translateToken(def.detail) ||
+			translateToken(summary.detail) ||
+			normalize(meta?.source?.labelToken) ||
+			normalize(def.detail) ||
+			normalize(summary.detail) ||
+			normalize(summary.name) ||
+			summary.id
+		);
 	};
 
 	const animatePassives = useAnimate<HTMLDivElement>();

--- a/packages/web/tests/passive-log-labels.test.ts
+++ b/packages/web/tests/passive-log-labels.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createEngine } from '@kingdom-builder/engine';
+import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
+import {
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	type ResourceKey,
+} from '@kingdom-builder/contents';
+
+vi.mock('@kingdom-builder/engine', async () => {
+	return await import('../../engine/src');
+});
+
+describe('passive log labels', () => {
+	it('uses tier summary tokens without exposing raw ids', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		const happinessKey = ctx.services.tieredResource.resourceKey as ResourceKey;
+
+		const setHappiness = (value: number) => {
+			ctx.activePlayer.resources[happinessKey] = value;
+			ctx.services.handleTieredResourceChange(ctx, happinessKey);
+		};
+
+		setHappiness(0);
+		const beforeActivation = snapshotPlayer(ctx.activePlayer, ctx);
+
+		setHappiness(6);
+		const afterActivation = snapshotPlayer(ctx.activePlayer, ctx);
+
+		const activationLines = diffStepSnapshots(
+			beforeActivation,
+			afterActivation,
+			undefined,
+			ctx,
+		);
+		const activationLog = activationLines.find((line) =>
+			line.includes('activated'),
+		);
+		expect(activationLog).toBeTruthy();
+		expect(activationLog).not.toContain('happiness.tier.summary');
+
+		const beforeExpiration = snapshotPlayer(ctx.activePlayer, ctx);
+		setHappiness(0);
+		const afterExpiration = snapshotPlayer(ctx.activePlayer, ctx);
+
+		const expirationLines = diffStepSnapshots(
+			beforeExpiration,
+			afterExpiration,
+			undefined,
+			ctx,
+		);
+		const expirationLog = expirationLines.find((line) =>
+			line.includes('expired'),
+		);
+		expect(expirationLog).toBeTruthy();
+		expect(expirationLog).not.toContain('happiness.tier.summary');
+	});
+});


### PR DESCRIPTION
## Summary
- capture tier summary tokens when swapping happiness passives so the metadata exposes a reusable label token
- translate passive labels and skip-source descriptions from tier summary tokens before falling back to longer prose
- cover the new passive log formatting with a regression test to ensure activation and expiration logs stay concise

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e13f9ba65c8325a05b7b305c70aafa