### PR TITLE
Add attack content method constants

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -16,6 +16,7 @@ import {
 	DevelopmentMethods,
 	PopulationMethods,
 	ActionMethods,
+	AttackMethods,
 	PassiveMethods,
 	CostModMethods,
 	ResultModMethods,
@@ -286,7 +287,7 @@ export function createActionRegistry() {
 					.build(),
 			)
 			.effect(
-				effect('attack', 'perform')
+				effect(Types.Attack, AttackMethods.PERFORM)
 					.params(
 						attackParams()
 							.powerStat(Stat.armyStrength)

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -37,6 +37,7 @@ export const Types = {
 	ResultMod: 'result_mod',
 	Population: 'population',
 	Action: 'action',
+	Attack: 'attack',
 	Stat: 'stat',
 } as const;
 
@@ -84,6 +85,10 @@ export const PopulationMethods = {
 export const ActionMethods = {
 	ADD: 'add',
 	REMOVE: 'remove',
+	PERFORM: 'perform',
+} as const;
+
+export const AttackMethods = {
 	PERFORM: 'perform',
 } as const;
 


### PR DESCRIPTION
## Summary
- extend the content builder types with an Attack entry and matching method constants
- update the action registry to use the new attack constants instead of hard-coded strings

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e174487f6c8325bdcfc69b0d93ccd3