### PR TITLE
Enforce 80-character lint limits

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -44,6 +44,7 @@ module.exports = {
 				ignoreStrings: true,
 				ignoreTemplateLiterals: true,
 				ignoreRegExpLiterals: true,
+				tabWidth: 1,
 			},
 		],
 		'max-lines': [
@@ -210,7 +211,6 @@ module.exports = {
 			],
 			rules: {
 				'max-lines': 'off',
-				'max-len': 'off',
 				'id-length': 'off',
 			},
 		},

--- a/packages/engine/tests/actions/army-attack-happiness.test.ts
+++ b/packages/engine/tests/actions/army-attack-happiness.test.ts
@@ -6,28 +6,28 @@ import { createContentFactory } from '../factories/content.ts';
 import { createTestEngine } from '../helpers.ts';
 
 describe('resource removal penalties', () => {
-  it('can target the opponent when shortfalls are allowed', () => {
-    const content = createContentFactory();
-    const ctx = createTestEngine(content);
-    advance(ctx);
-    const original = ctx.game.currentPlayerIndex;
-    ctx.game.currentPlayerIndex = 1;
-    ctx.activePlayer.resources[Resource.happiness] = 0;
-    const before = ctx.activePlayer.resources[Resource.happiness] ?? 0;
-    runEffects(
-      [
-        {
-          type: 'resource',
-          method: 'remove',
-          params: { key: Resource.happiness, amount: 1 },
-          meta: { allowShortfall: true },
-        },
-      ],
-      ctx,
-    );
-    const after = ctx.activePlayer.resources[Resource.happiness] ?? 0;
-    expect(after).toBe(before - 1);
-    expect(after).toBeLessThan(0);
-    ctx.game.currentPlayerIndex = original;
-  });
+	it('can target the opponent when shortfalls are allowed', () => {
+		const content = createContentFactory();
+		const ctx = createTestEngine(content);
+		advance(ctx);
+		const original = ctx.game.currentPlayerIndex;
+		ctx.game.currentPlayerIndex = 1;
+		ctx.activePlayer.resources[Resource.happiness] = 0;
+		const before = ctx.activePlayer.resources[Resource.happiness] ?? 0;
+		runEffects(
+			[
+				{
+					type: 'resource',
+					method: 'remove',
+					params: { key: Resource.happiness, amount: 1 },
+					meta: { allowShortfall: true },
+				},
+			],
+			ctx,
+		);
+		const after = ctx.activePlayer.resources[Resource.happiness] ?? 0;
+		expect(after).toBe(before - 1);
+		expect(after).toBeLessThan(0);
+		ctx.game.currentPlayerIndex = original;
+	});
 });

