### PR TITLE
Refine actions panel test helpers

### DIFF
--- a/packages/web/tests/helpers/createActionsPanelState.ts
+++ b/packages/web/tests/helpers/createActionsPanelState.ts
@@ -1,0 +1,27 @@
+import { vi } from 'vitest';
+
+export function createActionsPanelState(actionCostResource: string) {
+	return {
+		log: [],
+		hoverCard: null,
+		handleHoverCard: vi.fn(),
+		clearHoverCard: vi.fn(),
+		phaseSteps: [],
+		setPhaseSteps: vi.fn(),
+		phaseTimer: 0,
+		mainApStart: 0,
+		displayPhase: 'main',
+		setDisplayPhase: vi.fn(),
+		phaseHistories: {},
+		tabsEnabled: true,
+		actionCostResource,
+		handlePerform: vi.fn().mockResolvedValue(undefined),
+		runUntilActionPhase: vi.fn(),
+		handleEndTurn: vi.fn().mockResolvedValue(undefined),
+		updateMainPhaseStep: vi.fn(),
+		darkMode: false,
+		onToggleDark: vi.fn(),
+		timeScale: 1,
+		setTimeScale: vi.fn(),
+	} as const;
+}

--- a/packages/web/tests/helpers/evaluators.ts
+++ b/packages/web/tests/helpers/evaluators.ts
@@ -1,0 +1,15 @@
+export const compareRequirement = (left: unknown, right: unknown) => ({
+	type: 'evaluator',
+	method: 'compare',
+	params: { left, operator: 'lt', right },
+});
+
+export const populationEvaluator = (role?: string) => ({
+	type: 'population',
+	params: role ? { role } : {},
+});
+
+export const statEvaluator = (key: string) => ({
+	type: 'stat',
+	params: { key },
+});


### PR DESCRIPTION
## Summary
- refactor the actions panel test helper to build actions and populations from the synthetic content factory with configurable keys
- extract reusable evaluator and state helpers for the actions panel tests
- update ActionsPanel tests to consume generated metadata and cover category/role variations

## Testing
- npm run test -- ActionsPanel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e16301c61c83258e092627556dce43