### PR TITLE
Add effect meta builder helpers and refactor action meta usage

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -81,16 +81,13 @@ export function createActionRegistry() {
 							.params(resourceParams().key(Resource.gold).amount(2))
 							.build(),
 					)
-					.effect({
-						type: Types.Resource,
-						method: ResourceMethods.REMOVE,
-						round: 'up',
-						params: resourceParams()
-							.key(Resource.happiness)
-							.amount(0.5)
+					.effect(
+						effect(Types.Resource, ResourceMethods.REMOVE)
+							.round('up')
+							.params(resourceParams().key(Resource.happiness).amount(0.5))
+							.allowShortfall()
 							.build(),
-						meta: { allowShortfall: true },
-					})
+					)
 					.build(),
 			)
 			.build(),
@@ -131,16 +128,13 @@ export function createActionRegistry() {
 							.params(resourceParams().key(Resource.gold).amount(4))
 							.build(),
 					)
-					.effect({
-						type: Types.Resource,
-						method: ResourceMethods.REMOVE,
-						round: 'up',
-						params: resourceParams()
-							.key(Resource.happiness)
-							.amount(0.5)
+					.effect(
+						effect(Types.Resource, ResourceMethods.REMOVE)
+							.round('up')
+							.params(resourceParams().key(Resource.happiness).amount(0.5))
+							.allowShortfall()
 							.build(),
-						meta: { allowShortfall: true },
-					})
+					)
 					.build(),
 			)
 			.build(),
@@ -247,12 +241,12 @@ export function createActionRegistry() {
 							.param('id', 'watchtower'),
 					),
 			)
-			.effect({
-				type: Types.Resource,
-				method: ResourceMethods.REMOVE,
-				params: resourceParams().key(Resource.happiness).amount(3).build(),
-				meta: { allowShortfall: true },
-			})
+			.effect(
+				effect(Types.Resource, ResourceMethods.REMOVE)
+					.params(resourceParams().key(Resource.happiness).amount(3))
+					.allowShortfall()
+					.build(),
+			)
 			.build(),
 		category: 'basic',
 		order: 5,
@@ -294,15 +288,12 @@ export function createActionRegistry() {
 									.param('id', 'plunder')
 									.build(),
 							)
-							.onDamageDefender({
-								type: Types.Resource,
-								method: ResourceMethods.REMOVE,
-								params: resourceParams()
-									.key(Resource.happiness)
-									.amount(1)
+							.onDamageDefender(
+								effect(Types.Resource, ResourceMethods.REMOVE)
+									.params(resourceParams().key(Resource.happiness).amount(1))
+									.allowShortfall()
 									.build(),
-								meta: { allowShortfall: true },
-							}),
+							),
 					)
 					.build(),
 			)
@@ -364,15 +355,12 @@ export function createActionRegistry() {
 									.id('hold_festival_attack_happiness_penalty')
 									.actionId('army_attack'),
 							)
-							.effect({
-								type: Types.Resource,
-								method: ResourceMethods.REMOVE,
-								params: resourceParams()
-									.key(Resource.happiness)
-									.amount(3)
+							.effect(
+								effect(Types.Resource, ResourceMethods.REMOVE)
+									.params(resourceParams().key(Resource.happiness).amount(3))
+									.allowShortfall()
 									.build(),
-								meta: { allowShortfall: true },
-							})
+							)
 							.build(),
 					)
 					.build(),

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -1305,6 +1305,7 @@ export class EffectBuilder<P extends Params = Params> {
 	private roundSet = false;
 	private typeSet = false;
 	private methodSet = false;
+	private metaSet = false;
 	type(type: string) {
 		if (this.typeSet) {
 			throw new Error(
@@ -1392,6 +1393,19 @@ export class EffectBuilder<P extends Params = Params> {
 		this.config.round = mode;
 		this.roundSet = true;
 		return this;
+	}
+	meta(meta: EffectConfig['meta']) {
+		if (this.metaSet) {
+			throw new Error(
+				'Effect already has meta(). Remove the duplicate meta() call.',
+			);
+		}
+		this.config.meta = meta;
+		this.metaSet = true;
+		return this;
+	}
+	allowShortfall() {
+		return this.meta({ allowShortfall: true });
 	}
 	build(): EffectConfig {
 		if (!this.typeSet && !this.methodSet) {


### PR DESCRIPTION
## Summary
- add a `meta()` method with `allowShortfall()` helper to the effect builder to guard against duplicate metadata configuration
- refactor content action definitions to use the fluent metadata API instead of inline `meta` objects

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e17764d7e88325bd640f1b296e5390