### PR TITLE
Refine stat breakdown messaging for growth and hire sources

### DIFF
--- a/packages/web/src/utils/stats.ts
+++ b/packages/web/src/utils/stats.ts
@@ -71,16 +71,22 @@ function formatContribution(
 	const amountEntry = amountParts.join(' ').trim();
 	const detailEntries = buildDetailEntries(meta, player, context);
 	const title = formatSourceTitle(descriptor);
+	const prefixedTitle = title ? `Source: ${title}` : 'Source';
 	if (!title) {
-		if (!detailEntries.length) {
-			return amountEntry;
+		const items: SummaryEntry[] = [];
+		pushSummaryEntry(items, amountEntry);
+		detailEntries.forEach((entry) => {
+			pushSummaryEntry(items, entry);
+		});
+		if (!items.length) {
+			return prefixedTitle;
 		}
-		return { title: amountEntry, items: detailEntries };
+		return { title: prefixedTitle, items };
 	}
 	const items: SummaryEntry[] = [];
 	pushSummaryEntry(items, amountEntry);
 	detailEntries.forEach((entry) => {
 		pushSummaryEntry(items, entry);
 	});
-	return { title, items };
+	return { title: prefixedTitle, items };
 }

--- a/packages/web/src/utils/stats/descriptors.ts
+++ b/packages/web/src/utils/stats/descriptors.ts
@@ -23,7 +23,10 @@ type TriggerInfoRecord = Record<
 	{ icon?: string; future?: string; past?: string }
 >;
 
-export type SourceDescriptor = ResolveResult & { suffix?: string };
+export type SourceDescriptor = ResolveResult & {
+	suffix?: ResolveResult;
+	kind?: string;
+};
 
 export type DescriptorRegistryEntry = {
 	resolve(id?: string): ResolveResult;
@@ -222,7 +225,7 @@ const DESCRIPTOR_REGISTRY: Record<string, DescriptorRegistryEntry> = {
 		formatDetail: defaultFormatDetail,
 	},
 	start: {
-		resolve: () => ({ icon: '', label: 'Initial setup' }),
+		resolve: () => ({ icon: '', label: 'Initial Setup' }),
 		formatDetail: defaultFormatDetail,
 	},
 };
@@ -241,6 +244,110 @@ export function getDescriptor(kind?: string): DescriptorRegistryEntry {
 	return DESCRIPTOR_REGISTRY[kind] ?? createDefaultDescriptor(kind);
 }
 
+function formatKindLabel(kind?: string, id?: string): string | undefined {
+	if (!kind) {
+		return undefined;
+	}
+	const descriptor = getDescriptor(kind);
+	const resolved = descriptor.resolve(id);
+	const parts: string[] = [];
+	if (resolved.icon) {
+		parts.push(resolved.icon);
+	}
+	if (resolved.label) {
+		parts.push(resolved.label);
+	}
+	const label = parts.join(' ').trim();
+	return label || undefined;
+}
+
+export function formatLinkLabel(link?: StatSourceLink): string | undefined {
+	if (!link) {
+		return undefined;
+	}
+	const descriptor = getDescriptor(link.type);
+	const resolved = descriptor.resolve(link.id);
+	const parts: string[] = [];
+	if (resolved.icon) {
+		parts.push(resolved.icon);
+	}
+	if (resolved.label) {
+		parts.push(resolved.label);
+	}
+	const label = parts.join(' ').trim();
+	return label || undefined;
+}
+
+function resolveLinkDescriptor(
+	link?: StatSourceLink,
+	options: { omitAssignmentDetail?: boolean } = {},
+): ResolveResult | undefined {
+	if (!link?.type) {
+		return undefined;
+	}
+	const descriptor = getDescriptor(link.type);
+	const resolved = descriptor.resolve(link.id);
+	let label = resolved.label;
+	let detail = descriptor.formatDetail?.(link.id, link.detail);
+	if (detail === undefined && link?.detail) {
+		detail = defaultFormatDetail(link.id, link.detail);
+	}
+	if (options.omitAssignmentDetail && detail) {
+		const normalized = detail.trim().toLowerCase();
+		if (normalized === 'assigned' || normalized === 'unassigned') {
+			detail = undefined;
+		}
+	}
+	if (detail) {
+		label = label ? `${label} ${detail}`.trim() : detail;
+	}
+	if (!label && !resolved.icon) {
+		return undefined;
+	}
+	return {
+		icon: resolved.icon,
+		label: label ?? '',
+	} satisfies ResolveResult;
+}
+
+function deriveResolutionSuffix(
+	meta: StatSourceMeta,
+): ResolveResult | undefined {
+	if (meta.kind !== 'action') {
+		return undefined;
+	}
+	const detail = meta.detail?.trim().toLowerCase();
+	if (detail !== 'resolution') {
+		return undefined;
+	}
+	const candidates: (StatSourceLink | undefined)[] = [meta.removal];
+	if (meta.dependsOn) {
+		candidates.push(...meta.dependsOn);
+	}
+	const priority = ['development', 'building', 'population', 'passive', 'land'];
+	for (const type of priority) {
+		const match = candidates.find((link) => link?.type === type);
+		if (!match) {
+			continue;
+		}
+		const resolved = resolveLinkDescriptor(match, {
+			omitAssignmentDetail: true,
+		});
+		if (resolved) {
+			return resolved;
+		}
+	}
+	if (meta.removal) {
+		const fallback = resolveLinkDescriptor(meta.removal, {
+			omitAssignmentDetail: true,
+		});
+		if (fallback) {
+			return fallback;
+		}
+	}
+	return undefined;
+}
+
 export function getSourceDescriptor(meta: StatSourceMeta): SourceDescriptor {
 	const entry = getDescriptor(meta.kind);
 	const base = entry.resolve(meta.id);
@@ -248,36 +355,79 @@ export function getSourceDescriptor(meta: StatSourceMeta): SourceDescriptor {
 		icon: base.icon,
 		label: base.label,
 	};
-	let suffix = entry.formatDetail?.(meta.id, meta.detail);
-	if (suffix === undefined && meta.detail) {
-		suffix = defaultFormatDetail(meta.id, meta.detail);
+	if (meta.kind) {
+		descriptor.kind = meta.kind;
+	}
+	let suffixText = entry.formatDetail?.(meta.id, meta.detail);
+	if (suffixText === undefined && meta.detail) {
+		suffixText = defaultFormatDetail(meta.id, meta.detail);
+	}
+	let suffix = suffixText
+		? ({ icon: '', label: suffixText } satisfies ResolveResult)
+		: undefined;
+	const resolutionSuffix = deriveResolutionSuffix(meta);
+	if (resolutionSuffix) {
+		suffix = resolutionSuffix;
+	}
+	const isAction = meta.kind === 'action';
+	const noResolutionOverride = resolutionSuffix === undefined;
+	if (suffix != null && noResolutionOverride && isAction) {
+		const detail = suffix.label.trim().toLowerCase();
+		if (detail === 'resolution') {
+			suffix = undefined;
+		}
 	}
 	if (suffix) {
 		descriptor.suffix = suffix;
+	}
+	if (!descriptor.label) {
+		const fallbackLabel = formatKindLabel(meta.kind, meta.id);
+		if (fallbackLabel) {
+			descriptor.label = fallbackLabel;
+		}
 	}
 	return descriptor;
 }
 
 export function formatSourceTitle(descriptor: SourceDescriptor): string {
-	const titleParts: string[] = [];
-	if (descriptor.icon) {
-		titleParts.push(descriptor.icon);
+	const iconParts: string[] = [];
+	const pushIcon = (icon?: string) => {
+		if (!icon) {
+			return;
+		}
+		if (!iconParts.includes(icon)) {
+			iconParts.push(icon);
+		}
+	};
+	pushIcon(descriptor.icon);
+	pushIcon(descriptor.suffix?.icon);
+	const iconText = iconParts.join('');
+	const baseLabel = descriptor.label?.trim() ?? '';
+	const suffixLabel = descriptor.suffix?.label?.trim() ?? '';
+	let labelText = baseLabel;
+	if (descriptor.kind === 'action') {
+		if (baseLabel && suffixLabel) {
+			labelText = `${baseLabel}: ${suffixLabel}`;
+		} else if (suffixLabel) {
+			labelText = suffixLabel;
+		}
+	} else if (suffixLabel) {
+		const normalizedBase = baseLabel.toLowerCase();
+		const normalizedSuffix = suffixLabel.toLowerCase();
+		if (baseLabel && normalizedBase !== normalizedSuffix) {
+			labelText = `${baseLabel} · ${suffixLabel}`;
+		} else {
+			labelText = suffixLabel || baseLabel;
+		}
 	}
-	const labelParts: string[] = [];
-	if (descriptor.label?.trim()) {
-		labelParts.push(descriptor.label.trim());
+	const parts: string[] = [];
+	if (iconText) {
+		parts.push(iconText);
 	}
-	if (descriptor.suffix?.trim()) {
-		labelParts.push(descriptor.suffix.trim());
+	if (labelText) {
+		parts.push(labelText);
 	}
-	if (labelParts.length) {
-		titleParts.push(
-			labelParts.length > 1
-				? `${labelParts[0]!} · ${labelParts.slice(1).join(' · ')}`
-				: labelParts[0]!,
-		);
-	}
-	return titleParts.join(' ').trim();
+	return parts.join(' ').trim();
 }
 
 export function formatDependency(

--- a/packages/web/src/utils/stats/descriptors.ts
+++ b/packages/web/src/utils/stats/descriptors.ts
@@ -280,7 +280,10 @@ export function formatLinkLabel(link?: StatSourceLink): string | undefined {
 
 function resolveLinkDescriptor(
 	link?: StatSourceLink,
-	options: { omitAssignmentDetail?: boolean } = {},
+	options: {
+		omitAssignmentDetail?: boolean;
+		omitRemovalDetail?: boolean;
+	} = {},
 ): ResolveResult | undefined {
 	if (!link?.type) {
 		return undefined;
@@ -292,9 +295,14 @@ function resolveLinkDescriptor(
 	if (detail === undefined && link?.detail) {
 		detail = defaultFormatDetail(link.id, link.detail);
 	}
-	if (options.omitAssignmentDetail && detail) {
+	if (detail) {
 		const normalized = detail.trim().toLowerCase();
-		if (normalized === 'assigned' || normalized === 'unassigned') {
+		if (options.omitAssignmentDetail) {
+			if (normalized === 'assigned' || normalized === 'unassigned') {
+				detail = undefined;
+			}
+		}
+		if (options.omitRemovalDetail && normalized === 'removed') {
 			detail = undefined;
 		}
 	}
@@ -332,6 +340,7 @@ function deriveResolutionSuffix(
 		}
 		const resolved = resolveLinkDescriptor(match, {
 			omitAssignmentDetail: true,
+			omitRemovalDetail: true,
 		});
 		if (resolved) {
 			return resolved;
@@ -340,6 +349,7 @@ function deriveResolutionSuffix(
 	if (meta.removal) {
 		const fallback = resolveLinkDescriptor(meta.removal, {
 			omitAssignmentDetail: true,
+			omitRemovalDetail: true,
 		});
 		if (fallback) {
 			return fallback;

--- a/packages/web/tests/stat-breakdown.test.ts
+++ b/packages/web/tests/stat-breakdown.test.ts
@@ -72,33 +72,39 @@ describe('stat breakdown summary', () => {
 			entry.title.includes('Legion'),
 		);
 		expect(ongoing).toBeTruthy();
+		expect(ongoing?.title).toMatch(/^Source: /);
 		expect(ongoing?.items).toEqual(
-			expect.arrayContaining([
-				expect.stringContaining('⚔️ +1'),
-				expect.objectContaining({
-					title: expect.stringContaining('Ongoing'),
-					items: expect.arrayContaining([
-						expect.stringContaining('While 🎖️ Legion'),
-						expect.stringContaining('Active as long as'),
-					]),
-				}),
-			]),
+			expect.arrayContaining([expect.stringContaining('⚔️ +1')]),
 		);
+		const ongoingTexts = ongoing?.items.filter(
+			(item): item is string => typeof item === 'string',
+		);
+		expect(
+			ongoingTexts?.some((item) =>
+				item.includes('Ongoing as long as 🎖️ Legion is in play'),
+			),
+		).toBe(true);
 		const permanent = objectEntries.find((entry) =>
 			entry.title.includes('Raise Strength'),
 		);
 		expect(permanent).toBeTruthy();
+		expect(permanent?.title).toMatch(/^Source: /);
 		expect(permanent?.items).toEqual(
 			expect.arrayContaining([
 				expect.stringContaining('⚔️ +1'),
-				expect.objectContaining({
-					title: expect.stringContaining('Permanent'),
-					items: expect.arrayContaining([
-						expect.stringContaining('Triggered by 🎖️ Legion'),
-						expect.stringContaining('Triggered by 📈 Growth'),
-					]),
-				}),
+				expect.stringContaining('🗿 Permanent'),
 			]),
 		);
+		expect(
+			permanent?.items?.some(
+				(item) => typeof item === 'string' && item.includes('Triggered by'),
+			),
+		).toBe(false);
+		expect(
+			permanent?.items.some(
+				(item) =>
+					typeof item === 'string' && item.includes('Applies immediately'),
+			),
+		).toBe(false);
 	});
 });

--- a/packages/web/tests/stat-breakdown.test.ts
+++ b/packages/web/tests/stat-breakdown.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createEngine, runEffects, advance } from '@kingdom-builder/engine';
+import {
+	createEngine,
+	runEffects,
+	advance,
+	performAction,
+} from '@kingdom-builder/engine';
 import {
 	ACTIONS,
 	BUILDINGS,
@@ -10,6 +15,9 @@ import {
 	RULES,
 	PopulationRole,
 	Stat,
+	type StatKey,
+	STATS,
+	Resource,
 } from '@kingdom-builder/contents';
 import { getStatBreakdownSummary } from '../src/utils/stats';
 
@@ -25,6 +33,51 @@ const isSummaryObject = (
 vi.mock('@kingdom-builder/engine', async () => {
 	return await import('../../engine/src');
 });
+
+type EffectLike = {
+	type?: string;
+	method?: string;
+	params?: Record<string, unknown>;
+	effects?: EffectLike[];
+};
+
+function isStatKey(value: unknown): value is StatKey {
+	return typeof value === 'string' && value in STATS;
+}
+
+function extractStatKey(effects?: EffectLike[]): StatKey | undefined {
+	if (!effects) {
+		return undefined;
+	}
+	for (const effect of effects) {
+		if (!effect) {
+			continue;
+		}
+		const keyParam = effect.params?.['key'];
+		if (
+			effect.type === 'stat' &&
+			effect.method === 'add' &&
+			isStatKey(keyParam)
+		) {
+			return keyParam;
+		}
+		const nested = extractStatKey(effect.effects);
+		if (nested) {
+			return nested;
+		}
+	}
+	return undefined;
+}
+
+function findBuildingStatSource(): { id: string; stat: StatKey } {
+	for (const [id, building] of BUILDINGS.entries()) {
+		const stat = extractStatKey(building.onBuild);
+		if (stat) {
+			return { id, stat };
+		}
+	}
+	throw new Error('No stat-granting building found');
+}
 
 describe('stat breakdown summary', () => {
 	it('includes ongoing and permanent army strength sources', () => {
@@ -106,5 +159,45 @@ describe('stat breakdown summary', () => {
 					typeof item === 'string' && item.includes('Applies immediately'),
 			),
 		).toBe(false);
+	});
+
+	it('omits removal suffix from build sources', () => {
+		const { id: buildingId, stat } = findBuildingStatSource();
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+
+		runEffects(
+			[
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: Resource.gold, amount: 50 },
+				},
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: Resource.ap, amount: 5 },
+				},
+			],
+			ctx,
+		);
+
+		performAction('build', ctx, { id: buildingId });
+
+		const breakdown = getStatBreakdownSummary(stat, ctx.activePlayer, ctx);
+		const objectEntries = breakdown.filter(isSummaryObject);
+		const buildSource = objectEntries.find((entry) =>
+			entry.title.includes('Build'),
+		);
+		expect(buildSource).toBeTruthy();
+		expect(buildSource?.title).toMatch(/^Source: /);
+		expect(buildSource?.title).not.toContain('Removed');
 	});
 });

--- a/packages/web/tests/stat-descriptor-registry.test.ts
+++ b/packages/web/tests/stat-descriptor-registry.test.ts
@@ -167,7 +167,7 @@ describe('stat descriptor registry', () => {
 		if (PASSIVE_INFO.icon) expect(passiveLine).toContain(PASSIVE_INFO.icon);
 		expect(passiveLine).toContain(PASSIVE_INFO.label);
 		expect(landLine).toContain(String(landId));
-		expect(startLine).toContain('Initial setup');
+		expect(startLine).toContain('Initial Setup');
 		expect(unknownLine).toContain(unknownId);
 		expect(unknownLine).toContain(formatDetail(unknownDetail));
 	});


### PR DESCRIPTION
## Summary
- hide redundant dependency bullets for the Growth - Raise Strength permanent stat source while leaving other permanent sources unchanged
- drop the "Assigned"/"Unassigned" suffix from Hire source titles so they show only the population being hired
- update the stat breakdown test to match the streamlined copy and ensure no "Triggered by" rows remain for Raise Strength

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e145c4abd0832598542a75a0bd6612