### PR TITLE
Document domain boundaries and add dependency mapping tooling

### DIFF
--- a/docs/dependency-report.initial.json
+++ b/docs/dependency-report.initial.json
@@ -1,0 +1,29312 @@
+{
+	"modules": [
+		{
+			"source": "packages/contents/src/actions.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./defs",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/contents/src/defs.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./populationRoles",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/populationRoles.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/resources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/config/builders.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../defs",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/contents/src/defs.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../populationRoles",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/contents/src/populationRoles.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/contents/src/populationRoles.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/contents/src/config/builders.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../resources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/contents/src/resources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/contents/src/resources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/contents/src/config/builders.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/contents/src/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/contents/src/stats.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/contents/src/config/builders.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/effects/attack",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/effects/attack.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/evaluators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/actions.ts",
+				"packages/contents/src/populationRoles.ts",
+				"packages/contents/src/resources.ts",
+				"packages/contents/src/stats.ts",
+				"packages/contents/src/buildings.ts",
+				"packages/contents/src/developments.ts",
+				"packages/contents/src/index.ts",
+				"packages/contents/src/phases.ts",
+				"packages/contents/src/populations.ts",
+				"packages/contents/src/rules.ts",
+				"packages/contents/tests/builder-validations.test.ts",
+				"packages/engine/tests/actions/simulate-action.test.ts",
+				"packages/engine/tests/advance-skip.test.ts",
+				"packages/engine/tests/config/requirement_builder.test.ts",
+				"packages/engine/tests/effects/till_land.test.ts",
+				"packages/engine/tests/happiness-tier-controller.test.ts",
+				"packages/engine/tests/services/rules.test.ts",
+				"packages/web/tests/army-attack-translation.test.ts",
+				"packages/web/tests/land-till-formatter.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/defs.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/actions.ts",
+				"packages/contents/src/config/builders.ts",
+				"packages/contents/src/buildings.ts",
+				"packages/contents/src/developments.ts",
+				"packages/contents/src/index.ts",
+				"packages/contents/src/phases.ts",
+				"packages/contents/src/populations.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/config/schema.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/actions.ts",
+				"packages/contents/src/config/builders.ts",
+				"packages/contents/src/defs.ts",
+				"packages/engine/src/context.ts",
+				"packages/engine/src/index.ts",
+				"packages/engine/src/requirements/index.ts",
+				"packages/engine/src/actions/effect_groups.ts",
+				"packages/engine/src/services/pop_cap_service.ts",
+				"packages/engine/src/services/services.ts",
+				"packages/engine/src/setup/create_engine.ts",
+				"packages/engine/src/setup/player_setup.ts",
+				"packages/contents/src/buildings.ts",
+				"packages/contents/src/developments.ts",
+				"packages/contents/src/game.ts",
+				"packages/contents/src/populations.ts",
+				"packages/contents/src/rules.ts",
+				"packages/engine/tests/helpers.ts",
+				"packages/engine/tests/factories/content.ts",
+				"packages/engine/tests/phases/fixtures.ts",
+				"packages/web/src/translation/content/actionLogHooks.ts",
+				"packages/web/tests/army-attack-translation.test.ts",
+				"packages/web/tests/fixtures/syntheticPlow.ts",
+				"packages/web/tests/fixtures/syntheticRaidersGuild.ts",
+				"packages/web/tests/fixtures/syntheticTaxData.ts",
+				"packages/web/tests/modifier-eval-handlers.test.ts",
+				"packages/web/tests/passive-duration-formatter.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../evaluators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../evaluators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./action_add",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/action_add.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/action_add.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./action_perform",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/action_perform.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/action_perform.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./action_remove",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/action_remove.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/action_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attack",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/attack.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./building_add",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/building_add.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/building_add.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./building_remove",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/building_remove.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/building_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./cost_mod",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/cost_mod.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/cost_mod.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./development_add",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/development_add.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/development_add.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./development_remove",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/development_remove.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/development_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./land_add",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/land_add.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/land_add.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./land_till",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/land_till.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/land_till.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passive_add",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/passive_add.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/passive_add.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passive_remove",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/passive_remove.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/passive_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./population_add",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/population_add.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/population_add.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./population_remove",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/population_remove.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/population_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resource_add",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/resource_add.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/resource_add.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resource_remove",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/resource_remove.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/resource_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resource_transfer",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/resource_transfer.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/resource_transfer.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./result_mod",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/result_mod.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/result_mod.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stat_add",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/stat_add.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/stat_add.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stat_add_pct",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/stat_add_pct.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/stat_add_pct.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stat_remove",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/stat_remove.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/stat_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/config/builders.ts",
+				"packages/contents/src/defs.ts",
+				"packages/engine/src/config/schema.ts",
+				"packages/engine/src/index.ts",
+				"packages/engine/src/actions/action_execution.ts",
+				"packages/engine/src/state/index.ts",
+				"packages/engine/src/stat_sources/types.ts",
+				"packages/engine/src/stat_sources/resolver.ts",
+				"packages/engine/src/stat_sources/meta.ts",
+				"packages/engine/src/actions/effect_groups.ts",
+				"packages/engine/src/utils.ts",
+				"packages/engine/src/actions/costs.ts",
+				"packages/engine/src/services/passive_types.ts",
+				"packages/engine/src/services/passive_manager.ts",
+				"packages/engine/src/services/passive_helpers.ts",
+				"packages/engine/src/services/tiered_resource_types.ts",
+				"packages/engine/src/services/services.ts",
+				"packages/engine/src/effects/attack.ts",
+				"packages/engine/src/effects/attack_target_handlers/building.ts",
+				"packages/engine/src/effects/attack/log.types.ts",
+				"packages/engine/src/effects/attack/resolve.ts",
+				"packages/engine/src/triggers.ts",
+				"packages/engine/src/phases/advance.ts",
+				"packages/engine/src/setup/create_engine.ts",
+				"packages/engine/src/phases.ts",
+				"packages/engine/src/effects/action_add.ts",
+				"packages/engine/src/effects/action_perform.ts",
+				"packages/engine/src/effects/action_remove.ts",
+				"packages/engine/src/effects/building_add.ts",
+				"packages/engine/src/effects/building_remove.ts",
+				"packages/engine/src/effects/cost_mod.ts",
+				"packages/engine/src/effects/development_add.ts",
+				"packages/engine/src/effects/development_remove.ts",
+				"packages/engine/src/effects/land_add.ts",
+				"packages/engine/src/effects/land_till.ts",
+				"packages/engine/src/effects/passive_add.ts",
+				"packages/engine/src/effects/passive_remove.ts",
+				"packages/engine/src/effects/population_add.ts",
+				"packages/engine/src/effects/population_remove.ts",
+				"packages/engine/src/effects/resource_add.ts",
+				"packages/engine/src/effects/resource_remove.ts",
+				"packages/engine/src/effects/resource_transfer.ts",
+				"packages/engine/src/effects/result_mod.ts",
+				"packages/engine/src/effects/stat_add.ts",
+				"packages/engine/src/effects/stat_add_pct.ts",
+				"packages/engine/src/effects/stat_remove.ts",
+				"packages/engine/tests/actions/army-attack-happiness.test.ts",
+				"packages/engine/tests/effects/cost-mod-action-owner.test.ts",
+				"packages/engine/tests/effects/land_add.test.ts",
+				"packages/engine/tests/effects/passive-add.test.ts",
+				"packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts",
+				"packages/engine/tests/effects/stat-add-pct-step-reset.test.ts",
+				"packages/engine/tests/stat-sources.metadata.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/context.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./ai",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/ai/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./log",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/log.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./phases",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/phases.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/effects/index.ts",
+				"packages/engine/src/ai/index.ts",
+				"packages/engine/src/index.ts",
+				"packages/engine/src/actions/action_execution.ts",
+				"packages/engine/src/requirements/index.ts",
+				"packages/engine/src/evaluators/index.ts",
+				"packages/engine/src/evaluators/development.ts",
+				"packages/engine/src/evaluators/population.ts",
+				"packages/engine/src/evaluators/stat.ts",
+				"packages/engine/src/stat_sources/types.ts",
+				"packages/engine/src/stat_sources/frames.ts",
+				"packages/engine/src/stat_sources/resolver.ts",
+				"packages/engine/src/actions/effect_groups.ts",
+				"packages/engine/src/actions/context_clone.ts",
+				"packages/engine/src/actions/costs.ts",
+				"packages/engine/src/services/cost_modifier_service.ts",
+				"packages/engine/src/services/passive_types.ts",
+				"packages/engine/src/services/evaluation_modifier_service.ts",
+				"packages/engine/src/services/passive_manager.ts",
+				"packages/engine/src/services/result_modifier_service.ts",
+				"packages/engine/src/services/services.ts",
+				"packages/engine/src/log.ts",
+				"packages/engine/src/effects/attack_target_handlers/index.ts",
+				"packages/engine/src/effects/attack/resolve.ts",
+				"packages/engine/src/triggers.ts",
+				"packages/engine/src/phases/advance.ts",
+				"packages/engine/src/setup/create_engine.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/ai/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../index",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../log",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/log.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/context.ts",
+				"packages/engine/src/setup/create_engine.ts",
+				"packages/engine/tests/ai/tax-collector.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./actions/action_execution",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/actions/action_execution.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./actions/action_parameters",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/actions/action_parameters.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/action_parameters.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./actions/costs",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/actions/costs.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./actions/effect_groups",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/actions/effect_groups.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/effect_groups.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./effects/attack",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/effects/attack.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./effects/attack",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/effects/attack.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./evaluators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./evaluators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./log",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/log.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./log",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/log.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./phases/advance",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/phases/advance.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/phases/advance.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./phases/advance",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/phases/advance.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/phases/advance.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./requirements",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/requirements/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./requirements",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/requirements/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./setup/create_engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/setup/create_engine.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./setup/create_engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/setup/create_engine.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./triggers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/triggers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/triggers.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./utils",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/utils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/utils.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/ai/index.ts",
+				"packages/engine/tests/absorption-cap.test.ts",
+				"packages/engine/tests/helpers.ts",
+				"packages/engine/tests/actions/army-attack-happiness.test.ts",
+				"packages/engine/tests/actions/simulate-action.test.ts",
+				"packages/engine/tests/actions/synthetic.test.ts",
+				"packages/engine/tests/actions/tax-happiness.test.ts",
+				"packages/engine/tests/additive-stat-pct.test.ts",
+				"packages/engine/tests/advance-skip.test.ts",
+				"packages/engine/tests/ai/tax-collector.test.ts",
+				"packages/engine/tests/attack-zero-damage-no-effects.test.ts",
+				"packages/engine/tests/context/queue.test.ts",
+				"packages/engine/tests/effects/action_add.test.ts",
+				"packages/engine/tests/effects/action_remove.test.ts",
+				"packages/engine/tests/effects/add_building.test.ts",
+				"packages/engine/tests/effects/add_development.test.ts",
+				"packages/engine/tests/effects/add_stat.test.ts",
+				"packages/engine/tests/effects/cost-mod-action-owner.test.ts",
+				"packages/engine/tests/effects/cost_mod.test.ts",
+				"packages/engine/tests/effects/nonnegative.test.ts",
+				"packages/engine/tests/effects/passive-add.test.ts",
+				"packages/engine/tests/effects/population.test.ts",
+				"packages/engine/tests/effects/resource-add.test.ts",
+				"packages/engine/tests/effects/resource-remove.test.ts",
+				"packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts",
+				"packages/engine/tests/effects/till_land.test.ts",
+				"packages/engine/tests/engine.property.test.ts",
+				"packages/engine/tests/happiness-tier-controller.test.ts",
+				"packages/engine/tests/phases/fixtures.ts",
+				"packages/engine/tests/phases/growth.test.ts",
+				"packages/engine/tests/phases/upkeep.test.ts",
+				"packages/engine/tests/plunder-zero-gold.test.ts",
+				"packages/engine/tests/requirements/evaluator_compare.test.ts",
+				"packages/engine/tests/resolveAttack.test.ts",
+				"packages/engine/tests/result-mod-stack.test.ts",
+				"packages/engine/tests/services/rules.test.ts",
+				"packages/engine/tests/stat-sources.longevity.test.ts",
+				"packages/web/src/components/actions/ActionsPanel.tsx",
+				"packages/web/src/state/GameContext.tsx",
+				"packages/web/src/translation/content/action.ts",
+				"packages/web/src/translation/effects/factory.ts",
+				"packages/web/src/translation/effects/formatters/action.ts",
+				"packages/web/src/translation/effects/formatters/attack.ts",
+				"packages/web/src/translation/effects/formatters/attack/statContext.ts",
+				"packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+				"packages/web/src/translation/effects/formatters/attack/building.ts",
+				"packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+				"packages/web/src/utils/stats.ts",
+				"packages/web/src/translation/content/types.ts",
+				"packages/web/src/utils/stats/descriptors.ts",
+				"packages/web/src/utils/stats/summary.ts",
+				"packages/web/src/translation/effects/formatters/attack/shared.ts",
+				"packages/web/src/translation/effects/formatters/attack/types.ts",
+				"packages/web/src/translation/effects/formatters/attack/resource.ts",
+				"packages/web/src/translation/effects/formatters/attack/stat.ts",
+				"packages/web/src/translation/effects/formatters/attackFormatterUtils.ts",
+				"packages/web/src/translation/content/buildingIcons.ts",
+				"packages/web/src/translation/effects/formatters/modifier.ts",
+				"packages/web/src/translation/effects/formatters/modifier_helpers.ts",
+				"packages/web/src/translation/effects/formatters/transfer_helpers.ts",
+				"packages/web/src/translation/effects/formatters/passive.ts",
+				"packages/web/src/translation/content/actionLogHooks.ts",
+				"packages/web/src/translation/content/factory.ts",
+				"packages/web/src/translation/content/building.ts",
+				"packages/web/src/translation/content/decorators.ts",
+				"packages/web/src/translation/content/phased.ts",
+				"packages/web/src/translation/content/development.ts",
+				"packages/web/src/translation/content/land.ts",
+				"packages/web/src/translation/log/diff.ts",
+				"packages/web/src/translation/log/diffSections.ts",
+				"packages/web/src/translation/log/passives.ts",
+				"packages/web/src/translation/log/snapshots.ts",
+				"packages/web/src/translation/log/statBreakdown.ts",
+				"packages/web/src/translation/log/resourceSources.ts",
+				"packages/web/src/translation/log/resourceSources/evaluators.ts",
+				"packages/web/src/translation/log/resourceSources/meta.ts",
+				"packages/web/src/translation/log/resourceSources/modifiers.ts",
+				"packages/web/src/utils/describeSkipEvent.ts",
+				"packages/web/src/utils/getRequirementIcons.ts",
+				"packages/web/src/components/actions/GenericActions.tsx",
+				"packages/web/src/components/actions/GenericActionCard.tsx",
+				"packages/web/src/components/actions/useEffectGroupOptions.ts",
+				"packages/web/src/components/player/PlayerPanel.tsx",
+				"packages/web/src/components/player/BuildingDisplay.tsx",
+				"packages/web/src/components/player/LandDisplay.tsx",
+				"packages/web/src/components/player/PassiveDisplay.tsx",
+				"packages/web/src/components/player/PopulationInfo.tsx",
+				"packages/web/src/components/player/ResourceBar.tsx",
+				"packages/web/tests/Game.render.test.tsx",
+				"packages/web/tests/HoverCard.test.tsx",
+				"packages/web/tests/PhasePanel.test.tsx",
+				"packages/web/tests/PlayerPanel.test.tsx",
+				"packages/web/tests/army-attack-translation.test.ts",
+				"packages/web/tests/attack-diff-formatters.test.ts",
+				"packages/web/tests/attack-on-damage-registry.test.ts",
+				"packages/web/tests/describe-skip-event.test.ts",
+				"packages/web/tests/development-summary.test.ts",
+				"packages/web/tests/development-translation.test.ts",
+				"packages/web/tests/fixtures/syntheticFestival.ts",
+				"packages/web/tests/fixtures/syntheticPlow.ts",
+				"packages/web/tests/fixtures/syntheticRaidersGuild.ts",
+				"packages/web/tests/getRequirementIcons.test.ts",
+				"packages/web/tests/hold-festival-action-translation.test.ts",
+				"packages/web/tests/land-till-formatter.test.ts",
+				"packages/web/tests/log-source-icons.test.ts",
+				"packages/web/tests/log-source.test.ts",
+				"packages/web/tests/modifier-eval-handlers.test.ts",
+				"packages/web/tests/passive-display.test.tsx",
+				"packages/web/tests/passive-duration-formatter.test.ts",
+				"packages/web/tests/passive-log-labels.test.ts",
+				"packages/web/tests/phase-history.test.ts",
+				"packages/web/tests/plow-action-translation.test.ts",
+				"packages/web/tests/plow-workshop-translation.test.ts",
+				"packages/web/tests/population-summary.test.ts",
+				"packages/web/tests/raiders-guild-translation.test.ts",
+				"packages/web/tests/resource-bar.test.tsx",
+				"packages/web/tests/stat-breakdown.test.ts",
+				"packages/web/tests/stat-descriptor-registry.test.ts",
+				"packages/web/tests/subaction-log.test.ts",
+				"packages/web/tests/tax-market-log.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/actions/action_execution.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../requirements",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/requirements/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./action_parameters",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/actions/action_parameters.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/action_parameters.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./context_clone",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/actions/context_clone.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/context_clone.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./costs",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/actions/costs.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./effect_groups",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/actions/effect_groups.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/effect_groups.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/index.ts",
+				"packages/engine/src/setup/create_engine.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/requirements/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./evaluator_compare",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/requirements/evaluator_compare.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/requirements/evaluator_compare.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/index.ts",
+				"packages/engine/src/actions/action_execution.ts",
+				"packages/engine/src/requirements/evaluator_compare.ts",
+				"packages/engine/src/actions/costs.ts",
+				"packages/engine/src/setup/create_engine.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/registry.ts",
+			"dependencies": [],
+			"dependents": [
+				"packages/contents/src/actions.ts",
+				"packages/engine/src/effects/index.ts",
+				"packages/engine/src/context.ts",
+				"packages/engine/src/requirements/index.ts",
+				"packages/engine/src/evaluators/index.ts",
+				"packages/engine/src/services/pop_cap_service.ts",
+				"packages/engine/src/services/services.ts",
+				"packages/engine/src/setup/create_engine.ts",
+				"packages/engine/src/setup/player_setup.ts",
+				"packages/contents/src/buildings.ts",
+				"packages/contents/src/developments.ts",
+				"packages/contents/src/populations.ts",
+				"packages/engine/tests/helpers.ts",
+				"packages/engine/tests/factories/content.ts",
+				"packages/engine/tests/registry/registry.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/requirements/evaluator_compare.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../evaluators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/requirements/evaluator_compare.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./index",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/requirements/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/requirements/evaluator_compare.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/requirements/index.ts",
+				"packages/engine/tests/requirements/evaluator_compare.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/evaluators/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./compare",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/evaluators/compare.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/compare.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./development",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/evaluators/development.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./population",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/evaluators/population.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/population.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stat",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/evaluators/stat.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/stat.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/config/builders.ts",
+				"packages/engine/src/effects/index.ts",
+				"packages/engine/src/index.ts",
+				"packages/engine/src/requirements/evaluator_compare.ts",
+				"packages/engine/src/evaluators/compare.ts",
+				"packages/engine/src/evaluators/development.ts",
+				"packages/engine/src/evaluators/population.ts",
+				"packages/engine/src/evaluators/stat.ts",
+				"packages/engine/src/stat_sources/dependencies.ts",
+				"packages/engine/src/stat_sources/types.ts",
+				"packages/engine/src/setup/create_engine.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/evaluators/compare.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./index",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/compare.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/evaluators/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/evaluators/development.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./index",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/evaluators/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/evaluators/population.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/requirements/evaluator_compare.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/population.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./index",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/population.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/evaluators/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/state/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/context.ts",
+				"packages/engine/src/ai/index.ts",
+				"packages/engine/src/index.ts",
+				"packages/engine/src/evaluators/population.ts",
+				"packages/engine/src/evaluators/stat.ts",
+				"packages/engine/src/stat_sources/dependencies.ts",
+				"packages/engine/src/stat_sources/link_helpers.ts",
+				"packages/engine/src/stat_sources/types.ts",
+				"packages/engine/src/stat_sources/resolver.ts",
+				"packages/engine/src/stat_sources/meta.ts",
+				"packages/engine/src/actions/action_parameters.ts",
+				"packages/engine/src/actions/context_clone.ts",
+				"packages/engine/src/actions/costs.ts",
+				"packages/engine/src/services/passive_types.ts",
+				"packages/engine/src/services/passive_manager.ts",
+				"packages/engine/src/services/passive_helpers.ts",
+				"packages/engine/src/services/pop_cap_service.ts",
+				"packages/engine/src/services/services_types.ts",
+				"packages/engine/src/services/services.ts",
+				"packages/engine/src/services/tiered_resource_service.ts",
+				"packages/engine/src/log.ts",
+				"packages/engine/src/effects/attack_target_handlers/index.ts",
+				"packages/engine/src/effects/attack.types.ts",
+				"packages/engine/src/effects/attack/snapshot_diff.ts",
+				"packages/engine/src/effects/attack/resolve.ts",
+				"packages/engine/src/triggers.ts",
+				"packages/engine/src/phases/advance.ts",
+				"packages/engine/src/setup/create_engine.ts",
+				"packages/engine/src/setup/player_setup.ts",
+				"packages/engine/src/setup/stat_source_meta.ts",
+				"packages/engine/src/effects/cost_mod.ts",
+				"packages/engine/src/effects/land_add.ts",
+				"packages/engine/src/effects/population_add.ts",
+				"packages/engine/src/effects/population_remove.ts",
+				"packages/engine/src/effects/resource_add.ts",
+				"packages/engine/src/effects/resource_remove.ts",
+				"packages/engine/src/effects/resource_transfer.ts",
+				"packages/engine/src/effects/stat_add.ts",
+				"packages/engine/src/effects/stat_add_pct.ts",
+				"packages/engine/src/effects/stat_remove.ts",
+				"packages/engine/tests/absorption-cap.test.ts",
+				"packages/engine/tests/additive-stat-pct.test.ts",
+				"packages/engine/tests/attack-zero-damage-no-effects.test.ts",
+				"packages/engine/tests/effects/passive-add.test.ts",
+				"packages/engine/tests/effects/stat-add-pct-step-reset.test.ts",
+				"packages/engine/tests/resolveAttack.test.ts",
+				"packages/engine/tests/services/rules.test.ts",
+				"packages/engine/tests/state/state.test.ts",
+				"packages/engine/tests/utils/applyParamsToEffects.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/evaluators/stat.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/requirements/evaluator_compare.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/stat.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./index",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/stat.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/evaluators/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/stat_sources.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./stat_sources/index",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/stat_sources/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/effects/index.ts",
+				"packages/engine/src/context.ts",
+				"packages/engine/src/actions/action_execution.ts",
+				"packages/engine/src/services/passive_types.ts",
+				"packages/engine/src/services/passive_manager.ts",
+				"packages/engine/src/effects/attack/resolve.ts",
+				"packages/engine/src/triggers.ts",
+				"packages/engine/src/phases/advance.ts",
+				"packages/engine/src/setup/player_setup.ts",
+				"packages/engine/src/effects/action_perform.ts",
+				"packages/engine/src/effects/population_add.ts",
+				"packages/engine/src/effects/population_remove.ts",
+				"packages/engine/src/effects/stat_add.ts",
+				"packages/engine/src/effects/stat_add_pct.ts",
+				"packages/engine/src/effects/stat_remove.ts",
+				"packages/engine/tests/stat-sources.metadata.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/stat_sources/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./dependencies",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/stat_sources/dependencies.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./frames",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/stat_sources/frames.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/frames.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resolver",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/stat_sources/resolver.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/resolver.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/stat_sources/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/stat_sources.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/stat_sources/dependencies.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../evaluators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./link_helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources/link_helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/link_helpers.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/stat_sources/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/stat_sources/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/stat_sources/link_helpers.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/link_helpers.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/stat_sources/dependencies.ts",
+				"packages/engine/src/stat_sources/resolver.ts",
+				"packages/engine/src/stat_sources/meta.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/stat_sources/types.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../evaluators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/stat_sources/index.ts",
+				"packages/engine/src/stat_sources/dependencies.ts",
+				"packages/engine/src/stat_sources/frames.ts",
+				"packages/engine/src/stat_sources/resolver.ts",
+				"packages/engine/src/stat_sources/meta.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/stat_sources/frames.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/stat_sources/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/frames.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/stat_sources/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/stat_sources/resolver.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/resolver.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./link_helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources/link_helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/link_helpers.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/resolver.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./meta",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources/meta.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/meta.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/resolver.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/types.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/resolver.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/stat_sources/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/stat_sources/meta.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/resolver.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/meta.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./link_helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources/link_helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/link_helpers.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/resolver.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/meta.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/stat_sources/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/resolver.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/meta.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/stat_sources/resolver.ts",
+				"packages/engine/src/actions/context_clone.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/actions/action_parameters.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_parameters.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./effect_groups",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/actions/effect_groups.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/effect_groups.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_parameters.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/index.ts",
+				"packages/engine/src/actions/action_execution.ts",
+				"packages/engine/src/actions/effect_groups.ts",
+				"packages/engine/src/actions/costs.ts",
+				"packages/engine/src/effects/action_perform.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/actions/effect_groups.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/effect_groups.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/effect_groups.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../utils",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/utils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/utils.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/effect_groups.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./action_parameters",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/actions/action_parameters.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/action_parameters.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/effect_groups.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/index.ts",
+				"packages/engine/src/actions/action_execution.ts",
+				"packages/engine/src/actions/action_parameters.ts",
+				"packages/engine/src/actions/costs.ts",
+				"packages/engine/src/effects/action_perform.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/utils.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/utils.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/index.ts",
+				"packages/engine/src/actions/effect_groups.ts",
+				"packages/engine/src/actions/context_clone.ts",
+				"packages/engine/src/services/passive_helpers.ts",
+				"packages/engine/src/triggers.ts",
+				"packages/engine/src/effects/development_add.ts",
+				"packages/engine/src/effects/population_add.ts",
+				"packages/engine/src/effects/population_remove.ts",
+				"packages/engine/tests/utils/applyParamsToEffects.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/actions/context_clone.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/context_clone.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources/meta",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources/meta.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources/meta.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/context_clone.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/context_clone.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../utils",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/utils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/utils.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/context_clone.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/actions/action_execution.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/actions/costs.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../requirements",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/requirements/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./action_parameters",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/actions/action_parameters.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/action_parameters.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./effect_groups",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/actions/effect_groups.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/effect_groups.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/index.ts",
+				"packages/engine/src/actions/action_execution.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./cost_modifier_service",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/services/cost_modifier_service.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./evaluation_modifier_service",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/services/evaluation_modifier_service.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/evaluation_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passive_manager",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/services/passive_manager.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passive_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/services/passive_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./pop_cap_service",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/services/pop_cap_service.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/pop_cap_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./result_modifier_service",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/services/result_modifier_service.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/result_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/services/services.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/services.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./services_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/services/services_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/services_types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./tiered_resource_service",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/engine/src/services/tiered_resource_service.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/tiered_resource_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./tiered_resource_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/services/tiered_resource_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/tiered_resource_types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/config/builders.ts",
+				"packages/engine/src/effects/index.ts",
+				"packages/engine/src/context.ts",
+				"packages/engine/src/index.ts",
+				"packages/engine/src/actions/costs.ts",
+				"packages/engine/src/effects/attack.ts",
+				"packages/engine/src/log.ts",
+				"packages/engine/src/phases/advance.ts",
+				"packages/engine/src/setup/create_engine.ts",
+				"packages/engine/src/setup/player_setup.ts",
+				"packages/engine/src/effects/resource_transfer.ts",
+				"packages/contents/src/rules.ts",
+				"packages/contents/src/tieredResources.ts",
+				"packages/engine/tests/helpers.ts",
+				"packages/engine/tests/advance-skip.test.ts",
+				"packages/engine/tests/happiness-tier-controller.test.ts",
+				"packages/engine/tests/phases/fixtures.ts",
+				"packages/engine/tests/services/rules.test.ts",
+				"packages/web/tests/army-attack-translation.test.ts",
+				"packages/web/tests/fixtures/syntheticPlow.ts",
+				"packages/web/tests/fixtures/syntheticRaidersGuild.ts",
+				"packages/web/tests/fixtures/syntheticTaxData.ts",
+				"packages/web/tests/modifier-eval-handlers.test.ts",
+				"packages/web/tests/passive-duration-formatter.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/cost_modifier_service.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passive_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/passive_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/services/index.ts",
+				"packages/engine/src/services/passive_manager.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/passive_types.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/services/index.ts",
+				"packages/engine/src/services/cost_modifier_service.ts",
+				"packages/engine/src/services/evaluation_modifier_service.ts",
+				"packages/engine/src/services/passive_manager.ts",
+				"packages/engine/src/services/passive_helpers.ts",
+				"packages/engine/src/services/result_modifier_service.ts",
+				"packages/engine/src/effects/passive_add.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/evaluation_modifier_service.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/evaluation_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passive_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/passive_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/evaluation_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/services/index.ts",
+				"packages/engine/src/services/passive_manager.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/passive_manager.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./cost_modifier_service",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/services/cost_modifier_service.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./evaluation_modifier_service",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/services/evaluation_modifier_service.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/evaluation_modifier_service.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passive_helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/services/passive_helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/passive_helpers.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passive_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/passive_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./result_modifier_service",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/services/result_modifier_service.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/result_modifier_service.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/services/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/passive_helpers.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_helpers.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../utils",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/utils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/utils.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_helpers.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passive_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/passive_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_manager.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/services/passive_helpers.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/services/passive_manager.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/result_modifier_service.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/result_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passive_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/passive_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/result_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/services/index.ts",
+				"packages/engine/src/services/passive_manager.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/pop_cap_service.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/pop_cap_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/pop_cap_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./services_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/services_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/services_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/pop_cap_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/services/index.ts",
+				"packages/engine/src/services/services.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/services_types.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/services_types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./tiered_resource_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/tiered_resource_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/tiered_resource_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/services_types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/services/index.ts",
+				"packages/engine/src/services/pop_cap_service.ts",
+				"packages/engine/src/services/services.ts",
+				"packages/engine/src/services/tiered_resource_service.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/tiered_resource_types.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/tiered_resource_types.ts",
+							"dependencyTypes": ["local", "type-only", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/services/index.ts",
+				"packages/engine/src/services/services_types.ts",
+				"packages/engine/src/services/services.ts",
+				"packages/engine/src/services/tiered_resource_service.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/services.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/services.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/services.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/services.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/services.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./pop_cap_service",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/services/pop_cap_service.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/pop_cap_service.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/services.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./services_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/services_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/services_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/services.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./tiered_resource_service",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/services/tiered_resource_service.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/tiered_resource_service.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/services.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./tiered_resource_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/tiered_resource_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/tiered_resource_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/services.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/services/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/services/tiered_resource_service.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/tiered_resource_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./services_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/services_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/services_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/tiered_resource_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./tiered_resource_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/tiered_resource_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/tiered_resource_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/actions/costs.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/tiered_resource_service.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/services/index.ts",
+				"packages/engine/src/services/services.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/attack.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../log",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/log.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attack_target_handlers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/attack_target_handlers/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attack.types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack.types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attack/log.types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack/log.types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack/log.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attack/resolve",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/attack/resolve.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack/resolve.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attack/snapshot_diff",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/attack/snapshot_diff.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack/snapshot_diff.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attack/snapshot_diff",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/engine/src/effects/attack/snapshot_diff.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack/snapshot_diff.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/config/builders.ts",
+				"packages/engine/src/effects/index.ts",
+				"packages/engine/src/index.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/log.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/context.ts",
+				"packages/engine/src/ai/index.ts",
+				"packages/engine/src/index.ts",
+				"packages/engine/src/effects/attack.ts",
+				"packages/engine/src/effects/attack/snapshot_diff.ts",
+				"packages/engine/src/effects/action_perform.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/attack_target_handlers/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../attack.types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack.types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./building",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/attack_target_handlers/building.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resource",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/attack_target_handlers/resource.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/resource.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stat",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/attack_target_handlers/stat.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/stat.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/effects/attack.ts",
+				"packages/engine/src/effects/attack_target_handlers/building.ts",
+				"packages/engine/src/effects/attack_target_handlers/resource.ts",
+				"packages/engine/src/effects/attack_target_handlers/stat.ts",
+				"packages/engine/src/effects/attack/resolve.ts",
+				"packages/engine/tests/attack-zero-damage-no-effects.test.ts",
+				"packages/engine/tests/resolveAttack.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/attack.types.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/effects/attack.ts",
+				"packages/engine/src/effects/attack_target_handlers/index.ts",
+				"packages/engine/src/effects/attack_target_handlers/building.ts",
+				"packages/engine/src/effects/attack_target_handlers/resource.ts",
+				"packages/engine/src/effects/attack_target_handlers/stat.ts",
+				"packages/engine/src/effects/attack/log.types.ts",
+				"packages/engine/src/effects/attack/resolve.ts",
+				"packages/engine/tests/resolveAttack.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/attack_target_handlers/building.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "..",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../attack.types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack.types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/building.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./index",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack_target_handlers/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/building.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/effects/attack_target_handlers/index.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/attack_target_handlers/resource.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../attack.types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack.types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/resource.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./index",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack_target_handlers/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/resource.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/effects/attack_target_handlers/index.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/attack_target_handlers/stat.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../attack.types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack.types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/stat.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./index",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack_target_handlers/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/stat.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/effects/attack_target_handlers/index.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/attack/log.types.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "..",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/log.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../attack.types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack.types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/log.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./snapshot_diff",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack/snapshot_diff.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack/snapshot_diff.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/log.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/effects/attack.ts",
+				"packages/engine/src/effects/attack/resolve.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/attack/snapshot_diff.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../log",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/log.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/snapshot_diff.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/snapshot_diff.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/effects/attack.ts",
+				"packages/engine/src/effects/attack/log.types.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/attack/resolve.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "..",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/resolve.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/resolve.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/resolve.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../triggers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/triggers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/triggers.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/resolve.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../attack_target_handlers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/attack_target_handlers/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack_target_handlers/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/resolve.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../attack.types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack.types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/resolve.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./log.types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack/log.types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/attack/log.types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/attack/resolve.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/attack.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/triggers.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/triggers.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/triggers.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/triggers.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./utils",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/utils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/utils.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/triggers.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/index.ts",
+				"packages/engine/src/effects/attack/resolve.ts",
+				"packages/engine/src/phases/advance.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/phases/advance.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/phases/advance.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/phases/advance.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/phases/advance.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/phases/advance.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/phases/advance.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/phases/advance.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../triggers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/triggers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/triggers.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/phases/advance.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/index.ts",
+				"packages/engine/src/setup/create_engine.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/setup/create_engine.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../actions/action_execution",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/actions/action_execution.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../ai",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/ai/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../context",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/context.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../evaluators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/evaluators/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../phases",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/phases.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../phases/advance",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/phases/advance.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/phases/advance.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../requirements",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/requirements/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/requirements/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./player_setup",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/setup/player_setup.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/setup/player_setup.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/phases.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/phases.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/context.ts",
+				"packages/engine/src/setup/create_engine.ts",
+				"packages/engine/tests/helpers.ts",
+				"packages/engine/tests/phases/fixtures.ts",
+				"packages/web/src/translation/effects/formatters/passive.ts",
+				"packages/web/tests/army-attack-translation.test.ts",
+				"packages/web/tests/fixtures/syntheticPlow.ts",
+				"packages/web/tests/fixtures/syntheticRaidersGuild.ts",
+				"packages/web/tests/fixtures/syntheticTaxData.ts",
+				"packages/web/tests/modifier-eval-handlers.test.ts",
+				"packages/web/tests/passive-duration-formatter.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/setup/player_setup.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/setup/player_setup.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/setup/player_setup.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/setup/player_setup.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/setup/player_setup.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/setup/player_setup.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stat_source_meta",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/setup/stat_source_meta.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/setup/stat_source_meta.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/setup/player_setup.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/setup/create_engine.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/setup/stat_source_meta.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/create_engine.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/setup/player_setup.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/setup/stat_source_meta.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/setup/player_setup.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/action_add.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/action_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/action_perform.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/action_perform.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/action_perform.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../actions/action_parameters",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/actions/action_parameters.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/action_parameters.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/action_perform.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../actions/effect_groups",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/actions/effect_groups.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/actions/effect_groups.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/config/schema.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/action_perform.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../log",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/log.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/log.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/action_perform.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/action_perform.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/action_remove.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/action_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/building_add.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/building_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/building_remove.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/building_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/cost_mod.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/cost_mod.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/cost_mod.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/development_add.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/development_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../utils",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/utils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/utils.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/development_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/development_remove.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/development_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/land_add.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/land_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/land_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/land_till.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/land_till.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/passive_add.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/passive_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../services/passive_types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/passive_types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/passive_types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/passive_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/passive_remove.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/passive_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/population_add.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/population_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/population_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/population_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/population_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../utils",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/utils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/utils.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/population_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/population_remove.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/population_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/population_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/population_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/population_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../utils",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/utils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/utils.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/population_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/resource_add.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/resource_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/resource_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/resource_remove.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/resource_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/resource_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/resource_transfer.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/resource_transfer.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/services/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/services/cost_modifier_service.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/resource_transfer.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/resource_transfer.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/src/effects/index.ts",
+				"packages/contents/src/buildings.ts",
+				"packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/result_mod.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/result_mod.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/result_mod.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/stat_add.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/stat_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/stat_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/stat_add.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/stat_add_pct.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/stat_add_pct.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/stat_add_pct.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/stat_add_pct.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/src/effects/stat_remove.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": ".",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/stat_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../stat_sources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/stat_sources.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/index.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/stat_sources/dependencies.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/evaluators/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/context.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/ai/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/actions/action_execution.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/stat_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/engine/src/state/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/engine/src/effects/stat_remove.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/engine/src/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/populationRoles.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/contents/src/config/builders.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/contents/src/populationRoles.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/actions.ts",
+				"packages/contents/src/config/builders.ts",
+				"packages/contents/src/game.ts",
+				"packages/contents/src/index.ts",
+				"packages/contents/src/phases.ts",
+				"packages/contents/src/populations.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/resources.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/contents/src/config/builders.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/contents/src/resources.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/actions.ts",
+				"packages/contents/src/config/builders.ts",
+				"packages/contents/src/buildings.ts",
+				"packages/contents/src/developments.ts",
+				"packages/contents/src/game.ts",
+				"packages/contents/src/index.ts",
+				"packages/contents/src/populations.ts",
+				"packages/contents/src/rules.ts",
+				"packages/contents/src/startup.ts",
+				"packages/contents/src/tieredResources.ts",
+				"packages/contents/tests/builder-validations.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/stats.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/contents/src/config/builders.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/contents/src/stats.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/actions.ts",
+				"packages/contents/src/config/builders.ts",
+				"packages/contents/src/buildings.ts",
+				"packages/contents/src/developments.ts",
+				"packages/contents/src/game.ts",
+				"packages/contents/src/index.ts",
+				"packages/contents/src/phases.ts",
+				"packages/contents/src/populations.ts",
+				"packages/contents/src/rules.ts",
+				"packages/contents/tests/builder-validations.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/buildings.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./defs",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/contents/src/defs.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/resources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/effects/resource_transfer",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/effects/resource_transfer.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/developments.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./defs",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/contents/src/defs.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/resources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/game.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./populationRoles",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/populationRoles.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/resources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./actions",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/actions.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./actions",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/contents/src/actions.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./buildings",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/buildings.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./buildings",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/contents/src/buildings.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./defs",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/defs.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./defs",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/contents/src/defs.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./developments",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/developments.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./developments",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/contents/src/developments.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./game",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/game.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./land",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/land.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./modifiers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/modifiers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./overview",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/overview.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passive",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/passive.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./phases",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./population",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/population.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./populationRoles",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/populationRoles.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./populations",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/populations.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/resources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./rules",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/rules.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./startup",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/startup.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./tieredResources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/tieredResources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./triggers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/contents/src/triggers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/tests/helpers.ts",
+				"packages/engine/tests/actions/army-attack-happiness.test.ts",
+				"packages/engine/tests/factories/content.ts",
+				"packages/engine/tests/actions/synthetic.test.ts",
+				"packages/engine/tests/actions/tax-happiness.test.ts",
+				"packages/engine/tests/advance-skip.test.ts",
+				"packages/engine/tests/ai/tax-collector.test.ts",
+				"packages/engine/tests/config/requirement_builder.test.ts",
+				"packages/engine/tests/effects/action_add.test.ts",
+				"packages/engine/tests/effects/action_remove.test.ts",
+				"packages/engine/tests/effects/add_building.test.ts",
+				"packages/engine/tests/effects/add_development.test.ts",
+				"packages/engine/tests/effects/add_stat.test.ts",
+				"packages/engine/tests/effects/cost-mod-action-owner.test.ts",
+				"packages/engine/tests/effects/cost_mod.test.ts",
+				"packages/engine/tests/effects/nonnegative.test.ts",
+				"packages/engine/tests/effects/population.test.ts",
+				"packages/engine/tests/effects/resource-add.test.ts",
+				"packages/engine/tests/effects/resource-remove.test.ts",
+				"packages/engine/tests/engine.property.test.ts",
+				"packages/engine/tests/happiness-tier-controller.test.ts",
+				"packages/engine/tests/plunder-zero-gold.test.ts",
+				"packages/engine/tests/requirements/evaluator_compare.test.ts",
+				"packages/engine/tests/result-mod-stack.test.ts",
+				"packages/engine/tests/services/rules.test.ts",
+				"packages/engine/tests/stat-sources.longevity.test.ts",
+				"packages/engine/tests/stat-sources.metadata.test.ts",
+				"packages/engine/tests/state/state.test.ts",
+				"packages/web/src/components/actions/ActionsPanel.tsx",
+				"packages/web/src/state/GameContext.tsx",
+				"packages/web/src/translation/effects/evaluators/population.ts",
+				"packages/web/src/translation/effects/helpers.ts",
+				"packages/web/src/translation/effects/formatters/attack.ts",
+				"packages/web/src/translation/effects/formatters/attack/statContext.ts",
+				"packages/web/src/translation/effects/formatters/attack/building.ts",
+				"packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+				"packages/web/src/utils/stats.ts",
+				"packages/web/src/utils/stats/descriptors.ts",
+				"packages/web/src/utils/stats/summary.ts",
+				"packages/web/src/translation/effects/formatters/attack/shared.ts",
+				"packages/web/src/translation/effects/formatters/attack/types.ts",
+				"packages/web/src/translation/effects/formatters/attack/resource.ts",
+				"packages/web/src/translation/effects/formatters/attack/stat.ts",
+				"packages/web/src/translation/effects/formatters/attackFormatterUtils.ts",
+				"packages/web/src/translation/effects/formatters/land.ts",
+				"packages/web/src/translation/effects/formatters/modifier.ts",
+				"packages/web/src/translation/effects/formatters/modifier_helpers.ts",
+				"packages/web/src/translation/effects/formatters/passive.ts",
+				"packages/web/src/translation/effects/formatters/population.ts",
+				"packages/web/src/translation/effects/formatters/resource.ts",
+				"packages/web/src/translation/effects/formatters/stat/index.ts",
+				"packages/web/src/translation/content/decorators.ts",
+				"packages/web/src/translation/content/phased.ts",
+				"packages/web/src/translation/content/land.ts",
+				"packages/web/src/translation/content/tierSummaries.ts",
+				"packages/web/src/translation/log/diff.ts",
+				"packages/web/src/translation/log/diffSections.ts",
+				"packages/web/src/translation/log/passives.ts",
+				"packages/web/src/translation/log/snapshots.ts",
+				"packages/web/src/translation/log/resourceSources/evaluators.ts",
+				"packages/web/src/translation/log/resourceSources/meta.ts",
+				"packages/web/src/translation/log/resourceSources/modifiers.ts",
+				"packages/web/src/translation/render.tsx",
+				"packages/web/src/utils/getRequirementIcons.ts",
+				"packages/web/src/components/actions/ActionCard.tsx",
+				"packages/web/src/components/actions/GenericActionCard.tsx",
+				"packages/web/src/components/actions/utils.ts",
+				"packages/web/src/components/player/LandDisplay.tsx",
+				"packages/web/src/components/player/PassiveDisplay.tsx",
+				"packages/web/src/components/player/PopulationInfo.tsx",
+				"packages/web/src/components/player/ResourceBar.tsx",
+				"packages/web/src/Overview.tsx",
+				"packages/web/src/components/overview/overviewTokens.ts",
+				"packages/web/src/components/overview/sectionsData.ts",
+				"packages/web/src/main.tsx",
+				"packages/web/src/startup/resolvePrimaryIcon.test.ts",
+				"packages/web/tests/helpers/actionsPanel.ts",
+				"packages/web/tests/HoverCard.test.tsx",
+				"packages/web/tests/Overview.test.tsx",
+				"packages/web/tests/PhasePanel.test.tsx",
+				"packages/web/tests/PlayerPanel.test.tsx",
+				"packages/web/tests/army-attack-translation.test.ts",
+				"packages/web/tests/attack-diff-formatters.test.ts",
+				"packages/web/tests/attack-on-damage-registry.test.ts",
+				"packages/web/tests/development-summary.test.ts",
+				"packages/web/tests/development-translation.test.ts",
+				"packages/web/tests/fixtures/syntheticFestival.ts",
+				"packages/web/tests/fixtures/syntheticRaidersGuild.ts",
+				"packages/web/tests/getRequirementIcons.test.ts",
+				"packages/web/tests/hold-festival-action-translation.test.ts",
+				"packages/web/tests/land-till-formatter.test.ts",
+				"packages/web/tests/log-source-icons.test.ts",
+				"packages/web/tests/modifier-eval-handlers.test.ts",
+				"packages/web/tests/overview-content-source.test.tsx",
+				"packages/web/tests/overview-tokens.test.ts",
+				"packages/web/tests/passive-display.test.tsx",
+				"packages/web/tests/passive-log-labels.test.ts",
+				"packages/web/tests/population-summary.test.ts",
+				"packages/web/tests/raiders-guild-translation.test.ts",
+				"packages/web/tests/resource-bar.test.tsx",
+				"packages/web/tests/stat-breakdown.test.ts",
+				"packages/web/tests/stat-descriptor-registry.test.ts",
+				"packages/web/tests/tier-summary-translation.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/land.ts",
+			"dependencies": [],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/modifiers.ts",
+			"dependencies": [],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/overview.ts",
+			"dependencies": [],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/passive.ts",
+			"dependencies": [],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/phases.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./defs",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/defs.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./populationRoles",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/populationRoles.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/index.ts",
+				"packages/contents/src/triggers.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/population.ts",
+			"dependencies": [],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/populations.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./defs",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/contents/src/defs.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./populationRoles",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/populationRoles.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/resources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/rules.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/resources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/contents/src/index.ts",
+				"packages/contents/src/tieredResources.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/startup.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./resources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/resources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/tieredResources.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./resources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/contents/src/resources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./rules",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/rules.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/src/triggers.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./phases",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/contents/src/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/contents/tests/builder-validations.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/resources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/resources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/contents/src/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/absorption-cap.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/state/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/helpers.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/config/schema.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/phases.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/registry.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/tests/absorption-cap.test.ts",
+				"packages/engine/tests/actions/army-attack-happiness.test.ts",
+				"packages/engine/tests/actions/simulate-action.test.ts",
+				"packages/engine/tests/actions/synthetic.test.ts",
+				"packages/engine/tests/actions/tax-happiness.test.ts",
+				"packages/engine/tests/additive-stat-pct.test.ts",
+				"packages/engine/tests/advance-skip.test.ts",
+				"packages/engine/tests/ai/tax-collector.test.ts",
+				"packages/engine/tests/attack-zero-damage-no-effects.test.ts",
+				"packages/engine/tests/context/queue.test.ts",
+				"packages/engine/tests/effects/action_add.test.ts",
+				"packages/engine/tests/effects/action_remove.test.ts",
+				"packages/engine/tests/effects/add_building.test.ts",
+				"packages/engine/tests/effects/add_development.test.ts",
+				"packages/engine/tests/effects/add_stat.test.ts",
+				"packages/engine/tests/effects/cost-mod-action-owner.test.ts",
+				"packages/engine/tests/effects/cost_mod.test.ts",
+				"packages/engine/tests/effects/land_add.test.ts",
+				"packages/engine/tests/effects/nonnegative.test.ts",
+				"packages/engine/tests/effects/passive-add.test.ts",
+				"packages/engine/tests/effects/population.test.ts",
+				"packages/engine/tests/effects/resource-add.test.ts",
+				"packages/engine/tests/effects/resource-remove.test.ts",
+				"packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts",
+				"packages/engine/tests/effects/stat-add-pct-step-reset.test.ts",
+				"packages/engine/tests/effects/till_land.test.ts",
+				"packages/engine/tests/engine.property.test.ts",
+				"packages/engine/tests/happiness-tier-controller.test.ts",
+				"packages/engine/tests/plunder-zero-gold.test.ts",
+				"packages/engine/tests/requirements/evaluator_compare.test.ts",
+				"packages/engine/tests/resolveAttack.test.ts",
+				"packages/engine/tests/result-mod-stack.test.ts",
+				"packages/engine/tests/services/rules.test.ts",
+				"packages/engine/tests/stat-sources.longevity.test.ts",
+				"packages/engine/tests/stat-sources.metadata.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/actions/army-attack-happiness.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/effects/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/factories/content.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/registry",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/tests/actions/army-attack-happiness.test.ts",
+				"packages/engine/tests/actions/simulate-action.test.ts",
+				"packages/engine/tests/actions/synthetic.test.ts",
+				"packages/engine/tests/actions/tax-happiness.test.ts",
+				"packages/engine/tests/ai/tax-collector.test.ts",
+				"packages/engine/tests/attack-zero-damage-no-effects.test.ts",
+				"packages/engine/tests/effects/action_add.test.ts",
+				"packages/engine/tests/effects/action_remove.test.ts",
+				"packages/engine/tests/effects/add_building.test.ts",
+				"packages/engine/tests/effects/add_development.test.ts",
+				"packages/engine/tests/effects/cost-mod-action-owner.test.ts",
+				"packages/engine/tests/effects/cost_mod.test.ts",
+				"packages/engine/tests/effects/population.test.ts",
+				"packages/engine/tests/effects/till_land.test.ts",
+				"packages/engine/tests/engine.property.test.ts",
+				"packages/engine/tests/happiness-tier-controller.test.ts",
+				"packages/engine/tests/phases/fixtures.ts",
+				"packages/engine/tests/plunder-zero-gold.test.ts",
+				"packages/engine/tests/requirements/evaluator_compare.test.ts",
+				"packages/engine/tests/resolveAttack.test.ts",
+				"packages/engine/tests/result-mod-stack.test.ts",
+				"packages/engine/tests/services/rules.test.ts",
+				"packages/web/tests/army-attack-translation.test.ts",
+				"packages/web/tests/fixtures/syntheticFestival.ts",
+				"packages/web/tests/fixtures/syntheticPlow.ts",
+				"packages/web/tests/fixtures/syntheticRaidersGuild.ts",
+				"packages/web/tests/fixtures/syntheticTaxLog.ts",
+				"packages/web/tests/modifier-eval-handlers.test.ts",
+				"packages/web/tests/passive-duration-formatter.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/actions/simulate-action.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents/config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/actions/synthetic.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/actions/tax-happiness.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/additive-stat-pct.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/state/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/advance-skip.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents/config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/ai/tax-collector.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/ai/index",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/ai/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/attack-zero-damage-no-effects.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/effects/attack_target_handlers/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/attack_target_handlers/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/state/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./factories/content.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/config/requirement_builder.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents/config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/context/queue.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/action_add.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/action_remove.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/add_building.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/add_development.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/add_stat.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/cost-mod-action-owner.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/effects/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/cost_mod.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/land_add.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/effects/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/nonnegative.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/passive-add.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/effects/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/state/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/population.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/resource-add.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/resource-remove.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/effects/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/effects/resource_transfer.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/resource_transfer.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/stat-add-pct-step-reset.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/effects/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/state/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/effects/till_land.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents/config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/engine.property.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/happiness-tier-controller.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents/config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/phases/fixtures.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/config/schema.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/phases.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/services/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/engine/tests/phases/growth.test.ts",
+				"packages/engine/tests/phases/upkeep.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/phases/growth.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./fixtures.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/phases/fixtures.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/phases/upkeep.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./fixtures.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/phases/fixtures.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/plunder-zero-gold.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/registry/registry.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/registry.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/registry.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/requirements/evaluator_compare.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/requirements/evaluator_compare",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/requirements/evaluator_compare.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/resolveAttack.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/effects/attack_target_handlers/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/effects/attack_target_handlers/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/effects/attack.types.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/attack.types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/state/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./factories/content.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/result-mod-stack.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/services/rules.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/state",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents/config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/stat-sources.longevity.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/stat-sources.metadata.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/effects/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/stat_sources.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/stat_sources.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/engine/src/stat_sources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/state/state.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/state/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/engine/tests/utils/applyParamsToEffects.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../src/state/index.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/state/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/utils.ts",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/src/utils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/postcss.config.cjs",
+			"dependencies": [],
+			"dependents": [],
+			"orphan": true,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/App.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./components/audio/BackgroundMusic",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/audio/BackgroundMusic.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./Game",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/Game.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./Menu",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/Menu.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./Overview",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/Overview.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./state/appHistory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/appHistory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./state/useAppNavigation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/useAppNavigation.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./Tutorial",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/Tutorial.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/main.tsx",
+				"packages/web/tests/App.test.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/audio/BackgroundMusic.tsx",
+			"dependencies": [],
+			"dependents": ["packages/web/src/App.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/Game.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./components/actions/ActionsPanel",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/actions/ActionsPanel.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/common/Button",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/common/Button.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/common/ConfirmDialog",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/common/ConfirmDialog.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/common/ErrorToaster",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/common/ErrorToaster.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/common/TimeControl",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/common/TimeControl.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/HoverCard",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/HoverCard.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/LogPanel",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/LogPanel.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/phases/PhasePanel",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/phases/PhasePanel.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/player/PlayerPanel",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/player/PlayerPanel.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/settings/SettingsDialog",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/settings/SettingsDialog.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/App.tsx",
+				"packages/web/tests/Game.render.test.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/actions/ActionsPanel.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/getRequirementIcons",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/getRequirementIcons.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/isActionPhaseActive",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/isActionPhaseActive.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/useAutoAnimate",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/useAutoAnimate.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./ActionCard",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/actions/ActionCard.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./GenericActions",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/actions/GenericActions.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/components/actions/GenericActions.tsx",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/components/actions/ActionsPanel.tsx",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./utils",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/actions/utils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/Game.tsx",
+				"packages/web/src/components/actions/GenericActions.tsx",
+				"packages/web/src/components/actions/GenericActionCard.tsx",
+				"packages/web/tests/ActionsPanel.test.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/state/GameContext.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../utils/describeSkipEvent",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/describeSkipEvent.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./useTimeScale",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/useTimeScale.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./useTimeScale",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/web/src/state/useTimeScale.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/Game.tsx",
+				"packages/web/src/components/actions/ActionsPanel.tsx",
+				"packages/web/src/components/actions/GenericActions.tsx",
+				"packages/web/src/components/actions/types.ts",
+				"packages/web/src/components/common/ErrorToaster.tsx",
+				"packages/web/src/components/common/TimeControl.tsx",
+				"packages/web/src/components/HoverCard.tsx",
+				"packages/web/src/components/LogPanel.tsx",
+				"packages/web/src/components/phases/PhasePanel.tsx",
+				"packages/web/src/components/player/BuildingDisplay.tsx",
+				"packages/web/src/components/player/LandDisplay.tsx",
+				"packages/web/src/components/player/PassiveDisplay.tsx",
+				"packages/web/src/components/player/PopulationInfo.tsx",
+				"packages/web/src/components/player/ResourceBar.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/web/src/translation/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./log",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/web/src/translation/log.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./render",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/web/src/translation/render.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/components/actions/ActionsPanel.tsx",
+				"packages/web/src/state/GameContext.tsx",
+				"packages/web/src/components/actions/ActionCard.tsx",
+				"packages/web/src/components/actions/GenericActions.tsx",
+				"packages/web/src/components/actions/GenericActionCard.tsx",
+				"packages/web/src/components/actions/useEffectGroupOptions.ts",
+				"packages/web/src/components/player/BuildingDisplay.tsx",
+				"packages/web/src/components/player/LandDisplay.tsx",
+				"packages/web/src/components/player/PassiveDisplay.tsx",
+				"packages/web/src/components/player/ResourceBar.tsx",
+				"packages/web/tests/development-translation.test.ts",
+				"packages/web/tests/population-summary.test.ts",
+				"packages/web/tests/resource-bar.test.tsx",
+				"packages/web/tests/subaction-log.test.ts",
+				"packages/web/tests/tax-market-log.test.ts",
+				"packages/web/tests/tier-summary-translation.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./action",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/action.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./building",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/building.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/phased.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./development",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/development.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/phased.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/web/src/translation/content/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./land",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/land.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./partition",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/web/src/translation/content/partition.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./tierSummaries",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/web/src/translation/content/tierSummaries.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "export"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/index.ts",
+				"packages/web/src/translation/effects/factory.ts",
+				"packages/web/src/translation/effects/formatters/action.ts",
+				"packages/web/src/translation/effects/formatters/attack.ts",
+				"packages/web/src/translation/effects/formatters/attack/building.ts",
+				"packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+				"packages/web/src/translation/effects/formatters/attack/types.ts",
+				"packages/web/src/translation/effects/formatters/attackFormatterUtils.ts",
+				"packages/web/src/translation/effects/formatters/modifier.ts",
+				"packages/web/src/translation/log/diffSections.ts",
+				"packages/web/src/translation/log/snapshots.ts",
+				"packages/web/src/translation/render.tsx",
+				"packages/web/src/utils/describeSkipEvent.ts",
+				"packages/web/tests/army-attack-translation.test.ts",
+				"packages/web/tests/development-summary.test.ts",
+				"packages/web/tests/fixtures/syntheticRaidersGuild.ts",
+				"packages/web/tests/hold-festival-action-translation.test.ts",
+				"packages/web/tests/land-till-formatter.test.ts",
+				"packages/web/tests/plow-action-translation.test.ts",
+				"packages/web/tests/plow-workshop-translation.test.ts",
+				"packages/web/tests/raiders-guild-translation.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/action.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./actionLogHooks",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/actionLogHooks.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/content/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./evaluators/development",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/evaluators/development.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./evaluators/population",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/evaluators/population.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/evaluators/population.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "export"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./formatters/action",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/action.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./formatters/attack",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./formatters/building",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/building.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./formatters/development",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/development.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./formatters/land",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/land.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/land.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./formatters/modifier",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/modifier.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/modifier.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./formatters/passive",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/passive.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/passive.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./formatters/population",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/population.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/population.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./formatters/resource",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/resource.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/resource.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./formatters/stat",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/stat/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/stat/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/index.ts",
+				"packages/web/src/translation/content/action.ts",
+				"packages/web/src/translation/content/phased.ts",
+				"packages/web/tests/land-till-formatter.test.ts",
+				"packages/web/tests/modifier-eval-handlers.test.ts",
+				"packages/web/tests/passive-duration-formatter.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/evaluators/development.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/factory.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "export"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/index.ts",
+				"packages/web/src/translation/effects/evaluators/development.ts",
+				"packages/web/src/translation/effects/evaluators/population.ts",
+				"packages/web/src/translation/effects/formatters/action.ts",
+				"packages/web/src/translation/effects/formatters/attack.ts",
+				"packages/web/src/translation/effects/formatters/attackFormatterUtils.ts",
+				"packages/web/src/translation/effects/formatters/building.ts",
+				"packages/web/src/translation/effects/formatters/development.ts",
+				"packages/web/src/translation/effects/formatters/land.ts",
+				"packages/web/src/translation/effects/formatters/modifier.ts",
+				"packages/web/src/translation/effects/formatters/passive.ts",
+				"packages/web/src/translation/effects/formatters/population.ts",
+				"packages/web/src/translation/effects/formatters/resource.ts",
+				"packages/web/src/translation/effects/formatters/stat/index.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/evaluators/population.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/evaluators/population.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/helpers.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/evaluators/population.ts",
+				"packages/web/src/translation/effects/formatters/land.ts",
+				"packages/web/src/translation/effects/formatters/modifier.ts",
+				"packages/web/src/translation/effects/formatters/modifier_helpers.ts",
+				"packages/web/src/translation/effects/formatters/population.ts",
+				"packages/web/src/translation/effects/formatters/resource.ts",
+				"packages/web/src/translation/effects/formatters/stat/index.ts",
+				"packages/web/tests/raiders-guild-translation.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/action.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/action.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/action.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/attack.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attack/statContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attack/target-formatter",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attackFormatterUtils",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attackFormatterUtils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attackFormatterUtils.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/index.ts",
+				"packages/web/tests/attack-on-damage-registry.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../attack/target-formatter",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../attack/types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/attack.ts",
+				"packages/web/src/translation/effects/formatters/attackFormatterUtils.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./building",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/building.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resource",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/resource.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/resource.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stat",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/stat.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/stat.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/attack.ts",
+				"packages/web/src/translation/effects/formatters/attack/statContext.ts",
+				"packages/web/src/translation/effects/formatters/attackFormatterUtils.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/attack/building.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../../content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./evaluation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./shared",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/attack/target-formatter.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../../../utils/stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../../content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./shared",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/attack/building.ts",
+				"packages/web/src/translation/effects/formatters/attack/resource.ts",
+				"packages/web/src/translation/effects/formatters/attack/stat.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/utils/stats.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../translation/content/types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stats/descriptors",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/stats/descriptors.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stats/descriptors",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/utils/stats/descriptors.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./stats/summary",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/stats/summary.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+				"packages/web/src/translation/effects/formatters/attack/shared.ts",
+				"packages/web/src/translation/log/diffSections.ts",
+				"packages/web/src/translation/log/diffFormatting.ts",
+				"packages/web/src/components/player/PopulationInfo.tsx",
+				"packages/web/tests/stat-breakdown.test.ts",
+				"packages/web/tests/stat-descriptor-registry.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/types.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/content/index.ts",
+				"packages/web/src/translation/content/action.ts",
+				"packages/web/src/utils/stats.ts",
+				"packages/web/src/utils/stats/summary.ts",
+				"packages/web/src/translation/effects/formatters/modifier.ts",
+				"packages/web/src/translation/effects/formatters/modifier_helpers.ts",
+				"packages/web/src/translation/content/factory.ts",
+				"packages/web/src/translation/content/building.ts",
+				"packages/web/src/translation/content/decorators.ts",
+				"packages/web/src/translation/content/phased.ts",
+				"packages/web/src/translation/content/development.ts",
+				"packages/web/src/translation/content/land.ts",
+				"packages/web/src/translation/content/partition.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/utils/stats/descriptors.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/utils/stats.ts",
+				"packages/web/src/utils/stats/summary.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/utils/stats/summary.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../translation/content/types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./descriptors",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/stats/descriptors.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/utils/stats.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../../../utils/stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/attack/building.ts",
+				"packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+				"packages/web/src/translation/effects/formatters/attack/resource.ts",
+				"packages/web/src/translation/effects/formatters/attack/stat.ts",
+				"packages/web/tests/army-attack-translation.test.ts",
+				"packages/web/tests/attack-diff-formatters.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/attack/types.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../../content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/attack/statContext.ts",
+				"packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+				"packages/web/src/translation/effects/formatters/attack/building.ts",
+				"packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+				"packages/web/src/translation/effects/formatters/attack/shared.ts",
+				"packages/web/src/translation/effects/formatters/attack/resource.ts",
+				"packages/web/src/translation/effects/formatters/attack/stat.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/attack/resource.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./evaluation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/resource.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./shared",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/resource.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/resource.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/attack/target-formatter.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/attack/stat.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./evaluation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/evaluation.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/stat.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./shared",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/stat.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/types.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/stat.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/attack/target-formatter.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/attackFormatterUtils.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attackFormatterUtils.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attackFormatterUtils.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attack/statContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/statContext.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attackFormatterUtils.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./attack/target-formatter",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/target-formatter.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attack.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/attackFormatterUtils.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/attack.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/building.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../content/buildingIcons",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/buildingIcons.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/building.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/buildingIcons.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/building.ts",
+				"packages/web/src/translation/content/building.ts",
+				"packages/web/src/translation/log/resourceSources/meta.ts",
+				"packages/web/src/translation/log/resourceSources/modifiers.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/development.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/development.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/land.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/land.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/modifier.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/modifier.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../content/types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/modifier.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./modifier_helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/modifier_helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./transfer_helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/transfer_helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/index.ts",
+				"packages/web/tests/modifier-eval-handlers.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/modifier_helpers.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../../icons",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/icons/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../content/types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/modifier.ts",
+				"packages/web/src/translation/effects/formatters/transfer_helpers.ts",
+				"packages/web/tests/raiders-guild-translation.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/icons/index.ts",
+			"dependencies": [],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/modifier_helpers.ts",
+				"packages/web/src/components/player/infoCards.ts",
+				"packages/web/src/components/player/ResourceBar.tsx",
+				"packages/web/tests/raiders-guild-translation.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/transfer_helpers.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./modifier_helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/modifier_helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/effects/formatters/modifier.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/passive.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/passive.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/phases",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/population.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/population.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/resource.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/resource.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/effects/formatters/stat/index.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/action.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/formatters/stat/index.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/effects/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/actionLogHooks.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/content/action.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/factory.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/content/index.ts",
+				"packages/web/src/translation/content/action.ts",
+				"packages/web/src/translation/content/actionLogHooks.ts",
+				"packages/web/src/translation/content/building.ts",
+				"packages/web/src/translation/content/development.ts",
+				"packages/web/src/translation/content/land.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/building.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./buildingIcons",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/buildingIcons.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./decorators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/decorators.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./phased",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/phased.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/phased.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/building.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./phased",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/phased.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/phased.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/building.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/content/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/decorators.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/content/building.ts",
+				"packages/web/src/translation/content/development.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/phased.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/building.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/phased.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/content/building.ts",
+				"packages/web/src/translation/content/development.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/development.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./decorators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/decorators.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./phased",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/phased.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/phased.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/development.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./phased",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/phased.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/content/phased.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/index.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/evaluators/development.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/effects/factory.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/index.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/content/development.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/content/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/land.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./factory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/factory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/content/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/partition.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/content/index.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/content/tierSummaries.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/content/index.ts",
+				"packages/web/src/translation/log/passives.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./log/diff",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/web/src/translation/log/diff.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./log/resourceSources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/web/src/translation/log/resourceSources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./log/snapshots",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "export"],
+					"resolved": "packages/web/src/translation/log/snapshots.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/index.ts",
+				"packages/web/tests/log-source-icons.test.ts",
+				"packages/web/tests/log-source.test.ts",
+				"packages/web/tests/passive-log-labels.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log/diff.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./diffSections",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log/diffSections.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resourceSources",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log/resourceSources.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./snapshots",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log/snapshots.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./statBreakdown",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/log/statBreakdown.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/log.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log/diffSections.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../utils/stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./diffFormatting",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log/diffFormatting.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./passives",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log/passives.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./snapshots",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/log/snapshots.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/log/snapshots.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/log/diffSections.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./statBreakdown",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log/statBreakdown.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/log/diff.ts",
+				"packages/web/src/translation/log/snapshots.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log/diffFormatting.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../utils/stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/log/diffSections.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log/passives.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../content/tierSummaries",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/tierSummaries.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/log/diffSections.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log/snapshots.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./diffSections",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log/diffSections.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/translation/log/diffSections.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/translation/log/snapshots.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/log.ts",
+				"packages/web/src/translation/log/diff.ts",
+				"packages/web/src/translation/log/diffSections.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log/statBreakdown.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/log/diff.ts",
+				"packages/web/src/translation/log/diffSections.ts",
+				"packages/web/src/translation/log/resourceSources.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log/resourceSources.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./resourceSources/evaluators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log/resourceSources/evaluators.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resourceSources/meta",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log/resourceSources/meta.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resourceSources/modifiers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log/resourceSources/modifiers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./resourceSources/types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/log/resourceSources/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./statBreakdown",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/log/statBreakdown.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/log.ts",
+				"packages/web/src/translation/log/diff.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log/resourceSources/evaluators.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/log/resourceSources/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/log/resourceSources.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log/resourceSources/types.ts",
+			"dependencies": [],
+			"dependents": [
+				"packages/web/src/translation/log/resourceSources.ts",
+				"packages/web/src/translation/log/resourceSources/evaluators.ts",
+				"packages/web/src/translation/log/resourceSources/meta.ts",
+				"packages/web/src/translation/log/resourceSources/modifiers.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log/resourceSources/meta.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../content/buildingIcons",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/buildingIcons.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/log/resourceSources/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/log/resourceSources.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/log/resourceSources/modifiers.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../content/buildingIcons",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/buildingIcons.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/log/resourceSources/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/translation/log/resourceSources.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/translation/render.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/translation/index.ts",
+				"packages/web/src/components/actions/ActionCard.tsx",
+				"packages/web/src/components/HoverCard.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/utils/describeSkipEvent.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../translation/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/state/GameContext.tsx",
+				"packages/web/tests/describe-skip-event.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/state/useTimeScale.ts",
+			"dependencies": [],
+			"dependents": ["packages/web/src/state/GameContext.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/utils/getRequirementIcons.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/components/actions/ActionsPanel.tsx",
+				"packages/web/src/components/actions/GenericActionCard.tsx",
+				"packages/web/tests/getRequirementIcons.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/utils/isActionPhaseActive.ts",
+			"dependencies": [],
+			"dependents": [
+				"packages/web/src/components/actions/ActionsPanel.tsx",
+				"packages/web/src/components/phases/PhasePanel.tsx",
+				"packages/web/tests/phase-history.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/utils/useAutoAnimate.ts",
+			"dependencies": [],
+			"dependents": [
+				"packages/web/src/components/actions/ActionsPanel.tsx",
+				"packages/web/src/components/LogPanel.tsx",
+				"packages/web/src/components/phases/PhasePanel.tsx",
+				"packages/web/src/components/player/PlayerPanel.tsx",
+				"packages/web/src/components/player/BuildingDisplay.tsx",
+				"packages/web/src/components/player/LandDisplay.tsx",
+				"packages/web/src/components/player/PassiveDisplay.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/actions/ActionCard.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../translation/render",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/render.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/components/actions/ActionsPanel.tsx",
+				"packages/web/src/components/actions/GenericActionCard.tsx",
+				"packages/web/src/components/actions/useEffectGroupOptions.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/actions/GenericActions.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./ActionsPanel",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/actions/ActionsPanel.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/components/actions/ActionsPanel.tsx",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/components/actions/GenericActions.tsx",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./GenericActionCard",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/actions/GenericActionCard.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/components/actions/GenericActionCard.tsx",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/components/actions/GenericActions.tsx",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/components/actions/ActionsPanel.tsx",
+				"packages/web/src/components/actions/GenericActionCard.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/actions/GenericActionCard.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/getRequirementIcons",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/getRequirementIcons.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./ActionCard",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/actions/ActionCard.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./ActionsPanel",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/actions/ActionsPanel.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/components/actions/ActionsPanel.tsx",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/components/actions/GenericActions.tsx",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/components/actions/GenericActionCard.tsx",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./GenericActions",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/actions/GenericActions.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/components/actions/GenericActions.tsx",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/components/actions/GenericActionCard.tsx",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/actions/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./useEffectGroupOptions",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/actions/useEffectGroupOptions.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./utils",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/actions/utils.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/components/actions/GenericActions.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/actions/types.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/components/actions/GenericActionCard.tsx",
+				"packages/web/src/components/actions/useEffectGroupOptions.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/actions/useEffectGroupOptions.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./ActionCard",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/actions/ActionCard.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./types",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/actions/types.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/components/actions/GenericActionCard.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/actions/utils.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/components/actions/ActionsPanel.tsx",
+				"packages/web/src/components/actions/GenericActionCard.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/common/Button.tsx",
+			"dependencies": [],
+			"dependents": [
+				"packages/web/src/Game.tsx",
+				"packages/web/src/components/common/ConfirmDialog.tsx",
+				"packages/web/src/components/phases/PhasePanel.tsx",
+				"packages/web/src/components/settings/SettingsDialog.tsx",
+				"packages/web/src/menu/CallToActionSection.tsx",
+				"packages/web/src/Overview.tsx",
+				"packages/web/src/Tutorial.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/common/ConfirmDialog.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./Button",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/common/Button.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/Game.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/common/ErrorToaster.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/Game.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/common/TimeControl.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/Game.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/HoverCard.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../translation/render",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/render.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/Game.tsx",
+				"packages/web/tests/HoverCard.test.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/LogPanel.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../utils/useAutoAnimate",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/useAutoAnimate.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./hooks/useLogViewport",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/hooks/useLogViewport.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/Game.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/hooks/useLogViewport.ts",
+			"dependencies": [],
+			"dependents": ["packages/web/src/components/LogPanel.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/phases/PhasePanel.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/isActionPhaseActive",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/isActionPhaseActive.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/useAutoAnimate",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/useAutoAnimate.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../common/Button",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/common/Button.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../TimerCircle",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/TimerCircle.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/Game.tsx",
+				"packages/web/tests/PhasePanel.test.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/TimerCircle.tsx",
+			"dependencies": [],
+			"dependents": ["packages/web/src/components/phases/PhasePanel.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/player/PlayerPanel.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../utils/useAutoAnimate",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/useAutoAnimate.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./BuildingDisplay",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/player/BuildingDisplay.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./LandDisplay",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/player/LandDisplay.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./PassiveDisplay",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/player/PassiveDisplay.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./PopulationInfo",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/player/PopulationInfo.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./ResourceBar",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/player/ResourceBar.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/Game.tsx",
+				"packages/web/tests/PlayerPanel.test.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/player/BuildingDisplay.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/useAutoAnimate",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/useAutoAnimate.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/components/player/PlayerPanel.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/player/LandDisplay.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/useAutoAnimate",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/useAutoAnimate.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/components/player/PlayerPanel.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/player/PassiveDisplay.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/useAutoAnimate",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/useAutoAnimate.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/components/player/PlayerPanel.tsx",
+				"packages/web/tests/passive-display.test.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/player/PopulationInfo.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/useValueChangeIndicators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/useValueChangeIndicators.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./infoCards",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/player/infoCards.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/components/player/PlayerPanel.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/utils/useValueChangeIndicators.ts",
+			"dependencies": [],
+			"dependents": [
+				"packages/web/src/components/player/PopulationInfo.tsx",
+				"packages/web/src/components/player/ResourceBar.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/player/infoCards.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../icons",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/icons/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/components/player/PopulationInfo.tsx",
+				"packages/web/src/components/player/ResourceBar.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/player/ResourceBar.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../icons",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/icons/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../state/GameContext",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/GameContext.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../utils/useValueChangeIndicators",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/useValueChangeIndicators.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./infoCards",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/player/infoCards.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/components/player/PlayerPanel.tsx",
+				"packages/web/tests/resource-bar.test.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/settings/SettingsDialog.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../common/Button",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/common/Button.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../common/ToggleSwitch",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/common/ToggleSwitch.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/Game.tsx", "packages/web/src/Menu.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/common/ToggleSwitch.tsx",
+			"dependencies": [],
+			"dependents": ["packages/web/src/components/settings/SettingsDialog.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/Menu.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./components/layouts/ShowcasePage",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/layouts/ShowcasePage.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/settings/SettingsDialog",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/settings/SettingsDialog.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./menu/CallToActionSection",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/menu/CallToActionSection.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./menu/HeroSection",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/menu/HeroSection.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./menu/HighlightsSection",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/menu/HighlightsSection.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/App.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/layouts/ShowcasePage.tsx",
+			"dependencies": [],
+			"dependents": [
+				"packages/web/src/Menu.tsx",
+				"packages/web/src/menu/CallToActionSection.tsx",
+				"packages/web/src/menu/HeroSection.tsx",
+				"packages/web/src/Overview.tsx",
+				"packages/web/src/Tutorial.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/menu/CallToActionSection.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../components/common/Button",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/common/Button.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../components/layouts/ShowcasePage",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/layouts/ShowcasePage.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/Menu.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/menu/HeroSection.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../components/layouts/ShowcasePage",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/layouts/ShowcasePage.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/Menu.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/menu/HighlightsSection.tsx",
+			"dependencies": [],
+			"dependents": ["packages/web/src/Menu.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/Overview.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./components/common/Button",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/common/Button.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/layouts/ShowcasePage",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/layouts/ShowcasePage.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/overview/OverviewLayout",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/overview/OverviewLayout.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/overview/OverviewLayout",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/overview/OverviewLayout.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/overview/overviewTokens",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/overview/overviewTokens.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/overview/sectionsData",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/overview/sectionsData.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/overview/sectionsData",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/overview/sectionsData.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/App.tsx",
+				"packages/web/tests/Overview.test.tsx",
+				"packages/web/tests/overview-content-source.test.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/overview/OverviewLayout.tsx",
+			"dependencies": [],
+			"dependents": [
+				"packages/web/src/Overview.tsx",
+				"packages/web/src/components/overview/sectionsData.ts",
+				"packages/web/src/Tutorial.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/overview/overviewTokens.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./sectionsData",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/overview/sectionsData.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/components/overview/sectionsData.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						},
+						{
+							"name": "packages/web/src/components/overview/overviewTokens.ts",
+							"dependencyTypes": ["local", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/Overview.tsx",
+				"packages/web/src/components/overview/sectionsData.ts",
+				"packages/web/tests/overview-tokens.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/components/overview/sectionsData.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./OverviewLayout",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/overview/OverviewLayout.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./overviewTokens",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/overview/overviewTokens.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": true,
+					"cycle": [
+						{
+							"name": "packages/web/src/components/overview/overviewTokens.ts",
+							"dependencyTypes": ["local", "import"]
+						},
+						{
+							"name": "packages/web/src/components/overview/sectionsData.ts",
+							"dependencyTypes": ["local", "type-only", "import"]
+						}
+					],
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/src/Overview.tsx",
+				"packages/web/src/components/overview/overviewTokens.ts",
+				"packages/web/tests/Overview.test.tsx"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/state/appHistory.ts",
+			"dependencies": [],
+			"dependents": [
+				"packages/web/src/App.tsx",
+				"packages/web/src/state/useAppNavigation.ts",
+				"packages/web/src/state/appNavigationState.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/state/useAppNavigation.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./appHistory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/appHistory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./appNavigationState",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/state/appNavigationState.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./audioPreferences",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/state/audioPreferences.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/App.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/state/appNavigationState.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./appHistory",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/state/appHistory.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/state/useAppNavigation.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/state/audioPreferences.ts",
+			"dependencies": [],
+			"dependents": ["packages/web/src/state/useAppNavigation.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/Tutorial.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./components/common/Button",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/common/Button.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/layouts/ShowcasePage",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/layouts/ShowcasePage.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./components/overview/OverviewLayout",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/overview/OverviewLayout.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/src/App.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/main.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./App",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/App.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./index.css",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/index.css",
+					"coreModule": false,
+					"followable": false,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./startup/resolvePrimaryIcon",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/startup/resolvePrimaryIcon.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/index.css",
+			"followable": false,
+			"coreModule": false,
+			"couldNotResolve": false,
+			"matchesDoNotFollow": false,
+			"dependencyTypes": ["local", "import"],
+			"dependencies": [],
+			"dependents": ["packages/web/src/main.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/startup/resolvePrimaryIcon.ts",
+			"dependencies": [],
+			"dependents": [
+				"packages/web/src/main.tsx",
+				"packages/web/src/startup/resolvePrimaryIcon.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/src/startup/resolvePrimaryIcon.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "./resolvePrimaryIcon",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/startup/resolvePrimaryIcon.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tailwind.config.cjs",
+			"dependencies": [],
+			"dependents": [],
+			"orphan": true,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/ActionsPanel.test.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/components/actions/ActionsPanel",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/actions/ActionsPanel.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./helpers/actionsPanel",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/tests/helpers/actionsPanel.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/helpers/actionsPanel.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/tests/ActionsPanel.test.tsx"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/App.test.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/App",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/App.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/Game.render.test.tsx",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/Game",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/Game.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/HoverCard.test.tsx",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/components/HoverCard",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/HoverCard.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/Overview.test.tsx",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/components/overview/sectionsData",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/components/overview/sectionsData.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/Overview",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/Overview.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/PhasePanel.test.tsx",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/components/phases/PhasePanel",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/phases/PhasePanel.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/PlayerPanel.test.tsx",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/components/player/PlayerPanel",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/player/PlayerPanel.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/army-attack-translation.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../engine/tests/factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/effects/formatters/attack/shared",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents/config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/phases",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/attack-diff-formatters.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/translation/effects/formatters/attack/shared",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack/shared.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/attack-on-damage-registry.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/translation/effects/formatters/attack",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/attack.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/describe-skip-event.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/utils/describeSkipEvent",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/describeSkipEvent.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/development-summary.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/development-translation.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/fixtures/syntheticFestival.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../../engine/tests/factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/tests/hold-festival-action-translation.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/fixtures/syntheticPlow.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../../engine/tests/factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/phases",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/tests/plow-action-translation.test.ts",
+				"packages/web/tests/plow-workshop-translation.test.ts",
+				"packages/web/tests/subaction-log.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/fixtures/syntheticRaidersGuild.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../../engine/tests/factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../src/translation/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/phases",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/tests/raiders-guild-translation.test.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/fixtures/syntheticTaxData.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/phases",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": ["packages/web/tests/fixtures/syntheticTaxLog.ts"],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/fixtures/syntheticTaxLog.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../../../engine/tests/factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./syntheticTaxData",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/tests/fixtures/syntheticTaxData.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./syntheticTaxData",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "type-only", "import"],
+					"resolved": "packages/web/tests/fixtures/syntheticTaxData.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [
+				"packages/web/tests/log-source.test.ts",
+				"packages/web/tests/tax-market-log.test.ts"
+			],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/getRequirementIcons.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/utils/getRequirementIcons",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/getRequirementIcons.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/hold-festival-action-translation.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./fixtures/syntheticFestival",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/tests/fixtures/syntheticFestival.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/land-till-formatter.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents/config/builders",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/config/builders.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/log-source-icons.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/translation/log",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/log-source.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/log",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./fixtures/syntheticTaxLog",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/tests/fixtures/syntheticTaxLog.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/modifier-eval-handlers.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../engine/tests/factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/effects/formatters/modifier",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/modifier.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/phases",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/overview-content-source.test.tsx",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../src/Overview",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/web/src/Overview.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/overview-tokens.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/components/overview/overviewTokens",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/overview/overviewTokens.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/passive-display.test.tsx",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/components/player/PassiveDisplay",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/player/PassiveDisplay.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/passive-duration-formatter.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../../engine/tests/factories/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/engine/tests/factories/content.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/effects",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/config/schema",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/config/schema.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/phases",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/phases.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine/services",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/services/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/passive-log-labels.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/log",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/log.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/phase-history.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/utils/isActionPhaseActive",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/isActionPhaseActive.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/plow-action-translation.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./fixtures/syntheticPlow",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/tests/fixtures/syntheticPlow.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/plow-workshop-translation.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./fixtures/syntheticPlow",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/tests/fixtures/syntheticPlow.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/population-summary.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/raiders-guild-translation.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/icons",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/icons/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/content",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/content/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/effects/formatters/modifier_helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/formatters/modifier_helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation/effects/helpers",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/effects/helpers.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./fixtures/syntheticRaidersGuild",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/tests/fixtures/syntheticRaidersGuild.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/resource-bar.test.tsx",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/components/player/ResourceBar",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/components/player/ResourceBar.tsx",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"type-only",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/stat-breakdown.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/utils/stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/stat-descriptor-registry.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/utils/stats",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/utils/stats.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/subaction-log.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./fixtures/syntheticPlow",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/tests/fixtures/syntheticPlow.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/tax-market-log.test.ts",
+			"dependencies": [
+				{
+					"dynamic": true,
+					"module": "../../engine/src",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "dynamic-import"],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "../src/translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "./fixtures/syntheticTaxLog",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/tests/fixtures/syntheticTaxLog.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/engine",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/engine/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/tests/tier-summary-translation.test.ts",
+			"dependencies": [
+				{
+					"dynamic": false,
+					"module": "../src/translation",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": ["local", "import"],
+					"resolved": "packages/web/src/translation/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				},
+				{
+					"dynamic": false,
+					"module": "@kingdom-builder/contents",
+					"moduleSystem": "es6",
+					"exoticallyRequired": false,
+					"dependencyTypes": [
+						"aliased",
+						"aliased-tsconfig",
+						"aliased-tsconfig-paths",
+						"local",
+						"import"
+					],
+					"resolved": "packages/contents/src/index.ts",
+					"coreModule": false,
+					"followable": true,
+					"couldNotResolve": false,
+					"matchesDoNotFollow": false,
+					"circular": false,
+					"valid": true
+				}
+			],
+			"dependents": [],
+			"orphan": false,
+			"valid": true
+		},
+		{
+			"source": "packages/web/vite.config.ts",
+			"dependencies": [],
+			"dependents": [],
+			"orphan": true,
+			"valid": true
+		}
+	],
+	"summary": {
+		"violations": [],
+		"error": 0,
+		"warn": 0,
+		"info": 0,
+		"ignore": 0,
+		"totalCruised": 297,
+		"totalDependenciesCruised": 1109,
+		"optionsUsed": {
+			"baseDir": ".",
+			"combinedDependencies": false,
+			"detectJSDocImports": false,
+			"doNotFollow": {
+				"path": "node_modules"
+			},
+			"exoticRequireStrings": [],
+			"externalModuleResolutionStrategy": "node_modules",
+			"includeOnly": "^packages/engine|^packages/contents|^packages/web",
+			"metrics": false,
+			"moduleSystems": ["es6", "cjs", "tsd", "amd"],
+			"outputTo": "docs/dependency-report.initial.json",
+			"outputType": "json",
+			"preserveSymlinks": false,
+			"rulesFile": "scripts/dependency-cruiser.cjs",
+			"skipAnalysisNotInRules": false,
+			"tsConfig": {
+				"fileName": "./tsconfig.base.json"
+			},
+			"tsPreCompilationDeps": true,
+			"args": "packages/engine packages/contents packages/web"
+		},
+		"ruleSetUsed": {
+			"forbidden": []
+		}
+	}
+}

--- a/docs/domain-boundaries.md
+++ b/docs/domain-boundaries.md
@@ -1,0 +1,83 @@
+# Domain Boundaries
+
+This document clarifies how the Web client, Engine runtime, and Content layer
+collaborate inside Kingdom Builder. It focuses on responsibilities, sanctioned
+data exchange, and the invariants that the engine relies on when executing the
+game loop.
+
+## Responsibilities
+
+### Content (`@kingdom-builder/contents`)
+
+- Owns all player-facing data: actions, buildings, resources, phases, and
+  balance numbers.
+- Provides schema-validated definitions that other domains consume at runtime.
+- Supplies registries, factories, and metadata so that simulations and UIs never
+  hardcode resource names, identifiers, or numeric values.
+- Maintains backward-compatible structures when evolving content so that the
+  engine and web client can load new data without code changes.
+
+### Engine (`@kingdom-builder/engine`)
+
+- Interprets content definitions to advance the game state, enforce rules, and
+  emit derived data (e.g., log entries, prompts, computed modifiers).
+- Hosts mechanics such as triggers, evaluators, passives, and registries that
+  resolve effects described in content.
+- Exposes a pure, deterministic API that accepts content-driven inputs and
+  returns serializable state updates for persistence or presentation.
+- Guarantees that player-facing strings, icons, and lookup keys are surfaced
+  exactly as supplied by the content package.
+
+### Web (`@kingdom-builder/web`)
+
+- Presents the current game state and affordances by consuming the engine API
+  alongside content metadata.
+- Maps engine identifiers to localized names, art, and layout supplied by the
+  content layer.
+- Captures user intent (e.g., chosen actions) and forwards it to the engine in
+  terms of content-provided identifiers.
+- Avoids embedding rule logic; instead, it renders controls based on the engine
+  state and guidance exposed by content registries.
+
+## Sanctioned Data Exchange
+
+- **Content → Engine**: registries, definitions, schema guards, and helper
+  utilities. The engine may import types or factories but must not mutate content
+  definitions directly.
+- **Content → Web**: presentation metadata, localized strings, iconography, and
+  configuration required for UI rendering.
+- **Engine ↔ Web**:
+  - Web invokes engine APIs (`createGame`, `performAction`, evaluators, etc.)
+    using identifiers sourced from content definitions.
+  - Engine returns snapshots that include references to content IDs, derived
+    numeric values, prompts, and log entries. The web client enriches the
+    response using content metadata.
+- **Engine ↔ Content (runtime)**: the engine may execute callbacks or evaluators
+  registered by the content layer, provided they adhere to the schema contract
+  and remain free of side effects outside the simulated state.
+- **Persistence / Telemetry**: any stored game state uses engine-owned data
+  structures that reference content IDs instead of denormalized copies of
+  content definitions.
+
+## Engine Invariants
+
+The engine assumes the following guarantees from other domains:
+
+1. **Schema compliance**: content definitions satisfy the published zod schemas
+   and do not omit required hooks (e.g., triggers, effect handlers).
+2. **Pure callbacks**: content evaluators and passives do not rely on mutable
+   singletons or perform external I/O; they operate solely on supplied context
+   and state arguments.
+3. **Stable identifiers**: content IDs referenced in persisted games remain
+   available across releases. Deprecations must provide forward-compatible
+   aliases or migrations.
+4. **Read-only imports**: neither web nor content code mutates engine exports.
+   Similarly, the engine treats imported content as immutable data.
+5. **Deterministic inputs**: the web client forwards player intent using engine
+   request types without augmenting them with additional derived state.
+6. **Version parity**: all three packages are upgraded together so that shared
+   types remain in sync and runtime type mismatches cannot occur.
+
+Violating these expectations can surface as runtime assertion failures, invalid
+state transitions, or UI desynchronization. Each domain should validate inputs
+against the contracts above before releasing new features.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"@vitejs/plugin-react": "^4.3.1",
 				"@vitest/coverage-v8": "^3.2.4",
 				"autoprefixer": "^10.4.21",
+				"dependency-cruiser": "^17.0.2",
 				"eslint": "^8.57.0",
 				"eslint-plugin-import": "^2.32.0",
 				"eslint-plugin-markdown": "^5.1.0",
@@ -2068,6 +2069,39 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/acorn-jsx-walk": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+			"integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/acorn-loose": {
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+			"integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.15.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2717,10 +2751,11 @@
 			"dev": true
 		},
 		"node_modules/commander": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-			"integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+			"integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=20"
 			}
@@ -2928,6 +2963,93 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/dependency-cruiser": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.0.2.tgz",
+			"integrity": "sha512-Aryg/E8ostay8B7OBPqrxcxeGSgtPRKosP6do3L3TiPg4dAvIJFl2EFuG/mO8JAZv70pBTveKvKxhABPyNduvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"acorn-jsx": "^5.3.2",
+				"acorn-jsx-walk": "^2.0.0",
+				"acorn-loose": "^8.5.2",
+				"acorn-walk": "^8.3.4",
+				"ajv": "^8.17.1",
+				"commander": "^14.0.1",
+				"enhanced-resolve": "^5.18.3",
+				"ignore": "^7.0.5",
+				"interpret": "^3.1.1",
+				"is-installed-globally": "^1.0.0",
+				"json5": "^2.2.3",
+				"memoize": "^10.1.0",
+				"picomatch": "^4.0.3",
+				"prompts": "^2.4.2",
+				"rechoir": "^0.8.0",
+				"safe-regex": "^2.1.1",
+				"semver": "^7.7.2",
+				"tsconfig-paths-webpack-plugin": "^4.2.0",
+				"watskeburt": "^4.2.3"
+			},
+			"bin": {
+				"depcruise": "bin/dependency-cruise.mjs",
+				"depcruise-baseline": "bin/depcruise-baseline.mjs",
+				"depcruise-fmt": "bin/depcruise-fmt.mjs",
+				"depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
+				"dependency-cruise": "bin/dependency-cruise.mjs",
+				"dependency-cruiser": "bin/dependency-cruise.mjs"
+			},
+			"engines": {
+				"node": "^20.12||^22||>=24"
+			}
+		},
+		"node_modules/dependency-cruiser/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/dependency-cruiser/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/dependency-cruiser/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/dependency-cruiser/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/dequal": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3013,6 +3135,20 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
 			"integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
 			"dev": true
+		},
+		"node_modules/enhanced-resolve": {
+			"version": "5.18.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+			"integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
 		},
 		"node_modules/entities": {
 			"version": "6.0.1",
@@ -3683,6 +3819,23 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/fastq": {
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -3984,6 +4137,22 @@
 				"node": "*"
 			}
 		},
+		"node_modules/global-directory": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+			"integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ini": "4.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/globals": {
 			"version": "13.24.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -4046,6 +4215,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -4276,6 +4452,16 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"node_modules/ini": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+			"integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
 		"node_modules/internal-slot": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4288,6 +4474,16 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/interpret": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+			"integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/is-alphabetical": {
@@ -4541,6 +4737,36 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-installed-globally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+			"integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"global-directory": "^4.0.1",
+				"is-path-inside": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-installed-globally/node_modules/is-path-inside": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+			"integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-map": {
@@ -4938,6 +5164,16 @@
 				"json-buffer": "3.0.1"
 			}
 		},
+		"node_modules/kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5243,6 +5479,22 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/memoize": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/memoize/-/memoize-10.1.0.tgz",
+			"integrity": "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/memoize?sponsor=1"
 			}
 		},
 		"node_modules/merge2": {
@@ -6007,6 +6259,20 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/prompts": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6114,6 +6380,19 @@
 				"node": ">=8.10.0"
 			}
 		},
+		"node_modules/rechoir": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+			"integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve": "^1.20.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
 		"node_modules/redent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6150,6 +6429,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/regexp-tree": {
+			"version": "0.1.27",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+			"integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"regexp-tree": "bin/regexp-tree"
+			}
+		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -6168,6 +6457,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve": {
@@ -6349,6 +6648,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+			"integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"regexp-tree": "~0.1.1"
 			}
 		},
 		"node_modules/safe-regex-test": {
@@ -6564,6 +6873,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
+		},
+		"node_modules/sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
@@ -6971,6 +7287,20 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/tapable": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+			"integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			}
+		},
 		"node_modules/test-exclude": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -7202,6 +7532,37 @@
 				"json5": "^1.0.2",
 				"minimist": "^1.2.6",
 				"strip-bom": "^3.0.0"
+			}
+		},
+		"node_modules/tsconfig-paths-webpack-plugin": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+			"integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.0",
+				"enhanced-resolve": "^5.7.0",
+				"tapable": "^2.2.1",
+				"tsconfig-paths": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+			"integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json5": "^2.2.2",
+				"minimist": "^1.2.6",
+				"strip-bom": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/tsconfig-paths/node_modules/json5": {
@@ -7586,6 +7947,19 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/watskeburt": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-4.2.3.tgz",
+			"integrity": "sha512-uG9qtQYoHqAsnT711nG5iZc/8M5inSmkGCOp7pFaytKG2aTfIca7p//CjiVzAE4P7hzaYuCozMjNNaLgmhbK5g==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"watskeburt": "dist/run-cli.js"
+			},
+			"engines": {
+				"node": "^18||>=20"
 			}
 		},
 		"node_modules/webidl-conversions": {
@@ -9286,6 +9660,30 @@
 			"dev": true,
 			"requires": {}
 		},
+		"acorn-jsx-walk": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+			"integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+			"dev": true
+		},
+		"acorn-loose": {
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+			"integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+			"dev": true,
+			"requires": {
+				"acorn": "^8.15.0"
+			}
+		},
+		"acorn-walk": {
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"dev": true,
+			"requires": {
+				"acorn": "^8.11.0"
+			}
+		},
 		"agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -9718,9 +10116,9 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-			"integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+			"integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
 			"dev": true
 		},
 		"concat-map": {
@@ -9866,6 +10264,66 @@
 				"object-keys": "^1.1.1"
 			}
 		},
