### PR TITLE
Simplify passive badge labels for compact display

### DIFF
--- a/packages/web/tests/passive-display.test.tsx
+++ b/packages/web/tests/passive-display.test.tsx
@@ -58,21 +58,22 @@ describe('<PassiveDisplay />', () => {
 
 		render(<PassiveDisplay player={ctx.activePlayer} />);
 
-		const summaryText = screen.getByText(/Income \+25%/i);
-		expect(summaryText).toBeInTheDocument();
+		const badgeLabel = screen.getByText(/joyful/i);
+		expect(badgeLabel).toBeInTheDocument();
 		expect(
-			screen.getByText(
+			screen.queryByText(
 				/Active as long as happiness stays between \+5 and \+7/i,
 			),
-		).toBeInTheDocument();
+		).not.toBeInTheDocument();
 
-		const hoverTarget = summaryText.closest('div.hoverable');
+		const hoverTarget = badgeLabel.closest('div.hoverable');
 		expect(hoverTarget).not.toBeNull();
 		fireEvent.mouseEnter(hoverTarget!);
 		expect(handleHoverCard).toHaveBeenCalled();
 		const [{ description }] = handleHoverCard.mock.calls.at(-1) ?? [{}];
 		expect(description).toEqual(
 			expect.arrayContaining([
+				expect.stringMatching(/Income \+25%/i),
 				expect.stringMatching(
 					/Active as long as happiness stays between \+5 and \+7/i,
 				),


### PR DESCRIPTION
## Summary
- collapse passive card labels to short tokens derived from metadata and drop inline removal text
- surface the translated summary and removal condition within the hover card description entries
- refresh the passive display test to assert the compact label and hover details

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e14883e1508325846ab574cb787cd3