### PR TITLE
docs: add translation text formatting guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -605,6 +605,9 @@ params: { amount: 5 } }`.
 
 - The web client converts engine definitions into player-facing text through a
   layered translation system to keep UI strings decoupled from data.
+- **Read `docs/text-formatting.md` before adding or changing user-facing
+  wording.** It explains the translator pipeline, inventories existing
+  formatters, and lists the canonical verbs/icons that keep UI copy consistent.
 
 ### 6.1 Effect Formatters
 


### PR DESCRIPTION
## Summary
- add a text-formatting guide that documents the translation pipeline, existing formatter modules, and canonical helper utilities
- update AGENTS.md to require contributors to consult the new guide before changing user-facing copy

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e16d9bd76c8325995f988f12d17880