+		"dependency-cruiser": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.0.2.tgz",
+			"integrity": "sha512-Aryg/E8ostay8B7OBPqrxcxeGSgtPRKosP6do3L3TiPg4dAvIJFl2EFuG/mO8JAZv70pBTveKvKxhABPyNduvg==",
+			"dev": true,
+			"requires": {
+				"acorn": "^8.15.0",
+				"acorn-jsx": "^5.3.2",
+				"acorn-jsx-walk": "^2.0.0",
+				"acorn-loose": "^8.5.2",
+				"acorn-walk": "^8.3.4",
+				"ajv": "^8.17.1",
+				"commander": "^14.0.1",
+				"enhanced-resolve": "^5.18.3",
+				"ignore": "^7.0.5",
+				"interpret": "^3.1.1",
+				"is-installed-globally": "^1.0.0",
+				"json5": "^2.2.3",
+				"memoize": "^10.1.0",
+				"picomatch": "^4.0.3",
+				"prompts": "^2.4.2",
+				"rechoir": "^0.8.0",
+				"safe-regex": "^2.1.1",
+				"semver": "^7.7.2",
+				"tsconfig-paths-webpack-plugin": "^4.2.0",
+				"watskeburt": "^4.2.3"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "8.17.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.3",
+						"fast-uri": "^3.0.1",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2"
+					}
+				},
+				"ignore": {
+					"version": "7.0.5",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+					"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+					"dev": true
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				},
+				"picomatch": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+					"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+					"dev": true
+				}
+			}
+		},
 		"dequal": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -9937,6 +10395,16 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
 			"integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
 			"dev": true
