### PR TITLE
Revamp happiness tier summaries and hover card presentation

### DIFF
--- a/packages/contents/src/happinessHelpers.ts
+++ b/packages/contents/src/happinessHelpers.ts
@@ -1,0 +1,84 @@
+import type { EffectConfig } from '@kingdom-builder/engine/config/schema';
+import {
+	Types,
+	CostModMethods,
+	ResultModMethods,
+	StatMethods,
+	costModParams,
+	evaluationTarget,
+	resultModParams,
+	statParams,
+	effect,
+	PassiveMethods,
+} from './config/builders';
+import type { passiveParams } from './config/builders';
+import { Resource } from './resources';
+import { Stat } from './stats';
+
+export const GROWTH_PHASE_ID = 'growth';
+export const UPKEEP_PHASE_ID = 'upkeep';
+export const WAR_RECOVERY_STEP_ID = 'war-recovery';
+const BUILD_ACTION_ID = 'build';
+
+const DEVELOPMENT_EVALUATION = evaluationTarget('development');
+
+export const incomeModifier = (id: string, percent: number) =>
+	({
+		type: Types.ResultMod,
+		method: ResultModMethods.ADD,
+		params: resultModParams()
+			.id(id)
+			.evaluation(DEVELOPMENT_EVALUATION)
+			.percent(percent)
+			.build(),
+	}) as const;
+
+export const buildingDiscountModifier = (id: string) =>
+	({
+		type: Types.CostMod,
+		method: CostModMethods.ADD,
+		params: costModParams()
+			.id(id)
+			.actionId(BUILD_ACTION_ID)
+			.key(Resource.gold)
+			.percent(-0.2)
+			.build(),
+	}) as const;
+
+export const growthBonusEffect = (amount: number) =>
+	({
+		type: Types.Stat,
+		method: StatMethods.ADD,
+		params: statParams().key(Stat.growth).amount(amount).build(),
+	}) as const;
+
+export const formatRemoval = (description: string) =>
+	`Active as long as ${description}`;
+
+type TierPassiveEffectOptions = {
+	tierId: string;
+	summary: string;
+	removalDetail: string;
+	params: ReturnType<typeof passiveParams>;
+	effects?: EffectConfig[];
+};
+
+export function createTierPassiveEffect({
+	tierId,
+	summary,
+	removalDetail,
+	params,
+	effects = [],
+}: TierPassiveEffectOptions) {
+	params.detail(summary);
+	params.meta({
+		source: { type: 'tiered-resource', id: tierId },
+		removal: { token: removalDetail, text: formatRemoval(removalDetail) },
+	});
+	const builder = effect()
+		.type(Types.Passive)
+		.method(PassiveMethods.ADD)
+		.params(params);
+	effects.forEach((entry) => builder.effect(entry));
+	return builder;
+}

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -1,110 +1,11 @@
 import React from 'react';
-import {
-	PASSIVE_INFO,
-	RESOURCES,
-	type ResourceKey,
-} from '@kingdom-builder/contents';
+import { RESOURCES, type ResourceKey } from '@kingdom-builder/contents';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { useGameEngine } from '../../state/GameContext';
 import { useValueChangeIndicators } from '../../utils/useValueChangeIndicators';
 import { GENERAL_RESOURCE_ICON } from '../../icons';
 import { GENERAL_RESOURCE_INFO, PLAYER_INFO_CARD_BG } from './infoCards';
