### PR TITLE
Add id helper for population evaluator builder

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -125,7 +125,7 @@ export function createActionRegistry() {
 			.cost(Resource.ap, 1)
 			.effect(
 				effect()
-					.evaluator(populationEvaluator().param('id', 'tax'))
+					.evaluator(populationEvaluator().id('tax'))
 					.effect(
 						effect(Types.Resource, ResourceMethods.ADD)
 							.params(resourceParams().key(Resource.gold).amount(4))

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -1222,10 +1222,15 @@ export class EvaluatorBuilder<P extends Params = Params> {
 }
 
 class PopulationEvaluatorBuilder extends EvaluatorBuilder<{
+	id?: string;
 	role?: PopulationRoleId;
 }> {
 	constructor() {
 		super('population');
+	}
+	// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+	id(populationId: PopulationRoleId | string) {
+		return this.param('id', populationId);
 	}
 	role(role: PopulationRoleId) {
 		return this.param('role', role);


### PR DESCRIPTION
## Summary
- add a convenience `id()` helper on `PopulationEvaluatorBuilder`
- replace direct `param('id', …)` calls with the helper

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e177643b888325a9c28846af9ce378