### PR TITLE
Refactor attack formatter stat descriptors

### DIFF
--- a/docs/architecture/attack_effects.md
+++ b/docs/architecture/attack_effects.md
@@ -1,0 +1,39 @@
+# Attack Effect Stat Annotations
+
+The `attack:perform` effect now expects content authors to describe the combat
+statistics used during formatting. This keeps the UI adaptable when new combat
+systems are introduced.
+
+## Declaring combat stats
+
+Use the builder helpers to annotate each role:
+
+```ts
+effect('attack', 'perform').params(
+	attackParams()
+		.powerStat(Stat.armyStrength)
+		.absorptionStat(Stat.absorption)
+		.fortificationStat(Stat.fortificationStrength)
+		.targetResource(Resource.castleHP),
+);
+```
+
+Each call stores a stat descriptor in the effect definition. The formatter reads
+these descriptors to render summaries, descriptions, and logs. You can override
+the icon or label with optional overrides:
+
+```ts
+.powerStat('custom:valor' as StatKey, { icon: '⚔️', label: 'Valor' })
+```
+
+When no descriptors are provided, the formatter falls back to the legacy
+`army/absorption/fortification` trio for backward compatibility. Supplying a
+subset is also supported; missing roles are rendered with generic text instead
+of icons.
+
+## Test considerations
+
+Synthetic content used in tests should register custom stat IDs (via the
+`attackParams().powerStat(...)` helpers) to ensure formatting logic remains
+robust. Avoid asserting against hard-coded `⚔️/🌀/🛡️` icons; derive expectations
+from the annotated stat metadata instead.

