### PR TITLE
feat: centralize passive removal formatting

### DIFF
--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -47,3 +47,4 @@ export {
 	BROOM_ICON,
 	RESOURCE_TRANSFER_ICON,
 } from './defs';
+export { formatPassiveRemoval } from './text';

--- a/packages/contents/src/rules.ts
+++ b/packages/contents/src/rules.ts
@@ -5,6 +5,7 @@ import type {
 import type { EffectConfig } from '@kingdom-builder/engine/config/schema';
 import { Resource } from './resources';
 import { Stat } from './stats';
+import { formatPassiveRemoval } from './text';
 import {
 	Types,
 	CostModMethods,
@@ -19,12 +20,10 @@ import {
 	passiveParams,
 	PassiveMethods,
 } from './config/builders';
-
 const GROWTH_PHASE_ID = 'growth';
 const UPKEEP_PHASE_ID = 'upkeep';
-const WAR_RECOVERY_STEP_ID = 'war-recovery';
-const BUILD_ACTION_ID = 'build';
-
+const WAR_RECOVERY_STEP_ID = 'war-recovery',
+	BUILD_ACTION_ID = 'build';
 const DEVELOPMENT_EVALUATION = evaluationTarget('development');
 const incomeModifier = (id: string, percent: number) =>
 	({
@@ -36,7 +35,6 @@ const incomeModifier = (id: string, percent: number) =>
 			.percent(percent)
 			.build(),
 	}) as const;
-
 const buildingDiscountModifier = (id: string) =>
 	({
 		type: Types.CostMod,
@@ -48,17 +46,12 @@ const buildingDiscountModifier = (id: string) =>
 			.percent(-0.2)
 			.build(),
 	}) as const;
-
 const growthBonusEffect = (amount: number) =>
 	({
 		type: Types.Stat,
 		method: StatMethods.ADD,
 		params: statParams().key(Stat.growth).amount(amount).build(),
 	}) as const;
-
-const formatRemoval = (description: string) =>
-	`Active as long as ${description}`;
-
 type TierPassiveEffectOptions = {
 	tierId: string;
 	summary: string;
@@ -66,7 +59,6 @@ type TierPassiveEffectOptions = {
 	params: ReturnType<typeof passiveParams>;
 	effects?: EffectConfig[];
 };
-
 function createTierPassiveEffect({
 	tierId,
 	summary,
@@ -77,7 +69,10 @@ function createTierPassiveEffect({
 	params.detail(summary);
 	params.meta({
 		source: { type: 'tiered-resource', id: tierId },
-		removal: { token: removalDetail, text: formatRemoval(removalDetail) },
+		removal: {
+			token: removalDetail,
+			text: formatPassiveRemoval(removalDetail),
+		},
 	});
 	const builder = effect()
 		.type(Types.Passive)
@@ -86,10 +81,6 @@ function createTierPassiveEffect({
 	effects.forEach((entry) => builder.effect(entry));
 	return builder;
 }
-
-const happinessSummaryToken = (slug: string) =>
-	`happiness.tier.summary.${slug}`;
-
 const TIER_CONFIGS = [
 	{
 		id: 'happiness:tier:despair',
@@ -99,7 +90,7 @@ const TIER_CONFIGS = [
 		disableGrowth: true,
 		skipPhases: [GROWTH_PHASE_ID],
 		skipSteps: [{ phase: UPKEEP_PHASE_ID, step: WAR_RECOVERY_STEP_ID }],
-		summaryToken: happinessSummaryToken('despair'),
+		summaryToken: `happiness.tier.summary.despair`,
 		summary: '💰 Income -50%. ⏭️ Skip Growth. 🛡️ War Recovery skipped.',
 		removal: 'happiness is -10 or lower',
 		effects: [incomeModifier('happiness:despair:income', -0.5)],
@@ -111,7 +102,7 @@ const TIER_CONFIGS = [
 		incomeMultiplier: 0.5,
 		disableGrowth: true,
 		skipPhases: [GROWTH_PHASE_ID],
-		summaryToken: happinessSummaryToken('misery'),
+		summaryToken: `happiness.tier.summary.misery`,
 		summary: '💰 Income -50%. ⏭️ Skip Growth while morale is ' + 'desperate.',
 		removal: 'happiness stays between -9 and -8',
 		effects: [incomeModifier('happiness:misery:income', -0.5)],
@@ -123,7 +114,7 @@ const TIER_CONFIGS = [
 		incomeMultiplier: 0.75,
 		disableGrowth: true,
 		skipPhases: [GROWTH_PHASE_ID],
-		summaryToken: happinessSummaryToken('grim'),
+		summaryToken: `happiness.tier.summary.grim`,
 		summary: '💰 Income -25%. ⏭️ Skip Growth until spirits recover.',
 		removal: 'happiness stays between -7 and -5',
 		effects: [incomeModifier('happiness:grim:income', -0.25)],
@@ -133,7 +124,7 @@ const TIER_CONFIGS = [
 		passiveId: 'passive:happiness:unrest',
 		range: { min: -4, max: -3 },
 		incomeMultiplier: 0.75,
-		summaryToken: happinessSummaryToken('unrest'),
+		summaryToken: `happiness.tier.summary.unrest`,
 		summary: '💰 Income -25% while unrest simmers.',
 		removal: 'happiness stays between -4 and -3',
 		effects: [incomeModifier('happiness:unrest:income', -0.25)],
@@ -142,7 +133,7 @@ const TIER_CONFIGS = [
 		id: 'happiness:tier:steady',
 		range: { min: -2, max: 2 },
 		incomeMultiplier: 1,
-		summaryToken: happinessSummaryToken('steady'),
+		summaryToken: `happiness.tier.summary.steady`,
 		summary: 'Morale is steady. No tier bonuses are active.',
 		removal: 'happiness stays between -2 and +2',
 	},
@@ -151,7 +142,7 @@ const TIER_CONFIGS = [
 		passiveId: 'passive:happiness:content',
 		range: { min: 3, max: 4 },
 		incomeMultiplier: 1.2,
-		summaryToken: happinessSummaryToken('content'),
+		summaryToken: `happiness.tier.summary.content`,
 		summary: '💰 Income +20% while the realm is content.',
 		removal: 'happiness stays between +3 and +4',
 		effects: [incomeModifier('happiness:content:income', 0.2)],
@@ -162,7 +153,7 @@ const TIER_CONFIGS = [
 		range: { min: 5, max: 7 },
 		incomeMultiplier: 1.25,
 		buildingDiscountPct: 0.2,
-		summaryToken: happinessSummaryToken('joyful'),
+		summaryToken: `happiness.tier.summary.joyful`,
 		summary: '💰 Income +25%. 🏛️ Building costs reduced by 20%.',
 		removal: 'happiness stays between +5 and +7',
 		effects: [
@@ -176,7 +167,7 @@ const TIER_CONFIGS = [
 		range: { min: 8, max: 9 },
 		incomeMultiplier: 1.5,
 		buildingDiscountPct: 0.2,
-		summaryToken: happinessSummaryToken('elated'),
+		summaryToken: `happiness.tier.summary.elated`,
 		summary: '💰 Income +50%. 🏛️ Building costs reduced by 20%.',
 		removal: 'happiness stays between +8 and +9',
 		effects: [
@@ -191,7 +182,7 @@ const TIER_CONFIGS = [
 		incomeMultiplier: 1.5,
 		buildingDiscountPct: 0.2,
 		growthBonusPct: 0.2,
-		summaryToken: happinessSummaryToken('ecstatic'),
+		summaryToken: `happiness.tier.summary.ecstatic`,
 		summary:
 			'💰 Income +50%. 🏛️ Building costs reduced by 20%. ' + '📈 Growth +20%.',
 		removal: 'happiness is +10 or higher',
@@ -202,15 +193,15 @@ const TIER_CONFIGS = [
 		],
 	},
 ];
-
 type TierConfig = (typeof TIER_CONFIGS)[number];
-
 function buildTierDefinition(config: TierConfig): HappinessTierDefinition {
 	const builder = happinessTier(config.id)
 		.range(config.range.min, config.range.max)
 		.incomeMultiplier(config.incomeMultiplier)
 		.text((text) =>
-			text.summary(config.summary).removal(formatRemoval(config.removal)),
+			text
+				.summary(config.summary)
+				.removal(formatPassiveRemoval(config.removal)),
 		)
 		.display((display) =>
 			display
@@ -243,11 +234,9 @@ function buildTierDefinition(config: TierConfig): HappinessTierDefinition {
 	}
 	return builder.build();
 }
-
 const tierDefinitions: HappinessTierDefinition[] = TIER_CONFIGS.map((config) =>
 	buildTierDefinition(config),
 );
-
 export const RULES: RuleSet = {
 	defaultActionAPCost: 1,
 	absorptionCapPct: 1,

--- a/packages/contents/src/text.ts
+++ b/packages/contents/src/text.ts
@@ -1,0 +1,5 @@
+export function formatPassiveRemoval(condition: string): string {
+	const trimmed = condition.trim();
+	const detail = trimmed.length > 0 ? trimmed : condition;
+	return `Active as long as ${detail}`;
+}

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -5,6 +5,7 @@ import {
 	PHASES,
 	PASSIVE_INFO,
 	POPULATIONS,
+	formatPassiveRemoval,
 } from '@kingdom-builder/contents';
 import {
 	describeEffects,
@@ -110,7 +111,7 @@ export default function PassiveDisplay({
 			typeof meta.removal.token === 'string' &&
 			meta.removal.token.trim().length > 0
 		) {
-			return `Active as long as ${meta.removal.token}`;
+			return formatPassiveRemoval(meta.removal.token);
 		}
 		return undefined;
 	};

--- a/packages/web/src/translation/log/passives.ts
+++ b/packages/web/src/translation/log/passives.ts
@@ -1,4 +1,4 @@
-import { PASSIVE_INFO } from '@kingdom-builder/contents';
+import { PASSIVE_INFO, formatPassiveRemoval } from '@kingdom-builder/contents';
 import { type PassiveSummary } from '@kingdom-builder/engine';
 import {
 	hasTierSummaryTranslation,
@@ -45,7 +45,7 @@ function describeRemoval(meta: PassiveSummary['meta']): string | undefined {
 	}
 	const removalToken = meta?.removal?.token;
 	if (removalToken && removalToken.trim().length > 0) {
-		return `Active as long as ${removalToken}`;
+		return formatPassiveRemoval(removalToken);
 	}
 	return undefined;
 }

--- a/packages/web/src/utils/stats/summary.ts
+++ b/packages/web/src/utils/stats/summary.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { PASSIVE_INFO } from '@kingdom-builder/contents';
+import { PASSIVE_INFO, formatPassiveRemoval } from '@kingdom-builder/contents';
 import type {
 	EngineContext,
 	StatSourceLink,
@@ -88,9 +88,9 @@ function buildLongevityEntries(
 		collectRemovalLabels(removalLink),
 	);
 	if (removalCondition) {
-		pushSummaryEntry(items, `Active as long as ${removalCondition}`);
+		pushSummaryEntry(items, formatPassiveRemoval(removalCondition));
 	} else if (removal) {
-		pushSummaryEntry(items, `Active as long as ${removal}`);
+		pushSummaryEntry(items, formatPassiveRemoval(removal));
 	}
 	entries.push(`${PERMANENT_ICON} Permanent`);
 	items.forEach((item) => {

--- a/packages/web/tests/passive-display.test.tsx
+++ b/packages/web/tests/passive-display.test.tsx
@@ -14,8 +14,10 @@ import {
 	PHASES,
 	GAME_START,
 	RULES,
+	formatPassiveRemoval,
 	type ResourceKey,
 } from '@kingdom-builder/contents';
+import { resolvePassiveLogDetails } from '../src/translation/log/passives';
 
 vi.mock('@kingdom-builder/engine', async () => {
 	return await import('../../engine/src');
@@ -34,7 +36,7 @@ vi.mock('../src/state/GameContext', () => ({
 }));
 
 describe('<PassiveDisplay />', () => {
-	it('shows passive labels and removal text from metadata', () => {
+	it('uses shared passive removal formatting in UI and logs', () => {
 		const ctx = createEngine({
 			actions: ACTIONS,
 			buildings: BUILDINGS,
@@ -44,8 +46,10 @@ describe('<PassiveDisplay />', () => {
 			start: GAME_START,
 			rules: RULES,
 		});
-		const happinessKey = ctx.services.tieredResource.resourceKey as ResourceKey;
-		ctx.activePlayer.resources[happinessKey] = 6;
+		const { resourceKey } = ctx.services.tieredResource;
+		const happinessKey = resourceKey as ResourceKey;
+		const { activePlayer } = ctx;
+		activePlayer.resources[happinessKey] = 6;
 		ctx.services.handleTieredResourceChange(ctx, happinessKey);
 
 		const handleHoverCard = vi.fn();
@@ -56,32 +60,34 @@ describe('<PassiveDisplay />', () => {
 			clearHoverCard,
 		} as MockGame;
 
-		render(<PassiveDisplay player={ctx.activePlayer} />);
+		const summaries = ctx.passives.list(activePlayer.id);
+		expect(summaries).not.toHaveLength(0);
+		const passiveSummary = summaries[0];
+		const removalToken = passiveSummary.meta?.removal?.token;
+		expect(removalToken).toBeTruthy();
+		const expectedRemoval = formatPassiveRemoval(removalToken!);
+
+		render(<PassiveDisplay player={activePlayer} />);
 
 		const badgeLabel = screen.getByText(/joyful/i);
 		expect(badgeLabel).toBeInTheDocument();
-		expect(
-			screen.queryByText(
-				/Active as long as happiness stays between \+5 and \+7/i,
-			),
-		).not.toBeInTheDocument();
+		expect(screen.queryByText(expectedRemoval)).not.toBeInTheDocument();
 
 		const hoverTarget = badgeLabel.closest('div.hoverable');
 		expect(hoverTarget).not.toBeNull();
 		fireEvent.mouseEnter(hoverTarget!);
 		expect(handleHoverCard).toHaveBeenCalled();
 		const [{ description }] = handleHoverCard.mock.calls.at(-1) ?? [{}];
-		expect(description).toEqual(
-			expect.arrayContaining([
-				expect.stringMatching(/Income \+25%/i),
-				expect.stringMatching(
-					/Active as long as happiness stays between \+5 and \+7/i,
-				),
-			]),
-		);
+		expect(description).toBeDefined();
+		const entries = Array.isArray(description) ? description : [];
+		expect(entries).toContain(expectedRemoval);
+		expect(entries.some((entry) => /Income \+25%/i.test(entry))).toBe(true);
+
+		const details = resolvePassiveLogDetails(passiveSummary);
+		expect(details.removal).toBe(expectedRemoval);
 	});
 
-	it('renders no passive cards when the active tier has no passive effects', () => {
+	it('renders no passive cards when the tier lacks passives', () => {
 		const ctx = createEngine({
 			actions: ACTIONS,
 			buildings: BUILDINGS,
@@ -91,8 +97,10 @@ describe('<PassiveDisplay />', () => {
 			start: GAME_START,
 			rules: RULES,
 		});
-		const happinessKey = ctx.services.tieredResource.resourceKey as ResourceKey;
-		ctx.activePlayer.resources[happinessKey] = 0;
+		const { resourceKey } = ctx.services.tieredResource;
+		const happinessKey = resourceKey as ResourceKey;
+		const { activePlayer } = ctx;
+		activePlayer.resources[happinessKey] = 0;
 		ctx.services.handleTieredResourceChange(ctx, happinessKey);
 
 		const handleHoverCard = vi.fn();
@@ -103,7 +111,7 @@ describe('<PassiveDisplay />', () => {
 			clearHoverCard,
 		} as MockGame;
 
-		const { container } = render(<PassiveDisplay player={ctx.activePlayer} />);
+		const { container } = render(<PassiveDisplay player={activePlayer} />);
 
 		expect(container).toBeEmptyDOMElement();
 	});


### PR DESCRIPTION
## Summary
- add a shared `formatPassiveRemoval` helper to @kingdom-builder/contents and reuse it in rules, web UI, and log formatting
- inline the happiness tier summary tokens to avoid duplicated helper logic
- extend the passive display test to assert UI and log rendering both use the shared formatter

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e16f29470c8325a2b7df2d8e134df7