### PR TITLE
Adjust resource bar padding

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -47,7 +47,7 @@
     @apply flex items-center gap-1 whitespace-nowrap rounded-full border border-white/40 bg-white/50 px-3 py-1 text-sm font-semibold tabular-nums text-slate-700 shadow-sm shadow-white/30 transition appearance-none dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100;
   }
   .info-bar {
-    @apply relative flex w-full flex-wrap items-center gap-2 rounded-full pl-10 pr-3 py-1;
+    @apply relative flex w-full flex-wrap items-center gap-2 rounded-full pl-14 pr-3 py-1;
   }
   .info-bar::before {
     content: '';


### PR DESCRIPTION
## Summary
- increase the left padding on the player resource bar so the general resource icon has more breathing room before the individual resource boxes

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e172b038d48325a9457eb0ab136de4