### PR TITLE
feat: resolve favicon icon from content

### DIFF
--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -18,6 +18,7 @@ export { PASSIVE_INFO } from './passive';
 export { MODIFIER_INFO } from './modifiers';
 export { GAME_START } from './game';
 export { RULES } from './rules';
+export { PRIMARY_ICON_ID } from './startup';
 export type { ActionDef } from './actions';
 export type { BuildingDef } from './buildings';
 export type { DevelopmentDef } from './developments';

--- a/packages/contents/src/startup.ts
+++ b/packages/contents/src/startup.ts
@@ -1,0 +1,9 @@
+import { Resource, type ResourceKey } from './resources';
+
+/**
+ * Primary icon identifier used for branding (e.g., favicon, loading screens).
+ *
+ * Content designers can update this value to any defined resource key to
+ * change the global icon without touching the web client.
+ */
+export const PRIMARY_ICON_ID: ResourceKey = Resource.castleHP;

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,17 +1,22 @@
 import './index.css';
 import { createRoot } from 'react-dom/client';
 import App from './App';
-import { RESOURCES, Resource } from '@kingdom-builder/contents';
+import { PRIMARY_ICON_ID, RESOURCES } from '@kingdom-builder/contents';
+import { resolvePrimaryIcon } from './startup/resolvePrimaryIcon';
 
-const castleIcon = RESOURCES[Resource.castleHP].icon;
-const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">${castleIcon}</text></svg>`;
-const link =
-  document.querySelector<HTMLLinkElement>('#favicon') ??
-  document.createElement('link');
-link.id = 'favicon';
-link.rel = 'icon';
-link.href = `data:image/svg+xml,${encodeURIComponent(svg)}`;
-document.head.appendChild(link);
+const icon = resolvePrimaryIcon(RESOURCES, PRIMARY_ICON_ID);
+if (icon) {
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">${icon}</text></svg>`;
+	const link =
+		document.querySelector<HTMLLinkElement>('#favicon') ??
+		document.createElement('link');
+	link.id = 'favicon';
+	link.rel = 'icon';
+	link.href = `data:image/svg+xml,${encodeURIComponent(svg)}`;
+	document.head.appendChild(link);
+} else {
+	console.warn('Unable to resolve favicon icon from content.');
+}
 
 const root = createRoot(document.getElementById('root')!);
 root.render(<App />);

--- a/packages/web/src/startup/resolvePrimaryIcon.test.ts
+++ b/packages/web/src/startup/resolvePrimaryIcon.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { PRIMARY_ICON_ID, RESOURCES } from '@kingdom-builder/contents';
+import { resolvePrimaryIcon } from './resolvePrimaryIcon';
+
+describe('resolvePrimaryIcon', () => {
+	it('returns the configured resource icon when available', () => {
+		const resolved = resolvePrimaryIcon(RESOURCES, PRIMARY_ICON_ID);
+		expect(resolved).toBe(RESOURCES[PRIMARY_ICON_ID].icon);
+	});
+
+	it('falls back to the first available resource icon when missing', () => {
+		const fallbackEntry = Object.entries(RESOURCES)[0];
+		if (!fallbackEntry) {
+			throw new Error('Expected at least one resource to be defined.');
+		}
+		const [, fallbackResource] = fallbackEntry;
+		const resolved = resolvePrimaryIcon(RESOURCES, 'non-existent');
+		expect(resolved).toBe(fallbackResource.icon);
+	});
+});

--- a/packages/web/src/startup/resolvePrimaryIcon.ts
+++ b/packages/web/src/startup/resolvePrimaryIcon.ts
@@ -1,0 +1,23 @@
+export interface IconSource {
+	icon?: string;
+}
+
+export function resolvePrimaryIcon(
+	resources: Record<string, IconSource>,
+	primaryId?: string | null,
+): string | undefined {
+	const entries = Object.entries(resources);
+	if (entries.length === 0) {
+		return undefined;
+	}
+
+	if (primaryId) {
+		const resource = resources[primaryId];
+		if (resource?.icon) {
+			return resource.icon;
+		}
+	}
+
+	const fallback = entries.find(([, info]) => typeof info?.icon === 'string');
+	return fallback?.[1].icon;
+}


### PR DESCRIPTION
## Summary
- add a content-level `PRIMARY_ICON_ID` hook so designers can change the branding icon without touching code
- update the web startup to resolve the favicon icon dynamically with a safe fallback when the configured key is missing
- cover the icon resolution logic with unit tests to guard against regressions

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e1574acb9c83258336c0d9cee44b9e