### PR TITLE
chore: enforce runtime identifier length rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -208,11 +208,11 @@ module.exports = {
 				'packages/web/src/translation/effects/formatters/action.ts',
 				'packages/web/src/translation/effects/formatters/building.ts',
 				'packages/web/src/translation/effects/formatters/passive.ts',
-                        ],
-                        rules: {
-                                'max-lines': 'off',
-                        },
-                },
+			],
+			rules: {
+				'max-lines': 'off',
+			},
+		},
 		{
 			files: [
 				'packages/web/src/utils/stats.ts',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -208,12 +208,11 @@ module.exports = {
 				'packages/web/src/translation/effects/formatters/action.ts',
 				'packages/web/src/translation/effects/formatters/building.ts',
 				'packages/web/src/translation/effects/formatters/passive.ts',
-			],
-			rules: {
-				'max-lines': 'off',
-				'id-length': 'off',
-			},
-		},
+                        ],
+                        rules: {
+                                'max-lines': 'off',
+                        },
+                },
 		{
 			files: [
 				'packages/web/src/utils/stats.ts',


### PR DESCRIPTION
## Summary
- remove the runtime `id-length` override from ESLint so runtime files honor the global rule

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e175082eec8325a063d0090ef13a9d