--- a/packages/engine/tests/actions/synthetic.test.ts
+++ b/packages/engine/tests/actions/synthetic.test.ts
@@ -5,114 +5,116 @@ import { createTestEngine } from '../helpers';
 import { createContentFactory } from '../factories/content';
 
 function toMain(ctx: ReturnType<typeof createTestEngine>) {
-  while (ctx.game.currentPhase !== 'main') advance(ctx);
+	while (ctx.game.currentPhase !== 'main') {
+		advance(ctx);
+	}
 }
 
 describe('actions with synthetic content', () => {
-  it('pays costs and applies resource effects', () => {
-    const content = createContentFactory();
-    const actionDef = content.action({
-      baseCosts: { [CResource.ap]: 1, [CResource.gold]: 2 },
-      effects: [
-        {
-          type: 'resource',
-          method: 'add',
-          params: { key: CResource.gold, amount: 5 },
-        },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    toMain(ctx);
-    const costs = getActionCosts(actionDef.id, ctx);
-    ctx.activePlayer.ap = costs[CResource.ap] ?? 0;
-    ctx.activePlayer.gold = costs[CResource.gold] ?? 0;
-    const before = ctx.activePlayer.gold;
-    const gain = actionDef.effects.find(
-      (e) => e.type === 'resource' && e.method === 'add',
-    )?.params?.['amount'] as number;
-    performAction(actionDef.id, ctx);
-    expect(ctx.activePlayer.gold).toBe(
-      before - (costs[CResource.gold] ?? 0) + gain,
-    );
-  });
+	it('pays costs and applies resource effects', () => {
+		const content = createContentFactory();
+		const actionDef = content.action({
+			baseCosts: { [CResource.ap]: 1, [CResource.gold]: 2 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: CResource.gold, amount: 5 },
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		toMain(ctx);
+		const costs = getActionCosts(actionDef.id, ctx);
+		ctx.activePlayer.ap = costs[CResource.ap] ?? 0;
+		ctx.activePlayer.gold = costs[CResource.gold] ?? 0;
+		const before = ctx.activePlayer.gold;
+		const gain = actionDef.effects.find(
+			(e) => e.type === 'resource' && e.method === 'add',
+		)?.params?.['amount'] as number;
+		performAction(actionDef.id, ctx);
+		expect(ctx.activePlayer.gold).toBe(
+			before - (costs[CResource.gold] ?? 0) + gain,
+		);
+	});
 
-  it('builds a building and applies its onBuild effects', () => {
-    const content = createContentFactory();
-    const building = content.building({
-      costs: { [CResource.gold]: 3 },
-      onBuild: [
-        {
-          type: 'resource',
-          method: 'add',
-          params: { key: CResource.gold, amount: 2 },
-        },
-      ],
-    });
-    const buildAction = content.action({
-      baseCosts: { [CResource.ap]: 1 },
-      effects: [
-        { type: 'building', method: 'add', params: { id: building.id } },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    toMain(ctx);
-    const cost = getActionCosts(buildAction.id, ctx, { id: building.id });
-    ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
-    ctx.activePlayer.gold = cost[CResource.gold] ?? 0;
-    const before = ctx.activePlayer.gold;
-    const gain = building.onBuild?.find(
-      (e) => e.type === 'resource' && e.method === 'add',
-    )?.params?.['amount'] as number;
-    performAction(buildAction.id, ctx, { id: building.id });
-    expect(ctx.activePlayer.buildings.has(building.id)).toBe(true);
-    expect(ctx.activePlayer.gold).toBe(
-      before - (cost[CResource.gold] ?? 0) + gain,
-    );
-  });
+	it('builds a building and applies its onBuild effects', () => {
+		const content = createContentFactory();
+		const building = content.building({
+			costs: { [CResource.gold]: 3 },
+			onBuild: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: CResource.gold, amount: 2 },
+				},
+			],
+		});
+		const buildAction = content.action({
+			baseCosts: { [CResource.ap]: 1 },
+			effects: [
+				{ type: 'building', method: 'add', params: { id: building.id } },
+			],
+		});
+		const ctx = createTestEngine(content);
+		toMain(ctx);
+		const cost = getActionCosts(buildAction.id, ctx, { id: building.id });
+		ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
+		ctx.activePlayer.gold = cost[CResource.gold] ?? 0;
+		const before = ctx.activePlayer.gold;
+		const gain = building.onBuild?.find(
+			(e) => e.type === 'resource' && e.method === 'add',
+		)?.params?.['amount'] as number;
+		performAction(buildAction.id, ctx, { id: building.id });
+		expect(ctx.activePlayer.buildings.has(building.id)).toBe(true);
+		expect(ctx.activePlayer.gold).toBe(
+			before - (cost[CResource.gold] ?? 0) + gain,
+		);
+	});
 
-  it('adds a development and runs its onBuild effects', () => {
-    const content = createContentFactory();
-    const development = content.development({
-      onBuild: [
-        {
-          type: 'resource',
-          method: 'add',
-          params: { key: CResource.gold, amount: 1 },
-        },
-      ],
-    });
-    const developAction = content.action({
-      baseCosts: { [CResource.ap]: 1, [CResource.gold]: 1 },
-      effects: [
-        {
-          type: 'development',
-          method: 'add',
-          params: { id: development.id, landId: '$landId' },
-        },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    toMain(ctx);
-    const land = ctx.activePlayer.lands.find((l) => l.slotsUsed < l.slotsMax)!;
-    const cost = getActionCosts(developAction.id, ctx, {
-      id: development.id,
-      landId: land.id,
-    });
-    ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
-    ctx.activePlayer.gold = cost[CResource.gold] ?? 0;
-    const beforeGold = ctx.activePlayer.gold;
-    const beforeSlots = land.slotsUsed;
-    const gain = development.onBuild?.find(
-      (e) => e.type === 'resource' && e.method === 'add',
-    )?.params?.['amount'] as number;
-    performAction(developAction.id, ctx, {
-      id: development.id,
-      landId: land.id,
-    });
-    expect(land.developments).toContain(development.id);
-    expect(land.slotsUsed).toBe(beforeSlots + 1);
-    expect(ctx.activePlayer.gold).toBe(
-      beforeGold - (cost[CResource.gold] ?? 0) + gain,
-    );
-  });
+	it('adds a development and runs its onBuild effects', () => {
+		const content = createContentFactory();
+		const development = content.development({
+			onBuild: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: CResource.gold, amount: 1 },
+				},
+			],
+		});
+		const developAction = content.action({
+			baseCosts: { [CResource.ap]: 1, [CResource.gold]: 1 },
+			effects: [
+				{
+					type: 'development',
+					method: 'add',
+					params: { id: development.id, landId: '$landId' },
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		toMain(ctx);
+		const land = ctx.activePlayer.lands.find((l) => l.slotsUsed < l.slotsMax)!;
+		const cost = getActionCosts(developAction.id, ctx, {
+			id: development.id,
+			landId: land.id,
+		});
+		ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
+		ctx.activePlayer.gold = cost[CResource.gold] ?? 0;
+		const beforeGold = ctx.activePlayer.gold;
+		const beforeSlots = land.slotsUsed;
+		const gain = development.onBuild?.find(
+			(e) => e.type === 'resource' && e.method === 'add',
+		)?.params?.['amount'] as number;
+		performAction(developAction.id, ctx, {
+			id: development.id,
+			landId: land.id,
+		});
+		expect(land.developments).toContain(development.id);
+		expect(land.slotsUsed).toBe(beforeSlots + 1);
+		expect(ctx.activePlayer.gold).toBe(
+			beforeGold - (cost[CResource.gold] ?? 0) + gain,
+		);
+	});
 });

--- a/packages/engine/tests/actions/tax-happiness.test.ts
+++ b/packages/engine/tests/actions/tax-happiness.test.ts
@@ -5,70 +5,70 @@ import { createContentFactory } from '../factories/content.ts';
 import { createTestEngine } from '../helpers.ts';
 
 describe('resource removal penalties', () => {
-  it('reduces happiness when configured as a removal effect', () => {
-    const content = createContentFactory();
-    const action = content.action({
-      effects: [
-        {
-          type: 'resource',
-          method: 'remove',
-          params: { key: Resource.happiness, amount: 1 },
-          meta: { allowShortfall: true },
-        },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
-    ctx.activePlayer.resources[Resource.happiness] = 2;
-    const before = ctx.activePlayer.resources[Resource.happiness] ?? 0;
-    const cost = getActionCosts(action.id, ctx)[Resource.ap] ?? 0;
-    ctx.activePlayer.ap = cost;
-    performAction(action.id, ctx);
-    const after = ctx.activePlayer.resources[Resource.happiness] ?? 0;
-    expect(after).toBe(before - 1);
-  });
+	it('reduces happiness when configured as a removal effect', () => {
+		const content = createContentFactory();
+		const action = content.action({
+			effects: [
+				{
+					type: 'resource',
+					method: 'remove',
+					params: { key: Resource.happiness, amount: 1 },
+					meta: { allowShortfall: true },
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		advance(ctx);
+		ctx.game.currentPlayerIndex = 0;
+		ctx.activePlayer.resources[Resource.happiness] = 2;
+		const before = ctx.activePlayer.resources[Resource.happiness] ?? 0;
+		const cost = getActionCosts(action.id, ctx)[Resource.ap] ?? 0;
+		ctx.activePlayer.ap = cost;
+		performAction(action.id, ctx);
+		const after = ctx.activePlayer.resources[Resource.happiness] ?? 0;
+		expect(after).toBe(before - 1);
+	});
 
-  it('aggregates evaluator penalties before rounding when shortfalls are allowed', () => {
-    const content = createContentFactory();
-    const action = content.action({
-      effects: [
-        {
-          evaluator: {
-            type: 'population',
-            params: { role: PopulationRole.Council },
-          },
-          effects: [
-            {
-              type: 'resource',
-              method: 'remove',
-              round: 'up',
-              params: { key: Resource.happiness, amount: 0.5 },
-              meta: { allowShortfall: true },
-            },
-          ],
-        },
-      ],
-    });
-    const ctx = createTestEngine({ actions: content.actions });
-    advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
-    ctx.activePlayer.population[PopulationRole.Council] = 2;
-    ctx.activePlayer.resources[Resource.happiness] = 2;
-    const cost = getActionCosts(action.id, ctx)[Resource.ap] ?? 0;
+	it('aggregates evaluator penalties before rounding when shortfalls are allowed', () => {
+		const content = createContentFactory();
+		const action = content.action({
+			effects: [
+				{
+					evaluator: {
+						type: 'population',
+						params: { role: PopulationRole.Council },
+					},
+					effects: [
+						{
+							type: 'resource',
+							method: 'remove',
+							round: 'up',
+							params: { key: Resource.happiness, amount: 0.5 },
+							meta: { allowShortfall: true },
+						},
+					],
+				},
+			],
+		});
+		const ctx = createTestEngine({ actions: content.actions });
+		advance(ctx);
+		ctx.game.currentPlayerIndex = 0;
+		ctx.activePlayer.population[PopulationRole.Council] = 2;
+		ctx.activePlayer.resources[Resource.happiness] = 2;
+		const cost = getActionCosts(action.id, ctx)[Resource.ap] ?? 0;
 
-    ctx.activePlayer.ap = cost;
+		ctx.activePlayer.ap = cost;
 
-    performAction(action.id, ctx);
+		performAction(action.id, ctx);
 
-    expect(ctx.activePlayer.resources[Resource.happiness]).toBe(1);
+		expect(ctx.activePlayer.resources[Resource.happiness]).toBe(1);
 
-    ctx.activePlayer.resources[Resource.happiness] = 0;
+		ctx.activePlayer.resources[Resource.happiness] = 0;
 
-    ctx.activePlayer.ap = cost;
+		ctx.activePlayer.ap = cost;
 
-    performAction(action.id, ctx);
+		performAction(action.id, ctx);
 
-    expect(ctx.activePlayer.resources[Resource.happiness]).toBe(-1);
-  });
+		expect(ctx.activePlayer.resources[Resource.happiness]).toBe(-1);
+	});
 });

--- a/packages/engine/tests/ai/tax-collector.test.ts
+++ b/packages/engine/tests/ai/tax-collector.test.ts
@@ -2,50 +2,52 @@ import { describe, it, expect, vi } from 'vitest';
 import { Resource as CResource } from '@kingdom-builder/contents';
 import { performAction, advance } from '../../src';
 import {
-  createTaxCollectorController,
-  TAX_ACTION_ID,
+	createTaxCollectorController,
+	TAX_ACTION_ID,
 } from '../../src/ai/index';
 import { createContentFactory } from '../factories/content';
 import { createTestEngine } from '../helpers';
 
 describe('tax collector AI controller', () => {
-  it('collects tax until action points are spent then ends the turn', async () => {
-    const content = createContentFactory();
-    content.action({
-      id: TAX_ACTION_ID,
-      baseCosts: { [CResource.ap]: 1 },
-      effects: [
-        {
-          type: 'resource',
-          method: 'add',
-          params: { key: CResource.gold, amount: 1 },
-        },
-      ],
-    });
+	it('collects tax until action points are spent then ends the turn', async () => {
+		const content = createContentFactory();
+		content.action({
+			id: TAX_ACTION_ID,
+			baseCosts: { [CResource.ap]: 1 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: CResource.gold, amount: 1 },
+				},
+			],
+		});
 
-    const ctx = createTestEngine(content);
-    const actionPhaseIndex = ctx.phases.findIndex((phase) => phase.action);
-    if (actionPhaseIndex === -1) throw new Error('Action phase not found');
+		const ctx = createTestEngine(content);
+		const actionPhaseIndex = ctx.phases.findIndex((phase) => phase.action);
+		if (actionPhaseIndex === -1) {
+			throw new Error('Action phase not found');
+		}
 
-    ctx.game.currentPlayerIndex = 1;
-    ctx.game.phaseIndex = actionPhaseIndex;
-    ctx.game.stepIndex = 0;
-    ctx.game.currentPhase = ctx.phases[actionPhaseIndex]!.id;
-    ctx.game.currentStep = ctx.phases[actionPhaseIndex]!.steps[0]?.id ?? '';
+		ctx.game.currentPlayerIndex = 1;
+		ctx.game.phaseIndex = actionPhaseIndex;
+		ctx.game.stepIndex = 0;
+		ctx.game.currentPhase = ctx.phases[actionPhaseIndex]!.id;
+		ctx.game.currentStep = ctx.phases[actionPhaseIndex]!.steps[0]?.id ?? '';
 
-    const apKey = ctx.actionCostResource;
-    ctx.activePlayer.resources[apKey] = 2;
+		const apKey = ctx.actionCostResource;
+		ctx.activePlayer.resources[apKey] = 2;
 
-    const controller = createTaxCollectorController(ctx.activePlayer.id);
-    const perform = vi.fn((actionId: string) => performAction(actionId, ctx));
-    const endPhase = vi.fn(() => advance(ctx));
+		const controller = createTaxCollectorController(ctx.activePlayer.id);
+		const perform = vi.fn((actionId: string) => performAction(actionId, ctx));
+		const endPhase = vi.fn(() => advance(ctx));
 
-    await controller(ctx, { performAction: perform, advance: endPhase });
+		await controller(ctx, { performAction: perform, advance: endPhase });
 
-    expect(perform).toHaveBeenCalledTimes(2);
-    expect(perform).toHaveBeenNthCalledWith(1, TAX_ACTION_ID, ctx);
-    expect(perform).toHaveBeenNthCalledWith(2, TAX_ACTION_ID, ctx);
-    expect(ctx.activePlayer.resources[apKey]).toBe(0);
-    expect(endPhase).toHaveBeenCalledTimes(1);
-  });
+		expect(perform).toHaveBeenCalledTimes(2);
+		expect(perform).toHaveBeenNthCalledWith(1, TAX_ACTION_ID, ctx);
+		expect(perform).toHaveBeenNthCalledWith(2, TAX_ACTION_ID, ctx);
+		expect(ctx.activePlayer.resources[apKey]).toBe(0);
+		expect(endPhase).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/engine/tests/config/requirement_builder.test.ts
+++ b/packages/engine/tests/config/requirement_builder.test.ts
@@ -3,29 +3,29 @@ import { requirement } from '@kingdom-builder/contents/config/builders';
 import { Stat, PopulationRole } from '@kingdom-builder/contents';
 
 describe('RequirementBuilder', () => {
-  it('builds requirement configs with params', () => {
-    const req = requirement('evaluator', 'compare')
-      .param('left', { type: 'stat', params: { key: Stat.warWeariness } })
-      .param('operator', 'lt')
-      .param('right', {
-        type: 'population',
-        params: { role: PopulationRole.Legion },
-      })
-      .message('War weariness must be lower than legions')
-      .build();
+	it('builds requirement configs with params', () => {
+		const req = requirement('evaluator', 'compare')
+			.param('left', { type: 'stat', params: { key: Stat.warWeariness } })
+			.param('operator', 'lt')
+			.param('right', {
+				type: 'population',
+				params: { role: PopulationRole.Legion },
+			})
+			.message('War weariness must be lower than legions')
+			.build();
 
-    expect(req).toEqual({
-      type: 'evaluator',
-      method: 'compare',
-      params: {
-        left: { type: 'stat', params: { key: Stat.warWeariness } },
-        operator: 'lt',
-        right: {
-          type: 'population',
-          params: { role: PopulationRole.Legion },
-        },
-      },
-      message: 'War weariness must be lower than legions',
-    });
-  });
+		expect(req).toEqual({
+			type: 'evaluator',
+			method: 'compare',
+			params: {
+				left: { type: 'stat', params: { key: Stat.warWeariness } },
+				operator: 'lt',
+				right: {
+					type: 'population',
+					params: { role: PopulationRole.Legion },
+				},
+			},
+			message: 'War weariness must be lower than legions',
+		});
+	});
 });

--- a/packages/engine/tests/context/queue.test.ts
+++ b/packages/engine/tests/context/queue.test.ts
@@ -2,25 +2,25 @@ import { describe, it, expect } from 'vitest';
 import { advance } from '../../src/index.ts';
 import { createTestEngine } from '../helpers.ts';
 
-function wait(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function wait(milliseconds: number) {
+	return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 describe('EngineContext enqueue', () => {
-  it('runs tasks sequentially', async () => {
-    const ctx = createTestEngine();
-    const order: number[] = [];
-    void ctx.enqueue(async () => {
-      await wait(10);
-      order.push(1);
-    });
-    void ctx.enqueue(() => {
-      order.push(2);
-    });
-    void ctx.enqueue(() => {
-      order.push(3);
-    });
-    await ctx.enqueue(() => advance(ctx));
-    expect(order).toEqual([1, 2, 3]);
-  });
+	it('runs tasks sequentially', async () => {
+		const ctx = createTestEngine();
+		const order: number[] = [];
+		void ctx.enqueue(async () => {
+			await wait(10);
+			order.push(1);
+		});
+		void ctx.enqueue(() => {
+			order.push(2);
+		});
+		void ctx.enqueue(() => {
+			order.push(3);
+		});
+		await ctx.enqueue(() => advance(ctx));
+		expect(order).toEqual([1, 2, 3]);
+	});
 });

--- a/packages/engine/tests/effects/action_add.test.ts
+++ b/packages/engine/tests/effects/action_add.test.ts
@@ -5,17 +5,19 @@ import { createContentFactory } from '../factories/content';
 import { Resource as CResource } from '@kingdom-builder/contents';
 
 describe('action:add effect', () => {
-  it('grants a new action', () => {
-    const content = createContentFactory();
-    const extra = content.action();
-    const grant = content.action({
-      effects: [{ type: 'action', method: 'add', params: { id: extra.id } }],
-    });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    const cost = getActionCosts(grant.id, ctx);
-    ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
-    performAction(grant.id, ctx);
-    expect(ctx.activePlayer.actions.has(extra.id)).toBe(true);
-  });
+	it('grants a new action', () => {
+		const content = createContentFactory();
+		const extra = content.action();
+		const grant = content.action({
+			effects: [{ type: 'action', method: 'add', params: { id: extra.id } }],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		const cost = getActionCosts(grant.id, ctx);
+		ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
+		performAction(grant.id, ctx);
+		expect(ctx.activePlayer.actions.has(extra.id)).toBe(true);
+	});
 });

--- a/packages/engine/tests/effects/action_remove.test.ts
+++ b/packages/engine/tests/effects/action_remove.test.ts
@@ -5,18 +5,20 @@ import { createContentFactory } from '../factories/content';
 import { Resource as CResource } from '@kingdom-builder/contents';
 
 describe('action:remove effect', () => {
-  it('removes an action', () => {
-    const content = createContentFactory();
-    const extra = content.action();
-    const remove = content.action({
-      effects: [{ type: 'action', method: 'remove', params: { id: extra.id } }],
-    });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    ctx.activePlayer.actions.add(extra.id);
-    const cost = getActionCosts(remove.id, ctx);
-    ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
-    performAction(remove.id, ctx);
-    expect(ctx.activePlayer.actions.has(extra.id)).toBe(false);
-  });
+	it('removes an action', () => {
+		const content = createContentFactory();
+		const extra = content.action();
+		const remove = content.action({
+			effects: [{ type: 'action', method: 'remove', params: { id: extra.id } }],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		ctx.activePlayer.actions.add(extra.id);
+		const cost = getActionCosts(remove.id, ctx);
+		ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
+		performAction(remove.id, ctx);
+		expect(ctx.activePlayer.actions.has(extra.id)).toBe(false);
+	});
 });

--- a/packages/engine/tests/effects/add_building.test.ts
+++ b/packages/engine/tests/effects/add_building.test.ts
@@ -5,143 +5,154 @@ import { createTestEngine } from '../helpers';
 import { createContentFactory } from '../factories/content';
 
 describe('building:add effect', () => {
-  it('adds building and applies its passives', () => {
-    const content = createContentFactory();
-    const target = content.action({ baseCosts: { [CResource.gold]: 4 } });
-    const building = content.building({
-      costs: { [CResource.gold]: 3 },
-      onBuild: [
-        {
-          type: 'cost_mod',
-          method: 'add',
-          params: {
-            id: 'mod',
-            actionId: target.id,
-            key: CResource.gold,
-            amount: 2,
-          },
-        },
-      ],
-    });
-    const grant = content.action({
-      effects: [
-        { type: 'building', method: 'add', params: { id: building.id } },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    const before = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
-    const cost = getActionCosts(grant.id, ctx, { id: building.id });
-    ctx.activePlayer.gold = cost[CResource.gold] ?? 0;
-    ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
-    performAction(grant.id, ctx, { id: building.id });
-    const after = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
-    const bonus = building.onBuild?.find(
-      (e) => e.type === 'cost_mod' && e.method === 'add',
-    )?.params?.['amount'] as number;
-    expect(ctx.activePlayer.buildings.has(building.id)).toBe(true);
-    expect(after).toBe(before + bonus);
-  });
+	it('adds building and applies its passives', () => {
+		const content = createContentFactory();
+		const target = content.action({ baseCosts: { [CResource.gold]: 4 } });
+		const building = content.building({
+			costs: { [CResource.gold]: 3 },
+			onBuild: [
+				{
+					type: 'cost_mod',
+					method: 'add',
+					params: {
+						id: 'mod',
+						actionId: target.id,
+						key: CResource.gold,
+						amount: 2,
+					},
+				},
+			],
+		});
+		const grant = content.action({
+			effects: [
+				{ type: 'building', method: 'add', params: { id: building.id } },
+			],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		const before = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
+		const cost = getActionCosts(grant.id, ctx, { id: building.id });
+		ctx.activePlayer.gold = cost[CResource.gold] ?? 0;
+		ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
+		performAction(grant.id, ctx, { id: building.id });
+		const after = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
+		const bonus = building.onBuild?.find(
+			(e) => e.type === 'cost_mod' && e.method === 'add',
+		)?.params?.['amount'] as number;
+		expect(ctx.activePlayer.buildings.has(building.id)).toBe(true);
+		expect(after).toBe(before + bonus);
+	});
 
-  it('throws before paying costs when building already owned', () => {
-    const content = createContentFactory();
-    const building = content.building({ costs: { [CResource.gold]: 2 } });
-    const grant = content.action({
-      effects: [
-        { type: 'building', method: 'add', params: { id: building.id } },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    const cost = getActionCosts(grant.id, ctx, { id: building.id });
-    for (const [key, value] of Object.entries(cost))
-      ctx.activePlayer.resources[key] = (value ?? 0) * 2;
+	it('throws before paying costs when building already owned', () => {
+		const content = createContentFactory();
+		const building = content.building({ costs: { [CResource.gold]: 2 } });
+		const grant = content.action({
+			effects: [
+				{ type: 'building', method: 'add', params: { id: building.id } },
+			],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		const cost = getActionCosts(grant.id, ctx, { id: building.id });
+		for (const [key, value] of Object.entries(cost)) {
+			ctx.activePlayer.resources[key] = (value ?? 0) * 2;
+		}
 
-    performAction(grant.id, ctx, { id: building.id });
+		performAction(grant.id, ctx, { id: building.id });
 
-    const actionKey = ctx.actionCostResource as string;
-    ctx.activePlayer.resources[actionKey] = 5;
-    ctx.activePlayer.resources[CResource.gold] = 10;
-    expect(() => performAction(grant.id, ctx, { id: building.id })).toThrow(
-      `Building ${building.id} already built`,
-    );
-    expect(ctx.activePlayer.resources[actionKey]).toBe(5);
-    expect(ctx.activePlayer.resources[CResource.gold]).toBe(10);
-  });
+		const actionKey = ctx.actionCostResource as string;
+		ctx.activePlayer.resources[actionKey] = 5;
+		ctx.activePlayer.resources[CResource.gold] = 10;
+		expect(() => performAction(grant.id, ctx, { id: building.id })).toThrow(
+			`Building ${building.id} already built`,
+		);
+		expect(ctx.activePlayer.resources[actionKey]).toBe(5);
+		expect(ctx.activePlayer.resources[CResource.gold]).toBe(10);
+	});
 
-  it('allows rebuilding after the structure is removed', () => {
-    const content = createContentFactory();
-    const building = content.building();
-    const build = content.action({
-      effects: [
-        { type: 'building', method: 'add', params: { id: building.id } },
-      ],
-    });
-    const demolish = content.action({
-      effects: [
-        { type: 'building', method: 'remove', params: { id: building.id } },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    const cost = getActionCosts(build.id, ctx, { id: building.id });
-    const actionKey = ctx.actionCostResource as string;
-    for (const [key, value] of Object.entries(cost))
-      ctx.activePlayer.resources[key] = (value ?? 0) * 3;
+	it('allows rebuilding after the structure is removed', () => {
+		const content = createContentFactory();
+		const building = content.building();
+		const build = content.action({
+			effects: [
+				{ type: 'building', method: 'add', params: { id: building.id } },
+			],
+		});
+		const demolish = content.action({
+			effects: [
+				{ type: 'building', method: 'remove', params: { id: building.id } },
+			],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		const cost = getActionCosts(build.id, ctx, { id: building.id });
+		const actionKey = ctx.actionCostResource as string;
+		for (const [key, value] of Object.entries(cost)) {
+			ctx.activePlayer.resources[key] = (value ?? 0) * 3;
+		}
 
-    performAction(build.id, ctx, { id: building.id });
-    performAction(demolish.id, ctx, { id: building.id });
+		performAction(build.id, ctx, { id: building.id });
+		performAction(demolish.id, ctx, { id: building.id });
 
-    ctx.activePlayer.resources[actionKey] = 5;
-    performAction(build.id, ctx, { id: building.id });
+		ctx.activePlayer.resources[actionKey] = 5;
+		performAction(build.id, ctx, { id: building.id });
 
-    expect(ctx.activePlayer.buildings.has(building.id)).toBe(true);
-  });
+		expect(ctx.activePlayer.buildings.has(building.id)).toBe(true);
+	});
 
-  it('removes building passives when demolished', () => {
-    const content = createContentFactory();
-    const surcharge = 2;
-    const target = content.action({
-      baseCosts: { [CResource.gold]: 3 },
-    });
-    const building = content.building({
-      onBuild: [
-        {
-          type: 'cost_mod',
-          method: 'add',
-          params: {
-            id: 'building_surcharge',
-            actionId: target.id,
-            key: CResource.gold,
-            amount: surcharge,
-          },
-        },
-      ],
-    });
-    const build = content.action({
-      effects: [
-        { type: 'building', method: 'add', params: { id: building.id } },
-      ],
-    });
-    const demolish = content.action({
-      effects: [
-        { type: 'building', method: 'remove', params: { id: building.id } },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
+	it('removes building passives when demolished', () => {
+		const content = createContentFactory();
+		const surcharge = 2;
+		const target = content.action({
+			baseCosts: { [CResource.gold]: 3 },
+		});
+		const building = content.building({
+			onBuild: [
+				{
+					type: 'cost_mod',
+					method: 'add',
+					params: {
+						id: 'building_surcharge',
+						actionId: target.id,
+						key: CResource.gold,
+						amount: surcharge,
+					},
+				},
+			],
+		});
+		const build = content.action({
+			effects: [
+				{ type: 'building', method: 'add', params: { id: building.id } },
+			],
+		});
+		const demolish = content.action({
+			effects: [
+				{ type: 'building', method: 'remove', params: { id: building.id } },
+			],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
 
-    for (const key of Object.keys(ctx.activePlayer.resources))
-      ctx.activePlayer.resources[key] = 10;
+		for (const key of Object.keys(ctx.activePlayer.resources)) {
+			ctx.activePlayer.resources[key] = 10;
+		}
 
-    const baseCost = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
+		const baseCost = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
 
-    performAction(build.id, ctx, { id: building.id });
-    const afterBuild = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
-    expect(afterBuild - baseCost).toBe(surcharge);
+		performAction(build.id, ctx, { id: building.id });
+		const afterBuild = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
+		expect(afterBuild - baseCost).toBe(surcharge);
 
-    performAction(demolish.id, ctx, { id: building.id });
-    const afterRemoval = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
-    expect(afterRemoval).toBe(baseCost);
-  });
+		performAction(demolish.id, ctx, { id: building.id });
+		const afterRemoval = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
+		expect(afterRemoval).toBe(baseCost);
+	});
 });

--- a/packages/engine/tests/effects/add_development.test.ts
+++ b/packages/engine/tests/effects/add_development.test.ts
@@ -5,83 +5,89 @@ import { createTestEngine } from '../helpers';
 import { createContentFactory } from '../factories/content';
 
 describe('development:add effect', () => {
-  it('adds development and applies onBuild effects', () => {
-    const content = createContentFactory();
-    const development = content.development({
-      onBuild: [
-        {
-          type: 'resource',
-          method: 'add',
-          params: { key: CResource.gold, amount: 2 },
-        },
-      ],
-    });
-    const action = content.action({
-      baseCosts: { [CResource.ap]: 1 },
-      effects: [
-        {
-          type: 'development',
-          method: 'add',
-          params: { id: development.id, landId: '$landId' },
-        },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    const land = ctx.activePlayer.lands.find((l) => l.slotsUsed < l.slotsMax)!;
-    const cost = getActionCosts(action.id, ctx, {
-      id: development.id,
-      landId: land.id,
-    });
-    ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
-    const beforeGold = ctx.activePlayer.gold;
-    const beforeSlots = land.slotsUsed;
-    const gain = development.onBuild?.find(
-      (e) => e.type === 'resource' && e.method === 'add',
-    )?.params?.['amount'] as number;
-    performAction(action.id, ctx, { id: development.id, landId: land.id });
-    expect(land.developments).toContain(development.id);
-    expect(land.slotsUsed).toBe(beforeSlots + 1);
-    expect(ctx.activePlayer.gold).toBe(beforeGold + gain);
-  });
+	it('adds development and applies onBuild effects', () => {
+		const content = createContentFactory();
+		const development = content.development({
+			onBuild: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: CResource.gold, amount: 2 },
+				},
+			],
+		});
+		const action = content.action({
+			baseCosts: { [CResource.ap]: 1 },
+			effects: [
+				{
+					type: 'development',
+					method: 'add',
+					params: { id: development.id, landId: '$landId' },
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		const land = ctx.activePlayer.lands.find((l) => l.slotsUsed < l.slotsMax)!;
+		const cost = getActionCosts(action.id, ctx, {
+			id: development.id,
+			landId: land.id,
+		});
+		ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
+		const beforeGold = ctx.activePlayer.gold;
+		const beforeSlots = land.slotsUsed;
+		const gain = development.onBuild?.find(
+			(e) => e.type === 'resource' && e.method === 'add',
+		)?.params?.['amount'] as number;
+		performAction(action.id, ctx, { id: development.id, landId: land.id });
+		expect(land.developments).toContain(development.id);
+		expect(land.slotsUsed).toBe(beforeSlots + 1);
+		expect(ctx.activePlayer.gold).toBe(beforeGold + gain);
+	});
 
-  it('throws if land does not exist', () => {
-    const content = createContentFactory();
-    const development = content.development();
-    const action = content.action({
-      effects: [
-        {
-          type: 'development',
-          method: 'add',
-          params: { id: development.id, landId: 'missing' },
-        },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    expect(() => performAction(action.id, ctx)).toThrow(
-      /Land missing not found/,
-    );
-  });
+	it('throws if land does not exist', () => {
+		const content = createContentFactory();
+		const development = content.development();
+		const action = content.action({
+			effects: [
+				{
+					type: 'development',
+					method: 'add',
+					params: { id: development.id, landId: 'missing' },
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		expect(() => performAction(action.id, ctx)).toThrow(
+			/Land missing not found/,
+		);
+	});
 
-  it('throws if land has no free slots', () => {
-    const content = createContentFactory();
-    const development = content.development();
-    const action = content.action({
-      effects: [
-        {
-          type: 'development',
-          method: 'add',
-          params: { id: development.id, landId: '$landId' },
-        },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    const land = ctx.activePlayer.lands[0];
-    land.slotsUsed = land.slotsMax;
-    expect(() =>
-      performAction(action.id, ctx, { id: development.id, landId: land.id }),
-    ).toThrow(new RegExp(`No free slots on land ${land.id}`));
-  });
+	it('throws if land has no free slots', () => {
+		const content = createContentFactory();
+		const development = content.development();
+		const action = content.action({
+			effects: [
+				{
+					type: 'development',
+					method: 'add',
+					params: { id: development.id, landId: '$landId' },
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		const land = ctx.activePlayer.lands[0];
+		land.slotsUsed = land.slotsMax;
+		expect(() =>
+			performAction(action.id, ctx, { id: development.id, landId: land.id }),
+		).toThrow(new RegExp(`No free slots on land ${land.id}`));
+	});
 });

--- a/packages/engine/tests/effects/add_stat.test.ts
+++ b/packages/engine/tests/effects/add_stat.test.ts
@@ -1,46 +1,46 @@
 import { describe, it, expect } from 'vitest';
 import {
-  performAction,
-  Resource,
-  advance,
-  getActionCosts,
+	performAction,
+	Resource,
+	advance,
+	getActionCosts,
 } from '../../src/index.ts';
 import {
-  createActionRegistry,
-  Resource as CResource,
-  Stat as CStat,
+	createActionRegistry,
+	Resource as CResource,
+	Stat as CStat,
 } from '@kingdom-builder/contents';
 import { createTestEngine } from '../helpers.ts';
 
 describe('stat:add effect', () => {
-  it('increments a stat via action effect', () => {
-    const actions = createActionRegistry();
-    actions.add('train_army', {
-      id: 'train_army',
-      name: 'Train Army',
-      baseCosts: { [CResource.ap]: 0 },
-      effects: [
-        {
-          type: 'stat',
-          method: 'add',
-          params: { key: CStat.armyStrength, amount: 3 },
-        },
-      ],
-    });
-    const ctx = createTestEngine({ actions });
-    advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
-    const before = ctx.activePlayer.armyStrength;
-    const actionDefinition = actions.get('train_army');
-    const amount = actionDefinition.effects.find(
-      (effect) =>
-        effect.type === 'stat' &&
-        effect.method === 'add' &&
-        effect.params?.key === CStat.armyStrength,
-    )?.params?.amount as number;
-    const costs = getActionCosts('train_army', ctx);
-    ctx.activePlayer.ap = costs[Resource.ap] ?? 0;
-    performAction('train_army', ctx);
-    expect(ctx.activePlayer.armyStrength).toBe(before + amount);
-  });
+	it('increments a stat via action effect', () => {
+		const actions = createActionRegistry();
+		actions.add('train_army', {
+			id: 'train_army',
+			name: 'Train Army',
+			baseCosts: { [CResource.ap]: 0 },
+			effects: [
+				{
+					type: 'stat',
+					method: 'add',
+					params: { key: CStat.armyStrength, amount: 3 },
+				},
+			],
+		});
+		const ctx = createTestEngine({ actions });
+		advance(ctx);
+		ctx.game.currentPlayerIndex = 0;
+		const before = ctx.activePlayer.armyStrength;
+		const actionDefinition = actions.get('train_army');
+		const amount = actionDefinition.effects.find(
+			(effect) =>
+				effect.type === 'stat' &&
+				effect.method === 'add' &&
+				effect.params?.key === CStat.armyStrength,
+		)?.params?.amount as number;
+		const costs = getActionCosts('train_army', ctx);
+		ctx.activePlayer.ap = costs[Resource.ap] ?? 0;
+		performAction('train_army', ctx);
+		expect(ctx.activePlayer.armyStrength).toBe(before + amount);
+	});
 });

--- a/packages/engine/tests/effects/cost-mod-action-owner.test.ts
+++ b/packages/engine/tests/effects/cost-mod-action-owner.test.ts
@@ -6,43 +6,45 @@ import { createContentFactory } from '../factories/content.ts';
 import { Resource as CResource } from '@kingdom-builder/contents';
 
 describe('cost_mod owner scope', () => {
-  it('applies only to the player who added the modifier', () => {
-    const content = createContentFactory();
-    const actA = content.action({ baseCosts: { [CResource.gold]: 1 } });
-    const actB = content.action({ baseCosts: { [CResource.gold]: 1 } });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
-    runEffects(
-      [
-        {
-          type: 'cost_mod',
-          method: 'add',
-          params: { id: 'general', key: CResource.gold, amount: 1 },
-        },
-        {
-          type: 'cost_mod',
-          method: 'add',
-          params: {
-            id: 'specific',
-            actionId: actA.id,
-            key: CResource.gold,
-            amount: 2,
-          },
-        },
-      ],
-      ctx,
-    );
-    const baseA = actA.baseCosts[CResource.gold] ?? 0;
-    const baseB = actB.baseCosts[CResource.gold] ?? 0;
-    const costAA = getActionCosts(actA.id, ctx)[CResource.gold] ?? 0;
-    const costBA = getActionCosts(actB.id, ctx)[CResource.gold] ?? 0;
-    expect(costAA).toBe(baseA + 3);
-    expect(costBA).toBe(baseB + 1);
-    ctx.game.currentPlayerIndex = 1;
-    const costAB = getActionCosts(actA.id, ctx)[CResource.gold] ?? 0;
-    const costBB = getActionCosts(actB.id, ctx)[CResource.gold] ?? 0;
-    expect(costAB).toBe(baseA);
-    expect(costBB).toBe(baseB);
-  });
+	it('applies only to the player who added the modifier', () => {
+		const content = createContentFactory();
+		const actA = content.action({ baseCosts: { [CResource.gold]: 1 } });
+		const actB = content.action({ baseCosts: { [CResource.gold]: 1 } });
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		ctx.game.currentPlayerIndex = 0;
+		runEffects(
+			[
+				{
+					type: 'cost_mod',
+					method: 'add',
+					params: { id: 'general', key: CResource.gold, amount: 1 },
+				},
+				{
+					type: 'cost_mod',
+					method: 'add',
+					params: {
+						id: 'specific',
+						actionId: actA.id,
+						key: CResource.gold,
+						amount: 2,
+					},
+				},
+			],
+			ctx,
+		);
+		const baseA = actA.baseCosts[CResource.gold] ?? 0;
+		const baseB = actB.baseCosts[CResource.gold] ?? 0;
+		const costAA = getActionCosts(actA.id, ctx)[CResource.gold] ?? 0;
+		const costBA = getActionCosts(actB.id, ctx)[CResource.gold] ?? 0;
+		expect(costAA).toBe(baseA + 3);
+		expect(costBA).toBe(baseB + 1);
+		ctx.game.currentPlayerIndex = 1;
+		const costAB = getActionCosts(actA.id, ctx)[CResource.gold] ?? 0;
+		const costBB = getActionCosts(actB.id, ctx)[CResource.gold] ?? 0;
+		expect(costAB).toBe(baseA);
+		expect(costBB).toBe(baseB);
+	});
 });

--- a/packages/engine/tests/effects/cost_mod.test.ts
+++ b/packages/engine/tests/effects/cost_mod.test.ts
@@ -33,7 +33,9 @@ describe('cost_mod effects', () => {
 			],
 		});
 		const ctx = createTestEngine(content);
-		while (ctx.game.currentPhase !== 'main') advance(ctx);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
 		const before = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
 		const cost = getActionCosts(addMod.id, ctx);
 		ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
@@ -86,7 +88,9 @@ describe('cost_mod effects', () => {
 			],
 		});
 		const ctx = createTestEngine(content);
-		while (ctx.game.currentPhase !== 'main') advance(ctx);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
 		ctx.activePlayer.actions.add(addMods.id);
 		const before = getActionCosts(target.id, ctx)[CResource.gold] ?? 0;
 		performAction(addMods.id, ctx);

--- a/packages/engine/tests/effects/land_add.test.ts
+++ b/packages/engine/tests/effects/land_add.test.ts
@@ -3,30 +3,30 @@ import { runEffects } from '../../src/effects/index.ts';
 import { createTestEngine } from '../helpers.ts';
 
 describe('land:add effect', () => {
-  it('appends new lands to the end', () => {
-    const ctx = createTestEngine();
-    const beforeIds = ctx.activePlayer.lands.map((l) => l.id);
-    const beforeCount = beforeIds.length;
+	it('appends new lands to the end', () => {
+		const ctx = createTestEngine();
+		const beforeIds = ctx.activePlayer.lands.map((l) => l.id);
+		const beforeCount = beforeIds.length;
 
-    runEffects(
-      [
-        {
-          type: 'land',
-          method: 'add',
-          params: { count: 2 },
-        },
-      ],
-      ctx,
-    );
+		runEffects(
+			[
+				{
+					type: 'land',
+					method: 'add',
+					params: { count: 2 },
+				},
+			],
+			ctx,
+		);
 
-    const lands = ctx.activePlayer.lands;
-    expect(lands.length).toBe(beforeCount + 2);
-    expect(lands.slice(0, beforeCount).map((l) => l.id)).toEqual(beforeIds);
-    expect(lands[beforeCount]?.id).toBe(
-      `${ctx.activePlayer.id}-L${beforeCount + 1}`,
-    );
-    expect(lands[beforeCount + 1]?.id).toBe(
-      `${ctx.activePlayer.id}-L${beforeCount + 2}`,
-    );
-  });
+		const lands = ctx.activePlayer.lands;
+		expect(lands.length).toBe(beforeCount + 2);
+		expect(lands.slice(0, beforeCount).map((l) => l.id)).toEqual(beforeIds);
+		expect(lands[beforeCount]?.id).toBe(
+			`${ctx.activePlayer.id}-L${beforeCount + 1}`,
+		);
+		expect(lands[beforeCount + 1]?.id).toBe(
+			`${ctx.activePlayer.id}-L${beforeCount + 2}`,
+		);
+	});
 });

--- a/packages/engine/tests/effects/nonnegative.test.ts
+++ b/packages/engine/tests/effects/nonnegative.test.ts
@@ -1,96 +1,96 @@
 import { describe, it, expect } from 'vitest';
 import {
-  performAction,
-  Resource,
-  advance,
-  getActionCosts,
+	performAction,
+	Resource,
+	advance,
+	getActionCosts,
 } from '../../src/index.ts';
 import {
-  createActionRegistry,
-  Resource as CResource,
-  Stat as CStat,
+	createActionRegistry,
+	Resource as CResource,
+	Stat as CStat,
 } from '@kingdom-builder/contents';
 import { createTestEngine } from '../helpers.ts';
 
 describe('resource and stat bounds', () => {
-  it('clamps stat removal to zero', () => {
-    const actions = createActionRegistry();
-    actions.add('lower_fort', {
-      id: 'lower_fort',
-      name: 'Lower Fort',
-      baseCosts: { [CResource.ap]: 0 },
-      effects: [
-        {
-          type: 'stat',
-          method: 'remove',
-          params: { key: CStat.fortificationStrength, amount: 3 },
-        },
-      ],
-    });
-    const ctx = createTestEngine({ actions });
-    advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
-    const actionDef = actions.get('lower_fort');
-    const amt = actionDef.effects.find((e) => e.type === 'stat')?.params
-      ?.amount as number;
-    ctx.activePlayer.stats[CStat.fortificationStrength] = amt - 1;
-    const cost = getActionCosts('lower_fort', ctx)[Resource.ap] ?? 0;
-    ctx.activePlayer.ap = cost;
-    performAction('lower_fort', ctx);
-    expect(ctx.activePlayer.fortificationStrength).toBe(0);
-  });
+	it('clamps stat removal to zero', () => {
+		const actions = createActionRegistry();
+		actions.add('lower_fort', {
+			id: 'lower_fort',
+			name: 'Lower Fort',
+			baseCosts: { [CResource.ap]: 0 },
+			effects: [
+				{
+					type: 'stat',
+					method: 'remove',
+					params: { key: CStat.fortificationStrength, amount: 3 },
+				},
+			],
+		});
+		const ctx = createTestEngine({ actions });
+		advance(ctx);
+		ctx.game.currentPlayerIndex = 0;
+		const actionDef = actions.get('lower_fort');
+		const amt = actionDef.effects.find((e) => e.type === 'stat')?.params
+			?.amount as number;
+		ctx.activePlayer.stats[CStat.fortificationStrength] = amt - 1;
+		const cost = getActionCosts('lower_fort', ctx)[Resource.ap] ?? 0;
+		ctx.activePlayer.ap = cost;
+		performAction('lower_fort', ctx);
+		expect(ctx.activePlayer.fortificationStrength).toBe(0);
+	});
 
-  it('clamps resource additions to zero', () => {
-    const actions = createActionRegistry();
-    actions.add('lose_gold', {
-      id: 'lose_gold',
-      name: 'Lose Gold',
-      baseCosts: { [CResource.ap]: 0 },
-      effects: [
-        {
-          type: 'resource',
-          method: 'add',
-          params: { key: CResource.gold, amount: -5 },
-        },
-      ],
-    });
-    const ctx = createTestEngine({ actions });
-    advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
-    const actionDef = actions.get('lose_gold');
-    const amt = actionDef.effects.find((e) => e.type === 'resource')?.params
-      ?.amount as number;
-    ctx.activePlayer.gold = 1;
-    const cost = getActionCosts('lose_gold', ctx)[Resource.ap] ?? 0;
-    ctx.activePlayer.ap = cost;
-    performAction('lose_gold', ctx);
-    expect(ctx.activePlayer.gold).toBe(Math.max(1 + amt, 0));
-  });
+	it('clamps resource additions to zero', () => {
+		const actions = createActionRegistry();
+		actions.add('lose_gold', {
+			id: 'lose_gold',
+			name: 'Lose Gold',
+			baseCosts: { [CResource.ap]: 0 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: CResource.gold, amount: -5 },
+				},
+			],
+		});
+		const ctx = createTestEngine({ actions });
+		advance(ctx);
+		ctx.game.currentPlayerIndex = 0;
+		const actionDef = actions.get('lose_gold');
+		const amt = actionDef.effects.find((e) => e.type === 'resource')?.params
+			?.amount as number;
+		ctx.activePlayer.gold = 1;
+		const cost = getActionCosts('lose_gold', ctx)[Resource.ap] ?? 0;
+		ctx.activePlayer.ap = cost;
+		performAction('lose_gold', ctx);
+		expect(ctx.activePlayer.gold).toBe(Math.max(1 + amt, 0));
+	});
 
-  it('clamps negative stat additions to zero', () => {
-    const actions = createActionRegistry();
-    actions.add('bad_add', {
-      id: 'bad_add',
-      name: 'Bad Add',
-      baseCosts: { [CResource.ap]: 0 },
-      effects: [
-        {
-          type: 'stat',
-          method: 'add',
-          params: { key: CStat.armyStrength, amount: -4 },
-        },
-      ],
-    });
-    const ctx = createTestEngine({ actions });
-    advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
-    const actionDef = actions.get('bad_add');
-    const amt = actionDef.effects.find((e) => e.type === 'stat')?.params
-      ?.amount as number;
-    const before = ctx.activePlayer.armyStrength;
-    const cost = getActionCosts('bad_add', ctx)[Resource.ap] ?? 0;
-    ctx.activePlayer.ap = cost;
-    performAction('bad_add', ctx);
-    expect(ctx.activePlayer.armyStrength).toBe(Math.max(before + amt, 0));
-  });
+	it('clamps negative stat additions to zero', () => {
+		const actions = createActionRegistry();
+		actions.add('bad_add', {
+			id: 'bad_add',
+			name: 'Bad Add',
+			baseCosts: { [CResource.ap]: 0 },
+			effects: [
+				{
+					type: 'stat',
+					method: 'add',
+					params: { key: CStat.armyStrength, amount: -4 },
+				},
+			],
+		});
+		const ctx = createTestEngine({ actions });
+		advance(ctx);
+		ctx.game.currentPlayerIndex = 0;
+		const actionDef = actions.get('bad_add');
+		const amt = actionDef.effects.find((e) => e.type === 'stat')?.params
+			?.amount as number;
+		const before = ctx.activePlayer.armyStrength;
+		const cost = getActionCosts('bad_add', ctx)[Resource.ap] ?? 0;
+		ctx.activePlayer.ap = cost;
+		performAction('bad_add', ctx);
+		expect(ctx.activePlayer.armyStrength).toBe(Math.max(before + amt, 0));
+	});
 });

--- a/packages/engine/tests/effects/passive-add.test.ts
+++ b/packages/engine/tests/effects/passive-add.test.ts
@@ -5,55 +5,55 @@ import { createTestEngine } from '../helpers.ts';
 import type { EffectDef } from '../../src/effects/index.ts';
 
 describe('passive:add effect', () => {
-  it('applies nested effects and registers phase triggers', () => {
-    const ctx = createTestEngine();
-    const effect: EffectDef<{ id: string } & Record<string, EffectDef[]>> = {
-      type: 'passive',
-      method: 'add',
-      params: {
-        id: 'temp',
-        onGrowthPhase: [
-          {
-            type: 'resource',
-            method: 'add',
-            params: { key: Resource.gold, amount: 1 },
-          },
-        ],
-        onUpkeepPhase: [
-          {
-            type: 'resource',
-            method: 'add',
-            params: { key: Resource.gold, amount: 1 },
-          },
-        ],
-        onBeforeAttacked: [
-          {
-            type: 'resource',
-            method: 'add',
-            params: { key: Resource.gold, amount: 1 },
-          },
-        ],
-        onAttackResolved: [
-          {
-            type: 'resource',
-            method: 'add',
-            params: { key: Resource.gold, amount: 1 },
-          },
-        ],
-      },
-      effects: [
-        {
-          type: 'stat',
-          method: 'add',
-          params: { key: Stat.armyStrength, amount: 1 },
-        },
-      ],
-    };
+	it('applies nested effects and registers phase triggers', () => {
+		const ctx = createTestEngine();
+		const effect: EffectDef<{ id: string } & Record<string, EffectDef[]>> = {
+			type: 'passive',
+			method: 'add',
+			params: {
+				id: 'temp',
+				onGrowthPhase: [
+					{
+						type: 'resource',
+						method: 'add',
+						params: { key: Resource.gold, amount: 1 },
+					},
+				],
+				onUpkeepPhase: [
+					{
+						type: 'resource',
+						method: 'add',
+						params: { key: Resource.gold, amount: 1 },
+					},
+				],
+				onBeforeAttacked: [
+					{
+						type: 'resource',
+						method: 'add',
+						params: { key: Resource.gold, amount: 1 },
+					},
+				],
+				onAttackResolved: [
+					{
+						type: 'resource',
+						method: 'add',
+						params: { key: Resource.gold, amount: 1 },
+					},
+				],
+			},
+			effects: [
+				{
+					type: 'stat',
+					method: 'add',
+					params: { key: Stat.armyStrength, amount: 1 },
+				},
+			],
+		};
 
-    const before = ctx.activePlayer.stats[Stat.armyStrength];
-    runEffects([effect], ctx);
-    expect(ctx.activePlayer.stats[Stat.armyStrength]).toBe(before + 1);
-    ctx.passives.removePassive('temp', ctx);
-    expect(ctx.activePlayer.stats[Stat.armyStrength]).toBe(before);
-  });
+		const before = ctx.activePlayer.stats[Stat.armyStrength];
+		runEffects([effect], ctx);
+		expect(ctx.activePlayer.stats[Stat.armyStrength]).toBe(before + 1);
+		ctx.passives.removePassive('temp', ctx);
+		expect(ctx.activePlayer.stats[Stat.armyStrength]).toBe(before);
+	});
 });

--- a/packages/engine/tests/effects/population.test.ts
+++ b/packages/engine/tests/effects/population.test.ts
@@ -5,31 +5,33 @@ import { createContentFactory } from '../factories/content';
 import { Resource as CResource } from '@kingdom-builder/contents';
 
 describe('population effects', () => {
-  it('adds and removes population', () => {
-    const content = createContentFactory();
-    const role = content.population();
-    const add = content.action({
-      effects: [
-        { type: 'population', method: 'add', params: { role: role.id } },
-        { type: 'population', method: 'add', params: { role: role.id } },
-      ],
-    });
-    const remove = content.action({
-      effects: [
-        { type: 'population', method: 'remove', params: { role: role.id } },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    let cost = getActionCosts(add.id, ctx);
-    ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
-    performAction(add.id, ctx);
-    const added = add.effects.filter((e) => e.method === 'add').length;
-    expect(ctx.activePlayer.population[role.id]).toBe(added);
-    cost = getActionCosts(remove.id, ctx);
-    ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
-    performAction(remove.id, ctx);
-    const removed = remove.effects.filter((e) => e.method === 'remove').length;
-    expect(ctx.activePlayer.population[role.id]).toBe(added - removed);
-  });
+	it('adds and removes population', () => {
+		const content = createContentFactory();
+		const role = content.population();
+		const add = content.action({
+			effects: [
+				{ type: 'population', method: 'add', params: { role: role.id } },
+				{ type: 'population', method: 'add', params: { role: role.id } },
+			],
+		});
+		const remove = content.action({
+			effects: [
+				{ type: 'population', method: 'remove', params: { role: role.id } },
+			],
+		});
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		let cost = getActionCosts(add.id, ctx);
+		ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
+		performAction(add.id, ctx);
+		const added = add.effects.filter((e) => e.method === 'add').length;
+		expect(ctx.activePlayer.population[role.id]).toBe(added);
+		cost = getActionCosts(remove.id, ctx);
+		ctx.activePlayer.ap = cost[CResource.ap] ?? 0;
+		performAction(remove.id, ctx);
+		const removed = remove.effects.filter((e) => e.method === 'remove').length;
+		expect(ctx.activePlayer.population[role.id]).toBe(added - removed);
+	});
 });

--- a/packages/engine/tests/effects/resource-add.test.ts
+++ b/packages/engine/tests/effects/resource-add.test.ts
@@ -1,116 +1,118 @@
 import { describe, it, expect } from 'vitest';
 import {
-  performAction,
-  Resource,
-  advance,
-  getActionCosts,
+	performAction,
+	Resource,
+	advance,
+	getActionCosts,
 } from '../../src/index.ts';
 import {
-  createActionRegistry,
-  Resource as CResource,
+	createActionRegistry,
+	Resource as CResource,
 } from '@kingdom-builder/contents';
 import { createTestEngine } from '../helpers.ts';
 
 describe('resource:add effect', () => {
-  it('increments a resource via action effect', () => {
-    const actions = createActionRegistry();
-    actions.add('grant_gold', {
-      id: 'grant_gold',
-      name: 'Grant Gold',
-      baseCosts: { [CResource.ap]: 0 },
-      effects: [
-        {
-          type: 'resource',
-          method: 'add',
-          params: { key: CResource.gold, amount: 3 },
-        },
-      ],
-    });
-    const ctx = createTestEngine({ actions });
-    advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
-    const before = ctx.activePlayer.gold;
-    const actionDefinition = actions.get('grant_gold');
-    const amount = actionDefinition.effects.find(
-      (effect) =>
-        effect.type === 'resource' &&
-        effect.method === 'add' &&
-        effect.params?.key === CResource.gold,
-    )?.params?.amount as number;
-    const cost = getActionCosts('grant_gold', ctx)[Resource.ap] ?? 0;
-    ctx.activePlayer.ap = cost;
-    performAction('grant_gold', ctx);
-    expect(ctx.activePlayer.gold).toBe(before + amount);
-  });
+	it('increments a resource via action effect', () => {
+		const actions = createActionRegistry();
+		actions.add('grant_gold', {
+			id: 'grant_gold',
+			name: 'Grant Gold',
+			baseCosts: { [CResource.ap]: 0 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: CResource.gold, amount: 3 },
+				},
+			],
+		});
+		const ctx = createTestEngine({ actions });
+		advance(ctx);
+		ctx.game.currentPlayerIndex = 0;
+		const before = ctx.activePlayer.gold;
+		const actionDefinition = actions.get('grant_gold');
+		const amount = actionDefinition.effects.find(
+			(effect) =>
+				effect.type === 'resource' &&
+				effect.method === 'add' &&
+				effect.params?.key === CResource.gold,
+		)?.params?.amount as number;
+		const cost = getActionCosts('grant_gold', ctx)[Resource.ap] ?? 0;
+		ctx.activePlayer.ap = cost;
+		performAction('grant_gold', ctx);
+		expect(ctx.activePlayer.gold).toBe(before + amount);
+	});
 
-  it('rounds fractional amounts according to round setting', () => {
-    const actions = createActionRegistry();
-    actions.add('round_up', {
-      id: 'round_up',
-      name: 'Round Up',
-      baseCosts: { [CResource.ap]: 0 },
-      effects: [
-        {
-          type: 'resource',
-          method: 'add',
-          params: { key: CResource.gold, amount: 1.2 },
-          round: 'up',
-        },
-      ],
-    });
-    actions.add('round_down', {
-      id: 'round_down',
-      name: 'Round Down',
-      baseCosts: { [CResource.ap]: 0 },
-      effects: [
-        {
-          type: 'resource',
-          method: 'add',
-          params: { key: CResource.gold, amount: 1.8 },
-          round: 'down',
-        },
-      ],
-    });
-    const ctx = createTestEngine({ actions });
-    advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
+	it('rounds fractional amounts according to round setting', () => {
+		const actions = createActionRegistry();
+		actions.add('round_up', {
+			id: 'round_up',
+			name: 'Round Up',
+			baseCosts: { [CResource.ap]: 0 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: CResource.gold, amount: 1.2 },
+					round: 'up',
+				},
+			],
+		});
+		actions.add('round_down', {
+			id: 'round_down',
+			name: 'Round Down',
+			baseCosts: { [CResource.ap]: 0 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: CResource.gold, amount: 1.8 },
+					round: 'down',
+				},
+			],
+		});
+		const ctx = createTestEngine({ actions });
+		advance(ctx);
+		ctx.game.currentPlayerIndex = 0;
 
-    let before = ctx.activePlayer.gold;
-    let foundEffect = actions
-      .get('round_up')
-      .effects.find(
-        (effect) =>
-          effect.type === 'resource' &&
-          effect.method === 'add' &&
-          effect.params?.key === CResource.gold,
-      );
-    let total = (foundEffect?.params?.amount as number) || 0;
-    if (foundEffect?.round === 'up')
-      total = total >= 0 ? Math.ceil(total) : Math.floor(total);
-    else if (foundEffect?.round === 'down')
-      total = total >= 0 ? Math.floor(total) : Math.ceil(total);
-    let cost = getActionCosts('round_up', ctx)[Resource.ap] ?? 0;
-    ctx.activePlayer.ap = cost;
-    performAction('round_up', ctx);
-    expect(ctx.activePlayer.gold).toBe(before + total);
+		let before = ctx.activePlayer.gold;
+		let foundEffect = actions
+			.get('round_up')
+			.effects.find(
+				(effect) =>
+					effect.type === 'resource' &&
+					effect.method === 'add' &&
+					effect.params?.key === CResource.gold,
+			);
+		let total = (foundEffect?.params?.amount as number) || 0;
+		if (foundEffect?.round === 'up') {
+			total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+		} else if (foundEffect?.round === 'down') {
+			total = total >= 0 ? Math.floor(total) : Math.ceil(total);
+		}
+		let cost = getActionCosts('round_up', ctx)[Resource.ap] ?? 0;
+		ctx.activePlayer.ap = cost;
+		performAction('round_up', ctx);
+		expect(ctx.activePlayer.gold).toBe(before + total);
 
-    before = ctx.activePlayer.gold;
-    foundEffect = actions
-      .get('round_down')
-      .effects.find(
-        (effect) =>
-          effect.type === 'resource' &&
-          effect.method === 'add' &&
-          effect.params?.key === CResource.gold,
-      );
-    total = (foundEffect?.params?.amount as number) || 0;
-    if (foundEffect?.round === 'up')
-      total = total >= 0 ? Math.ceil(total) : Math.floor(total);
-    else if (foundEffect?.round === 'down')
-      total = total >= 0 ? Math.floor(total) : Math.ceil(total);
-    cost = getActionCosts('round_down', ctx)[Resource.ap] ?? 0;
-    ctx.activePlayer.ap = cost;
-    performAction('round_down', ctx);
-    expect(ctx.activePlayer.gold).toBe(before + total);
-  });
+		before = ctx.activePlayer.gold;
+		foundEffect = actions
+			.get('round_down')
+			.effects.find(
+				(effect) =>
+					effect.type === 'resource' &&
+					effect.method === 'add' &&
+					effect.params?.key === CResource.gold,
+			);
+		total = (foundEffect?.params?.amount as number) || 0;
+		if (foundEffect?.round === 'up') {
+			total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+		} else if (foundEffect?.round === 'down') {
+			total = total >= 0 ? Math.floor(total) : Math.ceil(total);
+		}
+		cost = getActionCosts('round_down', ctx)[Resource.ap] ?? 0;
+		ctx.activePlayer.ap = cost;
+		performAction('round_down', ctx);
+		expect(ctx.activePlayer.gold).toBe(before + total);
+	});
 });

--- a/packages/engine/tests/effects/resource-remove.test.ts
+++ b/packages/engine/tests/effects/resource-remove.test.ts
@@ -1,116 +1,118 @@
 import { describe, it, expect } from 'vitest';
 import {
-  performAction,
-  Resource,
-  advance,
-  getActionCosts,
+	performAction,
+	Resource,
+	advance,
+	getActionCosts,
 } from '../../src/index.ts';
 import {
-  createActionRegistry,
-  Resource as CResource,
+	createActionRegistry,
+	Resource as CResource,
 } from '@kingdom-builder/contents';
 import { createTestEngine } from '../helpers.ts';
 
 describe('resource:remove effect', () => {
-  it('decrements a resource via action effect', () => {
-    const actions = createActionRegistry();
-    actions.add('pay_gold', {
-      id: 'pay_gold',
-      name: 'Pay Gold',
-      baseCosts: { [CResource.ap]: 0 },
-      effects: [
-        {
-          type: 'resource',
-          method: 'remove',
-          params: { key: CResource.gold, amount: 3 },
-        },
-      ],
-    });
-    const ctx = createTestEngine({ actions });
-    advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
-    const before = ctx.activePlayer.gold;
-    const actionDefinition = actions.get('pay_gold');
-    const amount = actionDefinition.effects.find(
-      (effect) =>
-        effect.type === 'resource' &&
-        effect.method === 'remove' &&
-        effect.params?.key === CResource.gold,
-    )?.params?.amount as number;
-    const cost = getActionCosts('pay_gold', ctx)[Resource.ap] ?? 0;
-    ctx.activePlayer.ap = cost;
-    performAction('pay_gold', ctx);
-    expect(ctx.activePlayer.gold).toBe(before - amount);
-  });
+	it('decrements a resource via action effect', () => {
+		const actions = createActionRegistry();
+		actions.add('pay_gold', {
+			id: 'pay_gold',
+			name: 'Pay Gold',
+			baseCosts: { [CResource.ap]: 0 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'remove',
+					params: { key: CResource.gold, amount: 3 },
+				},
+			],
+		});
+		const ctx = createTestEngine({ actions });
+		advance(ctx);
+		ctx.game.currentPlayerIndex = 0;
+		const before = ctx.activePlayer.gold;
+		const actionDefinition = actions.get('pay_gold');
+		const amount = actionDefinition.effects.find(
+			(effect) =>
+				effect.type === 'resource' &&
+				effect.method === 'remove' &&
+				effect.params?.key === CResource.gold,
+		)?.params?.amount as number;
+		const cost = getActionCosts('pay_gold', ctx)[Resource.ap] ?? 0;
+		ctx.activePlayer.ap = cost;
+		performAction('pay_gold', ctx);
+		expect(ctx.activePlayer.gold).toBe(before - amount);
+	});
 
-  it('rounds fractional amounts according to round setting', () => {
-    const actions = createActionRegistry();
-    actions.add('round_up_remove', {
-      id: 'round_up_remove',
-      name: 'Round Up Remove',
-      baseCosts: { [CResource.ap]: 0 },
-      effects: [
-        {
-          type: 'resource',
-          method: 'remove',
-          params: { key: CResource.gold, amount: 1.2 },
-          round: 'up',
-        },
-      ],
-    });
-    actions.add('round_down_remove', {
-      id: 'round_down_remove',
-      name: 'Round Down Remove',
-      baseCosts: { [CResource.ap]: 0 },
-      effects: [
-        {
-          type: 'resource',
-          method: 'remove',
-          params: { key: CResource.gold, amount: 1.8 },
-          round: 'down',
-        },
-      ],
-    });
-    const ctx = createTestEngine({ actions });
-    advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
+	it('rounds fractional amounts according to round setting', () => {
+		const actions = createActionRegistry();
+		actions.add('round_up_remove', {
+			id: 'round_up_remove',
+			name: 'Round Up Remove',
+			baseCosts: { [CResource.ap]: 0 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'remove',
+					params: { key: CResource.gold, amount: 1.2 },
+					round: 'up',
+				},
+			],
+		});
+		actions.add('round_down_remove', {
+			id: 'round_down_remove',
+			name: 'Round Down Remove',
+			baseCosts: { [CResource.ap]: 0 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'remove',
+					params: { key: CResource.gold, amount: 1.8 },
+					round: 'down',
+				},
+			],
+		});
+		const ctx = createTestEngine({ actions });
+		advance(ctx);
+		ctx.game.currentPlayerIndex = 0;
 
-    let before = ctx.activePlayer.gold;
-    let foundEffect = actions
-      .get('round_up_remove')
-      .effects.find(
-        (effect) =>
-          effect.type === 'resource' &&
-          effect.method === 'remove' &&
-          effect.params?.key === CResource.gold,
-      );
-    let total = (foundEffect?.params?.amount as number) || 0;
-    if (foundEffect?.round === 'up')
-      total = total >= 0 ? Math.ceil(total) : Math.floor(total);
-    else if (foundEffect?.round === 'down')
-      total = total >= 0 ? Math.floor(total) : Math.ceil(total);
-    let cost = getActionCosts('round_up_remove', ctx)[Resource.ap] ?? 0;
-    ctx.activePlayer.ap = cost;
-    performAction('round_up_remove', ctx);
-    expect(ctx.activePlayer.gold).toBe(before - total);
+		let before = ctx.activePlayer.gold;
+		let foundEffect = actions
+			.get('round_up_remove')
+			.effects.find(
+				(effect) =>
+					effect.type === 'resource' &&
+					effect.method === 'remove' &&
+					effect.params?.key === CResource.gold,
+			);
+		let total = (foundEffect?.params?.amount as number) || 0;
+		if (foundEffect?.round === 'up') {
+			total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+		} else if (foundEffect?.round === 'down') {
+			total = total >= 0 ? Math.floor(total) : Math.ceil(total);
+		}
+		let cost = getActionCosts('round_up_remove', ctx)[Resource.ap] ?? 0;
+		ctx.activePlayer.ap = cost;
+		performAction('round_up_remove', ctx);
+		expect(ctx.activePlayer.gold).toBe(before - total);
 
-    before = ctx.activePlayer.gold;
-    foundEffect = actions
-      .get('round_down_remove')
-      .effects.find(
-        (effect) =>
-          effect.type === 'resource' &&
-          effect.method === 'remove' &&
-          effect.params?.key === CResource.gold,
-      );
-    total = (foundEffect?.params?.amount as number) || 0;
-    if (foundEffect?.round === 'up')
-      total = total >= 0 ? Math.ceil(total) : Math.floor(total);
-    else if (foundEffect?.round === 'down')
-      total = total >= 0 ? Math.floor(total) : Math.ceil(total);
-    cost = getActionCosts('round_down_remove', ctx)[Resource.ap] ?? 0;
-    ctx.activePlayer.ap = cost;
-    performAction('round_down_remove', ctx);
-    expect(ctx.activePlayer.gold).toBe(before - total);
-  });
+		before = ctx.activePlayer.gold;
+		foundEffect = actions
+			.get('round_down_remove')
+			.effects.find(
+				(effect) =>
+					effect.type === 'resource' &&
+					effect.method === 'remove' &&
+					effect.params?.key === CResource.gold,
+			);
+		total = (foundEffect?.params?.amount as number) || 0;
+		if (foundEffect?.round === 'up') {
+			total = total >= 0 ? Math.ceil(total) : Math.floor(total);
+		} else if (foundEffect?.round === 'down') {
+			total = total >= 0 ? Math.floor(total) : Math.ceil(total);
+		}
+		cost = getActionCosts('round_down_remove', ctx)[Resource.ap] ?? 0;
+		ctx.activePlayer.ap = cost;
+		performAction('round_down_remove', ctx);
+		expect(ctx.activePlayer.gold).toBe(before - total);
+	});
 });

--- a/packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts
+++ b/packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts
@@ -1,110 +1,114 @@
 import { describe, it, expect } from 'vitest';
 import { runEffects, advance, Resource } from '../../src/index.ts';
 import {
-  TRANSFER_PCT_EVALUATION_ID,
-  TRANSFER_PCT_EVALUATION_TYPE,
+	TRANSFER_PCT_EVALUATION_ID,
+	TRANSFER_PCT_EVALUATION_TYPE,
 } from '../../src/effects/resource_transfer.ts';
 import { createTestEngine } from '../helpers.ts';
 import type { EffectDef } from '../../src/effects/index.ts';
 
 describe('resource:transfer percent bounds', () => {
-  it('adjusts transfer percentage within bounds', () => {
-    const ctx = createTestEngine();
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
+	it('adjusts transfer percentage within bounds', () => {
+		const ctx = createTestEngine();
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		ctx.game.currentPlayerIndex = 0;
 
-    const transfer: EffectDef<{ key: string; percent: number }> = {
-      type: 'resource',
-      method: 'transfer',
-      params: { key: Resource.gold, percent: 50 },
-    };
-    const addBoost: EffectDef<{ id: string }> = {
-      type: 'result_mod',
-      method: 'add',
-      params: {
-        id: 'boost',
-        evaluation: {
-          type: TRANSFER_PCT_EVALUATION_TYPE,
-          id: TRANSFER_PCT_EVALUATION_ID,
-        },
-        adjust: 80,
-      },
-    };
-    const removeBoost: EffectDef<{ id: string }> = {
-      type: 'result_mod',
-      method: 'remove',
-      params: {
-        id: 'boost',
-        evaluation: {
-          type: TRANSFER_PCT_EVALUATION_TYPE,
-          id: TRANSFER_PCT_EVALUATION_ID,
-        },
-      },
-    };
-    const addNerf: EffectDef<{ id: string }> = {
-      type: 'result_mod',
-      method: 'add',
-      params: {
-        id: 'nerf',
-        evaluation: {
-          type: TRANSFER_PCT_EVALUATION_TYPE,
-          id: TRANSFER_PCT_EVALUATION_ID,
-        },
-        adjust: -200,
-      },
-    };
+		const transfer: EffectDef<{ key: string; percent: number }> = {
+			type: 'resource',
+			method: 'transfer',
+			params: { key: Resource.gold, percent: 50 },
+		};
+		const addBoost: EffectDef<{ id: string }> = {
+			type: 'result_mod',
+			method: 'add',
+			params: {
+				id: 'boost',
+				evaluation: {
+					type: TRANSFER_PCT_EVALUATION_TYPE,
+					id: TRANSFER_PCT_EVALUATION_ID,
+				},
+				adjust: 80,
+			},
+		};
+		const removeBoost: EffectDef<{ id: string }> = {
+			type: 'result_mod',
+			method: 'remove',
+			params: {
+				id: 'boost',
+				evaluation: {
+					type: TRANSFER_PCT_EVALUATION_TYPE,
+					id: TRANSFER_PCT_EVALUATION_ID,
+				},
+			},
+		};
+		const addNerf: EffectDef<{ id: string }> = {
+			type: 'result_mod',
+			method: 'add',
+			params: {
+				id: 'nerf',
+				evaluation: {
+					type: TRANSFER_PCT_EVALUATION_TYPE,
+					id: TRANSFER_PCT_EVALUATION_ID,
+				},
+				adjust: -200,
+			},
+		};
 
-    ctx.activePlayer.gold = 0;
-    ctx.opponent.gold = 10;
-    const total = ctx.opponent.gold;
+		ctx.activePlayer.gold = 0;
+		ctx.opponent.gold = 10;
+		const total = ctx.opponent.gold;
 
-    runEffects([addBoost], ctx);
-    runEffects([transfer], ctx);
-    expect(ctx.activePlayer.gold).toBe(total);
-    expect(ctx.opponent.gold).toBe(0);
+		runEffects([addBoost], ctx);
+		runEffects([transfer], ctx);
+		expect(ctx.activePlayer.gold).toBe(total);
+		expect(ctx.opponent.gold).toBe(0);
 
-    runEffects([removeBoost], ctx);
-    ctx.activePlayer.gold = 0;
-    ctx.opponent.gold = total;
+		runEffects([removeBoost], ctx);
+		ctx.activePlayer.gold = 0;
+		ctx.opponent.gold = total;
 
-    runEffects([addNerf], ctx);
-    runEffects([transfer], ctx);
-    expect(ctx.activePlayer.gold).toBe(0);
-    expect(ctx.opponent.gold).toBe(total);
-  });
+		runEffects([addNerf], ctx);
+		runEffects([transfer], ctx);
+		expect(ctx.activePlayer.gold).toBe(0);
+		expect(ctx.opponent.gold).toBe(total);
+	});
 
-  it('respects rounding configuration', () => {
-    const ctx = createTestEngine();
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    ctx.game.currentPlayerIndex = 0;
+	it('respects rounding configuration', () => {
+		const ctx = createTestEngine();
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		ctx.game.currentPlayerIndex = 0;
 
-    const base: EffectDef<{ key: string; percent: number }> = {
-      type: 'resource',
-      method: 'transfer',
-      params: { key: Resource.gold, percent: 25 },
-    };
+		const base: EffectDef<{ key: string; percent: number }> = {
+			type: 'resource',
+			method: 'transfer',
+			params: { key: Resource.gold, percent: 25 },
+		};
 
-    const run = (round?: 'up' | 'down') => {
-      ctx.activePlayer.gold = 0;
-      ctx.opponent.gold = 5;
-      const effect: EffectDef<{ key: string; percent: number }> = {
-        ...base,
-        round,
-      };
-      runEffects([effect], ctx);
-      return { attacker: ctx.activePlayer.gold, defender: ctx.opponent.gold };
-    };
+		const run = (round?: 'up' | 'down') => {
+			ctx.activePlayer.gold = 0;
+			ctx.opponent.gold = 5;
+			const effect: EffectDef<{ key: string; percent: number }> = {
+				...base,
+				round,
+			};
+			runEffects([effect], ctx);
+			return { attacker: ctx.activePlayer.gold, defender: ctx.opponent.gold };
+		};
 
-    const floor = run();
-    expect(floor.attacker).toBe(1);
-    expect(floor.defender).toBe(4);
+		const floor = run();
+		expect(floor.attacker).toBe(1);
+		expect(floor.defender).toBe(4);
 
-    const roundedUp = run('up');
-    expect(roundedUp.attacker).toBe(2);
-    expect(roundedUp.defender).toBe(3);
+		const roundedUp = run('up');
+		expect(roundedUp.attacker).toBe(2);
+		expect(roundedUp.defender).toBe(3);
 
-    const roundedDown = run('down');
-    expect(roundedDown.attacker).toBe(1);
-    expect(roundedDown.defender).toBe(4);
-  });
+		const roundedDown = run('down');
+		expect(roundedDown.attacker).toBe(1);
+		expect(roundedDown.defender).toBe(4);
+	});
 });

--- a/packages/engine/tests/effects/stat-add-pct-step-reset.test.ts
+++ b/packages/engine/tests/effects/stat-add-pct-step-reset.test.ts
@@ -4,19 +4,19 @@ import { createTestEngine } from '../helpers.ts';
 import { Stat } from '../../src/state/index.ts';
 
 describe('stat:add_pct effect', () => {
-  it('resets cached base between steps', () => {
-    const ctx = createTestEngine();
-    ctx.activePlayer.stats[Stat.absorption] = 0.2;
-    ctx.game.currentStep = 's1';
-    const effect = {
-      type: 'stat',
-      method: 'add_pct',
-      params: { key: Stat.absorption, percent: 0.5 },
-    } as const;
-    runEffects([effect], ctx);
-    expect(ctx.activePlayer.stats[Stat.absorption]).toBeCloseTo(0.3);
-    ctx.game.currentStep = 's2';
-    runEffects([effect], ctx);
-    expect(ctx.activePlayer.stats[Stat.absorption]).toBeCloseTo(0.45);
-  });
+	it('resets cached base between steps', () => {
+		const ctx = createTestEngine();
+		ctx.activePlayer.stats[Stat.absorption] = 0.2;
+		ctx.game.currentStep = 's1';
+		const effect = {
+			type: 'stat',
+			method: 'add_pct',
+			params: { key: Stat.absorption, percent: 0.5 },
+		} as const;
+		runEffects([effect], ctx);
+		expect(ctx.activePlayer.stats[Stat.absorption]).toBeCloseTo(0.3);
+		ctx.game.currentStep = 's2';
+		runEffects([effect], ctx);
+		expect(ctx.activePlayer.stats[Stat.absorption]).toBeCloseTo(0.45);
+	});
 });

--- a/packages/engine/tests/effects/till_land.test.ts
+++ b/packages/engine/tests/effects/till_land.test.ts
@@ -5,48 +5,48 @@ import { createContentFactory } from '../factories/content.ts';
 import { LandMethods } from '@kingdom-builder/contents/config/builders';
 
 describe('land:till effect', () => {
-  it('tills the specified land and marks it as tilled', () => {
-    const content = createContentFactory();
-    const till = content.action({
-      system: true,
-      effects: [
-        { type: 'land', method: LandMethods.TILL, params: { landId: 'A-L2' } },
-      ],
-    });
-    const ctx = createTestEngine({ actions: content.actions });
-    ctx.activePlayer.actions.add(till.id);
-    const land = ctx.activePlayer.lands[1];
-    const before = land.slotsMax;
-    const expected = Math.min(before + 1, ctx.services.rules.maxSlotsPerLand);
-    performAction(till.id, ctx);
-    expect(land.slotsMax).toBe(expected);
-    expect(land.tilled).toBe(true);
-  });
+	it('tills the specified land and marks it as tilled', () => {
+		const content = createContentFactory();
+		const till = content.action({
+			system: true,
+			effects: [
+				{ type: 'land', method: LandMethods.TILL, params: { landId: 'A-L2' } },
+			],
+		});
+		const ctx = createTestEngine({ actions: content.actions });
+		ctx.activePlayer.actions.add(till.id);
+		const land = ctx.activePlayer.lands[1];
+		const before = land.slotsMax;
+		const expected = Math.min(before + 1, ctx.services.rules.maxSlotsPerLand);
+		performAction(till.id, ctx);
+		expect(land.slotsMax).toBe(expected);
+		expect(land.tilled).toBe(true);
+	});
 
-  it('throws if the land is already tilled', () => {
-    const content = createContentFactory();
-    const till = content.action({
-      system: true,
-      effects: [
-        { type: 'land', method: LandMethods.TILL, params: { landId: 'A-L2' } },
-      ],
-    });
-    const ctx = createTestEngine({ actions: content.actions });
-    ctx.activePlayer.actions.add(till.id);
-    performAction(till.id, ctx);
-    expect(() => performAction(till.id, ctx)).toThrow(/already tilled/);
-  });
+	it('throws if the land is already tilled', () => {
+		const content = createContentFactory();
+		const till = content.action({
+			system: true,
+			effects: [
+				{ type: 'land', method: LandMethods.TILL, params: { landId: 'A-L2' } },
+			],
+		});
+		const ctx = createTestEngine({ actions: content.actions });
+		ctx.activePlayer.actions.add(till.id);
+		performAction(till.id, ctx);
+		expect(() => performAction(till.id, ctx)).toThrow(/already tilled/);
+	});
 
-  it('tills the first available land when no id is given', () => {
-    const content = createContentFactory();
-    const till = content.action({
-      system: true,
-      effects: [{ type: 'land', method: LandMethods.TILL }],
-    });
-    const ctx = createTestEngine({ actions: content.actions });
-    ctx.activePlayer.actions.add(till.id);
-    performAction(till.id, ctx);
-    const tilledCount = ctx.activePlayer.lands.filter((l) => l.tilled).length;
-    expect(tilledCount).toBe(1);
-  });
+	it('tills the first available land when no id is given', () => {
+		const content = createContentFactory();
+		const till = content.action({
+			system: true,
+			effects: [{ type: 'land', method: LandMethods.TILL }],
+		});
+		const ctx = createTestEngine({ actions: content.actions });
+		ctx.activePlayer.actions.add(till.id);
+		performAction(till.id, ctx);
+		const tilledCount = ctx.activePlayer.lands.filter((l) => l.tilled).length;
+		expect(tilledCount).toBe(1);
+	});
 });

--- a/packages/engine/tests/engine.property.test.ts
+++ b/packages/engine/tests/engine.property.test.ts
@@ -6,70 +6,72 @@ import { createContentFactory } from './factories/content';
 import { advance, performAction, getActionCosts, snapshotPlayer } from '../src';
 
 function toMain(ctx: ReturnType<typeof createTestEngine>) {
-  while (ctx.game.currentPhase !== 'main') advance(ctx);
+	while (ctx.game.currentPhase !== 'main') {
+		advance(ctx);
+	}
 }
 
 const resourceKeys = Object.values(CResource);
 const resourceKeyArb = fc.constantFrom(...resourceKeys);
 const resourceMapArb = fc.dictionary(
-  resourceKeyArb,
-  fc.integer({ min: 1, max: 5 }),
+	resourceKeyArb,
+	fc.integer({ min: 1, max: 5 }),
 );
 
 function toResourceEffects(map: Record<string, number>) {
-  return Object.entries(map).map(([key, amount]) => ({
-    type: 'resource' as const,
-    method: 'add' as const,
-    params: { key, amount },
-  }));
+	return Object.entries(map).map(([key, amount]) => ({
+		type: 'resource' as const,
+		method: 'add' as const,
+		params: { key, amount },
+	}));
 }
 
 describe('engine property invariants', () => {
-  it('pays costs, executes triggers, keeps resources non-negative and preserves snapshots', () => {
-    fc.assert(
-      fc.property(
-        resourceMapArb, // action base costs
-        resourceMapArb, // building costs
-        resourceMapArb, // onBuild gains
-        (baseCosts, buildingCosts, gains) => {
-          const content = createContentFactory();
-          const building = content.building({
-            costs: buildingCosts,
-            onBuild: toResourceEffects(gains),
-          });
-          const action = content.action({
-            baseCosts,
-            effects: [
-              { type: 'building', method: 'add', params: { id: building.id } },
-            ],
-          });
-          const ctx = createTestEngine(content);
-          toMain(ctx);
-          const costs = getActionCosts(action.id, ctx, { id: building.id });
-          for (const [key, amount] of Object.entries(costs)) {
-            ctx.activePlayer.resources[key] = amount;
-          }
-          const before = snapshotPlayer(ctx.activePlayer, ctx);
-          const beforeCopy = JSON.parse(JSON.stringify(before));
-          performAction(action.id, ctx, { id: building.id });
-          expect(ctx.activePlayer.buildings.has(building.id)).toBe(true);
-          for (const key of Object.keys(ctx.activePlayer.resources)) {
-            expect(ctx.activePlayer.resources[key]).toBeGreaterThanOrEqual(0);
-          }
-          for (const key of new Set([
-            ...Object.keys(costs),
-            ...Object.keys(gains),
-          ])) {
-            const expected =
-              (before.resources[key] ?? 0) -
-              (costs[key] ?? 0) +
-              (gains[key] ?? 0);
-            expect(ctx.activePlayer.resources[key]).toBe(expected);
-          }
-          expect(before).toEqual(beforeCopy);
-          expect(before.buildings.includes(building.id)).toBe(false);
-        },
-      ),
-    );
-  });
+	it('pays costs, executes triggers, keeps resources non-negative and preserves snapshots', () => {
+		fc.assert(
+			fc.property(
+				resourceMapArb, // action base costs
+				resourceMapArb, // building costs
+				resourceMapArb, // onBuild gains
+				(baseCosts, buildingCosts, gains) => {
+					const content = createContentFactory();
+					const building = content.building({
+						costs: buildingCosts,
+						onBuild: toResourceEffects(gains),
+					});
+					const action = content.action({
+						baseCosts,
+						effects: [
+							{ type: 'building', method: 'add', params: { id: building.id } },
+						],
+					});
+					const ctx = createTestEngine(content);
+					toMain(ctx);
+					const costs = getActionCosts(action.id, ctx, { id: building.id });
+					for (const [key, amount] of Object.entries(costs)) {
+						ctx.activePlayer.resources[key] = amount;
+					}
+					const before = snapshotPlayer(ctx.activePlayer, ctx);
+					const beforeCopy = JSON.parse(JSON.stringify(before));
+					performAction(action.id, ctx, { id: building.id });
+					expect(ctx.activePlayer.buildings.has(building.id)).toBe(true);
+					for (const key of Object.keys(ctx.activePlayer.resources)) {
+						expect(ctx.activePlayer.resources[key]).toBeGreaterThanOrEqual(0);
+					}
+					for (const key of new Set([
+						...Object.keys(costs),
+						...Object.keys(gains),
+					])) {
+						const expected =
+							(before.resources[key] ?? 0) -
+							(costs[key] ?? 0) +
+							(gains[key] ?? 0);
+						expect(ctx.activePlayer.resources[key]).toBe(expected);
+					}
+					expect(before).toEqual(beforeCopy);
+					expect(before.buildings.includes(building.id)).toBe(false);
+				},
+			),
+		);
+	});
 });

--- a/packages/engine/tests/phases/growth.test.ts
+++ b/packages/engine/tests/phases/growth.test.ts
@@ -8,7 +8,9 @@ describe('Growth phase', () => {
 		const player = ctx.activePlayer;
 		const apBefore = player.resources[resources.ap];
 		const goldBefore = player.resources[resources.gold];
-		while (ctx.game.currentPhase === ids.phases.growth) advance(ctx);
+		while (ctx.game.currentPhase === ids.phases.growth) {
+			advance(ctx);
+		}
 		const councils = player.population[roles.council];
 		expect(player.resources[resources.ap]).toBe(
 			apBefore + values.councilApGain * councils,
@@ -81,7 +83,9 @@ describe('Growth phase', () => {
 		player.stats[stats.army] = 8;
 		player.stats[stats.fort] = 4;
 		const growth = player.stats[stats.growth];
-		while (ctx.game.currentPhase === ids.phases.growth) advance(ctx);
+		while (ctx.game.currentPhase === ids.phases.growth) {
+			advance(ctx);
+		}
 		const expectedArmy = Math.ceil(8 + 8 * growth);
 		const expectedFort = Math.ceil(4 + 4 * growth);
 		expect(player.stats[stats.army]).toBe(expectedArmy);
@@ -100,7 +104,9 @@ describe('Growth phase', () => {
 		player.stats[stats.army] = 10;
 		player.stats[stats.fort] = 10;
 		const growth = player.stats[stats.growth];
-		while (ctx.game.currentPhase === ids.phases.growth) advance(ctx);
+		while (ctx.game.currentPhase === ids.phases.growth) {
+			advance(ctx);
+		}
 		const expectedArmy = Math.ceil(10 + 10 * growth * 2);
 		const expectedFort = Math.ceil(10 + 10 * growth * 2);
 		expect(player.stats[stats.army]).toBe(expectedArmy);
@@ -144,7 +150,9 @@ describe('Growth phase', () => {
 			player.stats[stats.army] = baseArmy;
 			player.stats[stats.fort] = baseFort;
 			const baseGrowth = values.baseGrowth;
-			while (ctx.game.currentPhase === ids.phases.growth) advance(ctx);
+			while (ctx.game.currentPhase === ids.phases.growth) {
+				advance(ctx);
+			}
 			const expectedArmy = Math.ceil(
 				baseArmy + baseArmy * baseGrowth * legions,
 			);
@@ -166,7 +174,9 @@ describe('Growth phase', () => {
 			player.population[roles.fortifier] = 1;
 			player.stats[stats.army] = -5;
 			player.stats[stats.fort] = -5;
-			while (ctx.game.currentPhase === ids.phases.growth) advance(ctx);
+			while (ctx.game.currentPhase === ids.phases.growth) {
+				advance(ctx);
+			}
 			expect(player.stats[stats.army]).toBe(0);
 			expect(player.stats[stats.fort]).toBe(0);
 			expect(Number.isInteger(player.stats[stats.army])).toBe(true);

--- a/packages/engine/tests/plunder-zero-gold.test.ts
+++ b/packages/engine/tests/plunder-zero-gold.test.ts
@@ -5,29 +5,31 @@ import { createContentFactory } from './factories/content';
 import { createTestEngine } from './helpers';
 
 function toMain(ctx: ReturnType<typeof createTestEngine>) {
-  while (ctx.game.currentPhase !== 'main') advance(ctx);
+	while (ctx.game.currentPhase !== 'main') {
+		advance(ctx);
+	}
 }
 
 describe('plunder action with zero opponent resource', () => {
-  it("doesn't modify resources when opponent has none", () => {
-    const content = createContentFactory();
-    const action = content.action({
-      baseCosts: { [CResource.ap]: 0 },
-      effects: [
-        {
-          type: 'resource',
-          method: 'transfer',
-          params: { key: CResource.gold },
-        },
-      ],
-    });
-    const ctx = createTestEngine(content);
-    toMain(ctx);
-    ctx.opponent.resources[CResource.gold] = 0;
-    const beforeAttacker = ctx.activePlayer.resources[CResource.gold] ?? 0;
-    const beforeDefender = ctx.opponent.resources[CResource.gold] ?? 0;
-    expect(() => performAction(action.id, ctx)).not.toThrow();
-    expect(ctx.activePlayer.resources[CResource.gold]).toBe(beforeAttacker);
-    expect(ctx.opponent.resources[CResource.gold]).toBe(beforeDefender);
-  });
+	it("doesn't modify resources when opponent has none", () => {
+		const content = createContentFactory();
+		const action = content.action({
+			baseCosts: { [CResource.ap]: 0 },
+			effects: [
+				{
+					type: 'resource',
+					method: 'transfer',
+					params: { key: CResource.gold },
+				},
+			],
+		});
+		const ctx = createTestEngine(content);
+		toMain(ctx);
+		ctx.opponent.resources[CResource.gold] = 0;
+		const beforeAttacker = ctx.activePlayer.resources[CResource.gold] ?? 0;
+		const beforeDefender = ctx.opponent.resources[CResource.gold] ?? 0;
+		expect(() => performAction(action.id, ctx)).not.toThrow();
+		expect(ctx.activePlayer.resources[CResource.gold]).toBe(beforeAttacker);
+		expect(ctx.opponent.resources[CResource.gold]).toBe(beforeDefender);
+	});
 });

--- a/packages/engine/tests/registry/registry.test.ts
+++ b/packages/engine/tests/registry/registry.test.ts
@@ -3,17 +3,17 @@ import { z } from 'zod';
 import { Registry } from '../../src/registry.ts';
 
 describe('Registry', () => {
-  it('adds and retrieves values using schema', () => {
-    const schema = z.object({ value: z.number() });
-    const registry = new Registry<{ value: number }>(schema);
-    const entry = { value: 1 };
-    registry.add('one', entry);
-    expect(registry.get('one')).toEqual(entry);
-  });
+	it('adds and retrieves values using schema', () => {
+		const schema = z.object({ value: z.number() });
+		const registry = new Registry<{ value: number }>(schema);
+		const entry = { value: 1 };
+		registry.add('one', entry);
+		expect(registry.get('one')).toEqual(entry);
+	});
 
-  it('throws when id is unknown', () => {
-    const registry = new Registry<{ id: string }>();
-    registry.add('known', { id: 'known' });
-    expect(() => registry.get('unknown')).toThrow('Unknown id: unknown');
-  });
+	it('throws when id is unknown', () => {
+		const registry = new Registry<{ id: string }>();
+		registry.add('known', { id: 'known' });
+		expect(() => registry.get('unknown')).toThrow('Unknown id: unknown');
+	});
 });

--- a/packages/engine/tests/requirements/evaluator_compare.test.ts
+++ b/packages/engine/tests/requirements/evaluator_compare.test.ts
@@ -6,24 +6,26 @@ import { advance } from '../../src';
 import { Stat } from '@kingdom-builder/contents';
 
 describe('evaluator:compare requirement', () => {
-  it('compares stat values', () => {
-    const ctx = createTestEngine(createContentFactory());
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
-    ctx.activePlayer.stats[Stat.maxPopulation] = 2;
-    const req = {
-      params: {
-        left: { type: 'stat', params: { key: Stat.maxPopulation } },
-        right: 1,
-        operator: 'gt',
-      },
-    } as unknown as Parameters<typeof evaluatorCompare>[0];
-    expect(evaluatorCompare(req, ctx)).toBe(true);
-    req.params.operator = 'lte';
-    expect(evaluatorCompare(req, ctx)).toBe('Requirement failed');
-    req.params.operator = 'eq';
-    req.params.right = 2;
-    expect(evaluatorCompare(req, ctx)).toBe(true);
-    req.params.operator = 'ne';
-    expect(evaluatorCompare(req, ctx)).toBe('Requirement failed');
-  });
+	it('compares stat values', () => {
+		const ctx = createTestEngine(createContentFactory());
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
+		ctx.activePlayer.stats[Stat.maxPopulation] = 2;
+		const req = {
+			params: {
+				left: { type: 'stat', params: { key: Stat.maxPopulation } },
+				right: 1,
+				operator: 'gt',
+			},
+		} as unknown as Parameters<typeof evaluatorCompare>[0];
+		expect(evaluatorCompare(req, ctx)).toBe(true);
+		req.params.operator = 'lte';
+		expect(evaluatorCompare(req, ctx)).toBe('Requirement failed');
+		req.params.operator = 'eq';
+		req.params.right = 2;
+		expect(evaluatorCompare(req, ctx)).toBe(true);
+		req.params.operator = 'ne';
+		expect(evaluatorCompare(req, ctx)).toBe('Requirement failed');
+	});
 });

--- a/packages/engine/tests/resolveAttack.test.ts
+++ b/packages/engine/tests/resolveAttack.test.ts
@@ -349,8 +349,9 @@ describe('resolveAttack', () => {
 		expect(defender.resources[Resource.castleHP]).toBe(castleBefore);
 		expect(defender.buildings.has(stronghold.id)).toBe(false);
 		expect(result.evaluation.target.type).toBe('building');
-		if (result.evaluation.target.type === 'building')
+		if (result.evaluation.target.type === 'building') {
 			expect(result.evaluation.target.destroyed).toBe(true);
+		}
 	});
 
 	it('delegates target application to registered handlers', () => {

--- a/packages/engine/tests/result-mod-stack.test.ts
+++ b/packages/engine/tests/result-mod-stack.test.ts
@@ -5,69 +5,71 @@ import { createContentFactory } from './factories/content';
 import { createTestEngine } from './helpers';
 
 describe('result modifiers', () => {
-  it('stack for the same action', () => {
-    const resourceKey = Object.values(CResource)[0];
-    const baseGain = 1;
-    const modGainA = 2;
-    const modGainB = 3;
+	it('stack for the same action', () => {
+		const resourceKey = Object.values(CResource)[0];
+		const baseGain = 1;
+		const modGainA = 2;
+		const modGainB = 3;
 
-    const content = createContentFactory();
-    const action = content.action({
-      effects: [
-        {
-          type: 'resource',
-          method: 'add',
-          params: { key: resourceKey, amount: baseGain },
-        },
-      ],
-    });
+		const content = createContentFactory();
+		const action = content.action({
+			effects: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: resourceKey, amount: baseGain },
+				},
+			],
+		});
 
-    const passiveA = {
-      id: 'pa',
-      effects: [
-        {
-          type: 'result_mod',
-          method: 'add',
-          params: { id: 'ma', actionId: action.id },
-          effects: [
-            {
-              type: 'resource',
-              method: 'add',
-              params: { key: resourceKey, amount: modGainA },
-            },
-          ],
-        },
-      ],
-    };
+		const passiveA = {
+			id: 'pa',
+			effects: [
+				{
+					type: 'result_mod',
+					method: 'add',
+					params: { id: 'ma', actionId: action.id },
+					effects: [
+						{
+							type: 'resource',
+							method: 'add',
+							params: { key: resourceKey, amount: modGainA },
+						},
+					],
+				},
+			],
+		};
 
-    const passiveB = {
-      id: 'pb',
-      effects: [
-        {
-          type: 'result_mod',
-          method: 'add',
-          params: { id: 'mb', actionId: action.id },
-          effects: [
-            {
-              type: 'resource',
-              method: 'add',
-              params: { key: resourceKey, amount: modGainB },
-            },
-          ],
-        },
-      ],
-    };
+		const passiveB = {
+			id: 'pb',
+			effects: [
+				{
+					type: 'result_mod',
+					method: 'add',
+					params: { id: 'mb', actionId: action.id },
+					effects: [
+						{
+							type: 'resource',
+							method: 'add',
+							params: { key: resourceKey, amount: modGainB },
+						},
+					],
+				},
+			],
+		};
 
-    const ctx = createTestEngine(content);
-    while (ctx.game.currentPhase !== 'main') advance(ctx);
+		const ctx = createTestEngine(content);
+		while (ctx.game.currentPhase !== 'main') {
+			advance(ctx);
+		}
 
-    ctx.passives.addPassive(passiveA, ctx);
-    ctx.passives.addPassive(passiveB, ctx);
+		ctx.passives.addPassive(passiveA, ctx);
+		ctx.passives.addPassive(passiveB, ctx);
 
-    const before = ctx.activePlayer.resources[resourceKey] ?? 0;
-    performAction(action.id, ctx);
-    const after = ctx.activePlayer.resources[resourceKey] ?? 0;
+		const before = ctx.activePlayer.resources[resourceKey] ?? 0;
+		performAction(action.id, ctx);
+		const after = ctx.activePlayer.resources[resourceKey] ?? 0;
 
-    expect(after).toBe(before + baseGain + modGainA + modGainB);
-  });
+		expect(after).toBe(before + baseGain + modGainA + modGainB);
+	});
 });

--- a/packages/engine/tests/services/rules.test.ts
+++ b/packages/engine/tests/services/rules.test.ts
@@ -132,7 +132,7 @@ describe('PassiveManager', () => {
 		const content = createContentFactory();
 		const action = content.action();
 		const ctx = createTestEngine({ actions: content.actions });
-		ctx.passives.registerResultModifier('happy', (_a, innerCtx) => {
+		ctx.passives.registerResultModifier('happy', (_result, innerCtx) => {
 			innerCtx.activePlayer.happiness += 1;
 		});
 		ctx.passives.runResultMods(action.id, ctx);

--- a/packages/engine/tests/state/state.test.ts
+++ b/packages/engine/tests/state/state.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
-  Land,
-  PlayerState,
-  GameState,
-  setResourceKeys,
-  setStatKeys,
+	Land,
+	PlayerState,
+	GameState,
+	setResourceKeys,
+	setStatKeys,
 } from '../../src/state/index.ts';
 import { Resource, Stat } from '@kingdom-builder/contents';
 
@@ -12,43 +12,43 @@ setResourceKeys(Object.values(Resource));
 setStatKeys(Object.values(Stat));
 
 describe('State classes', () => {
-  it('calculates free slots on land', () => {
-    const land = new Land('l1', 2, true);
-    expect(land.slotsFree).toBe(2);
-    land.slotsUsed = 1;
-    expect(land.slotsFree).toBe(1);
-  });
+	it('calculates free slots on land', () => {
+		const land = new Land('l1', 2, true);
+		expect(land.slotsFree).toBe(2);
+		land.slotsUsed = 1;
+		expect(land.slotsFree).toBe(1);
+	});
 
-  it('updates resources and stats via getters and setters', () => {
-    const player = new PlayerState('A', 'Alice');
-    player.gold = 5;
-    player.maxPopulation = 3;
-    player.warWeariness = 2;
-    expect(player.gold).toBe(5);
-    expect(player.maxPopulation).toBe(3);
-    expect(player.warWeariness).toBe(2);
-  });
+	it('updates resources and stats via getters and setters', () => {
+		const player = new PlayerState('A', 'Alice');
+		player.gold = 5;
+		player.maxPopulation = 3;
+		player.warWeariness = 2;
+		expect(player.gold).toBe(5);
+		expect(player.maxPopulation).toBe(3);
+		expect(player.warWeariness).toBe(2);
+	});
 
-  it('defaults war weariness to 0', () => {
-    const player = new PlayerState('A', 'Alice');
-    expect(player.warWeariness).toBe(0);
-  });
+	it('defaults war weariness to 0', () => {
+		const player = new PlayerState('A', 'Alice');
+		expect(player.warWeariness).toBe(0);
+	});
 
-  it('tracks stat history when values become non-zero', () => {
-    const player = new PlayerState('A', 'Alice');
-    expect(player.statsHistory[Stat.armyStrength]).toBe(false);
-    player.armyStrength = 1;
-    expect(player.statsHistory[Stat.armyStrength]).toBe(true);
-    player.armyStrength = 0;
-    expect(player.statsHistory[Stat.armyStrength]).toBe(true);
-  });
+	it('tracks stat history when values become non-zero', () => {
+		const player = new PlayerState('A', 'Alice');
+		expect(player.statsHistory[Stat.armyStrength]).toBe(false);
+		player.armyStrength = 1;
+		expect(player.statsHistory[Stat.armyStrength]).toBe(true);
+		player.armyStrength = 0;
+		expect(player.statsHistory[Stat.armyStrength]).toBe(true);
+	});
 
-  it('provides active and opponent players', () => {
-    const game = new GameState('Alice', 'Bob');
-    expect(game.active.id).toBe('A');
-    expect(game.opponent.id).toBe('B');
-    game.currentPlayerIndex = 1;
-    expect(game.active.id).toBe('B');
-    expect(game.opponent.id).toBe('A');
-  });
+	it('provides active and opponent players', () => {
+		const game = new GameState('Alice', 'Bob');
+		expect(game.active.id).toBe('A');
+		expect(game.opponent.id).toBe('B');
+		game.currentPlayerIndex = 1;
+		expect(game.active.id).toBe('B');
+		expect(game.opponent.id).toBe('A');
+	});
 });

--- a/packages/engine/tests/utils/applyParamsToEffects.test.ts
+++ b/packages/engine/tests/utils/applyParamsToEffects.test.ts
@@ -3,48 +3,48 @@ import { applyParamsToEffects } from '../../src/utils.ts';
 import { Resource } from '../../src/state/index.ts';
 
 describe('applyParamsToEffects', () => {
-  it('replaces placeholders in params, evaluator and nested effects', () => {
-    const effects = [
-      {
-        type: 'resource',
-        method: 'add',
-        params: { key: '$key', amount: '$amount' },
-        evaluator: { type: 'dummy', params: { times: '$count' } },
-        effects: [
-          {
-            type: 'resource',
-            method: 'add',
-            params: { key: '$nestedKey', amount: '$nestedAmount' },
-          },
-        ],
-      },
-    ];
-    const params = {
-      key: Resource.gold,
-      amount: 2,
-      count: 3,
-      nestedKey: Resource.ap,
-      nestedAmount: 1,
-    };
-    const applied = applyParamsToEffects(effects, params);
-    const effect = applied[0]!;
-    expect(effect.params?.key).toBe(params.key);
-    expect(effect.params?.amount).toBe(params.amount);
-    expect(effect.evaluator?.params?.times).toBe(params.count);
-    expect(effect.effects?.[0]?.params?.key).toBe(params.nestedKey);
-    expect(effect.effects?.[0]?.params?.amount).toBe(params.nestedAmount);
-  });
+	it('replaces placeholders in params, evaluator and nested effects', () => {
+		const effects = [
+			{
+				type: 'resource',
+				method: 'add',
+				params: { key: '$key', amount: '$amount' },
+				evaluator: { type: 'dummy', params: { times: '$count' } },
+				effects: [
+					{
+						type: 'resource',
+						method: 'add',
+						params: { key: '$nestedKey', amount: '$nestedAmount' },
+					},
+				],
+			},
+		];
+		const params = {
+			key: Resource.gold,
+			amount: 2,
+			count: 3,
+			nestedKey: Resource.ap,
+			nestedAmount: 1,
+		};
+		const applied = applyParamsToEffects(effects, params);
+		const effect = applied[0]!;
+		expect(effect.params?.key).toBe(params.key);
+		expect(effect.params?.amount).toBe(params.amount);
+		expect(effect.evaluator?.params?.times).toBe(params.count);
+		expect(effect.effects?.[0]?.params?.key).toBe(params.nestedKey);
+		expect(effect.effects?.[0]?.params?.amount).toBe(params.nestedAmount);
+	});
 
-  it('leaves non-placeholder strings untouched', () => {
-    const effects = [
-      {
-        type: 'resource',
-        method: 'add',
-        params: { key: 'static', amount: '$amount' },
-      },
-    ];
-    const applied = applyParamsToEffects(effects, { amount: 5 });
-    expect(applied[0]?.params?.key).toBe('static');
-    expect(applied[0]?.params?.amount).toBe(5);
-  });
+	it('leaves non-placeholder strings untouched', () => {
+		const effects = [
+			{
+				type: 'resource',
+				method: 'add',
+				params: { key: 'static', amount: '$amount' },
+			},
+		];
+		const applied = applyParamsToEffects(effects, { amount: 5 });
+		expect(applied[0]?.params?.key).toBe('static');
+		expect(applied[0]?.params?.amount).toBe(5);
+	});
 });

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -520,7 +520,8 @@ function DevelopOptions({
 							([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
 						);
 					const summary = summaries.get(d.id);
-					const implemented = (summary?.length ?? 0) > 0; // TODO: implement development effects
+					const implemented = (summary?.length ?? 0) > 0;
+					// TODO: implement development effects
 					const enabled = canPay && isActionPhase && canInteract && implemented;
 					const insufficientTooltip = formatMissingResources(
 						costs,
@@ -658,7 +659,8 @@ function BuildOptions({
 						([k, v]) => (player.resources[k] || 0) >= (v ?? 0),
 					);
 					const summary = summaries.get(b.id);
-					const implemented = (summary?.length ?? 0) > 0; // TODO: implement building effects
+					const implemented = (summary?.length ?? 0) > 0;
+					// TODO: implement building effects
 					const enabled = canPay && isActionPhase && canInteract && implemented;
 					const insufficientTooltip = formatMissingResources(
 						costs,

--- a/packages/web/src/utils/getRequirementIcons.ts
+++ b/packages/web/src/utils/getRequirementIcons.ts
@@ -50,10 +50,14 @@ export type RequirementIconGetter = (
  * Register additional handlers via {@link registerRequirementIconGetter}:
  *
  * ```ts
- * const unregister = registerRequirementIconGetter('myType', 'myMethod', (requirement, ctx) => {
+ * const unregister = registerRequirementIconGetter(
+ *         'myType',
+ *         'myMethod',
+ *         (requirement, ctx) => {
  *         // derive icons from requirement.params / ctx
  *         return ['🛠️'];
- * });
+ *         },
+ * );
  * // Call unregister() in tests or teardown logic if necessary.
  * ```
  */
@@ -94,7 +98,8 @@ export function getRequirementIcons(
 		return [];
 	}
 	const icons: string[] = [];
-	for (const requirement of actionDefinition.requirements as RequirementConfig[]) {
+	const requirements = actionDefinition.requirements as RequirementConfig[];
+	for (const requirement of requirements) {
 		const registryKey = `${requirement.type}:${requirement.method}`;
 		const getter = REQUIREMENT_ICON_GETTERS.get(registryKey);
 		if (!getter) {

--- a/packages/web/tests/Game.render.test.tsx
+++ b/packages/web/tests/Game.render.test.tsx
@@ -7,11 +7,12 @@ import Game from '../src/Game';
 // dynamic action effects (e.g. build with "$id") don't crash
 // the rendering pipeline when summarized.
 vi.mock('@kingdom-builder/engine', async () => {
-  // Re-export the actual engine source since vitest doesn't resolve the monorepo alias
-  return await import('../../engine/src');
+	// Re-export the actual engine source since vitest doesn't
+	// resolve the monorepo alias.
+	return await import('../../engine/src');
 });
 describe('<Game /> integration', () => {
-  it('renders without crashing', () => {
-    expect(() => renderToString(<Game />)).not.toThrow();
-  });
+	it('renders without crashing', () => {
+		expect(() => renderToString(<Game />)).not.toThrow();
+	});
 });

--- a/packages/web/tests/development-translation.test.ts
+++ b/packages/web/tests/development-translation.test.ts
@@ -1,112 +1,115 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-  createEngine,
-  type EffectDef,
-  type EngineContext,
+	createEngine,
+	type EffectDef,
+	type EngineContext,
 } from '@kingdom-builder/engine';
 import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
-  type DevelopmentDef,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	type DevelopmentDef,
 } from '@kingdom-builder/contents';
 import {
-  describeContent,
-  logContent,
-  summarizeContent,
-  type SummaryEntry,
+	describeContent,
+	logContent,
+	summarizeContent,
+	type SummaryEntry,
 } from '../src/translation';
 
 vi.mock('@kingdom-builder/engine', async () => {
-  return await import('../../engine/src');
+	return await import('../../engine/src');
 });
 
 const ctx = createEngine({
-  actions: ACTIONS,
-  buildings: BUILDINGS,
-  developments: DEVELOPMENTS,
-  populations: POPULATIONS,
-  phases: PHASES,
-  start: GAME_START,
-  rules: RULES,
+	actions: ACTIONS,
+	buildings: BUILDINGS,
+	developments: DEVELOPMENTS,
+	populations: POPULATIONS,
+	phases: PHASES,
+	start: GAME_START,
+	rules: RULES,
 });
 
 function flatten(entries: SummaryEntry[]): string[] {
-  const result: string[] = [];
-  for (const entry of entries) {
-    if (typeof entry === 'string') {
-      result.push(entry);
-    } else {
-      result.push(entry.title);
-      result.push(...flatten(entry.items));
-    }
-  }
-  return result;
+	const result: string[] = [];
+	for (const entry of entries) {
+		if (typeof entry === 'string') {
+			result.push(entry);
+		} else {
+			result.push(entry.title);
+			result.push(...flatten(entry.items));
+		}
+	}
+	return result;
 }
 
 function hasSelfEvaluator(effects: EffectDef[] | undefined): boolean {
-  if (!effects) return false;
-  for (const effect of effects) {
-    const params = effect.evaluator?.params as
-      | Record<string, unknown>
-      | undefined;
-    if (effect.evaluator?.type === 'development' && params?.['id'] === '$id') {
-      return true;
-    }
-    if (hasSelfEvaluator(effect.effects as EffectDef[] | undefined))
-      return true;
-  }
-  return false;
+	if (!effects) {
+		return false;
+	}
+	for (const effect of effects) {
+		const params = effect.evaluator?.params as
+			| Record<string, unknown>
+			| undefined;
+		if (effect.evaluator?.type === 'development' && params?.['id'] === '$id') {
+			return true;
+		}
+		if (hasSelfEvaluator(effect.effects as EffectDef[] | undefined)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 function findSelfReferentialDevelopment(
-  registry: Iterable<[string, DevelopmentDef]>,
+	registry: Iterable<[string, DevelopmentDef]>,
 ): string {
-  for (const [id, def] of registry) {
-    const values = def as unknown as Record<string, unknown>;
-    for (const value of Object.values(values)) {
-      if (Array.isArray(value) && hasSelfEvaluator(value as EffectDef[])) {
-        return id;
-      }
-    }
-  }
-  throw new Error('Expected development with self-referential evaluator');
+	for (const [id, def] of registry) {
+		const values = def as unknown as Record<string, unknown>;
+		for (const value of Object.values(values)) {
+			if (Array.isArray(value) && hasSelfEvaluator(value as EffectDef[])) {
+				return id;
+			}
+		}
+	}
+	throw new Error('Expected development with self-referential evaluator');
 }
 
 describe('development translation', () => {
-  it('replaces self-referential placeholders when describing developments', () => {
-    const id = findSelfReferentialDevelopment(DEVELOPMENTS.entries());
-    const summary = summarizeContent('development', id, ctx as EngineContext);
-    const description = describeContent(
-      'development',
-      id,
-      ctx as EngineContext,
-    );
-    const strings = [...flatten(summary), ...flatten(description)];
+	it('replaces self-referential placeholders when describing developments', () => {
+		const id = findSelfReferentialDevelopment(DEVELOPMENTS.entries());
+		const summary = summarizeContent('development', id, ctx as EngineContext);
+		const description = describeContent(
+			'development',
+			id,
+			ctx as EngineContext,
+		);
+		const strings = [...flatten(summary), ...flatten(description)];
 
-    expect(strings.some((line) => line.includes('$id'))).toBe(false);
+		expect(strings.some((line) => line.includes('$id'))).toBe(false);
 
-    const def = ctx.developments.get(id);
-    const icon = def.icon || '';
+		const def = ctx.developments.get(id);
+		const icon = def.icon || '';
 
-    expect(strings.some((line) => /During income step/.test(line))).toBe(true);
-    expect(strings.some((line) => /\+2/.test(line))).toBe(true);
-    expect(strings.some((line) => /Gold/.test(line))).toBe(true);
-    const prohibited = strings.filter(
-      (line) =>
-        line.includes(`per ${icon} ${def.name}`) ||
-        line.includes(`for each ${icon} ${def.name}`),
-    );
-    expect(prohibited).toHaveLength(0);
+		expect(strings.some((line) => /During income step/.test(line))).toBe(true);
+		expect(strings.some((line) => /\+2/.test(line))).toBe(true);
+		expect(strings.some((line) => /Gold/.test(line))).toBe(true);
+		const prohibited = strings.filter(
+			(line) =>
+				line.includes(`per ${icon} ${def.name}`) ||
+				line.includes(`for each ${icon} ${def.name}`),
+		);
+		expect(prohibited).toHaveLength(0);
 
-    const logEntry = logContent('development', id, ctx as EngineContext);
-    expect(logEntry.some((line) => line.includes(def.name))).toBe(true);
-    if (icon) {
-      expect(logEntry.some((line) => line.includes(icon))).toBe(true);
-    }
-  });
+		const logEntry = logContent('development', id, ctx as EngineContext);
+		expect(logEntry.some((line) => line.includes(def.name))).toBe(true);
+		if (icon) {
+			expect(logEntry.some((line) => line.includes(icon))).toBe(true);
+		}
+	});
 });

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -63,7 +63,9 @@ describe('log resource sources', () => {
 		);
 		const before = snapshotPlayer(ctx.activePlayer, ctx);
 		const bundles = collectTriggerEffects('onGainIncomeStep', ctx);
-		for (const bundle of bundles) runEffects(bundle.effects, ctx);
+		for (const bundle of bundles) {
+			runEffects(bundle.effects, ctx);
+		}
 		const effects = bundles.flatMap((bundle) => bundle.effects);
 		const after = snapshotPlayer(ctx.activePlayer, ctx);
 		const lines = diffStepSnapshots(
@@ -105,7 +107,9 @@ describe('log resource sources', () => {
 			],
 			ctx,
 		);
-		while (ctx.game.currentPhase !== SYNTHETIC_PHASE_IDS.main) advance(ctx);
+		while (ctx.game.currentPhase !== SYNTHETIC_PHASE_IDS.main) {
+			advance(ctx);
+		}
 		const step = {
 			id: SYNTHETIC_IDS.taxAction,
 			effects: ctx.actions.get(SYNTHETIC_IDS.taxAction).effects,
@@ -157,7 +161,9 @@ describe('log resource sources', () => {
 		);
 		const before = snapshotPlayer(ctx.activePlayer, ctx);
 		const bundles = collectTriggerEffects('onPayUpkeepStep', ctx);
-		for (const bundle of bundles) runEffects(bundle.effects, ctx);
+		for (const bundle of bundles) {
+			runEffects(bundle.effects, ctx);
+		}
 		const effects = bundles.flatMap((bundle) => bundle.effects);
 		const after = snapshotPlayer(ctx.activePlayer, ctx);
 		const lines = diffStepSnapshots(
@@ -183,26 +189,40 @@ describe('log resource sources', () => {
 						source?: { type?: string; id?: string; count?: number };
 					}
 				)?.source;
-				if (!source?.type) return '';
+				if (!source?.type) {
+					return '';
+				}
 				if (source.type === 'population') {
 					const role = source.id;
 					const icon = role
 						? ctx.populations.get(role)?.icon || role
 						: SYNTHETIC_POPULATION_INFO.icon;
-					if (!icon) return '';
-					if (source.count === undefined) return icon;
+					if (!icon) {
+						return '';
+					}
+					if (source.count === undefined) {
+						return icon;
+					}
 					const rawCount = Number(source.count);
-					if (!Number.isFinite(rawCount)) return icon;
+					if (!Number.isFinite(rawCount)) {
+						return icon;
+					}
 					const normalizedCount =
 						rawCount > 0 ? Math.max(1, Math.round(rawCount)) : 0;
-					if (normalizedCount === 0) return '';
+					if (normalizedCount === 0) {
+						return '';
+					}
 					return icon.repeat(normalizedCount);
 				}
-				if (source.type === 'development' && source.id)
+				if (source.type === 'development' && source.id) {
 					return ctx.developments.get(source.id)?.icon || '';
-				if (source.type === 'building' && source.id)
+				}
+				if (source.type === 'building' && source.id) {
 					return ctx.buildings.get(source.id)?.icon || '';
-				if (source.type === 'land') return SYNTHETIC_LAND_INFO.icon || '';
+				}
+				if (source.type === 'land') {
+					return SYNTHETIC_LAND_INFO.icon || '';
+				}
 				return '';
 			})
 			.filter(Boolean)

--- a/packages/web/tests/stat-descriptor-registry.test.ts
+++ b/packages/web/tests/stat-descriptor-registry.test.ts
@@ -21,16 +21,22 @@ import {
 import { getStatBreakdownSummary, formatStatValue } from '../src/utils/stats';
 
 const collectSummaryLines = (entry: unknown): string[] => {
-	if (typeof entry === 'string') return [entry];
-	if (!entry || typeof entry !== 'object') return [];
+	if (typeof entry === 'string') {
+		return [entry];
+	}
+	if (!entry || typeof entry !== 'object') {
+		return [];
+	}
 	const record = entry as { title?: unknown; items?: unknown[] };
 	const lines: string[] = [];
-	if (typeof record.title === 'string' && record.title.trim())
+	if (typeof record.title === 'string' && record.title.trim()) {
 		lines.push(record.title);
-	if (Array.isArray(record.items))
+	}
+	if (Array.isArray(record.items)) {
 		record.items.forEach((item) => {
 			collectSummaryLines(item).forEach((line) => lines.push(line));
 		});
+	}
 	return lines;
 };
 
@@ -120,38 +126,59 @@ describe('stat descriptor registry', () => {
 			startLine,
 			unknownLine,
 		] = triggered;
-		if (populationRole.icon)
+		if (populationRole.icon) {
 			expect(populationLine).toContain(populationRole.icon);
+		}
 		expect(populationLine).toContain(populationRole.label ?? populationId);
 		expect(populationLine).toContain(`×${player.population[populationId]}`);
-		if (building.icon) expect(buildingLine).toContain(building.icon);
+		if (building.icon) {
+			expect(buildingLine).toContain(building.icon);
+		}
 		expect(buildingLine).toContain(building.name ?? buildingId);
-		if (development.icon) expect(developmentLine).toContain(development.icon);
+		if (development.icon) {
+			expect(developmentLine).toContain(development.icon);
+		}
 		expect(developmentLine).toContain(development.name ?? developmentId);
 		const phaseParts: string[] = [];
-		if (phaseWithStep!.icon) phaseParts.push(phaseWithStep!.icon);
-		if (phaseWithStep!.label) phaseParts.push(phaseWithStep!.label);
+		if (phaseWithStep!.icon) {
+			phaseParts.push(phaseWithStep!.icon);
+		}
+		if (phaseWithStep!.label) {
+			phaseParts.push(phaseWithStep!.label);
+		}
 		const phaseText = phaseParts.join(' ').trim();
 		const stepParts: string[] = [];
-		if (step!.icon) stepParts.push(step!.icon);
+		if (step!.icon) {
+			stepParts.push(step!.icon);
+		}
 		const stepLabel = step!.title ?? step!.id;
-		if (stepLabel) stepParts.push(stepLabel);
+		if (stepLabel) {
+			stepParts.push(stepLabel);
+		}
 		const stepText = stepParts.join(' ').trim();
 		const expectedPhaseText = stepText
 			? phaseText
 				? `${phaseText} · ${stepText}`
 				: stepText
 			: phaseText;
-		if (expectedPhaseText) expect(phaseLine).toContain(expectedPhaseText);
-		if (action.icon) expect(actionLine).toContain(action.icon);
+		if (expectedPhaseText) {
+			expect(phaseLine).toContain(expectedPhaseText);
+		}
+		if (action.icon) {
+			expect(actionLine).toContain(action.icon);
+		}
 		expect(actionLine).toContain(action.name ?? actionId);
 		const statInfo = STATS[secondaryStatKey as keyof typeof STATS];
-		if (statInfo?.icon) expect(statLine).toContain(statInfo.icon);
+		if (statInfo?.icon) {
+			expect(statLine).toContain(statInfo.icon);
+		}
 		expect(statLine).toContain(statInfo?.label ?? secondaryStatKey);
 		expect(statLine).toContain(
 			formatStatValue(secondaryStatKey, player.stats[secondaryStatKey]!),
 		);
-		if (resource?.icon) expect(resourceLine).toContain(resource.icon);
+		if (resource?.icon) {
+			expect(resourceLine).toContain(resource.icon);
+		}
 		expect(resourceLine).toContain(resource?.label ?? resourceKey);
 		const formatDetail = (detail: string) =>
 			detail
@@ -160,11 +187,15 @@ describe('stat descriptor registry', () => {
 				.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
 				.join(' ');
 		expect(resourceLine).toContain(formatDetail(resourceDetail));
-		if (triggerInfo?.icon) expect(triggerLine).toContain(triggerInfo.icon);
+		if (triggerInfo?.icon) {
+			expect(triggerLine).toContain(triggerInfo.icon);
+		}
 		expect(triggerLine).toContain(
 			triggerInfo?.past ?? triggerInfo?.future ?? triggerId,
 		);
-		if (PASSIVE_INFO.icon) expect(passiveLine).toContain(PASSIVE_INFO.icon);
+		if (PASSIVE_INFO.icon) {
+			expect(passiveLine).toContain(PASSIVE_INFO.icon);
+		}
 		expect(passiveLine).toContain(PASSIVE_INFO.label);
 		expect(landLine).toContain(String(landId));
 		expect(startLine).toContain('Initial Setup');

--- a/packages/web/tests/subaction-log.test.ts
+++ b/packages/web/tests/subaction-log.test.ts
@@ -56,7 +56,9 @@ describe('sub-action logging', () => {
 			costs,
 		) as (keyof typeof SYNTHETIC_RESOURCES)[]) {
 			const amt = costs[key] ?? 0;
-			if (!amt) continue;
+			if (!amt) {
+				continue;
+			}
 			const info = SYNTHETIC_RESOURCES[key];
 			const icon = info?.icon ? `${info.icon} ` : '';
 			const label = info?.label ?? key;
@@ -64,8 +66,9 @@ describe('sub-action logging', () => {
 			const a = b - amt;
 			costLines.push(`    ${icon}${label} -${amt} (${b}→${a})`);
 		}
-		if (costLines.length)
+		if (costLines.length) {
 			messages.splice(1, 0, '  💲 Action cost', ...costLines);
+		}
 
 		const subLines: string[] = [];
 		for (const trace of traces) {
@@ -76,26 +79,33 @@ describe('sub-action logging', () => {
 				ctx,
 				RESOURCE_KEYS,
 			);
-			if (!subChanges.length) continue;
+			if (!subChanges.length) {
+				continue;
+			}
 			subLines.push(...subChanges);
 			const action = ctx.actions.get(trace.id);
 			const icon = action?.icon || '';
 			const name = action?.name || trace.id;
 			const line = `  ${icon} ${name}`;
 			const idx = messages.indexOf(line);
-			if (idx !== -1)
+			if (idx !== -1) {
 				messages.splice(idx + 1, 0, ...subChanges.map((c) => `    ${c}`));
+			}
 		}
 
 		const costLabels = new Set(
 			Object.keys(costs) as (keyof typeof SYNTHETIC_RESOURCES)[],
 		);
 		const filtered = changes.filter((line) => {
-			if (subLines.includes(line)) return false;
+			if (subLines.includes(line)) {
+				return false;
+			}
 			for (const key of costLabels) {
 				const info = SYNTHETIC_RESOURCES[key];
 				const prefix = info?.icon ? `${info.icon} ${info.label}` : info.label;
-				if (line.startsWith(prefix)) return false;
+				if (line.startsWith(prefix)) {
+					return false;
+				}
 			}
 			return true;
 		});

--- a/packages/web/tests/tax-market-log.test.ts
+++ b/packages/web/tests/tax-market-log.test.ts
@@ -55,7 +55,9 @@ describe('tax action logging with market', () => {
 			ctx,
 		);
 		ctx.activePlayer.resources[SYNTHETIC_RESOURCE_KEYS.coin] = 0;
-		while (ctx.game.currentPhase !== SYNTHETIC_PHASE_IDS.main) advance(ctx);
+		while (ctx.game.currentPhase !== SYNTHETIC_PHASE_IDS.main) {
+			advance(ctx);
+		}
 		const action = ctx.actions.get(SYNTHETIC_IDS.taxAction);
 		const before = snapshotPlayer(ctx.activePlayer, ctx);
 		const costs = getActionCosts(SYNTHETIC_IDS.taxAction, ctx);
@@ -72,7 +74,9 @@ describe('tax action logging with market', () => {
 		const costLines: string[] = [];
 		for (const key of Object.keys(costs) as SyntheticResourceKey[]) {
 			const amt = costs[key] ?? 0;
-			if (!amt) continue;
+			if (!amt) {
+				continue;
+			}
 			const info = SYNTHETIC_RESOURCES[key];
 			const icon = info?.icon ? `${info.icon} ` : '';
 			const label = info?.label ?? key;
@@ -80,8 +84,9 @@ describe('tax action logging with market', () => {
 			const a = b - amt;
 			costLines.push(`    ${icon}${label} -${amt} (${b}→${a})`);
 		}
-		if (costLines.length)
+		if (costLines.length) {
 			messages.splice(1, 0, '  💲 Action cost', ...costLines);
+		}
 		const subLines: string[] = [];
 		for (const trace of traces) {
 			const subStep = ctx.actions.get(trace.id);
@@ -92,25 +97,32 @@ describe('tax action logging with market', () => {
 				ctx,
 				RESOURCE_KEYS,
 			);
-			if (!subChanges.length) continue;
+			if (!subChanges.length) {
+				continue;
+			}
 			subLines.push(...subChanges);
 			const icon = ctx.actions.get(trace.id)?.icon || '';
 			const name = ctx.actions.get(trace.id).name;
 			const line = `  ${icon} ${name}`;
 			const idx = messages.indexOf(line);
-			if (idx !== -1)
+			if (idx !== -1) {
 				messages.splice(idx + 1, 0, ...subChanges.map((c) => `    ${c}`));
+			}
 		}
 		const normalize = (line: string) =>
 			(line.split(' (')[0] ?? '').replace(/\s[+-]?\d+$/, '').trim();
 		const subPrefixes = subLines.map(normalize);
 		const costLabels = new Set(Object.keys(costs) as SyntheticResourceKey[]);
 		const filtered = changes.filter((line) => {
-			if (subPrefixes.includes(normalize(line))) return false;
+			if (subPrefixes.includes(normalize(line))) {
+				return false;
+			}
 			for (const key of costLabels) {
 				const info = SYNTHETIC_RESOURCES[key];
 				const prefix = info?.icon ? `${info.icon} ${info.label}` : info.label;
-				if (line.startsWith(prefix)) return false;
+				if (line.startsWith(prefix)) {
+					return false;
+				}
 			}
 			return true;
 		});

--- a/tests/integration/action-log-hooks.test.ts
+++ b/tests/integration/action-log-hooks.test.ts
@@ -62,12 +62,16 @@ describe('content-driven action log hooks', () => {
 		});
 
 		const buildings = createBuildingRegistry();
-		for (const [id, def] of BUILDINGS.entries()) buildings.add(id, def);
+		for (const [id, def] of BUILDINGS.entries()) {
+			buildings.add(id, def);
+		}
 		buildings.add(hall.id, hall);
 		buildings.add(plainHall.id, plainHall);
 
 		const developments = createDevelopmentRegistry();
-		for (const [id, def] of DEVELOPMENTS.entries()) developments.add(id, def);
+		for (const [id, def] of DEVELOPMENTS.entries()) {
+			developments.add(id, def);
+		}
 		developments.add(improvement.id, improvement);
 
 		const ctx = createEngine({

--- a/tests/integration/building-placement.test.ts
+++ b/tests/integration/building-placement.test.ts
@@ -1,57 +1,57 @@
 import { describe, it, expect } from 'vitest';
 import { performAction, getActionCosts } from '@kingdom-builder/engine';
 import {
-  createTestContext,
-  getActionOutcome,
-  getBuildingWithActionMods,
-  getBuildActionId,
+	createTestContext,
+	getActionOutcome,
+	getBuildingWithActionMods,
+	getBuildActionId,
 } from './fixtures';
 
 describe('Building placement integration', () => {
-  it('applies building effects to subsequent actions', () => {
-    const ctx = createTestContext();
-    const { buildingId, actionId } = getBuildingWithActionMods();
-    const buildActionId = getBuildActionId(ctx);
-    const expandBefore = getActionOutcome(actionId, ctx);
-    const buildCosts = getActionCosts(buildActionId, ctx, { id: buildingId });
-    for (const [key, cost] of Object.entries(buildCosts)) {
-      ctx.activePlayer.resources[key] =
-        (ctx.activePlayer.resources[key] || 0) + (cost ?? 0);
-    }
-    const apKey = Object.keys(buildCosts)[0];
-    ctx.activePlayer.resources[apKey] += expandBefore.costs[apKey] ?? 0;
-    const resBefore = { ...ctx.activePlayer.resources };
+	it('applies building effects to subsequent actions', () => {
+		const ctx = createTestContext();
+		const { buildingId, actionId } = getBuildingWithActionMods();
+		const buildActionId = getBuildActionId(ctx);
+		const expandBefore = getActionOutcome(actionId, ctx);
+		const buildCosts = getActionCosts(buildActionId, ctx, { id: buildingId });
+		for (const [key, cost] of Object.entries(buildCosts)) {
+			ctx.activePlayer.resources[key] =
+				(ctx.activePlayer.resources[key] || 0) + (cost ?? 0);
+		}
+		const apKey = Object.keys(buildCosts)[0];
+		ctx.activePlayer.resources[apKey] += expandBefore.costs[apKey] ?? 0;
+		const resBefore = { ...ctx.activePlayer.resources };
 
-    performAction(buildActionId, ctx, { id: buildingId });
+		performAction(buildActionId, ctx, { id: buildingId });
 
-    expect(ctx.activePlayer.buildings.has(buildingId)).toBe(true);
-    for (const [key, cost] of Object.entries(buildCosts)) {
-      expect(ctx.activePlayer.resources[key]).toBe(resBefore[key] - cost);
-    }
+		expect(ctx.activePlayer.buildings.has(buildingId)).toBe(true);
+		for (const [key, cost] of Object.entries(buildCosts)) {
+			expect(ctx.activePlayer.resources[key]).toBe(resBefore[key] - cost);
+		}
 
-    const expandAfter = getActionOutcome(actionId, ctx);
-    expect(expandAfter).not.toEqual(expandBefore);
+		const expandAfter = getActionOutcome(actionId, ctx);
+		expect(expandAfter).not.toEqual(expandBefore);
 
-    const resPre = { ...ctx.activePlayer.resources };
-    const statsPre = { ...ctx.activePlayer.stats };
-    const landPre = ctx.activePlayer.lands.length;
+		const resPre = { ...ctx.activePlayer.resources };
+		const statsPre = { ...ctx.activePlayer.stats };
+		const landPre = ctx.activePlayer.lands.length;
 
-    performAction(actionId, ctx);
+		performAction(actionId, ctx);
 
-    for (const [key, cost] of Object.entries(expandAfter.costs)) {
-      const gain = expandAfter.results.resources[key] || 0;
-      expect(ctx.activePlayer.resources[key]).toBe(resPre[key] - cost + gain);
-    }
-    for (const [key, gain] of Object.entries(expandAfter.results.resources)) {
-      if (expandAfter.costs[key] === undefined) {
-        expect(ctx.activePlayer.resources[key]).toBe(resPre[key] + gain);
-      }
-    }
-    expect(ctx.activePlayer.lands.length).toBe(
-      landPre + expandAfter.results.land,
-    );
-    for (const [key, gain] of Object.entries(expandAfter.results.stats)) {
-      expect(ctx.activePlayer.stats[key]).toBe(statsPre[key] + gain);
-    }
-  });
+		for (const [key, cost] of Object.entries(expandAfter.costs)) {
+			const gain = expandAfter.results.resources[key] || 0;
+			expect(ctx.activePlayer.resources[key]).toBe(resPre[key] - cost + gain);
+		}
+		for (const [key, gain] of Object.entries(expandAfter.results.resources)) {
+			if (expandAfter.costs[key] === undefined) {
+				expect(ctx.activePlayer.resources[key]).toBe(resPre[key] + gain);
+			}
+		}
+		expect(ctx.activePlayer.lands.length).toBe(
+			landPre + expandAfter.results.land,
+		);
+		for (const [key, gain] of Object.entries(expandAfter.results.stats)) {
+			expect(ctx.activePlayer.stats[key]).toBe(statsPre[key] + gain);
+		}
+	});
 });

--- a/tests/integration/building-stat-bonus.test.ts
+++ b/tests/integration/building-stat-bonus.test.ts
@@ -1,54 +1,56 @@
 import { describe, it, expect } from 'vitest';
 import {
-  performAction,
-  runEffects,
-  getActionCosts,
+	performAction,
+	runEffects,
+	getActionCosts,
 } from '@kingdom-builder/engine';
 import {
-  createTestContext,
-  getBuildingWithStatBonuses,
-  getBuildActionId,
+	createTestContext,
+	getBuildingWithStatBonuses,
+	getBuildActionId,
 } from './fixtures';
 
 describe('Building stat bonuses', () => {
-  it('applies and removes stat bonuses when built and removed', () => {
-    const { buildingId, stats } = getBuildingWithStatBonuses();
-    const ctx = createTestContext();
-    const buildActionId = getBuildActionId(ctx);
-    const buildCosts = getActionCosts(buildActionId, ctx, { id: buildingId });
-    for (const [key, cost] of Object.entries(buildCosts)) {
-      ctx.activePlayer.resources[key] = cost ?? 0;
-    }
-    const before: Record<string, number> = {};
-    for (const s of stats) before[s.key] = ctx.activePlayer.stats[s.key];
+	it('applies and removes stat bonuses when built and removed', () => {
+		const { buildingId, stats } = getBuildingWithStatBonuses();
+		const ctx = createTestContext();
+		const buildActionId = getBuildActionId(ctx);
+		const buildCosts = getActionCosts(buildActionId, ctx, { id: buildingId });
+		for (const [key, cost] of Object.entries(buildCosts)) {
+			ctx.activePlayer.resources[key] = cost ?? 0;
+		}
+		const before: Record<string, number> = {};
+		for (const s of stats) {
+			before[s.key] = ctx.activePlayer.stats[s.key];
+		}
 
-    performAction(buildActionId, ctx, { id: buildingId });
+		performAction(buildActionId, ctx, { id: buildingId });
 
-    expect(ctx.activePlayer.buildings.has(buildingId)).toBe(true);
-    for (const s of stats) {
-      expect(ctx.activePlayer.stats[s.key]).toBeCloseTo(
-        before[s.key] + s.amount,
-      );
-    }
+		expect(ctx.activePlayer.buildings.has(buildingId)).toBe(true);
+		for (const s of stats) {
+			expect(ctx.activePlayer.stats[s.key]).toBeCloseTo(
+				before[s.key] + s.amount,
+			);
+		}
 
-    runEffects(
-      [{ type: 'building', method: 'remove', params: { id: buildingId } }],
-      ctx,
-    );
+		runEffects(
+			[{ type: 'building', method: 'remove', params: { id: buildingId } }],
+			ctx,
+		);
 
-    expect(ctx.activePlayer.buildings.has(buildingId)).toBe(false);
-    for (const s of stats) {
-      expect(ctx.activePlayer.stats[s.key]).toBeCloseTo(before[s.key]);
-    }
+		expect(ctx.activePlayer.buildings.has(buildingId)).toBe(false);
+		for (const s of stats) {
+			expect(ctx.activePlayer.stats[s.key]).toBeCloseTo(before[s.key]);
+		}
 
-    runEffects(
-      [{ type: 'building', method: 'remove', params: { id: buildingId } }],
-      ctx,
-    );
+		runEffects(
+			[{ type: 'building', method: 'remove', params: { id: buildingId } }],
+			ctx,
+		);
 
-    expect(ctx.activePlayer.buildings.has(buildingId)).toBe(false);
-    for (const s of stats) {
-      expect(ctx.activePlayer.stats[s.key]).toBeCloseTo(before[s.key]);
-    }
-  });
+		expect(ctx.activePlayer.buildings.has(buildingId)).toBe(false);
+		for (const s of stats) {
+			expect(ctx.activePlayer.stats[s.key]).toBeCloseTo(before[s.key]);
+		}
+	});
 });

--- a/tests/integration/edge-cases.test.ts
+++ b/tests/integration/edge-cases.test.ts
@@ -1,46 +1,46 @@
 import { describe, it, expect } from 'vitest';
 import { performAction } from '@kingdom-builder/engine';
 import {
-  createTestContext,
-  getActionWithMultipleCosts,
-  getActionWithCost,
+	createTestContext,
+	getActionWithMultipleCosts,
+	getActionWithCost,
 } from './fixtures';
 
 describe('Action edge cases', () => {
-  it('throws for unknown action', () => {
-    const ctx = createTestContext();
-    expect(() => performAction('not_real', ctx)).toThrow(/Unknown id/);
-  });
+	it('throws for unknown action', () => {
+		const ctx = createTestContext();
+		expect(() => performAction('not_real', ctx)).toThrow(/Unknown id/);
+	});
 
-  it('rejects actions when a required resource is exhausted', () => {
-    const ctx = createTestContext();
-    const { actionId, costs } = getActionWithMultipleCosts(ctx);
-    for (const [key, amount] of Object.entries(costs)) {
-      ctx.activePlayer.resources[key] = amount ?? 0;
-    }
-    const entries = Object.entries(costs);
-    const resourceKey = entries[1][0];
-    const amount = entries[1][1] ?? 0;
-    ctx.activePlayer.resources[resourceKey] = amount - 1;
-    expect(() => performAction(actionId, ctx)).toThrow(
-      new RegExp(`Insufficient ${resourceKey}`),
-    );
-    expect(ctx.activePlayer.resources[resourceKey]).toBe(amount - 1);
-  });
+	it('rejects actions when a required resource is exhausted', () => {
+		const ctx = createTestContext();
+		const { actionId, costs } = getActionWithMultipleCosts(ctx);
+		for (const [key, amount] of Object.entries(costs)) {
+			ctx.activePlayer.resources[key] = amount ?? 0;
+		}
+		const entries = Object.entries(costs);
+		const resourceKey = entries[1][0];
+		const amount = entries[1][1] ?? 0;
+		ctx.activePlayer.resources[resourceKey] = amount - 1;
+		expect(() => performAction(actionId, ctx)).toThrow(
+			new RegExp(`Insufficient ${resourceKey}`),
+		);
+		expect(ctx.activePlayer.resources[resourceKey]).toBe(amount - 1);
+	});
 
-  it('rejects actions when a primary resource is exhausted', () => {
-    const ctx = createTestContext();
-    const { actionId, costs } = getActionWithCost(ctx);
-    const entries = Object.entries(costs);
-    const primaryKey = entries[0][0];
-    const primaryAmount = entries[0][1] ?? 0;
-    for (const [key, amount] of entries.slice(1)) {
-      ctx.activePlayer.resources[key] = amount ?? 0;
-    }
-    ctx.activePlayer.resources[primaryKey] = primaryAmount - 1;
-    expect(() => performAction(actionId, ctx)).toThrow(
-      new RegExp(`Insufficient ${primaryKey}`),
-    );
-    expect(ctx.activePlayer.resources[primaryKey]).toBe(primaryAmount - 1);
-  });
+	it('rejects actions when a primary resource is exhausted', () => {
+		const ctx = createTestContext();
+		const { actionId, costs } = getActionWithCost(ctx);
+		const entries = Object.entries(costs);
+		const primaryKey = entries[0][0];
+		const primaryAmount = entries[0][1] ?? 0;
+		for (const [key, amount] of entries.slice(1)) {
+			ctx.activePlayer.resources[key] = amount ?? 0;
+		}
+		ctx.activePlayer.resources[primaryKey] = primaryAmount - 1;
+		expect(() => performAction(actionId, ctx)).toThrow(
+			new RegExp(`Insufficient ${primaryKey}`),
+		);
+		expect(ctx.activePlayer.resources[primaryKey]).toBe(primaryAmount - 1);
+	});
 });

--- a/tests/integration/fixtures.ts
+++ b/tests/integration/fixtures.ts
@@ -51,7 +51,9 @@ export function createTestContext(
 	if (overrides) {
 		for (const key of Object.keys(RESOURCES) as (keyof typeof RESOURCES)[]) {
 			const value = overrides[key];
-			if (value !== undefined) ctx.activePlayer.resources[key] = value;
+			if (value !== undefined) {
+				ctx.activePlayer.resources[key] = value;
+			}
 		}
 	}
 	return ctx;
@@ -66,14 +68,18 @@ export function simulateEffects(
 	const dummy = clonePlayer(ctx.activePlayer);
 	const dummyCtx = { ...ctx, activePlayer: dummy } as EngineContext;
 	runEffects(effects, dummyCtx);
-	if (actionId) ctx.passives.runResultMods(actionId, dummyCtx);
+	if (actionId) {
+		ctx.passives.runResultMods(actionId, dummyCtx);
+	}
 
 	const resources: Record<string, number> = {};
 	for (const key of Object.keys(before.resources)) {
 		const delta =
 			dummy.resources[key as keyof typeof dummy.resources] -
 			before.resources[key as keyof typeof before.resources];
-		if (delta !== 0) resources[key] = delta;
+		if (delta !== 0) {
+			resources[key] = delta;
+		}
 	}
 
 	const stats: Record<string, number> = {};
@@ -81,7 +87,9 @@ export function simulateEffects(
 		const delta =
 			dummy.stats[key as keyof typeof dummy.stats] -
 			before.stats[key as keyof typeof before.stats];
-		if (delta !== 0) stats[key] = delta;
+		if (delta !== 0) {
+			stats[key] = delta;
+		}
 	}
 
 	const land = dummy.lands.length - before.lands.length;
@@ -101,11 +109,15 @@ function findEffect(
 	predicate: (e: EffectDef) => boolean,
 ): EffectDef | undefined {
 	for (const effect of effects) {
-		if (predicate(effect)) return effect;
+		if (predicate(effect)) {
+			return effect;
+		}
 		const nested =
 			(effect as { effects?: EffectDef[] }).effects &&
 			findEffect((effect as { effects?: EffectDef[] }).effects!, predicate);
-		if (nested) return nested;
+		if (nested) {
+			return nested;
+		}
 	}
 	return undefined;
 }
@@ -161,7 +173,9 @@ export function getBuildingWithStatBonuses() {
 					key: (e.params as { key: string }).key,
 					amount: (e.params as { amount: number }).amount,
 				}));
-			if (stats.length > 0) return { buildingId: id, stats };
+			if (stats.length > 0) {
+				return { buildingId: id, stats };
+			}
 		}
 	}
 	throw new Error('No building with stat bonuses found');
@@ -170,7 +184,9 @@ export function getBuildingWithStatBonuses() {
 export function getActionWithMultipleCosts(ctx: EngineContext) {
 	for (const [id] of ctx.actions.entries()) {
 		const costs = getActionCosts(id, ctx);
-		if (Object.keys(costs).length > 1) return { actionId: id, costs };
+		if (Object.keys(costs).length > 1) {
+			return { actionId: id, costs };
+		}
 	}
 	throw new Error('No action with multiple costs found');
 }
@@ -178,7 +194,9 @@ export function getActionWithMultipleCosts(ctx: EngineContext) {
 export function getActionWithCost(ctx: EngineContext) {
 	for (const [id] of ctx.actions.entries()) {
 		const costs = getActionCosts(id, ctx);
-		if (Object.keys(costs).length > 0) return { actionId: id, costs };
+		if (Object.keys(costs).length > 0) {
+			return { actionId: id, costs };
+		}
 	}
 	throw new Error('No action with costs found');
 }

--- a/tests/integration/random-game-flow.test.ts
+++ b/tests/integration/random-game-flow.test.ts
@@ -1,71 +1,71 @@
 import { describe, it, expect } from 'vitest';
 import {
-  performAction,
-  advance,
-  getActionCosts,
+	performAction,
+	advance,
+	getActionCosts,
 } from '@kingdom-builder/engine';
 import { createSyntheticContext } from './synthetic';
 
 function createRng(seed: number) {
-  let state = seed >>> 0;
-  return () => {
-    state = (state * 1664525 + 1013904223) >>> 0;
-    return state / 0x100000000;
-  };
+	let state = seed >>> 0;
+	return () => {
+		state = (state * 1664525 + 1013904223) >>> 0;
+		return state / 0x100000000;
+	};
 }
 
 describe('random action flow', () => {
-  it('advances phases, pays costs and applies effects across turns', () => {
-    const { ctx, actions, phases, costKey, gainKey } = createSyntheticContext();
-    const actionIds = actions.map((a) => a.id);
-    const mainPhase = phases[0].id;
-    const endPhase = phases[1].id;
-    const endStep = phases[1].steps[0];
-    const effects = endStep.effects as
-      | { type?: string; method?: string; params?: { amount: number } }[]
-      | undefined;
-    const regenEffect = (effects || []).find(
-      (e) => e.type === 'resource' && e.method === 'add',
-    );
-    const regenAmount = (regenEffect?.params as { amount: number }).amount;
-    const rng = createRng(42);
-    const initialTurn = ctx.game.turn;
-    const turns = 3;
+	it('advances phases, pays costs and applies effects across turns', () => {
+		const { ctx, actions, phases, costKey, gainKey } = createSyntheticContext();
+		const actionIds = actions.map((a) => a.id);
+		const mainPhase = phases[0].id;
+		const endPhase = phases[1].id;
+		const endStep = phases[1].steps[0];
+		const effects = endStep.effects as
+			| { type?: string; method?: string; params?: { amount: number } }[]
+			| undefined;
+		const regenEffect = (effects || []).find(
+			(e) => e.type === 'resource' && e.method === 'add',
+		);
+		const regenAmount = (regenEffect?.params as { amount: number }).amount;
+		const rng = createRng(42);
+		const initialTurn = ctx.game.turn;
+		const turns = 3;
 
-    for (let t = 0; t < turns; t++) {
-      for (let p = 0; p < ctx.game.players.length; p++) {
-        expect(ctx.game.currentPhase).toBe(mainPhase);
-        while ((ctx.activePlayer.resources[costKey] ?? 0) > 0) {
-          const actionId = actionIds[Math.floor(rng() * actionIds.length)];
-          const costs = getActionCosts(actionId, ctx);
-          const beforeCost = ctx.activePlayer.resources[costKey];
-          const beforeGain = ctx.activePlayer.resources[gainKey];
-          const action = ctx.actions.get(actionId)!;
-          const gain = (
-            action.effects.find(
-              (e) => e.type === 'resource' && e.method === 'add',
-            )!.params as { amount: number }
-          ).amount;
-          performAction(actionId, ctx);
-          expect(ctx.activePlayer.resources[costKey]).toBe(
-            beforeCost - (costs[costKey] ?? 0),
-          );
-          expect(ctx.activePlayer.resources[gainKey]).toBe(beforeGain + gain);
-        }
-        const currentIndex = ctx.game.currentPlayerIndex;
-        advance(ctx);
-        expect(ctx.game.currentPhase).toBe(endPhase);
-        expect(ctx.game.currentPlayerIndex).toBe(currentIndex);
-        const player = ctx.activePlayer;
-        const beforeRegen = player.resources[costKey];
-        advance(ctx);
-        expect(player.resources[costKey]).toBe(beforeRegen + regenAmount);
-        expect(ctx.game.currentPhase).toBe(mainPhase);
-        expect(ctx.game.currentPlayerIndex).toBe(
-          (currentIndex + 1) % ctx.game.players.length,
-        );
-      }
-    }
-    expect(ctx.game.turn).toBe(initialTurn + turns);
-  });
+		for (let t = 0; t < turns; t++) {
+			for (let p = 0; p < ctx.game.players.length; p++) {
+				expect(ctx.game.currentPhase).toBe(mainPhase);
+				while ((ctx.activePlayer.resources[costKey] ?? 0) > 0) {
+					const actionId = actionIds[Math.floor(rng() * actionIds.length)];
+					const costs = getActionCosts(actionId, ctx);
+					const beforeCost = ctx.activePlayer.resources[costKey];
+					const beforeGain = ctx.activePlayer.resources[gainKey];
+					const action = ctx.actions.get(actionId)!;
+					const gain = (
+						action.effects.find(
+							(e) => e.type === 'resource' && e.method === 'add',
+						)!.params as { amount: number }
+					).amount;
+					performAction(actionId, ctx);
+					expect(ctx.activePlayer.resources[costKey]).toBe(
+						beforeCost - (costs[costKey] ?? 0),
+					);
+					expect(ctx.activePlayer.resources[gainKey]).toBe(beforeGain + gain);
+				}
+				const currentIndex = ctx.game.currentPlayerIndex;
+				advance(ctx);
+				expect(ctx.game.currentPhase).toBe(endPhase);
+				expect(ctx.game.currentPlayerIndex).toBe(currentIndex);
+				const player = ctx.activePlayer;
+				const beforeRegen = player.resources[costKey];
+				advance(ctx);
+				expect(player.resources[costKey]).toBe(beforeRegen + regenAmount);
+				expect(ctx.game.currentPhase).toBe(mainPhase);
+				expect(ctx.game.currentPlayerIndex).toBe(
+					(currentIndex + 1) % ctx.game.players.length,
+				);
+			}
+		}
+		expect(ctx.game.turn).toBe(initialTurn + turns);
+	});
 });

--- a/tests/integration/tax-translation.test.ts
+++ b/tests/integration/tax-translation.test.ts
@@ -2,46 +2,46 @@ import { describe, it, expect } from 'vitest';
 import { createEngine } from '@kingdom-builder/engine';
 import { summarizeContent } from '@kingdom-builder/web/translation/content';
 import {
-  PHASES,
-  POPULATIONS,
-  GAME_START,
-  RULES,
-  Resource,
+	PHASES,
+	POPULATIONS,
+	GAME_START,
+	RULES,
+	Resource,
 } from '@kingdom-builder/contents';
 import { createContentFactory } from '../../packages/engine/tests/factories/content';
 
 describe('Action translation with population scaling', () => {
-  it('mentions population scaling', () => {
-    const content = createContentFactory();
-    const action = content.action({
-      effects: [
-        {
-          evaluator: { type: 'population' },
-          effects: [
-            {
-              type: 'resource',
-              method: 'add',
-              params: { key: Resource.gold, amount: 1 },
-            },
-          ],
-        },
-      ],
-    });
-    const ctx = createEngine({
-      actions: content.actions,
-      buildings: content.buildings,
-      developments: content.developments,
-      populations: POPULATIONS,
-      phases: PHASES,
-      start: GAME_START,
-      rules: RULES,
-    });
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const summary = summarizeContent('action', action.id, ctx) as (
-      | string
-      | { title: string; items: unknown[] }
-    )[];
-    const lines = summary.filter((i): i is string => typeof i === 'string');
-    expect(lines.some((i) => i.includes('per 👥'))).toBe(true);
-  });
+	it('mentions population scaling', () => {
+		const content = createContentFactory();
+		const action = content.action({
+			effects: [
+				{
+					evaluator: { type: 'population' },
+					effects: [
+						{
+							type: 'resource',
+							method: 'add',
+							params: { key: Resource.gold, amount: 1 },
+						},
+					],
+				},
+			],
+		});
+		const ctx = createEngine({
+			actions: content.actions,
+			buildings: content.buildings,
+			developments: content.developments,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		const summary = summarizeContent('action', action.id, ctx) as (
+			| string
+			| { title: string; items: unknown[] }
+		)[];
+		const lines = summary.filter((i): i is string => typeof i === 'string');
+		expect(lines.some((i) => i.includes('per 👥'))).toBe(true);
+	});
 });

--- a/tests/integration/turn-cycle.test.ts
+++ b/tests/integration/turn-cycle.test.ts
@@ -62,13 +62,17 @@ describe('Turn cycle integration', () => {
 			rules,
 		});
 
-		while (ctx.game.currentPhase !== phaseIds.main) advance(ctx);
+		while (ctx.game.currentPhase !== phaseIds.main) {
+			advance(ctx);
+		}
 		expect(ctx.game.currentPlayerIndex).toBe(0);
 		expect(ctx.game.currentPhase).toBe(phaseIds.main);
 
 		advance(ctx);
 
-		while (ctx.game.currentPhase !== phaseIds.main) advance(ctx);
+		while (ctx.game.currentPhase !== phaseIds.main) {
+			advance(ctx);
+		}
 		expect(ctx.game.currentPlayerIndex).toBe(1);
 		expect(ctx.game.currentPhase).toBe(phaseIds.main);
 


### PR DESCRIPTION
## Summary
- tighten the repository lint config by re-enabling the runtime max-len rule and counting tabs as a single column
- normalize engine, web, and integration tests to satisfy curly/length checks after the config change
- wrap long UI helper strings and docs so runtime files stay within the 80-character standard

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68e17019eb7c83259b38cbfd7ec3e162