+		},
+		"enhanced-resolve": {
+			"version": "5.18.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+			"integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
+			}
 		},
 		"entities": {
 			"version": "6.0.1",
@@ -10448,6 +10916,12 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
+		"fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"dev": true
+		},
 		"fastq": {
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -10661,6 +11135,15 @@
 				"is-glob": "^4.0.3"
 			}
 		},
+		"global-directory": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+			"integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+			"dev": true,
+			"requires": {
+				"ini": "4.1.1"
+			}
+		},
 		"globals": {
 			"version": "13.24.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -10698,6 +11181,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true
+		},
+		"graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true
 		},
 		"graphemer": {
@@ -10854,6 +11343,12 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"ini": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+			"integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+			"dev": true
+		},
 		"internal-slot": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -10864,6 +11359,12 @@
 				"hasown": "^2.0.2",
 				"side-channel": "^1.1.0"
 			}
+		},
+		"interpret": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+			"integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+			"dev": true
 		},
 		"is-alphabetical": {
 			"version": "1.0.4",
@@ -11022,6 +11523,24 @@
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
 			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
 			"dev": true
+		},
+		"is-installed-globally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+			"integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+			"dev": true,
+			"requires": {
+				"global-directory": "^4.0.1",
+				"is-path-inside": "^4.0.0"
+			},
+			"dependencies": {
+				"is-path-inside": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+					"integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+					"dev": true
+				}
+			}
 		},
 		"is-map": {
 			"version": "2.0.3",
@@ -11292,6 +11811,12 @@
 				"json-buffer": "3.0.1"
 			}
 		},