--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -289,6 +289,9 @@ export function createActionRegistry() {
 				effect('attack', 'perform')
 					.params(
 						attackParams()
+							.powerStat(Stat.armyStrength)
+							.absorptionStat(Stat.absorption)
+							.fortificationStat(Stat.fortificationStrength)
 							.targetResource(Resource.castleHP)
 							.onDamageAttacker(
 								effect(Types.Resource, ResourceMethods.ADD)

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -1019,10 +1019,20 @@ export function populationParams() {
 	return new PopulationEffectParamsBuilder();
 }
 
+type AttackStatRole = 'power' | 'absorption' | 'fortification';
+
+type AttackStatAnnotation = {
+	role: AttackStatRole;
+	key: StatKey;
+	label?: string;
+	icon?: string;
+};
+
 class AttackParamsBuilder extends ParamsBuilder<{
 	target?: AttackTarget;
 	ignoreAbsorption?: boolean;
 	ignoreFortification?: boolean;
+	stats?: AttackStatAnnotation[];
 	onDamage?: {
 		attacker?: EffectDef[];
 		defender?: EffectDef[];
@@ -1048,6 +1058,37 @@ class AttackParamsBuilder extends ParamsBuilder<{
 	}
 	ignoreFortification(flag = true) {
 		return this.set('ignoreFortification', flag);
+	}
+	stat(
+		role: AttackStatRole,
+		key: StatKey,
+		overrides: { label?: string; icon?: string } = {},
+	) {
+		const stats = this.params.stats || (this.params.stats = []);
+		const existingIndex = stats.findIndex((item) => item.role === role);
+		const annotation: AttackStatAnnotation = {
+			role,
+			key,
+			...overrides,
+		};
+		if (existingIndex >= 0) {
+			stats.splice(existingIndex, 1, annotation);
+		} else {
+			stats.push(annotation);
+		}
+		return this;
+	}
+	powerStat(key: StatKey, overrides?: { label?: string; icon?: string }) {
+		return this.stat('power', key, overrides);
+	}
+	absorptionStat(key: StatKey, overrides?: { label?: string; icon?: string }) {
+		return this.stat('absorption', key, overrides);
+	}
+	fortificationStat(
+		key: StatKey,
+		overrides?: { label?: string; icon?: string },
+	) {
+		return this.stat('fortification', key, overrides);
 	}
 	onDamageAttacker(...effects: Array<EffectConfig | EffectBuilder>) {
 		const onDamage = this.ensureOnDamage();

--- a/packages/web/src/translation/effects/formatters/attack/building.ts
+++ b/packages/web/src/translation/effects/formatters/attack/building.ts
@@ -1,14 +1,16 @@
 import { BUILDINGS } from '@kingdom-builder/contents';
 import type { AttackLog } from '@kingdom-builder/engine';
 import {
-	buildDescribeEntry,
-	buildingFortificationItems,
 	formatDiffCommon,
 	formatNumber,
 	formatPercent,
-	getBuildingDisplay,
 	iconLabel,
 } from './shared';
+import {
+	buildDescribeEntry,
+	buildingFortificationItems,
+	getBuildingDisplay,
+} from './evaluation';
 import type { AttackTargetFormatter } from './types';
 import type { SummaryEntry } from '../../../content';
 
@@ -42,7 +44,9 @@ const buildingFormatter: AttackTargetFormatter<{
 	},
 	buildBaseEntry(context) {
 		if (context.mode === 'summarize') {
-			return `${context.army.icon} destroy opponent's ${context.targetLabel}`;
+			const power = context.stats.power;
+			const powerDisplay = power ? power.icon || power.label : 'Attack';
+			return `${powerDisplay} destroy opponent's ${context.targetLabel}`;
 		}
 		return buildDescribeEntry(context, buildingFortificationItems(context));
 	},
@@ -54,38 +58,67 @@ const buildingFormatter: AttackTargetFormatter<{
 			: `On opponent ${describeTarget} destruction`;
 	},
 	buildEvaluationEntry(log, context) {
-		const { army, absorption, fort, targetLabel } = context;
+		const { stats, targetLabel } = context;
+		const power = stats.power;
+		const absorption = stats.absorption;
+		const fort = stats.fortification;
+		const powerValue = (value: number) =>
+			power?.icon
+				? `${power.icon}${formatNumber(value)}`
+				: power
+					? `${power.label} ${formatNumber(value)}`
+					: `Attack ${formatNumber(value)}`;
+		const absorptionValue = (value: number) =>
+			absorption?.icon
+				? `${absorption.icon}${formatPercent(value)}`
+				: absorption
+					? `${absorption.label} ${formatPercent(value)}`
+					: `Absorption ${formatPercent(value)}`;
+		const fortValue = (value: number) =>
+			fort?.icon
+				? `${fort.icon}${formatNumber(value)}`
+				: fort
+					? `${fort.label} ${formatNumber(value)}`
+					: `Fortification ${formatNumber(value)}`;
+		const absorptionLabel = absorption
+			? iconLabel(absorption.icon, absorption.label)
+			: 'damage reduction';
+		const fortLabel = fort ? iconLabel(fort.icon, fort.label) : 'fortification';
 		const target = log.target as Extract<
 			AttackLog['evaluation']['target'],
 			{ type: 'building' }
 		>;
 		const absorptionPart = log.absorption.ignored
-			? `${absorption.icon} ignored`
-			: `${absorption.icon}${formatPercent(log.absorption.before)}`;
+			? absorption?.icon
+				? `${absorption.icon} ignored`
+				: `${absorptionLabel} ignored`
+			: absorptionValue(log.absorption.before);
 		const fortPart = log.fortification.ignored
-			? `${fort.icon} ignored`
-			: `${fort.icon}${formatNumber(log.fortification.before)}`;
+			? fort?.icon
+				? `${fort.icon} ignored`
+				: `${fortLabel} ignored`
+			: fortValue(log.fortification.before);
 
-		const title = `Damage evaluation: ${army.icon}${formatNumber(
+		const title = `Damage evaluation: ${powerValue(
 			log.power.modified,
 		)} vs. ${absorptionPart} ${fortPart} ${targetLabel}`;
 		const items: SummaryEntry[] = [];
 
 		if (log.absorption.ignored) {
 			items.push(
-				`${army.icon}${formatNumber(log.power.modified)} ignores ${absorption.icon} ${absorption.label}`,
+				`${powerValue(log.power.modified)} ignores ${absorptionLabel}`,
 			);
 		} else {
 			items.push(
-				`${army.icon}${formatNumber(log.power.modified)} vs. ${absorption.icon}${formatPercent(
+				`${powerValue(log.power.modified)} vs. ${absorptionValue(
 					log.absorption.before,
-				)} --> ${army.icon}${formatNumber(log.absorption.damageAfter)}`,
+				)} --> ${powerValue(log.absorption.damageAfter)}`,
 			);
 		}
 
 		if (log.fortification.ignored) {
 			items.push(
-				`${army.icon}${formatNumber(log.absorption.damageAfter)} bypasses ${fort.icon} ${fort.label}`,
+				`${powerValue(log.absorption.damageAfter)} bypasses ${fortLabel}`,
 			);
 		} else {
 			const remaining = Math.max(
@@ -93,18 +126,16 @@ const buildingFormatter: AttackTargetFormatter<{
 				log.absorption.damageAfter - log.fortification.damage,
 			);
 			items.push(
-				`${army.icon}${formatNumber(log.absorption.damageAfter)} vs. ${fort.icon}${formatNumber(
+				`${powerValue(log.absorption.damageAfter)} vs. ${fortValue(
 					log.fortification.before,
-				)} --> ${fort.icon}${formatNumber(log.fortification.after)} ${army.icon}${formatNumber(
-					remaining,
-				)}`,
+				)} --> ${fortValue(log.fortification.after)} ${powerValue(remaining)}`,
 			);
 		}
 
 		if (!target.existed) {
 			items.push(`No ${targetLabel} to destroy`);
 		} else {
-			const damageText = `${army.icon}${formatNumber(target.damage)}`;
+			const damageText = powerValue(target.damage);
 			items.push(
 				target.destroyed
 					? `${damageText} destroys ${targetLabel}`
@@ -118,7 +149,8 @@ const buildingFormatter: AttackTargetFormatter<{
 		return formatDiffCommon(prefix, diff, options);
 	},
 	onDamageLogTitle(info) {
-		return `${iconLabel(info.icon, info.label)} destruction trigger evaluation`;
+		const display = iconLabel(info.icon, info.label);
+		return `${display} destruction trigger evaluation`;
 	},
 };
 

--- a/packages/web/src/translation/effects/formatters/attack/resource.ts
+++ b/packages/web/src/translation/effects/formatters/attack/resource.ts
@@ -4,13 +4,12 @@ import {
 	type ResourceKey,
 } from '@kingdom-builder/contents';
 import type { AttackLog } from '@kingdom-builder/engine';
+import { formatDiffCommon, iconLabel } from './shared';
 import {
 	buildDescribeEntry,
 	buildStandardEvaluationEntry,
 	defaultFortificationItems,
-	formatDiffCommon,
-	iconLabel,
-} from './shared';
+} from './evaluation';
 import type { AttackTargetFormatter } from './types';
 
 const resourceFormatter: AttackTargetFormatter<{
@@ -42,7 +41,9 @@ const resourceFormatter: AttackTargetFormatter<{
 	},
 	buildBaseEntry(context) {
 		if (context.mode === 'summarize') {
-			return `${context.army.icon} opponent's ${context.fort.icon}${context.info.icon}`;
+			const power = context.stats.power;
+			const powerDisplay = power ? power.icon || power.label : 'Attack';
+			return `${powerDisplay} vs opponent's ${context.targetLabel}`;
 		}
 		return buildDescribeEntry(context, defaultFortificationItems(context));
 	},

--- a/packages/web/src/translation/effects/formatters/attack/shared.ts
+++ b/packages/web/src/translation/effects/formatters/attack/shared.ts
@@ -1,20 +1,12 @@
 import {
-	BUILDINGS,
 	RESOURCES,
 	STATS,
 	type ResourceKey,
 	type StatKey,
 } from '@kingdom-builder/contents';
-import type { AttackLog, AttackPlayerDiff } from '@kingdom-builder/engine';
+import type { AttackPlayerDiff } from '@kingdom-builder/engine';
 import { formatStatValue } from '../../../../utils/stats';
-import type { SummaryEntry } from '../../../content';
-import type {
-	AttackTarget,
-	BaseEntryContext,
-	DiffFormatOptions,
-	EvaluationContext,
-	TargetInfo,
-} from './types';
+import type { DiffFormatOptions } from './types';
 
 export function iconLabel(icon: string | undefined, label: string): string {
 	return icon ? `${icon} ${label}` : label;
@@ -112,123 +104,4 @@ export function formatDiffCommon(
 		throw new Error(`Unsupported attack diff type: ${diff.type}`);
 	}
 	return formatter(prefix, diff as never, options);
-}
-
-export function buildDescribeEntry(
-	context: BaseEntryContext<AttackTarget>,
-	fortificationItems: string[],
-): SummaryEntry {
-	const { army, absorption, ignoreAbsorption } = context;
-	const absorptionItem = ignoreAbsorption
-		? `Ignoring ${absorption.icon} ${absorption.label} damage reduction`
-		: `${absorption.icon} ${absorption.label} damage reduction applied`;
-	return {
-		title: `Attack opponent with your ${army.icon} ${army.label}`,
-		items: [absorptionItem, ...fortificationItems],
-	};
-}
-
-export function defaultFortificationItems(
-	context: BaseEntryContext<AttackTarget>,
-): string[] {
-	const { fort, targetLabel } = context;
-	return [
-		`Damage applied to opponent's ${fort.icon} ${fort.label}`,
-		`If opponent ${fort.icon} ${fort.label} reduced to 0, overflow remaining damage on opponent ${targetLabel}`,
-	];
-}
-
-export function buildingFortificationItems(
-	context: BaseEntryContext<AttackTarget>,
-): string[] {
-	const { fort, targetLabel } = context;
-	return [
-		`Damage applied to opponent's ${fort.icon} ${fort.label}`,
-		`If opponent ${fort.icon} ${fort.label} reduced to 0, overflow remaining damage attempts to destroy opponent ${targetLabel}`,
-	];
-}
-
-export function buildStandardEvaluationEntry(
-	log: AttackLog['evaluation'],
-	context: EvaluationContext<AttackTarget>,
-	isStat: boolean,
-): SummaryEntry {
-	const { army, absorption, fort, info } = context;
-	const absorptionPart = log.absorption.ignored
-		? `${absorption.icon} ignored`
-		: `${absorption.icon}${formatPercent(log.absorption.before)}`;
-	const fortPart = log.fortification.ignored
-		? `${fort.icon} ignored`
-		: `${fort.icon}${formatNumber(log.fortification.before)}`;
-	const target = log.target as Extract<
-		AttackLog['evaluation']['target'],
-		{ type: 'resource' | 'stat' }
-	>;
-	const title = `Damage evaluation: ${army.icon}${formatNumber(
-		log.power.modified,
-	)} vs. ${absorptionPart} ${fortPart} ${info.icon}${formatNumber(
-		target.before,
-	)}`;
-	const items: SummaryEntry[] = [];
-
-	if (log.absorption.ignored) {
-		items.push(
-			`${army.icon}${formatNumber(log.power.modified)} ignores ${absorption.icon} ${absorption.label}`,
-		);
-	} else {
-		items.push(
-			`${army.icon}${formatNumber(log.power.modified)} vs. ${absorption.icon}${formatPercent(
-				log.absorption.before,
-			)} --> ${army.icon}${formatNumber(log.absorption.damageAfter)}`,
-		);
-	}
-
-	if (log.fortification.ignored) {
-		items.push(
-			`${army.icon}${formatNumber(log.absorption.damageAfter)} bypasses ${fort.icon} ${fort.label}`,
-		);
-	} else {
-		const remaining = Math.max(
-			0,
-			log.absorption.damageAfter - log.fortification.damage,
-		);
-		items.push(
-			`${army.icon}${formatNumber(log.absorption.damageAfter)} vs. ${fort.icon}${formatNumber(
-				log.fortification.before,
-			)} --> ${fort.icon}${formatNumber(log.fortification.after)} ${army.icon}${formatNumber(
-				remaining,
-			)}`,
-		);
-	}
-
-	const formatTargetValue = (value: number) => {
-		if (isStat) {
-			return formatStatValue(String(target.key), value);
-		}
-		return formatNumber(value);
-	};
-	const targetDisplay = (value: number) => {
-		const formatted = formatTargetValue(value);
-		if (info.icon) {
-			return `${info.icon}${formatted}`;
-		}
-		return `${info.label} ${formatted}`;
-	};
-
-	items.push(
-		`${army.icon}${formatNumber(target.damage)} vs. ${targetDisplay(
-			target.before,
-		)} --> ${targetDisplay(target.after)}`,
-	);
-
-	return { title, items };
-}
-
-export function getBuildingDisplay(id: string): TargetInfo {
-	try {
-		const def = BUILDINGS.get(id);
-		return { icon: def.icon ?? '', label: def.name ?? id };
-	} catch {
-		return { icon: '', label: id };
-	}
 }

--- a/packages/web/src/translation/effects/formatters/attack/stat.ts
+++ b/packages/web/src/translation/effects/formatters/attack/stat.ts
@@ -1,12 +1,11 @@
 import { STATS, type StatKey } from '@kingdom-builder/contents';
 import type { AttackLog } from '@kingdom-builder/engine';
+import { formatDiffCommon, iconLabel } from './shared';
 import {
 	buildDescribeEntry,
 	buildStandardEvaluationEntry,
 	defaultFortificationItems,
-	formatDiffCommon,
-	iconLabel,
-} from './shared';
+} from './evaluation';
 import type { AttackTargetFormatter } from './types';
 
 const statFormatter: AttackTargetFormatter<{
@@ -42,7 +41,9 @@ const statFormatter: AttackTargetFormatter<{
 	},
 	buildBaseEntry(context) {
 		if (context.mode === 'summarize') {
-			return `${context.army.icon} opponent's ${context.fort.icon}${context.info.icon}`;
+			const power = context.stats.power;
+			const powerDisplay = power ? power.icon || power.label : 'Attack';
+			return `${powerDisplay} vs opponent's ${context.targetLabel}`;
 		}
 		return buildDescribeEntry(context, defaultFortificationItems(context));
 	},

--- a/packages/web/src/translation/effects/formatters/attack/statContext.ts
+++ b/packages/web/src/translation/effects/formatters/attack/statContext.ts
@@ -1,0 +1,120 @@
+import { STATS, Stat, type StatKey } from '@kingdom-builder/contents';
+import type { EffectDef } from '@kingdom-builder/engine';
+import {
+	resolveAttackTargetFormatter,
+	type AttackTargetFormatter,
+	type AttackTarget,
+	type TargetInfo,
+} from '../attack/target-formatter';
+import {
+	type AttackStatContext,
+	type AttackStatDescriptor,
+	type AttackStatRole,
+	DEFAULT_ATTACK_STAT_LABELS,
+} from '../attack/types';
+
+const ATTACK_STAT_ROLES: AttackStatRole[] = [
+	'power',
+	'absorption',
+	'fortification',
+];
+
+const DEFAULT_ATTACK_STAT_KEYS: Record<AttackStatRole, StatKey> = {
+	power: Stat.armyStrength,
+	absorption: Stat.absorption,
+	fortification: Stat.fortificationStrength,
+};
+
+type RawAttackStatParam = {
+	role?: unknown;
+	key?: unknown;
+	label?: unknown;
+	icon?: unknown;
+};
+
+type AttackStatOverrides = Partial<
+	Pick<AttackStatDescriptor, 'label' | 'icon'>
+>;
+
+function isAttackStatRole(value: unknown): value is AttackStatRole {
+	return (
+		typeof value === 'string' &&
+		ATTACK_STAT_ROLES.some((role) => role === value)
+	);
+}
+
+function isRawAttackStatParam(value: unknown): value is RawAttackStatParam {
+	return typeof value === 'object' && value !== null;
+}
+
+function buildStatDescriptor(
+	role: AttackStatRole,
+	key: StatKey | undefined,
+	overrides: AttackStatOverrides,
+): AttackStatDescriptor {
+	const definition = key ? STATS[key] : undefined;
+	const labelOverride = overrides.label ?? definition?.label;
+	const iconOverride = overrides.icon ?? definition?.icon;
+	const descriptor: AttackStatDescriptor = {
+		role,
+		label: labelOverride ?? DEFAULT_ATTACK_STAT_LABELS[role],
+		icon: iconOverride ?? '',
+	};
+	if (key !== undefined) {
+		descriptor.key = key;
+	}
+	return descriptor;
+}
+
+function resolveAttackStats(
+	effectDefinition: EffectDef<Record<string, unknown>>,
+): AttackStatContext {
+	const stats: AttackStatContext = {};
+	const rawStats = effectDefinition.params?.['stats'];
+	if (Array.isArray(rawStats)) {
+		for (const entry of rawStats) {
+			if (!isRawAttackStatParam(entry)) {
+				continue;
+			}
+			const { role } = entry;
+			if (!isAttackStatRole(role)) {
+				continue;
+			}
+			const key =
+				typeof entry.key === 'string' ? (entry.key as StatKey) : undefined;
+			const label = typeof entry.label === 'string' ? entry.label : undefined;
+			const icon = typeof entry.icon === 'string' ? entry.icon : undefined;
+			const overrides: AttackStatOverrides = {};
+			if (label !== undefined) {
+				overrides.label = label;
+			}
+			if (icon !== undefined) {
+				overrides.icon = icon;
+			}
+			stats[role] = buildStatDescriptor(role, key, overrides);
+		}
+		return stats;
+	}
+	for (const role of ATTACK_STAT_ROLES) {
+		const key = DEFAULT_ATTACK_STAT_KEYS[role];
+		stats[role] = buildStatDescriptor(role, key, {});
+	}
+	return stats;
+}
+
+export type AttackFormatterContext = {
+	formatter: AttackTargetFormatter;
+	info: TargetInfo;
+	target: AttackTarget;
+	targetLabel: string;
+	stats: AttackStatContext;
+};
+
+export function resolveAttackFormatterContext(
+	effectDefinition: EffectDef<Record<string, unknown>>,
+): AttackFormatterContext {
+	const { formatter, target, info, targetLabel } =
+		resolveAttackTargetFormatter(effectDefinition);
+	const stats = resolveAttackStats(effectDefinition);
+	return { formatter, target, info, targetLabel, stats };
+}

--- a/packages/web/src/translation/effects/formatters/attack/types.ts
+++ b/packages/web/src/translation/effects/formatters/attack/types.ts
@@ -15,13 +15,28 @@ export type AttackTarget =
 	| { type: 'stat'; key: StatKey }
 	| { type: 'building'; id: string };
 
-export type StatInfo = { icon?: string; label: string };
+export type AttackStatRole = 'power' | 'absorption' | 'fortification';
+
+export type AttackStatDescriptor = {
+	role: AttackStatRole;
+	label: string;
+	icon?: string;
+	key?: StatKey;
+};
+
+export type AttackStatContext = Partial<
+	Record<AttackStatRole, AttackStatDescriptor>
+>;
+
+export const DEFAULT_ATTACK_STAT_LABELS: Record<AttackStatRole, string> = {
+	power: 'Attack Power',
+	absorption: 'Absorption',
+	fortification: 'Fortification',
+};
 
 export type BaseEntryContext<TTarget extends AttackTarget> = {
 	mode: Mode;
-	army: StatInfo;
-	absorption: StatInfo;
-	fort: StatInfo;
+	stats: AttackStatContext;
 	info: TargetInfo;
 	target: TTarget;
 	targetLabel: string;
@@ -36,9 +51,7 @@ export type OnDamageTitleContext<TTarget extends AttackTarget> = {
 };
 
 export type EvaluationContext<TTarget extends AttackTarget> = {
-	army: StatInfo;
-	absorption: StatInfo;
-	fort: StatInfo;
+	stats: AttackStatContext;
 	info: TargetInfo;
 	target: TTarget;
 	targetLabel: string;


### PR DESCRIPTION
## Summary
- derive attack stat descriptors from effect parameters so formatters work with custom combat stats
- update attack target formatters and helpers to render flexible stat metadata and add coverage for missing descriptors
- document stat annotations and extend content builders/actions to emit descriptor config

## Testing
- npm run lint
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e15751f0a48325a3cf8e4b35c6f687