### PR TITLE
docs: align coding standards documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,14 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.
 - Legacy files above 250 lines remain until refactored; new code should respect
   the limit.
 
+#### Coding Standards Checklist
+
+- [ ] Wrap every conditional or loop body in braces, even for single statements.
+- [ ] Keep lines at or below 80 characters.
+- [ ] Ensure files stay at or under 250 lines unless grandfathered.
+- [ ] Use descriptive, human-readable identifiers instead of abbreviations.
+- [ ] Indent code with tabs to preserve consistent formatting.
+
 ### 2.3 Code Standards & Naming
 
 - Prefer descriptive names; avoid one-letter identifiers except for familiar

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ The repository consists of three isolated domains: Web, Content and Engine. Each
 - Web: The _visual_ heart of the game. This domain is responsible for housing the game's frontend. It talks to Engine domain to receive game state updates and inform Engine of player-driven actions.
 - Content: The _practical_ heart of the game. This domain houses all of the game's configurations. The domain is configured in a way that allows extremely broad and deep updates to the game's configuration. The intent is for this domain to eventually become separated into it's own service and either passed to a content curation team or even allow players themselves to build gamemodes by giving them access, through some interface, to manipulate/override parts of 'Contents' domain at runtime.
 
+## 4) Coding Standards
+
+To keep the project readable and maintainable, every contribution must follow
+these rules:
+
+- Use braces around every conditional or loop body, even when it contains a
+  single statement.
+- Wrap lines at 80 characters to prevent horizontal scrolling in reviews.
+- Keep individual source files at or below 250 lines unless legacy code already
+  exceeds the limit.
+- Choose descriptive, human-readable identifiers instead of terse abbreviations.
+- Indent code with tab characters so formatting remains consistent across
+  editors.
+
 ## 5) Turn Structure
 
 Each turn flows through three phases:


### PR DESCRIPTION
## Summary
- add a Coding Standards section to the README so contributors can quickly review required formatting rules
- extend the repository AGENTS.md with a concise checklist that mirrors the README guidance

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e16240c7f88325bdeb03c43d44d704