### PR TITLE
Improve passive duration phase resolution

### DIFF
--- a/packages/web/tests/fixtures/syntheticFestival.ts
+++ b/packages/web/tests/fixtures/syntheticFestival.ts
@@ -195,6 +195,12 @@ export const getSyntheticFestivalDetails = (
 			: Number(innerRes.params.amount);
 	const armyAttack = ctx.actions.get(attackActionId)!;
 	const upkeepPhase =
+		ctx.phases.find((phase) =>
+			phase.steps.some((step) => step.triggers?.includes('onUpkeepPhase')),
+		) ??
+		PHASES.find((phase) =>
+			phase.steps.some((step) => step.triggers?.includes('onUpkeepPhase')),
+		) ??
 		ctx.phases.find((p) => p.id === 'upkeep') ??
 		PHASES.find((p) => p.id === 'upkeep');
 	const upkeepLabel = upkeepPhase?.label || 'Upkeep';

--- a/packages/web/tests/hold-festival-action-translation.test.ts
+++ b/packages/web/tests/hold-festival-action-translation.test.ts
@@ -53,7 +53,7 @@ describe('hold festival action translation', () => {
 		);
 		const upkeepDescriptionLabel = `${
 			details.upkeepIcon ? `${details.upkeepIcon} ` : ''
-		}${details.upkeepLabel} Phase`;
+		}${details.upkeepLabel}`;
 
 		expect(desc).toEqual([
 			`${details.happinessInfo.icon}${sign(details.happinessAmt)}${details.happinessAmt} ${details.happinessInfo.label}`,
@@ -78,7 +78,7 @@ describe('hold festival action translation', () => {
 		);
 		const upkeepDescriptionLabel = `${
 			details.upkeepIcon ? `${details.upkeepIcon} ` : ''
-		}${details.upkeepLabel} Phase`;
+		}${details.upkeepLabel}`;
 
 		expect(log).toEqual([
 			`Played ${details.festival.icon} ${details.festival.name}`,

--- a/packages/web/tests/passive-duration-formatter.test.ts
+++ b/packages/web/tests/passive-duration-formatter.test.ts
@@ -78,16 +78,14 @@ describe('passive formatter duration metadata', () => {
 		]);
 		expect(description).toEqual([
 			{
-				title: '✨ Festival Spirit – Until your next 🎉 Festival Phase',
+				title: '✨ Festival Spirit – Until your next 🎉 Festival',
 				items: [],
 			},
 		]);
 		expect(log).toEqual([
 			{
 				title: '✨ Festival Spirit added',
-				items: [
-					"✨ Festival Spirit duration: Until player's next 🎉 Festival Phase",
-				],
+				items: ["✨ Festival Spirit duration: Until player's next 🎉 Festival"],
 			},
 		]);
 	});

--- a/packages/web/tests/plow-action-translation.test.ts
+++ b/packages/web/tests/plow-action-translation.test.ts
@@ -96,7 +96,7 @@ describe('plow action translation', () => {
 		const upkeepIcon = SYNTHETIC_UPKEEP_PHASE.icon;
 		const upkeepDescriptionLabel = `${
 			upkeepIcon ? `${upkeepIcon} ` : ''
-		}${upkeepLabel} Phase`;
+		}${upkeepLabel}`;
 		const expandLand = expand.effects.find((e: EffectDef) => e.type === 'land');
 		const landCount = (expandLand?.params as { count?: number })?.count ?? 0;
 		const expandHap = expand.effects.find(


### PR DESCRIPTION
## Summary
- resolve passive duration metadata via explicit phase ids, manual labels, or trigger lookups instead of assuming upkeep
- derive synthetic festival upkeep details from trigger metadata so custom phase labels/icons flow into the formatter
- update passive translation tests to reflect the new phase label handling and icon propagation

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e157589d888325920f41e2df063ee3