### PR TITLE
feat: drive overview from content metadata

### DIFF
--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -18,6 +18,14 @@ export { PASSIVE_INFO } from './passive';
 export { MODIFIER_INFO } from './modifiers';
 export { GAME_START } from './game';
 export { RULES } from './rules';
+export {
+	OVERVIEW_CONTENT,
+	type OverviewContentTemplate,
+	type OverviewHeroTemplate,
+	type OverviewSectionTemplate,
+	type OverviewTokenCandidates,
+	type OverviewTokenCategoryName,
+} from './overview';
 export type { ActionDef } from './actions';
 export type { BuildingDef } from './buildings';
 export type { DevelopmentDef } from './developments';

--- a/packages/contents/src/overview.ts
+++ b/packages/contents/src/overview.ts
@@ -1,6 +1,104 @@
-import type { OverviewContentSection } from './sectionsData';
+export type OverviewTokenCategoryName =
+	| 'actions'
+	| 'phases'
+	| 'resources'
+	| 'stats'
+	| 'population'
+	| 'static';
 
-export const DEFAULT_OVERVIEW_CONTENT: OverviewContentSection[] = [
+export type OverviewTokenCandidates = Partial<
+	Record<OverviewTokenCategoryName, Record<string, string[]>>
+>;
+
+export type OverviewListItemTemplate = {
+	icon?: string;
+	label: string;
+	body: string[];
+};
+
+export type OverviewParagraphTemplate = {
+	kind: 'paragraph';
+	id: string;
+	icon: string;
+	title: string;
+	span?: boolean;
+	paragraphs: string[];
+};
+
+export type OverviewListTemplate = {
+	kind: 'list';
+	id: string;
+	icon: string;
+	title: string;
+	span?: boolean;
+	items: OverviewListItemTemplate[];
+};
+
+export type OverviewSectionTemplate =
+	| OverviewParagraphTemplate
+	| OverviewListTemplate;
+
+export type OverviewHeroTemplate = {
+	badgeIcon: string;
+	badgeLabel: string;
+	title: string;
+	intro: string;
+	paragraph: string;
+	tokens: Record<string, string>;
+};
+
+export type OverviewContentTemplate = {
+	hero: OverviewHeroTemplate;
+	sections: OverviewSectionTemplate[];
+	tokens: OverviewTokenCandidates;
+};
+
+const HERO_INTRO_TEXT = [
+	'Map the rhythms of the realm before you issue your first decree.',
+	'Know where every resource, phase, and population surge will carry you.',
+].join(' ');
+
+const HERO_PARAGRAPH_TEXT = [
+	'Welcome to {game}, a brisk duel of wits where {expand} expansion,',
+	'{build} clever construction, and {army_attack} daring raids decide who steers the crown.',
+].join(' ');
+
+const DEFAULT_TOKENS: OverviewTokenCandidates = {
+	actions: {
+		expand: ['expand'],
+		build: ['build'],
+		develop: ['develop'],
+		raise_pop: ['raise_pop'],
+		army_attack: ['army_attack'],
+	},
+	phases: {
+		growth: ['growth'],
+		upkeep: ['upkeep'],
+		main: ['main'],
+	},
+	resources: {
+		gold: ['gold'],
+		ap: ['ap'],
+		happiness: ['happiness'],
+		castleHP: ['castleHP'],
+	},
+	stats: {
+		armyStrength: ['armyStrength'],
+		fortificationStrength: ['fortificationStrength'],
+	},
+	population: {
+		council: ['council'],
+		legion: ['legion'],
+		fortifier: ['fortifier'],
+		citizen: ['citizen'],
+	},
+	static: {
+		land: ['land'],
+		slot: ['slot'],
+	},
+};
+
+const DEFAULT_SECTIONS: OverviewSectionTemplate[] = [
 	{
 		kind: 'paragraph',
 		id: 'objective',
@@ -127,3 +225,18 @@ export const DEFAULT_OVERVIEW_CONTENT: OverviewContentSection[] = [
 		],
 	},
 ];
+
+export const OVERVIEW_CONTENT: OverviewContentTemplate = {
+	hero: {
+		badgeIcon: '📘',
+		badgeLabel: 'Know The Realm',
+		title: 'Game Overview',
+		intro: HERO_INTRO_TEXT,
+		paragraph: HERO_PARAGRAPH_TEXT,
+		tokens: {
+			game: 'Kingdom Builder',
+		},
+	},
+	sections: DEFAULT_SECTIONS,
+	tokens: DEFAULT_TOKENS,
+};

--- a/packages/web/src/Overview.tsx
+++ b/packages/web/src/Overview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { OVERVIEW_CONTENT } from '@kingdom-builder/contents';
 import Button from './components/common/Button';
 import {
 	ShowcaseBackground,
@@ -18,9 +19,7 @@ import {
 import type { OverviewSectionDef } from './components/overview/OverviewLayout';
 import { createOverviewSections } from './components/overview/sectionsData';
 import type { OverviewContentSection } from './components/overview/sectionsData';
-import { buildOverviewIconSet } from './components/overview/overviewTokens';
 import type { OverviewTokenConfig } from './components/overview/overviewTokens';
-import { DEFAULT_OVERVIEW_CONTENT } from './components/overview/defaultContent';
 
 export type { OverviewTokenConfig } from './components/overview/overviewTokens';
 
@@ -30,38 +29,29 @@ export interface OverviewProps {
 	content?: OverviewContentSection[];
 }
 
-const HERO_INTRO_TEXT = [
-	'Map the rhythms of the realm before you issue your first decree.',
-	'Know where every resource, phase, and population surge will carry you.',
-].join(' ');
-
-const HERO_PARAGRAPH_TEXT = [
-	'Welcome to {game}, a brisk duel of wits where {expand} expansion,',
-	'{build} clever construction, and {army_attack} daring raids decide who steers the crown.',
-].join(' ');
+const DEFAULT_SECTIONS = OVERVIEW_CONTENT.sections;
+const DEFAULT_TOKENS = OVERVIEW_CONTENT.tokens;
+const HERO_CONTENT = OVERVIEW_CONTENT.hero;
 
 export default function Overview({
 	onBack,
 	tokenConfig,
 	content,
 }: OverviewProps) {
-	const icons = React.useMemo(
-		() => buildOverviewIconSet(tokenConfig),
-		[tokenConfig],
+	const sections = content ?? DEFAULT_SECTIONS;
+	const { sections: renderedSections, tokens: iconTokens } = React.useMemo(
+		() => createOverviewSections(DEFAULT_TOKENS, tokenConfig, sections),
+		[sections, tokenConfig],
 	);
+	const tokens = React.useMemo(() => ({ ...iconTokens }), [iconTokens]);
 
-	const sections = content ?? DEFAULT_OVERVIEW_CONTENT;
-	const tokens = React.useMemo(() => ({ ...icons }), [icons]);
-
-	const heroTokens: Record<string, React.ReactNode> = React.useMemo(
-		() => ({
-			...tokens,
-			game: <strong>Kingdom Builder</strong>,
-		}),
-		[tokens],
-	);
-
-	const renderedSections = createOverviewSections(icons, sections);
+	const heroTokens: Record<string, React.ReactNode> = React.useMemo(() => {
+		const heroTokenNodes: Record<string, React.ReactNode> = {};
+		for (const [tokenKey, label] of Object.entries(HERO_CONTENT.tokens)) {
+			heroTokenNodes[tokenKey] = <strong>{label}</strong>;
+		}
+		return { ...tokens, ...heroTokenNodes };
+	}, [tokens]);
 
 	const renderSection = (section: OverviewSectionDef) => {
 		if (section.kind === 'paragraph') {
@@ -99,18 +89,20 @@ export default function Overview({
 			<ShowcaseLayout className="items-center">
 				<header className="flex flex-col items-center text-center">
 					<span className={SHOWCASE_BADGE_CLASS}>
-						<span className="text-lg">📘</span>
-						<span>Know The Realm</span>
+						<span className="text-lg">{HERO_CONTENT.badgeIcon}</span>
+						<span>{HERO_CONTENT.badgeLabel}</span>
 					</span>
 					<h1 className="mt-6 text-4xl font-black tracking-tight sm:text-5xl md:text-6xl">
-						Game Overview
+						{HERO_CONTENT.title}
 					</h1>
-					<p className={SHOWCASE_INTRO_CLASS}>{HERO_INTRO_TEXT}</p>
+					<p className={SHOWCASE_INTRO_CLASS}>
+						{renderTokens(HERO_CONTENT.intro, heroTokens)}
+					</p>
 				</header>
 
 				<ShowcaseCard as="article" className={OVERVIEW_CARD_CLASS}>
 					<p className="text-base leading-relaxed">
-						{renderTokens(HERO_PARAGRAPH_TEXT, heroTokens)}
+						{renderTokens(HERO_CONTENT.paragraph, heroTokens)}
 					</p>
 
 					<div className={OVERVIEW_GRID_CLASS}>

--- a/packages/web/src/components/overview/overviewTokens.ts
+++ b/packages/web/src/components/overview/overviewTokens.ts
@@ -7,19 +7,13 @@ import {
 	PHASES,
 	POPULATION_ROLES,
 	STATS,
+	type OverviewTokenCategoryName,
 } from '@kingdom-builder/contents';
 import type { OverviewIconSet } from './sectionsData';
 
-type TokenCandidateInput = string | ReadonlyArray<string>;
+export type TokenCandidateInput = string | ReadonlyArray<string>;
 type OverviewTokenCategoryOverrides = Record<string, TokenCandidateInput>;
 type OverviewTokenCategoryConfig = Record<string, string[]>;
-type OverviewTokenCategoryName =
-	| 'actions'
-	| 'phases'
-	| 'resources'
-	| 'stats'
-	| 'population'
-	| 'static';
 type OverviewTokenConfigResolved = Record<
 	OverviewTokenCategoryName,
 	OverviewTokenCategoryConfig

--- a/packages/web/tests/overview-content-source.test.tsx
+++ b/packages/web/tests/overview-content-source.test.tsx
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import type * as ContentsModule from '@kingdom-builder/contents';
+
+describe('Overview content integration', () => {
+	it('consumes swapped overview metadata from the content package', async () => {
+		vi.resetModules();
+
+		const actual = await vi.importActual<ContentsModule>(
+			'@kingdom-builder/contents',
+		);
+
+		vi.doMock('@kingdom-builder/contents', () => ({
+			...actual,
+			OVERVIEW_CONTENT: {
+				hero: {
+					badgeIcon: '🧭',
+					badgeLabel: 'Scout The Wilds',
+					title: 'Frontier Briefing',
+					intro: 'Chart {gold} prospects before the caravan departs.',
+					paragraph:
+						'Rally {council} envoys and {expand} into unclaimed wilds.',
+					tokens: {
+						game: 'Frontier Duel',
+					},
+				},
+				tokens: actual.OVERVIEW_CONTENT.tokens,
+				sections: [
+					{
+						kind: 'paragraph',
+						id: 'scouting',
+						icon: 'growth',
+						title: 'Scouting Notes',
+						paragraphs: [
+							'Secure {land} footholds and guard your {castleHP} borders.',
+							'Keep {happiness} high to fuel {ap} ambitions.',
+						],
+					},
+				],
+			},
+		}));
+
+		const { default: Overview } = await import('../src/Overview');
+
+		render(<Overview onBack={vi.fn()} />);
+
+		expect(screen.getByText('Frontier Briefing')).toBeInTheDocument();
+		expect(screen.getByText('Scout The Wilds')).toBeInTheDocument();
+
+		const intro = screen.getByText(/Chart/);
+		expect(intro.textContent).not.toContain('{');
+		const paragraph = screen.getByText(/Rally/);
+		expect(paragraph.textContent).not.toContain('{');
+
+		const scoutingSection = screen
+			.getByText('Scouting Notes')
+			.closest('section');
+		expect(scoutingSection).not.toBeNull();
+		if (scoutingSection) {
+			expect(scoutingSection.textContent).not.toContain('{');
+		}
+
+		vi.doUnmock('@kingdom-builder/contents');
+		vi.resetModules();
+	});
+});


### PR DESCRIPTION
## Summary
- add overview metadata to `@kingdom-builder/contents`, providing hero copy, default sections, and token candidates for icon resolution
- refactor the web overview component and section builder to consume the shared metadata and merge token overrides
- add a regression test that mocks the content package to prove swapping metadata updates the rendered overview

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e15749eff08325b19d59aa913ff0df