+		"kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"dev": true
+		},
 		"levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -11507,6 +12032,15 @@
 			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
 			"integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
 			"dev": true
+		},
+		"memoize": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/memoize/-/memoize-10.1.0.tgz",
+			"integrity": "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==",
+			"dev": true,
+			"requires": {
+				"mimic-function": "^5.0.1"
+			}
 		},
 		"merge2": {
 			"version": "1.4.1",
@@ -11993,6 +12527,16 @@
 				}
 			}
 		},
+		"prompts": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+			"dev": true,
+			"requires": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.5"
+			}
+		},
 		"punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -12059,6 +12603,15 @@
 				"picomatch": "^2.2.1"
 			}
 		},
+		"rechoir": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+			"integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+			"dev": true,
+			"requires": {
+				"resolve": "^1.20.0"
+			}
+		},
 		"redent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -12085,6 +12638,12 @@
 				"which-builtin-type": "^1.2.1"
 			}
 		},
+		"regexp-tree": {
+			"version": "0.1.27",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+			"integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+			"dev": true
+		},
 		"regexp.prototype.flags": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -12098,6 +12657,12 @@
 				"gopd": "^1.2.0",
 				"set-function-name": "^2.0.2"
 			}
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.22.10",
@@ -12213,6 +12778,15 @@
 			"requires": {
 				"es-errors": "^1.3.0",
 				"isarray": "^2.0.5"
+			}
+		},
+		"safe-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+			"integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+			"dev": true,
+			"requires": {
+				"regexp-tree": "~0.1.1"
 			}
 		},
 		"safe-regex-test": {
@@ -12365,6 +12939,12 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true
+		},
+		"sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
 			"dev": true
 		},
 		"slash": {
@@ -12660,6 +13240,12 @@
 				"sucrase": "^3.35.0"
 			}
 		},
