### PR TITLE
Fix attack formatter number locale

### DIFF
--- a/packages/web/src/translation/effects/formatters/attack/shared.ts
+++ b/packages/web/src/translation/effects/formatters/attack/shared.ts
@@ -20,14 +20,16 @@ export function iconLabel(icon: string | undefined, label: string): string {
 	return icon ? `${icon} ${label}` : label;
 }
 
+const NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
+	minimumFractionDigits: 0,
+	maximumFractionDigits: 2,
+});
+
 export function formatNumber(value: number): string {
 	if (Number.isInteger(value)) {
 		return value.toString();
 	}
-	return value.toLocaleString(undefined, {
-		minimumFractionDigits: 0,
-		maximumFractionDigits: 2,
-	});
+	return NUMBER_FORMATTER.format(value);
 }
 
 export function formatPercent(value: number): string {


### PR DESCRIPTION
## Summary
- use a dedicated en-US number formatter so attack logs render consistent decimal separators

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e1525486708325bd08a42415fa8bb2