### PR TITLE
Improve player panel container contrast

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -40,7 +40,7 @@ function GameLayout() {
 		setQuitDialogOpen(false);
 		onExit();
 	}, [onExit]);
-	const playerAreaRef = useRef<HTMLDivElement | null>(null);
+	const playerAreaRef = useRef<HTMLElement | null>(null);
 	const [phasePanelHeight, setPhasePanelHeight] = useState(320);
 	useEffect(() => {
 		const node = playerAreaRef.current;
@@ -176,11 +176,11 @@ function GameLayout() {
 				</div>
 
 				<div className="grid grid-cols-1 gap-y-6 gap-x-6 lg:grid-cols-[minmax(0,1fr)_30rem]">
-					<section className="relative flex min-h-[275px] items-stretch rounded-3xl bg-white/70 shadow-2xl dark:bg-slate-900/70 dark:shadow-slate-900/50 frosted-surface">
-						<div
-							ref={playerAreaRef}
-							className="flex flex-1 items-stretch gap-6 overflow-hidden rounded-3xl px-6 py-6"
-						>
+					<section
+						ref={playerAreaRef}
+						className="relative flex min-h-[275px] items-stretch rounded-3xl border border-white/60 bg-white/80 p-6 shadow-2xl dark:border-white/10 dark:bg-slate-900/75 dark:shadow-slate-900/50 frosted-surface"
+					>
+						<div className="flex flex-1 items-stretch gap-6">
 							{playerPanels}
 						</div>
 					</section>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -261,7 +261,7 @@
     @apply panel-card border border-white/40 p-1.5 text-lg leading-none hoverable cursor-help flex items-center justify-center gap-1 shrink-0 min-w-8 min-h-8 dark:border-white/10;
   }
   .player-bg {
-    @apply relative overflow-hidden rounded-3xl text-slate-900 shadow-xl shadow-slate-900/10 dark:text-slate-100 dark:shadow-black/40;
+    @apply relative overflow-hidden rounded-3xl border border-white/60 text-slate-900 shadow-xl shadow-slate-900/10 dark:border-white/10 dark:text-slate-100 dark:shadow-black/40;
     --stripe-color: rgba(255, 255, 255, 0.45);
     background-color: var(--player-color);
   }


### PR DESCRIPTION
## Summary
- align the player area wrapper styling with other panels by adding the shared border, padding, and frosted treatment
- add player card borders so the blue/red gradients stay visible against the global background

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e16d0a9ab48325b503a76d5c1f6ad0