+		"tapable": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+			"integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+			"dev": true
+		},
 		"test-exclude": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -12840,6 +13426,31 @@
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"
+					}
+				}
+			}
+		},
+		"tsconfig-paths-webpack-plugin": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+			"integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.0",
+				"enhanced-resolve": "^5.7.0",
+				"tapable": "^2.2.1",
+				"tsconfig-paths": "^4.1.2"
+			},
+			"dependencies": {
+				"tsconfig-paths": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+					"integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+					"dev": true,
+					"requires": {
+						"json5": "^2.2.2",
+						"minimist": "^1.2.6",
+						"strip-bom": "^3.0.0"
 					}
 				}
 			}
@@ -13042,6 +13653,12 @@
 			"requires": {
 				"xml-name-validator": "^5.0.0"
 			}
+		},
+		"watskeburt": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-4.2.3.tgz",
+			"integrity": "sha512-uG9qtQYoHqAsnT711nG5iZc/8M5inSmkGCOp7pFaytKG2aTfIca7p//CjiVzAE4P7hzaYuCozMjNNaLgmhbK5g==",
+			"dev": true
 		},
 		"webidl-conversions": {
 			"version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"test:coverage": "vitest run --coverage",
 		"test:ci": "npm run test:coverage",
 		"format": "prettier .",
-		"prepare": "husky install"
+		"prepare": "husky install",
+		"lint:deps": "dependency-cruiser packages/engine packages/contents packages/web --config scripts/dependency-cruiser.cjs --output-type text"
 	},
 	"dependencies": {
 		"react": "^18.3.1",
@@ -41,6 +42,7 @@
 		"@vitejs/plugin-react": "^4.3.1",
 		"@vitest/coverage-v8": "^3.2.4",
 		"autoprefixer": "^10.4.21",
+		"dependency-cruiser": "^17.0.2",
 		"eslint": "^8.57.0",
 		"eslint-plugin-import": "^2.32.0",
 		"eslint-plugin-markdown": "^5.1.0",

--- a/scripts/dependency-cruiser.cjs
+++ b/scripts/dependency-cruiser.cjs
@@ -1,0 +1,20 @@
+/* eslint-env node */
+
+module.exports = {
+	forbidden: [],
+	options: {
+		includeOnly: [
+			"^packages/engine",
+			"^packages/contents",
+			"^packages/web"
+		],
+		doNotFollow: {
+			path: "node_modules"
+		},
+		tsPreCompilationDeps: true,
+		baseDir: ".",
+		tsConfig: {
+			fileName: "./tsconfig.base.json"
+		}
+	}
+};


### PR DESCRIPTION
## Summary
- add documentation outlining responsibilities, data contracts, and invariants for the web, engine, and content domains
- configure dependency-cruiser with project path resolution plus an npm script to emit dependency reports
- check in the initial dependency-cruiser JSON report to establish a measurable baseline

## Testing
- npm run lint
- npm run test:quick
- npm run lint:deps

------
https://chatgpt.com/codex/tasks/task_e_68e16a6756548325887a2ca3a39f3c12