### PR TITLE
Fix building hover cursor in player panel

### DIFF
--- a/packages/web/src/components/player/BuildingDisplay.tsx
+++ b/packages/web/src/components/player/BuildingDisplay.tsx
@@ -24,7 +24,7 @@ const BuildingDisplay: React.FC<BuildingDisplayProps> = ({ player }) => {
 				return (
 					<div
 						key={b}
-						className="panel-card flex min-w-[9rem] flex-col items-center gap-1 px-4 py-3 text-center text-sm font-semibold text-slate-700 hoverable dark:text-slate-100"
+						className="panel-card flex min-w-[9rem] flex-col items-center gap-1 px-4 py-3 text-center text-sm font-semibold text-slate-700 hoverable cursor-help dark:text-slate-100"
 						onMouseEnter={() => {
 							const full = describeContent('building', b, ctx, {
 								installed: true,


### PR DESCRIPTION
## Summary
- ensure building entries in the player panel use the help cursor on hover to match other hoverable UI elements

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e147577d8c8325bf6c2815eea3d40f