### PR TITLE
feat(contents): add evaluation target helpers

### DIFF
--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -1,221 +1,223 @@
 import { Registry } from '@kingdom-builder/engine/registry';
 import {
-  TRANSFER_PCT_EVALUATION_ID,
-  TRANSFER_PCT_EVALUATION_TYPE,
+	TRANSFER_PCT_EVALUATION_ID,
+	TRANSFER_PCT_EVALUATION_TYPE,
 } from '@kingdom-builder/engine/effects/resource_transfer';
 import { Resource } from './resources';
 import { Stat } from './stats';
 import { buildingSchema } from '@kingdom-builder/engine/config/schema';
 import {
-  building,
-  effect,
-  Types,
-  CostModMethods,
-  ResultModMethods,
-  ResourceMethods,
-  ActionMethods,
-  PassiveMethods,
-  StatMethods,
-  resourceParams,
-  resultModParams,
-  evaluationTarget,
-  costModParams,
-  statParams,
+	building,
+	effect,
+	Types,
+	CostModMethods,
+	ResultModMethods,
+	ResourceMethods,
+	ActionMethods,
+	PassiveMethods,
+	StatMethods,
+	resourceParams,
+	resultModParams,
+	evaluationTarget,
+	developmentTarget,
+	populationTarget,
+	costModParams,
+	statParams,
 } from './config/builders';
 import type { BuildingDef } from './defs';
 
 export type { BuildingDef } from './defs';
 
 export function createBuildingRegistry() {
-  const registry = new Registry<BuildingDef>(buildingSchema.passthrough());
+	const registry = new Registry<BuildingDef>(buildingSchema.passthrough());
 
-  registry.add('town_charter', {
-    ...building()
-      .id('town_charter')
-      .name('Town Charter')
-      .icon('🏘️')
-      .cost(Resource.gold, 5)
-      .onBuild(
-        effect(Types.CostMod, CostModMethods.ADD)
-          .params(
-            costModParams()
-              .id('tc_expand_cost')
-              .actionId('expand')
-              .key(Resource.gold)
-              .amount(2),
-          )
-          .build(),
-      )
-      .onBuild(
-        effect(Types.ResultMod, ResultModMethods.ADD)
-          .params(resultModParams().id('tc_expand_result').actionId('expand'))
-          .effect(
-            effect(Types.Resource, ResourceMethods.ADD)
-              .params(resourceParams().key(Resource.happiness).amount(1))
-              .build(),
-          )
-          .build(),
-      )
-      .build(),
-    focus: 'economy',
-  });
+	registry.add('town_charter', {
+		...building()
+			.id('town_charter')
+			.name('Town Charter')
+			.icon('🏘️')
+			.cost(Resource.gold, 5)
+			.onBuild(
+				effect(Types.CostMod, CostModMethods.ADD)
+					.params(
+						costModParams()
+							.id('tc_expand_cost')
+							.actionId('expand')
+							.key(Resource.gold)
+							.amount(2),
+					)
+					.build(),
+			)
+			.onBuild(
+				effect(Types.ResultMod, ResultModMethods.ADD)
+					.params(resultModParams().id('tc_expand_result').actionId('expand'))
+					.effect(
+						effect(Types.Resource, ResourceMethods.ADD)
+							.params(resourceParams().key(Resource.happiness).amount(1))
+							.build(),
+					)
+					.build(),
+			)
+			.build(),
+		focus: 'economy',
+	});
 
-  // TODO: remaining buildings from original manual config
-  registry.add('mill', {
-    ...building()
-      .id('mill')
-      .name('Mill')
-      .icon('⚙️')
-      .cost(Resource.gold, 7)
-      .onBuild(
-        effect(Types.ResultMod, ResultModMethods.ADD)
-          .params(
-            resultModParams()
-              .id('mill_farm_bonus')
-              .evaluation(evaluationTarget('development').id('farm'))
-              .amount(1),
-          )
-          .build(),
-      )
-      .build(),
-    focus: 'economy',
-  });
-  registry.add('raiders_guild', {
-    ...building()
-      .id('raiders_guild')
-      .name("Raider's Guild")
-      .icon('🏴‍☠️')
-      .cost(Resource.gold, 8)
-      .cost(Resource.ap, 1)
-      .upkeep(Resource.gold, 1)
-      .onBuild(
-        effect(Types.ResultMod, ResultModMethods.ADD)
-          .params(
-            resultModParams()
-              .id('raiders_guild_plunder_bonus')
-              .evaluation(
-                evaluationTarget(TRANSFER_PCT_EVALUATION_TYPE).id(
-                  TRANSFER_PCT_EVALUATION_ID,
-                ),
-              )
-              .adjust(25),
-          )
-          .build(),
-      )
-      .build(),
-    focus: 'aggressive',
-  });
-  registry.add('plow_workshop', {
-    ...building()
-      .id('plow_workshop')
-      .name('Plow Workshop')
-      .icon('🏭')
-      .cost(Resource.gold, 10)
-      .onBuild(
-        effect(Types.Action, ActionMethods.ADD).param('id', 'plow').build(),
-      )
-      .build(),
-    focus: 'economy',
-  });
-  registry.add('market', {
-    ...building()
-      .id('market')
-      .name('Market')
-      .icon('🏪')
-      .cost(Resource.gold, 10)
-      .onBuild(
-        effect(Types.ResultMod, ResultModMethods.ADD)
-          .params(
-            resultModParams()
-              .id('market_tax_bonus')
-              .evaluation(evaluationTarget('population').id('tax'))
-              .amount(1),
-          )
-          .build(),
-      )
-      .build(),
-    focus: 'economy',
-  });
-  registry.add('barracks', {
-    ...building()
-      .id('barracks')
-      .name('Barracks')
-      .icon('🪖')
-      .cost(Resource.gold, 12)
-      .build(),
-    focus: 'aggressive',
-  });
-  registry.add('citadel', {
-    ...building()
-      .id('citadel')
-      .name('Citadel')
-      .icon('🏯')
-      .cost(Resource.gold, 12)
-      .build(),
-    focus: 'defense',
-  });
-  registry.add('castle_walls', {
-    ...building()
-      .id('castle_walls')
-      .name('Castle Walls')
-      .icon('🧱')
-      .cost(Resource.gold, 12)
-      .onBuild(
-        effect(Types.Passive, PassiveMethods.ADD)
-          .param('id', 'castle_walls_bonus')
-          .effect(
-            effect(Types.Stat, StatMethods.ADD)
-              .params(statParams().key(Stat.fortificationStrength).amount(5))
-              .build(),
-          )
-          .effect(
-            effect(Types.Stat, StatMethods.ADD)
-              .params(statParams().key(Stat.absorption).amount(0.2))
-              .build(),
-          )
-          .build(),
-      )
-      .build(),
-    focus: 'defense',
-  });
-  registry.add('castle_gardens', {
-    ...building()
-      .id('castle_gardens')
-      .name('Castle Gardens')
-      .icon('🌷')
-      .cost(Resource.gold, 15)
-      .build(),
-    focus: 'economy',
-  });
-  registry.add('temple', {
-    ...building()
-      .id('temple')
-      .name('Temple')
-      .icon('⛪')
-      .cost(Resource.gold, 16)
-      .build(),
-    focus: 'other',
-  });
-  registry.add('palace', {
-    ...building()
-      .id('palace')
-      .name('Palace')
-      .icon('👑')
-      .cost(Resource.gold, 20)
-      .build(),
-    focus: 'other',
-  });
-  registry.add('great_hall', {
-    ...building()
-      .id('great_hall')
-      .name('Great Hall')
-      .icon('🏟️')
-      .cost(Resource.gold, 22)
-      .build(),
-    focus: 'other',
-  });
+	// TODO: remaining buildings from original manual config
+	registry.add('mill', {
+		...building()
+			.id('mill')
+			.name('Mill')
+			.icon('⚙️')
+			.cost(Resource.gold, 7)
+			.onBuild(
+				effect(Types.ResultMod, ResultModMethods.ADD)
+					.params(
+						resultModParams()
+							.id('mill_farm_bonus')
+							.evaluation(developmentTarget().id('farm'))
+							.amount(1),
+					)
+					.build(),
+			)
+			.build(),
+		focus: 'economy',
+	});
+	registry.add('raiders_guild', {
+		...building()
+			.id('raiders_guild')
+			.name("Raider's Guild")
+			.icon('🏴‍☠️')
+			.cost(Resource.gold, 8)
+			.cost(Resource.ap, 1)
+			.upkeep(Resource.gold, 1)
+			.onBuild(
+				effect(Types.ResultMod, ResultModMethods.ADD)
+					.params(
+						resultModParams()
+							.id('raiders_guild_plunder_bonus')
+							.evaluation(
+								evaluationTarget(TRANSFER_PCT_EVALUATION_TYPE).id(
+									TRANSFER_PCT_EVALUATION_ID,
+								),
+							)
+							.adjust(25),
+					)
+					.build(),
+			)
+			.build(),
+		focus: 'aggressive',
+	});
+	registry.add('plow_workshop', {
+		...building()
+			.id('plow_workshop')
+			.name('Plow Workshop')
+			.icon('🏭')
+			.cost(Resource.gold, 10)
+			.onBuild(
+				effect(Types.Action, ActionMethods.ADD).param('id', 'plow').build(),
+			)
+			.build(),
+		focus: 'economy',
+	});
+	registry.add('market', {
+		...building()
+			.id('market')
+			.name('Market')
+			.icon('🏪')
+			.cost(Resource.gold, 10)
+			.onBuild(
+				effect(Types.ResultMod, ResultModMethods.ADD)
+					.params(
+						resultModParams()
+							.id('market_tax_bonus')
+							.evaluation(populationTarget().id('tax'))
+							.amount(1),
+					)
+					.build(),
+			)
+			.build(),
+		focus: 'economy',
+	});
+	registry.add('barracks', {
+		...building()
+			.id('barracks')
+			.name('Barracks')
+			.icon('🪖')
+			.cost(Resource.gold, 12)
+			.build(),
+		focus: 'aggressive',
+	});
+	registry.add('citadel', {
+		...building()
+			.id('citadel')
+			.name('Citadel')
+			.icon('🏯')
+			.cost(Resource.gold, 12)
+			.build(),
+		focus: 'defense',
+	});
+	registry.add('castle_walls', {
+		...building()
+			.id('castle_walls')
+			.name('Castle Walls')
+			.icon('🧱')
+			.cost(Resource.gold, 12)
+			.onBuild(
+				effect(Types.Passive, PassiveMethods.ADD)
+					.param('id', 'castle_walls_bonus')
+					.effect(
+						effect(Types.Stat, StatMethods.ADD)
+							.params(statParams().key(Stat.fortificationStrength).amount(5))
+							.build(),
+					)
+					.effect(
+						effect(Types.Stat, StatMethods.ADD)
+							.params(statParams().key(Stat.absorption).amount(0.2))
+							.build(),
+					)
+					.build(),
+			)
+			.build(),
+		focus: 'defense',
+	});
+	registry.add('castle_gardens', {
+		...building()
+			.id('castle_gardens')
+			.name('Castle Gardens')
+			.icon('🌷')
+			.cost(Resource.gold, 15)
+			.build(),
+		focus: 'economy',
+	});
+	registry.add('temple', {
+		...building()
+			.id('temple')
+			.name('Temple')
+			.icon('⛪')
+			.cost(Resource.gold, 16)
+			.build(),
+		focus: 'other',
+	});
+	registry.add('palace', {
+		...building()
+			.id('palace')
+			.name('Palace')
+			.icon('👑')
+			.cost(Resource.gold, 20)
+			.build(),
+		focus: 'other',
+	});
+	registry.add('great_hall', {
+		...building()
+			.id('great_hall')
+			.name('Great Hall')
+			.icon('🏟️')
+			.cost(Resource.gold, 22)
+			.build(),
+		focus: 'other',
+	});
 
-  return registry;
+	return registry;
 }
 
 export const BUILDINGS = createBuildingRegistry();

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -943,11 +943,22 @@ export function costModParams() {
 	return new CostModParamsBuilder();
 }
 
