### PR TITLE
Refactor overview tokens to use dynamic registries

### DIFF
--- a/packages/web/src/Overview.tsx
+++ b/packages/web/src/Overview.tsx
@@ -37,7 +37,7 @@ const HERO_INTRO_TEXT = [
 
 const HERO_PARAGRAPH_TEXT = [
 	'Welcome to {game}, a brisk duel of wits where {expand} expansion,',
-	'{build} clever construction, and {attack} daring raids decide who steers the crown.',
+	'{build} clever construction, and {army_attack} daring raids decide who steers the crown.',
 ].join(' ');
 
 export default function Overview({
@@ -51,34 +51,15 @@ export default function Overview({
 	);
 
 	const sections = content ?? DEFAULT_OVERVIEW_CONTENT;
+	const tokens = React.useMemo(() => ({ ...icons }), [icons]);
 
-	const tokens: Record<string, React.ReactNode> = {
-		castle: icons.castle,
-		army: icons.army,
-		fort: icons.fort,
-		ap: icons.ap,
-		expand: icons.expand,
-		develop: icons.develop,
-		raisePop: icons.raisePop,
-		attack: icons.attack,
-		build: icons.build,
-		land: icons.land,
-		slot: icons.slot,
-		gold: icons.gold,
-		main: icons.main,
-		growth: icons.growth,
-		upkeep: icons.upkeep,
-		happiness: icons.happiness,
-		council: icons.council,
-		legion: icons.legion,
-		fortifier: icons.fortifier,
-		citizen: icons.citizen,
-	};
-
-	const heroTokens: Record<string, React.ReactNode> = {
-		...tokens,
-		game: <strong>Kingdom Builder</strong>,
-	};
+	const heroTokens: Record<string, React.ReactNode> = React.useMemo(
+		() => ({
+			...tokens,
+			game: <strong>Kingdom Builder</strong>,
+		}),
+		[tokens],
+	);
 
 	const renderedSections = createOverviewSections(icons, sections);
 

--- a/packages/web/src/components/overview/OverviewLayout.tsx
+++ b/packages/web/src/components/overview/OverviewLayout.tsx
@@ -99,11 +99,11 @@ export function renderTokens<TTokens extends Record<string, React.ReactNode>>(
 	text: string,
 	tokens: TTokens,
 ): React.ReactNode {
-	const parts = text.split(/(\{[a-zA-Z]+\})/g);
+	const parts = text.split(/(\{[\w]+\})/g);
 	return (
 		<>
 			{parts.map((part, index) => {
-				const match = part.match(/^\{([a-zA-Z]+)\}$/);
+				const match = part.match(/^\{([\w]+)\}$/);
 				if (match) {
 					const tokenKey = match[1] as keyof TTokens;
 					const hasToken = Object.prototype.hasOwnProperty.call(

--- a/packages/web/src/components/overview/defaultContent.ts
+++ b/packages/web/src/components/overview/defaultContent.ts
@@ -4,11 +4,11 @@ export const DEFAULT_OVERVIEW_CONTENT: OverviewContentSection[] = [
 	{
 		kind: 'paragraph',
 		id: 'objective',
-		icon: 'castle',
+		icon: 'castleHP',
 		title: 'Your Objective',
 		span: true,
 		paragraphs: [
-			'Keep your {castle} castle standing through every assault.',
+			'Keep your {castleHP} castle standing through every assault.',
 			"Plot daring turns that unravel your rival's engine.",
 			'Victory strikes when a stronghold falls or a ruler stalls out.',
 			'The final round crowns the monarch with the healthiest realm.',
@@ -25,8 +25,8 @@ export const DEFAULT_OVERVIEW_CONTENT: OverviewContentSection[] = [
 				icon: 'growth',
 				label: 'Growth',
 				body: [
-					'Kickstarts your engine with income and {army} Army strength.',
-					'Stacks {fort} Fortification bonuses and triggers automatic boons.',
+					'Kickstarts your engine with income and {armyStrength} Army strength.',
+					'Stacks {fortificationStrength} Fortification bonuses and triggers automatic boons.',
 				],
 			},
 			{
@@ -68,7 +68,7 @@ export const DEFAULT_OVERVIEW_CONTENT: OverviewContentSection[] = [
 				body: ['Keeps the populace cheering instead of rioting.'],
 			},
 			{
-				icon: 'castle',
+				icon: 'castleHP',
 				label: 'Castle HP',
 				body: ['Is your lifeline—lose it and the dynasty topples.'],
 			},
@@ -100,7 +100,7 @@ export const DEFAULT_OVERVIEW_CONTENT: OverviewContentSection[] = [
 				icon: 'legion',
 				label: 'Legion',
 				body: [
-					'Reinforces {army} Army strength for devastating {attack} raids.',
+					'Reinforces {armyStrength} Army strength for devastating {army_attack} raids.',
 				],
 			},
 			{
@@ -123,7 +123,7 @@ export const DEFAULT_OVERVIEW_CONTENT: OverviewContentSection[] = [
 		span: true,
 		paragraphs: [
 			'Spend {ap} AP to {expand} grow territory or {develop} upgrade key lands.',
-			'Field {raisePop} specialists or launch {attack} attacks to snowball momentum.',
+			'Field {raise_pop} specialists or launch {army_attack} attacks to snowball momentum.',
 		],
 	},
 ];

--- a/packages/web/src/components/overview/sectionsData.ts
+++ b/packages/web/src/components/overview/sectionsData.ts
@@ -1,30 +1,9 @@
 import type { ReactNode } from 'react';
 import type { OverviewSectionDef } from './OverviewLayout';
 
-export interface OverviewIconSet {
-	expand?: ReactNode;
-	build?: ReactNode;
-	attack?: ReactNode;
-	develop?: ReactNode;
-	raisePop?: ReactNode;
-	growth?: ReactNode;
-	upkeep?: ReactNode;
-	main?: ReactNode;
-	land?: ReactNode;
-	slot?: ReactNode;
-	gold?: ReactNode;
-	ap?: ReactNode;
-	happiness?: ReactNode;
-	castle?: ReactNode;
-	army?: ReactNode;
-	fort?: ReactNode;
-	council?: ReactNode;
-	legion?: ReactNode;
-	fortifier?: ReactNode;
-	citizen?: ReactNode;
-}
+export type OverviewIconSet = Record<string, ReactNode | undefined>;
 
-export type OverviewIconKey = keyof OverviewIconSet;
+export type OverviewIconKey = string;
 
 export type OverviewParagraphContent = {
 	kind: 'paragraph';
@@ -67,7 +46,7 @@ export function createOverviewSections(
 			return {
 				kind: 'paragraph',
 				id: section.id,
-				icon: icons[section.icon],
+				icon: icons[section.icon] ?? null,
 				title: section.title,
 				paragraphs: section.paragraphs,
 				...spanProps(section.span),
@@ -77,10 +56,10 @@ export function createOverviewSections(
 		return {
 			kind: 'list',
 			id: section.id,
-			icon: icons[section.icon],
+			icon: icons[section.icon] ?? null,
 			title: section.title,
 			items: section.items.map((item) => ({
-				icon: item.icon ? icons[item.icon] : undefined,
+				icon: item.icon ? (icons[item.icon] ?? null) : undefined,
 				label: item.label,
 				body: item.body,
 			})),

--- a/packages/web/tests/overview-tokens.test.ts
+++ b/packages/web/tests/overview-tokens.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+	ACTIONS,
+	LAND_INFO,
+	SLOT_INFO,
+	PHASES,
+	RESOURCES,
+	STATS,
+	POPULATION_ROLES,
+} from '@kingdom-builder/contents';
+import { buildOverviewIconSet } from '../src/components/overview/overviewTokens';
+
+describe('buildOverviewIconSet', () => {
+	it('includes icons for ids provided by content registries', () => {
+		const icons = buildOverviewIconSet();
+		const actionRegistry = ACTIONS as unknown as {
+			keys(): string[];
+			get(id: string): { icon?: unknown };
+		};
+		const actionKeys = actionRegistry.keys();
+
+		for (const id of actionKeys) {
+			expect(icons[id]).toBe(actionRegistry.get(id)?.icon);
+		}
+
+		const hasOwn = (obj: Record<string, unknown>, key: string) =>
+			Object.prototype.hasOwnProperty.call(obj, key);
+
+		const uniquePhase = PHASES.find(
+			(phase) =>
+				!hasOwn(RESOURCES, phase.id) &&
+				!hasOwn(STATS as Record<string, unknown>, phase.id) &&
+				!hasOwn(POPULATION_ROLES, phase.id) &&
+				!actionKeys.includes(phase.id),
+		);
+		expect(uniquePhase).toBeDefined();
+		if (uniquePhase) {
+			expect(icons[uniquePhase.id]).toBe(uniquePhase.icon);
+		}
+
+		const uniqueResource = Object.entries(RESOURCES).find(
+			([id]) =>
+				!PHASES.some((phase) => phase.id === id) &&
+				!hasOwn(STATS as Record<string, unknown>, id) &&
+				!hasOwn(POPULATION_ROLES, id) &&
+				!actionKeys.includes(id),
+		);
+		expect(uniqueResource).toBeDefined();
+		if (uniqueResource) {
+			const [id, info] = uniqueResource;
+			expect(icons[id]).toBe(info.icon);
+		}
+
+		const uniqueStat = Object.entries(STATS).find(
+			([id]) =>
+				!PHASES.some((phase) => phase.id === id) &&
+				!hasOwn(RESOURCES, id) &&
+				!hasOwn(POPULATION_ROLES, id) &&
+				!actionKeys.includes(id),
+		);
+		expect(uniqueStat).toBeDefined();
+		if (uniqueStat) {
+			const [id, info] = uniqueStat;
+			expect(icons[id]).toBe(info.icon);
+		}
+
+		Object.entries(POPULATION_ROLES).forEach(([id, info]) => {
+			expect(icons[id]).toBe(info.icon);
+		});
+
+		expect(icons.land).toBe(LAND_INFO.icon);
+		expect(icons.slot).toBe(SLOT_INFO.icon);
+	});
+
+	it('allows custom token keys to reference registry identifiers', () => {
+		const actionRegistry = ACTIONS as unknown as {
+			keys(): string[];
+			get(id: string): { icon?: unknown };
+		};
+		const [actionId] = actionRegistry.keys();
+		const alias = `alias_${actionId}`;
+
+		const icons = buildOverviewIconSet({
+			actions: {
+				[alias]: actionId,
+			},
+		});
+
+		expect(icons[alias]).toBe(actionRegistry.get(actionId)?.icon);
+	});
+});


### PR DESCRIPTION
## Summary
- build the overview token catalog from content registries so overrides can reference any discovered ids
- adjust overview layout and default content to read icons from the dynamic lookup map
- cover the new token resolution behaviour with vitest cases

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e13f5cde8c8325a171892831b246d3