### PR TITLE
Add Royal Decree multi-step action and effect group support

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -210,16 +210,19 @@ export function createActionRegistry() {
 			.effectGroup(
 				actionEffectGroup('royal_decree_develop')
 					.title('Decree a development')
-					.summary('Choose what to raise on the newly claimed land.')
+					.summary('Select one project to finish on the freshly claimed land.')
 					.description(
-						'After expanding and tilling, select one project to complete before unrest rises. Each option runs Develop on the prepared land.',
+						'After expanding and tilling, decree which development is completed immediately. Each choice performs Develop on the new territory before unrest grows.',
 					)
 					.layout('compact')
 					.option(
 						actionEffectGroupOption('royal_decree_house')
 							.label('Raise a House')
 							.icon('🏠')
-							.summary('Expand housing and raise the population cap by 1.')
+							.summary('Build a House to increase the population cap by 1.')
+							.description(
+								'Perform Develop to add House on the prepared land, granting +1 Max Population.',
+							)
 							.action('develop')
 							.param('landId', '$landId')
 							.param('id', 'house'),
@@ -228,7 +231,10 @@ export function createActionRegistry() {
 						actionEffectGroupOption('royal_decree_farm')
 							.label('Establish a Farm')
 							.icon('🌾')
-							.summary('Gain +2 gold during each income step.')
+							.summary('Build a Farm to gain +2 gold during each income step.')
+							.description(
+								'Perform Develop to add Farm on the decree land, securing +2 gold income each Growth phase.',
+							)
 							.action('develop')
 							.param('landId', '$landId')
 							.param('id', 'farm'),
@@ -237,7 +243,12 @@ export function createActionRegistry() {
 						actionEffectGroupOption('royal_decree_outpost')
 							.label('Fortify with an Outpost')
 							.icon('🏹')
-							.summary('Gain +1 Army Strength and +1 Fortification Strength.')
+							.summary(
+								'Build an Outpost for +1 Army and +1 Fortification Strength.',
+							)
+							.description(
+								'Perform Develop to add Outpost on the decreed land, bolstering both Army and Fortification Strength by 1.',
+							)
 							.action('develop')
 							.param('landId', '$landId')
 							.param('id', 'outpost'),
@@ -247,7 +258,10 @@ export function createActionRegistry() {
 							.label('Raise a Watchtower')
 							.icon('🗼')
 							.summary(
-								'Add +2 Fortification Strength and absorption after one defense.',
+								'Build a Watchtower for +2 Fortification and 0.5 Absorption once.',
+							)
+							.description(
+								'Perform Develop to add Watchtower on the decreed land, adding +2 Fortification Strength and +0.5 Absorption before it spends itself defending once.',
 							)
 							.action('develop')
 							.param('landId', '$landId')

--- a/packages/engine/src/actions/effect_groups.ts
+++ b/packages/engine/src/actions/effect_groups.ts
@@ -43,8 +43,8 @@ function buildOptionEffects(
 		type: 'action',
 		method: 'perform',
 		params: {
-			id: option.actionId,
 			...(option.params || {}),
+			__actionId: option.actionId,
 		},
 	};
 	return applyParamsToEffects([effect], substitutionParams);

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -54,8 +54,8 @@ export const actionEffectGroupSchema = z.object({
 });
 
 export const actionEffectSchema = z.union([
-	effectSchema,
 	actionEffectGroupSchema,
+	effectSchema,
 ]);
 
 export type ActionEffectGroupOption = z.infer<

--- a/packages/engine/src/effects/action_perform.ts
+++ b/packages/engine/src/effects/action_perform.ts
@@ -5,16 +5,26 @@ import { withStatSourceFrames } from '../stat_sources';
 import { resolveActionEffects } from '../actions/effect_groups';
 import type { ActionParameters } from '../actions/action_parameters';
 
+type ActionPerformParams = ActionParameters<string> & {
+	__actionId?: string;
+};
+
 export const actionPerform: EffectHandler = (effect, ctx, mult = 1) => {
-	const id = effect.params?.['id'] as string;
+	const rawParams = effect.params as ActionPerformParams | undefined;
+	const idParam = rawParams?.__actionId ?? rawParams?.id;
+	const id = typeof idParam === 'string' ? idParam : undefined;
 	if (!id) {
 		throw new Error('action:perform requires id');
 	}
-	const params = effect.params as ActionParameters<string> | undefined;
+	let forwarded: ActionParameters<string> | undefined;
+	if (rawParams) {
+		const { __actionId: _ignored, ...rest } = rawParams;
+		forwarded = rest;
+	}
 	for (let i = 0; i < Math.floor(mult); i++) {
 		const def = ctx.actions.get(id);
 		const before = snapshotPlayer(ctx.activePlayer, ctx);
-		const resolved = resolveActionEffects(def, params);
+		const resolved = resolveActionEffects(def, forwarded);
 		if (resolved.missingSelections.length > 0) {
 			const formatted = resolved.missingSelections
 				.map((selection) => `"${selection}"`)

--- a/packages/engine/tests/actions/royal-decree-effect-group.test.ts
+++ b/packages/engine/tests/actions/royal-decree-effect-group.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { advance, getActionCosts, performAction } from '../../src';
+import { createTestEngine } from '../helpers';
+import { Resource as CResource } from '@kingdom-builder/contents';
+
+interface EffectGroupOption {
+	id: string;
+	actionId: string;
+	params?: Record<string, unknown>;
+}
+
+interface EffectGroup {
+	id: string;
+	options: EffectGroupOption[];
+}
+
+function isEffectGroup(effect: unknown): effect is EffectGroup {
+	return (
+		typeof effect === 'object' &&
+		effect !== null &&
+		Array.isArray((effect as { options?: unknown }).options)
+	);
+}
+
+function toMain(ctx: ReturnType<typeof createTestEngine>) {
+	while (ctx.game.currentPhase !== 'main') {
+		advance(ctx);
+	}
+}
+
+describe('royal decree action effect group', () => {
+	it('expands, tills and develops the chosen project', () => {
+		const ctx = createTestEngine();
+		toMain(ctx);
+
+		const [actionId, royalDecree] = ctx.actions
+			.entries()
+			.find(([, def]) => def.effects.some(isEffectGroup))!;
+		const group = royalDecree.effects.find(isEffectGroup)!;
+		const chosenOption = group.options[0];
+		const optionId = chosenOption.id;
+		const developmentId = String(chosenOption.params?.['id']);
+		expect(developmentId).toBeTruthy();
+
+		const nextLandId = `${ctx.activePlayer.id}-L${ctx.activePlayer.lands.length + 1}`;
+		const params = {
+			landId: nextLandId,
+			choices: {
+				[group.id]: { optionId },
+			},
+		} as const;
+
+		const costs = getActionCosts(actionId, ctx, params);
+		ctx.activePlayer.ap = costs[CResource.ap] ?? 0;
+		ctx.activePlayer.gold = costs[CResource.gold] ?? 0;
+
+		const beforeLands = ctx.activePlayer.lands.length;
+		const beforeHappiness =
+			ctx.activePlayer.resources[CResource.happiness] ?? 0;
+		const beforeGold = ctx.activePlayer.gold;
+		const tilledBefore = ctx.activePlayer.lands.filter(
+			(land) => land.tilled,
+		).length;
+
+		const traces = performAction(actionId, ctx, params);
+
+		expect(ctx.activePlayer.lands.length).toBe(beforeLands + 1);
+		const newLand = ctx.activePlayer.lands.find(
+			(land) => land.id === nextLandId,
+		);
+		expect(newLand).toBeDefined();
+		expect(newLand?.developments).toContain(developmentId);
+		expect(newLand?.slotsUsed).toBe(1);
+
+		const tilledAfter = ctx.activePlayer.lands.filter(
+			(land) => land.tilled,
+		).length;
+		expect(tilledAfter).toBe(tilledBefore + 1);
+
+		const traceIds = traces.map((trace) => trace.id);
+		const expectedNested = royalDecree.effects.flatMap((effect) => {
+			if (!isEffectGroup(effect)) {
+				if (effect.type === 'action' && effect.method === 'perform') {
+					const nestedId = (effect.params as { id?: string } | undefined)?.id;
+					return nestedId ? [nestedId] : [];
+				}
+				return [];
+			}
+			const option = effect.options.find(
+				(candidate) => candidate.id === optionId,
+			);
+			return option ? [option.actionId] : [];
+		});
+		expect(traceIds).toEqual(expect.arrayContaining(expectedNested));
+
+		let happinessGain = 0;
+		for (const nestedId of expectedNested) {
+			const nested = ctx.actions.get(nestedId);
+			const effect = nested.effects.find(
+				(candidate) =>
+					candidate.type === 'resource' &&
+					candidate.method === 'add' &&
+					(candidate.params as { key?: string }).key === CResource.happiness,
+			);
+			if (effect) {
+				happinessGain += (effect.params as { amount?: number })?.amount ?? 0;
+			}
+		}
+		const happinessPenalty = ctx.actions
+			.get(actionId)
+			.effects.filter(
+				(effect) => effect.type === 'resource' && effect.method === 'remove',
+			)
+			.reduce((total, effect) => {
+				const params = effect.params as
+					| { key?: string; amount?: number }
+					| undefined;
+				return params?.key === CResource.happiness
+					? total + (params.amount ?? 0)
+					: total;
+			}, 0);
+		expect(ctx.activePlayer.resources[CResource.happiness]).toBe(
+			beforeHappiness + happinessGain - happinessPenalty,
+		);
+
+		expect(ctx.activePlayer.gold).toBe(
+			beforeGold - (costs[CResource.gold] ?? 0),
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- define the Royal Decree action with compact develop options and clarify its copy
- carry effect-group metadata through schema parsing and nested action execution
- add a regression test that performs Royal Decree end-to-end via effect groups

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e141fbb8788325ac06ac20a781f6b1