+export enum EvaluationTargetTypes {
+	Development = 'development',
+	Population = 'population',
+}
+
+type LooseEvaluationTargetType = string & {
+	readonly __evaluationTargetBrand?: never;
+};
+
+type EvaluationTargetType = EvaluationTargetTypes | LooseEvaluationTargetType;
+
 class EvaluationTargetBuilder extends ParamsBuilder<{
-	type: string;
+	type: EvaluationTargetType;
 	id?: string;
 }> {
-	constructor(type: string) {
+	constructor(type: EvaluationTargetType) {
 		super();
 		this.set('type', type);
 	}
@@ -956,14 +967,22 @@ class EvaluationTargetBuilder extends ParamsBuilder<{
 	}
 }
 
-export function evaluationTarget(type: string) {
+export function evaluationTarget(type: EvaluationTargetTypes | string) {
 	return new EvaluationTargetBuilder(type);
+}
+
+export function developmentTarget() {
+	return evaluationTarget(EvaluationTargetTypes.Development);
+}
+
+export function populationTarget() {
+	return evaluationTarget(EvaluationTargetTypes.Population);
 }
 
 class ResultModParamsBuilder extends ParamsBuilder<{
 	id?: string;
 	actionId?: string;
-	evaluation?: { type: string; id?: string };
+	evaluation?: { type: EvaluationTargetType; id?: string };
 	amount?: number;
 	adjust?: number;
 	percent?: number;
@@ -974,7 +993,11 @@ class ResultModParamsBuilder extends ParamsBuilder<{
 	actionId(actionId: string) {
 		return this.set('actionId', actionId);
 	}
-	evaluation(target: EvaluationTargetBuilder | { type: string; id?: string }) {
+	evaluation(
+		target:
+			| EvaluationTargetBuilder
+			| { type: EvaluationTargetType; id?: string },
+	) {
 		return this.set(
 			'evaluation',
 			target instanceof EvaluationTargetBuilder ? target.build() : target,

--- a/packages/contents/src/happinessHelpers.ts
+++ b/packages/contents/src/happinessHelpers.ts
@@ -5,7 +5,7 @@ import {
 	ResultModMethods,
 	StatMethods,
 	costModParams,
-	evaluationTarget,
+	developmentTarget,
 	resultModParams,
 	statParams,
 	effect,
@@ -20,7 +20,7 @@ export const UPKEEP_PHASE_ID = 'upkeep';
 export const WAR_RECOVERY_STEP_ID = 'war-recovery';
 const BUILD_ACTION_ID = 'build';
 
-const DEVELOPMENT_EVALUATION = evaluationTarget('development');
+const DEVELOPMENT_EVALUATION = developmentTarget();
 
 export const incomeModifier = (id: string, percent: number) =>
 	({


### PR DESCRIPTION
## Summary
- add an `EvaluationTargetTypes` enum and helpers for common evaluation targets
- refactor building and happiness configurations to rely on the shared helpers

## Testing
- npm run test:quick


------
https://chatgpt.com/codex/tasks/task_e_68e177660fb48325b3cfa7e884953753