### PR TITLE
Add fade animation to hover card

### DIFF
--- a/packages/web/src/components/HoverCard.tsx
+++ b/packages/web/src/components/HoverCard.tsx
@@ -1,49 +1,117 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { renderSummary, renderCosts } from '../translation/render';
 import { useGameEngine } from '../state/GameContext';
 
+const FADE_DURATION_MS = 200;
+
 export default function HoverCard() {
-	const {
-		hoverCard: data,
-		clearHoverCard,
-		ctx,
-		actionCostResource,
-	} = useGameEngine();
-	if (!data) {
+	const { hoverCard, clearHoverCard, ctx, actionCostResource } =
+		useGameEngine();
+	const [renderedCard, setRenderedCard] = useState<typeof hoverCard>(hoverCard);
+	const [isVisible, setIsVisible] = useState(false);
+	const showTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		if (showTimeoutRef.current) {
+			clearTimeout(showTimeoutRef.current);
+			showTimeoutRef.current = null;
+		}
+		if (hideTimeoutRef.current) {
+			clearTimeout(hideTimeoutRef.current);
+			hideTimeoutRef.current = null;
+		}
+
+		if (hoverCard) {
+			if (renderedCard !== hoverCard) {
+				setRenderedCard(hoverCard);
+			}
+			showTimeoutRef.current = setTimeout(() => {
+				setIsVisible(true);
+				showTimeoutRef.current = null;
+			}, 0);
+		} else if (renderedCard) {
+			setIsVisible(false);
+			hideTimeoutRef.current = setTimeout(() => {
+				setRenderedCard(null);
+				hideTimeoutRef.current = null;
+			}, FADE_DURATION_MS);
+		} else {
+			setIsVisible(false);
+		}
+
+		return () => {
+			if (showTimeoutRef.current) {
+				clearTimeout(showTimeoutRef.current);
+				showTimeoutRef.current = null;
+			}
+		};
+	}, [hoverCard, renderedCard]);
+
+	useEffect(() => {
+		return () => {
+			if (showTimeoutRef.current) {
+				clearTimeout(showTimeoutRef.current);
+			}
+			if (hideTimeoutRef.current) {
+				clearTimeout(hideTimeoutRef.current);
+			}
+		};
+	}, []);
+
+	if (!renderedCard) {
 		return null;
 	}
+	const {
+		title,
+		costs,
+		upkeep,
+		effects,
+		effectsTitle,
+		bgClass,
+		description,
+		descriptionTitle,
+		descriptionClass,
+		requirements,
+	} = renderedCard;
+	const visibilityClass = isVisible
+		? 'opacity-100 translate-y-0'
+		: 'opacity-0 translate-y-2';
 	return (
 		<div
-			className={`pointer-events-none w-full rounded-3xl border border-white/60 bg-white/80 p-6 shadow-2xl shadow-amber-500/10 transition dark:border-white/10 dark:bg-slate-900/80 dark:shadow-slate-900/60 frosted-surface ${
-				data.bgClass ?? ''
-			}`}
+			className={`pointer-events-none w-full rounded-3xl border border-white/60 bg-white/80 p-6 shadow-2xl shadow-amber-500/10 transition-opacity transition-transform duration-200 ease-out dark:border-white/10 dark:bg-slate-900/80 dark:shadow-slate-900/60 frosted-surface ${[
+				bgClass,
+				visibilityClass,
+			]
+				.filter(Boolean)
+				.join(' ')}`}
 			onMouseLeave={clearHoverCard}
 		>
 			<div className="mb-3 flex items-start justify-between gap-4">
 				<div className="text-lg font-semibold tracking-tight text-slate-900 dark:text-slate-100">
-					{data.title}
+					{title}
 				</div>
 				<div className="text-right text-sm text-slate-600 dark:text-slate-300">
 					{renderCosts(
-						data.costs,
+						costs,
 						ctx.activePlayer.resources,
 						actionCostResource,
-						data.upkeep,
+						upkeep,
 					)}
 				</div>
 			</div>
-			{data.effects.length > 0 && (
+			{effects.length > 0 && (
 				<div className="mb-2">
 					<div className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-300">
-						{data.effectsTitle ?? 'Effects'}
+						{effectsTitle ?? 'Effects'}
 					</div>
 					<ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-slate-700 dark:text-slate-200">
-						{renderSummary(data.effects)}
+						{renderSummary(effects)}
 					</ul>
 				</div>
 			)}
 			{(() => {
-				const desc = data.description;
+				const desc = description;
 				const hasDescription =
 					typeof desc === 'string'
 						? desc.trim().length > 0
@@ -55,15 +123,15 @@ export default function HoverCard() {
 					<div className="mt-2">
 						<div
 							className={`text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-300 ${
-								data.descriptionClass ?? ''
+								descriptionClass ?? ''
 							}`}
 						>
-							{data.descriptionTitle ?? 'Description'}
+							{descriptionTitle ?? 'Description'}
 						</div>
 						{typeof desc === 'string' ? (
 							<div
 								className={`mt-1 text-sm text-slate-700 dark:text-slate-200 ${
-									data.descriptionClass ?? ''
+									descriptionClass ?? ''
 								}`}
 							>
 								{desc}
@@ -76,13 +144,13 @@ export default function HoverCard() {
 					</div>
 				);
 			})()}
-			{data.requirements.length > 0 && (
+			{requirements.length > 0 && (
 				<div className="mt-2 text-sm text-rose-600 dark:text-rose-300">
 					<div className="text-xs font-semibold uppercase tracking-[0.3em]">
 						Requirements
 					</div>
 					<ul className="mt-1 list-disc space-y-1 pl-5">
-						{data.requirements.map((r, i) => (
+						{requirements.map((r, i) => (
 							<li key={i}>{r}</li>
 						))}
 					</ul>


### PR DESCRIPTION
## Summary
- add fade transition state management to the hover card so it animates in and out when hover data changes
- delay unmounting until the fade completes and update styles to use opacity/transform transitions

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e142ce58e48325bf79bbb59f7473c9