-import { summarizeEffects, translateTierSummary } from '../../translation';
-
-type TierDefinition =
-	EngineContext['services']['rules']['tierDefinitions'][number];
-type TierSummaryEntry = TierDefinition & { active: boolean };
-
-function formatTierRange(tier: TierDefinition) {
-	const { min, max } = tier.range;
-	if (max === undefined) {
-		return `${min}+`;
-	}
-	if (min === max) {
-		return `${min}`;
-	}
-	return `${min} to ${max}`;
-}
-
-function collectSummaryLines(
-	entries: ReturnType<typeof summarizeEffects>,
-	limit: number,
-) {
-	if (limit <= 0) {
-		return [] as string[];
-	}
-	const lines: string[] = [];
-	const queue = [...entries];
-	while (queue.length && lines.length < limit) {
-		const entry = queue.shift();
-		if (entry === undefined) {
-			continue;
-		}
-		if (typeof entry === 'string') {
-			const trimmed = entry.trim();
-			if (trimmed && !lines.includes(trimmed)) {
-				lines.push(trimmed);
-			}
-			continue;
-		}
-		const title = entry.title.trim();
-		if (title && !lines.includes(title)) {
-			lines.push(title);
-		}
-		if (lines.length >= limit) {
-			break;
-		}
-		if (entry.items?.length) {
-			queue.unshift(...entry.items);
-		}
-	}
-	return lines;
-}
-
-function buildTierEntries(
-	tiers: TierDefinition[],
-	activeId: string | undefined,
-	ctx: EngineContext,
-) {
-	const entries: TierSummaryEntry[] = tiers.map((tier) => ({
-		...tier,
-		active: tier.id === activeId,
-	}));
-	return entries.map((entry) => {
-		const { preview, display, text, active } = entry;
-		const rangeLabel = formatTierRange(entry);
-		const statusIcon = active ? '🟢' : '⚪';
-		const icon = display?.icon ?? PASSIVE_INFO.icon ?? '';
-		const titleParts = [statusIcon, icon, rangeLabel].filter(
-			(part) => part && String(part).trim().length > 0,
-		);
-		const title = titleParts.join(' ').trim();
-
-		const summaryToken = display?.summaryToken;
-		const items: string[] = [];
-		const translatedSummary = translateTierSummary(summaryToken);
-		if (translatedSummary) {
-			items.push(translatedSummary);
-		} else if (text?.summary) {
-			items.push(text.summary.trim());
-		}
-
-		const remainingSlots = Math.max(0, 2 - items.length);
-		if (remainingSlots > 0) {
-			const summaries = collectSummaryLines(
-				summarizeEffects(preview?.effects || [], ctx),
-				remainingSlots,
-			);
-			items.push(...summaries);
-		}
-
-		if (!items.length) {
-			items.push('No tier bonuses active');
-		}
-
-		return { title, items };
-	});
-}
+import { buildTierEntries } from './buildTierEntries';
 
 interface ResourceButtonProps {
 	resourceKey: keyof typeof RESOURCES;

--- a/packages/web/src/components/player/buildTierEntries.ts
+++ b/packages/web/src/components/player/buildTierEntries.ts
@@ -1,0 +1,142 @@
+import { PASSIVE_INFO } from '@kingdom-builder/contents';
+import type { EngineContext } from '@kingdom-builder/engine';
+import { summarizeEffects, translateTierSummary } from '../../translation';
+
+export type TierDefinition =
+	EngineContext['services']['rules']['tierDefinitions'][number];
+
+type TierSummaryEntry = TierDefinition & { active: boolean };
+
+const MAX_SUMMARY_LINES = 4;
+
+function formatTierRange(tier: TierDefinition) {
+	const { min, max } = tier.range;
+	if (max === undefined) {
+		return `${min}`;
+	}
+	if (min === max) {
+		return `${min}`;
+	}
+	return `${min} to ${max}`;
+}
+
+function splitSummary(summary?: string) {
+	if (!summary) {
+		return [] as string[];
+	}
+	return summary
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+}
+
+function toBullet(line: string) {
+	const trimmed = line.trim();
+	if (!trimmed) {
+		return trimmed;
+	}
+	if (/^[-•]/u.test(trimmed)) {
+		return trimmed;
+	}
+	return `- ${trimmed}`;
+}
+
+function appendUnique(target: string[], values: string[]) {
+	values.forEach((value) => {
+		if (value && !target.includes(value)) {
+			target.push(value);
+		}
+	});
+}
+
+function collectSummaryLines(
+	entries: ReturnType<typeof summarizeEffects>,
+	limit: number,
+) {
+	if (limit <= 0) {
+		return [] as string[];
+	}
+	const lines: string[] = [];
+	const queue = [...entries];
+	while (queue.length && lines.length < limit) {
+		const entry = queue.shift();
+		if (entry === undefined) {
+			continue;
+		}
+		if (typeof entry === 'string') {
+			const segments = entry
+				.split(/\r?\n/)
+				.map((segment) => segment.trim())
+				.filter((segment) => segment.length > 0);
+			appendUnique(lines, segments);
+			continue;
+		}
+		const title = entry.title.trim();
+		if (title && !lines.includes(title)) {
+			lines.push(title);
+		}
+		if (lines.length >= limit) {
+			break;
+		}
+		if (entry.items?.length) {
+			queue.unshift(...entry.items);
+		}
+	}
+	return lines;
+}
+
+export function buildTierEntries(
+	tiers: TierDefinition[],
+	activeId: string | undefined,
+	ctx: EngineContext,
+) {
+	const getRangeStart = (tier: TierDefinition) =>
+		tier.range.min ?? Number.NEGATIVE_INFINITY;
+	const orderedTiers = [...tiers].sort(
+		(a, b) => getRangeStart(b) - getRangeStart(a),
+	);
+	const entries: TierSummaryEntry[] = orderedTiers.map((tier) => ({
+		...tier,
+		active: tier.id === activeId,
+	}));
+	return entries.map((entry) => {
+		const { preview, display, text, active } = entry;
+		const rangeLabel = formatTierRange(entry);
+		const statusIcon = active ? '🟢' : '⚪';
+		const icon = display?.icon ?? PASSIVE_INFO.icon ?? '';
+		const titleParts = [statusIcon, icon, rangeLabel].filter(
+			(part) => part && String(part).trim().length > 0,
+		);
+		const title = titleParts.join(' ').trim();
+
+		const summaryToken = display?.summaryToken;
+		const items: string[] = [];
+		const translatedSummary = translateTierSummary(summaryToken);
+		const summaryLines = splitSummary(translatedSummary ?? text?.summary);
+		if (summaryLines.length > 0) {
+			const bulletLines = summaryLines.map(toBullet);
+			appendUnique(items, bulletLines);
+		}
+
+		if (!items.length && text?.summary) {
+			const summaryBullet = toBullet(text.summary);
+			appendUnique(items, [summaryBullet]);
+		}
+		if (!items.length) {
+			const slots = MAX_SUMMARY_LINES - items.length;
+			if (slots > 0) {
+				const effectArgs = preview?.effects || [];
+				const summaries = summarizeEffects(effectArgs, ctx);
+				const lines = collectSummaryLines(summaries, slots);
+				const bulletLines = lines.map(toBullet);
+				appendUnique(items, bulletLines);
+			}
+		}
+
+		if (!items.length) {
+			items.push('- No tier bonuses active.');
+		}
+
+		return { title, items };
+	});
+}

--- a/packages/web/tests/passive-display.test.tsx
+++ b/packages/web/tests/passive-display.test.tsx
@@ -29,6 +29,9 @@ type MockGame = {
 
 let currentGame: MockGame;
 
+const INCOME_BONUS_TEXT = 'During income step, gain 25% more 🪙 gold.';
+const BUILD_DISCOUNT_TEXT = 'Build action costs 20% less 🪙 gold.';
+
 vi.mock('../src/state/GameContext', () => ({
 	useGameEngine: () => currentGame,
 }));
@@ -71,9 +74,14 @@ describe('<PassiveDisplay />', () => {
 		fireEvent.mouseEnter(hoverTarget!);
 		expect(handleHoverCard).toHaveBeenCalled();
 		const [{ description }] = handleHoverCard.mock.calls.at(-1) ?? [{}];
+		const primaryLine = Array.isArray(description)
+			? (description[0] as string | undefined)
+			: undefined;
+		expect(primaryLine).toBeDefined();
+		expect(primaryLine).toContain(INCOME_BONUS_TEXT);
+		expect(primaryLine).toContain(BUILD_DISCOUNT_TEXT);
 		expect(description).toEqual(
 			expect.arrayContaining([
-				expect.stringMatching(/Income \+25%/i),
 				expect.stringMatching(
 					/Active as long as happiness stays between \+5 and \+7/i,
 				),

--- a/tests/integration/happiness-tier-content.test.ts
+++ b/tests/integration/happiness-tier-content.test.ts
@@ -51,136 +51,136 @@ describe('content happiness tiers', () => {
 		}
 
 		expect(snapshot).toMatchInlineSnapshot(`
+{
+  "content": {
+    "happiness": 3,
+    "passives": [
       {
-        "content": {
-          "happiness": 3,
-          "passives": [
-            {
-              "id": "passive:happiness:content",
-              "removalToken": "happiness stays between +3 and +4",
-              "summary": "💰 Income +20% while the realm is content.",
-              "summaryToken": "happiness.tier.summary.content",
-            },
-          ],
-          "skipPhases": {},
-          "skipSteps": {},
+        "id": "passive:happiness:content",
+        "removalToken": "happiness stays between +3 and +4",
+        "summary": "During income step, gain 20% more 🪙 gold.",
+        "summaryToken": "happiness.tier.summary.content",
+      },
+    ],
+    "skipPhases": {},
+    "skipSteps": {},
+  },
+  "despair": {
+    "happiness": -10,
+    "passives": [
+      {
+        "id": "passive:happiness:despair",
+        "removalToken": "happiness is -10 or lower",
+        "summary": "During income step, gain 50% less 🪙 gold.\nSkip Growth phase.\nSkip War Recovery step during Upkeep phase.",
+        "summaryToken": "happiness.tier.summary.despair",
+      },
+    ],
+    "skipPhases": {
+      "growth": {
+        "passive:happiness:despair": true,
+      },
+    },
+    "skipSteps": {
+      "upkeep": {
+        "war-recovery": {
+          "passive:happiness:despair": true,
         },
-        "despair": {
-          "happiness": -10,
-          "passives": [
-            {
-              "id": "passive:happiness:despair",
-              "removalToken": "happiness is -10 or lower",
-              "summary": "💰 Income -50%. ⏭️ Skip Growth. 🛡️ War Recovery skipped.",
-              "summaryToken": "happiness.tier.summary.despair",
-            },
-          ],
-          "skipPhases": {
-            "growth": {
-              "passive:happiness:despair": true,
-            },
-          },
-          "skipSteps": {
-            "upkeep": {
-              "war-recovery": {
-                "passive:happiness:despair": true,
-              },
-            },
-          },
-        },
-        "ecstatic": {
-          "happiness": 10,
-          "passives": [
-            {
-              "id": "passive:happiness:ecstatic",
-              "removalToken": "happiness is +10 or higher",
-              "summary": "💰 Income +50%. 🏛️ Building costs reduced by 20%. 📈 Growth +20%.",
-              "summaryToken": "happiness.tier.summary.ecstatic",
-            },
-          ],
-          "skipPhases": {},
-          "skipSteps": {},
-        },
-        "elated": {
-          "happiness": 8,
-          "passives": [
-            {
-              "id": "passive:happiness:elated",
-              "removalToken": "happiness stays between +8 and +9",
-              "summary": "💰 Income +50%. 🏛️ Building costs reduced by 20%.",
-              "summaryToken": "happiness.tier.summary.elated",
-            },
-          ],
-          "skipPhases": {},
-          "skipSteps": {},
-        },
-        "grim": {
-          "happiness": -5,
-          "passives": [
-            {
-              "id": "passive:happiness:grim",
-              "removalToken": "happiness stays between -7 and -5",
-              "summary": "💰 Income -25%. ⏭️ Skip Growth until spirits recover.",
-              "summaryToken": "happiness.tier.summary.grim",
-            },
-          ],
-          "skipPhases": {
-            "growth": {
-              "passive:happiness:grim": true,
-            },
-          },
-          "skipSteps": {},
-        },
-        "joyful": {
-          "happiness": 5,
-          "passives": [
-            {
-              "id": "passive:happiness:joyful",
-              "removalToken": "happiness stays between +5 and +7",
-              "summary": "💰 Income +25%. 🏛️ Building costs reduced by 20%.",
-              "summaryToken": "happiness.tier.summary.joyful",
-            },
-          ],
-          "skipPhases": {},
-          "skipSteps": {},
-        },
-        "misery": {
-          "happiness": -8,
-          "passives": [
-            {
-              "id": "passive:happiness:misery",
-              "removalToken": "happiness stays between -9 and -8",
-              "summary": "💰 Income -50%. ⏭️ Skip Growth while morale is desperate.",
-              "summaryToken": "happiness.tier.summary.misery",
-            },
-          ],
-          "skipPhases": {
-            "growth": {
-              "passive:happiness:misery": true,
-            },
-          },
-          "skipSteps": {},
-        },
-        "steady": {
-          "happiness": 0,
-          "passives": [],
-          "skipPhases": {},
-          "skipSteps": {},
-        },
-        "unrest": {
-          "happiness": -3,
-          "passives": [
-            {
-              "id": "passive:happiness:unrest",
-              "removalToken": "happiness stays between -4 and -3",
-              "summary": "💰 Income -25% while unrest simmers.",
-              "summaryToken": "happiness.tier.summary.unrest",
-            },
-          ],
-          "skipPhases": {},
-          "skipSteps": {},
-        },
-      }
-    `);
+      },
+    },
+  },
+  "ecstatic": {
+    "happiness": 10,
+    "passives": [
+      {
+        "id": "passive:happiness:ecstatic",
+        "removalToken": "happiness is +10 or higher",
+        "summary": "During income step, gain 50% more 🪙 gold.\nBuild action costs 20% less 🪙 gold.\nDuring Growth phase, gain 20% more 📈 Growth.",
+        "summaryToken": "happiness.tier.summary.ecstatic",
+      },
+    ],
+    "skipPhases": {},
+    "skipSteps": {},
+  },
+  "elated": {
+    "happiness": 8,
+    "passives": [
+      {
+        "id": "passive:happiness:elated",
+        "removalToken": "happiness stays between +8 and +9",
+        "summary": "During income step, gain 50% more 🪙 gold.\nBuild action costs 20% less 🪙 gold.",
+        "summaryToken": "happiness.tier.summary.elated",
+      },
+    ],
+    "skipPhases": {},
+    "skipSteps": {},
+  },
+  "grim": {
+    "happiness": -5,
+    "passives": [
+      {
+        "id": "passive:happiness:grim",
+        "removalToken": "happiness stays between -7 and -5",
+        "summary": "During income step, gain 25% less 🪙 gold.\nSkip Growth phase.",
+        "summaryToken": "happiness.tier.summary.grim",
+      },
+    ],
+    "skipPhases": {
+      "growth": {
+        "passive:happiness:grim": true,
+      },
+    },
+    "skipSteps": {},
+  },
+  "joyful": {
+    "happiness": 5,
+    "passives": [
+      {
+        "id": "passive:happiness:joyful",
+        "removalToken": "happiness stays between +5 and +7",
+        "summary": "During income step, gain 25% more 🪙 gold.\nBuild action costs 20% less 🪙 gold.",
+        "summaryToken": "happiness.tier.summary.joyful",
+      },
+    ],
+    "skipPhases": {},
+    "skipSteps": {},
+  },
+  "misery": {
+    "happiness": -8,
+    "passives": [
+      {
+        "id": "passive:happiness:misery",
+        "removalToken": "happiness stays between -9 and -8",
+        "summary": "During income step, gain 50% less 🪙 gold.\nSkip Growth phase.",
+        "summaryToken": "happiness.tier.summary.misery",
+      },
+    ],
+    "skipPhases": {
+      "growth": {
+        "passive:happiness:misery": true,
+      },
+    },
+    "skipSteps": {},
+  },
+  "steady": {
+    "happiness": 0,
+    "passives": [],
+    "skipPhases": {},
+    "skipSteps": {},
+  },
+  "unrest": {
+    "happiness": -3,
+    "passives": [
+      {
+        "id": "passive:happiness:unrest",
+        "removalToken": "happiness stays between -4 and -3",
+        "summary": "During income step, gain 25% less 🪙 gold.",
+        "summaryToken": "happiness.tier.summary.unrest",
+      },
+    ],
+    "skipPhases": {},
+    "skipSteps": {},
+  },
+}
+`);
 	});
 });


### PR DESCRIPTION
## Summary
- add a `happinessHelpers` module and refactor tier definitions to use bullet-style summaries, capped ranges, and unified removal phrasing
- rebuild the happiness hover card with a dedicated `buildTierEntries` helper so tiers render from +10 to -10 with concise bullet effects
- update passive, component, and integration tests to reflect the new happiness copy and hover card behavior

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e1675764b48325b3c0ef99a1f010c0