### PR TITLE
chore: enforce prettier formatting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -156,6 +156,25 @@ module.exports = {
 			},
 		},
 		{
+			files: ['scripts/**/*.js', 'scripts/**/*.cjs'],
+			parserOptions: {
+				project: null,
+			},
+			rules: {
+				'@typescript-eslint/await-thenable': 'off',
+				'@typescript-eslint/no-floating-promises': 'off',
+				'@typescript-eslint/no-misused-promises': 'off',
+				'@typescript-eslint/require-await': 'off',
+				'@typescript-eslint/unbound-method': 'off',
+				'@typescript-eslint/no-unsafe-assignment': 'off',
+				'@typescript-eslint/no-unsafe-call': 'off',
+				'@typescript-eslint/no-unsafe-member-access': 'off',
+				'@typescript-eslint/no-unsafe-return': 'off',
+				'@typescript-eslint/no-unsafe-argument': 'off',
+				'@typescript-eslint/no-var-requires': 'off',
+			},
+		},
+		{
 			files: [
 				'packages/engine/src/action_perform.ts',
 				'packages/engine/src/effects/**/*.ts',

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
-  "singleQuote": true,
-  "trailingComma": "all",
-  "useTabs": true,
-  "printWidth": 80
+	"singleQuote": true,
+	"trailingComma": "all",
+	"useTabs": true,
+	"printWidth": 80
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"lint": "eslint . --ext .ts,.tsx --rulesdir scripts",
 		"typecheck": "tsc -b --noEmit --pretty false",
 		"fix": "eslint . --ext .ts,.tsx --fix --rulesdir scripts",
-		"check": "npm run typecheck && npm run lint",
+		"format:check": "prettier --check .",
+		"check": "npm run format:check && npm run typecheck && npm run lint",
 		"pretest": "node scripts/ensure-dev-dependencies.cjs",
 		"test": "vitest run",
 		"test:quick": "npm test",
@@ -59,8 +60,8 @@
 		"vitest": "^3.2.4"
 	},
 	"lint-staged": {
-		"*.{js,jsx,ts,tsx,json,md}": "prettier --write",
-		"*.{js,jsx,ts,tsx}": "eslint --max-warnings=0 --rulesdir scripts",
+		"*.{js,jsx,ts,tsx,json,md,cjs}": "prettier --write",
+		"*.{ts,tsx}": "eslint --max-warnings=0 --rulesdir scripts",
 		"*.{ts,tsx}": "bash -c 'tsc --noEmit'"
 	}
 }

--- a/packages/contents/README.md
+++ b/packages/contents/README.md
@@ -21,16 +21,16 @@ messages point you to the fix.
 
   ```ts
   import {
-    effect,
-    resourceParams,
-    Types,
-    ResourceMethods,
+  	effect,
+  	resourceParams,
+  	Types,
+  	ResourceMethods,
   } from './config/builders';
   import { Resource } from './resources';
 
   const gainGold = effect(Types.Resource, ResourceMethods.ADD)
-    .params(resourceParams().key(Resource.gold).amount(2))
-    .build();
+  	.params(resourceParams().key(Resource.gold).amount(2))
+  	.build();
   ```
 
 - **Passives, developments, population effects and attacks all need a target id

--- a/packages/contents/src/defs.ts
+++ b/packages/contents/src/defs.ts
@@ -1,7 +1,7 @@
 import type {
-  BuildingConfig,
-  DevelopmentConfig,
-  PopulationConfig,
+	BuildingConfig,
+	DevelopmentConfig,
+	PopulationConfig,
 } from '@kingdom-builder/engine/config/schema';
 import type { EffectDef } from '@kingdom-builder/engine/effects';
 
@@ -15,22 +15,22 @@ export const RESOURCE_TRANSFER_ICON = '🔁';
 export type Focus = 'economy' | 'aggressive' | 'defense' | 'other';
 
 export interface Triggered {
-  onGrowthPhase?: EffectDef[] | undefined;
-  onUpkeepPhase?: EffectDef[] | undefined;
-  onBeforeAttacked?: EffectDef[] | undefined;
-  onAttackResolved?: EffectDef[] | undefined;
-  onPayUpkeepStep?: EffectDef[] | undefined;
-  onGainIncomeStep?: EffectDef[] | undefined;
-  onGainAPStep?: EffectDef[] | undefined;
+	onGrowthPhase?: EffectDef[] | undefined;
+	onUpkeepPhase?: EffectDef[] | undefined;
+	onBeforeAttacked?: EffectDef[] | undefined;
+	onAttackResolved?: EffectDef[] | undefined;
+	onPayUpkeepStep?: EffectDef[] | undefined;
+	onGainIncomeStep?: EffectDef[] | undefined;
+	onGainAPStep?: EffectDef[] | undefined;
 }
 
 export interface PopulationDef extends PopulationConfig, Triggered {}
 export interface DevelopmentDef extends DevelopmentConfig, Triggered {
-  order?: number;
-  focus?: Focus;
+	order?: number;
+	focus?: Focus;
 }
 export interface BuildingDef extends BuildingConfig, Triggered {
-  focus?: Focus;
+	focus?: Focus;
 }
 
 export type TriggerKey = keyof Triggered;

--- a/packages/contents/src/developments.ts
+++ b/packages/contents/src/developments.ts
@@ -3,113 +3,113 @@ import { Stat } from './stats';
 import { Resource } from './resources';
 import { developmentSchema } from '@kingdom-builder/engine/config/schema';
 import {
-  development,
-  effect,
-  Types,
-  StatMethods,
-  DevelopmentMethods,
-  ResourceMethods,
-  resourceParams,
-  statParams,
-  developmentParams,
-  developmentEvaluator,
+	development,
+	effect,
+	Types,
+	StatMethods,
+	DevelopmentMethods,
+	ResourceMethods,
+	resourceParams,
+	statParams,
+	developmentParams,
+	developmentEvaluator,
 } from './config/builders';
 import type { DevelopmentDef } from './defs';
 
 export type { DevelopmentDef } from './defs';
 
 export function createDevelopmentRegistry() {
-  const registry = new Registry<DevelopmentDef>(
-    developmentSchema.passthrough(),
-  );
+	const registry = new Registry<DevelopmentDef>(
+		developmentSchema.passthrough(),
+	);
 
-  registry.add('farm', {
-    ...development()
-      .id('farm')
-      .name('Farm')
-      .icon('🌾')
-      .onGainIncomeStep(
-        effect()
-          .evaluator(developmentEvaluator().id('$id'))
-          .effect(
-            effect(Types.Resource, ResourceMethods.ADD)
-              .params(resourceParams().key(Resource.gold).amount(2))
-              .build(),
-          )
-          .build(),
-      )
-      .build(),
-    order: 2,
-    focus: 'economy',
-  });
+	registry.add('farm', {
+		...development()
+			.id('farm')
+			.name('Farm')
+			.icon('🌾')
+			.onGainIncomeStep(
+				effect()
+					.evaluator(developmentEvaluator().id('$id'))
+					.effect(
+						effect(Types.Resource, ResourceMethods.ADD)
+							.params(resourceParams().key(Resource.gold).amount(2))
+							.build(),
+					)
+					.build(),
+			)
+			.build(),
+		order: 2,
+		focus: 'economy',
+	});
 
-  registry.add('house', {
-    ...development()
-      .id('house')
-      .name('House')
-      .icon('🏠')
-      .populationCap(1)
-      .onBuild(
-        effect(Types.Stat, StatMethods.ADD)
-          .params(statParams().key(Stat.maxPopulation).amount(1))
-          .build(),
-      )
-      .build(),
-    order: 1,
-    focus: 'economy',
-  });
+	registry.add('house', {
+		...development()
+			.id('house')
+			.name('House')
+			.icon('🏠')
+			.populationCap(1)
+			.onBuild(
+				effect(Types.Stat, StatMethods.ADD)
+					.params(statParams().key(Stat.maxPopulation).amount(1))
+					.build(),
+			)
+			.build(),
+		order: 1,
+		focus: 'economy',
+	});
 
-  registry.add('outpost', {
-    ...development()
-      .id('outpost')
-      .name('Outpost')
-      .icon('🏹')
-      .onBuild(
-        effect(Types.Stat, StatMethods.ADD)
-          .params(statParams().key(Stat.armyStrength).amount(1))
-          .build(),
-      )
-      .onBuild(
-        effect(Types.Stat, StatMethods.ADD)
-          .params(statParams().key(Stat.fortificationStrength).amount(1))
-          .build(),
-      )
-      .build(),
-    order: 3,
-    focus: 'defense',
-  });
+	registry.add('outpost', {
+		...development()
+			.id('outpost')
+			.name('Outpost')
+			.icon('🏹')
+			.onBuild(
+				effect(Types.Stat, StatMethods.ADD)
+					.params(statParams().key(Stat.armyStrength).amount(1))
+					.build(),
+			)
+			.onBuild(
+				effect(Types.Stat, StatMethods.ADD)
+					.params(statParams().key(Stat.fortificationStrength).amount(1))
+					.build(),
+			)
+			.build(),
+		order: 3,
+		focus: 'defense',
+	});
 
-  registry.add('watchtower', {
-    ...development()
-      .id('watchtower')
-      .name('Watchtower')
-      .icon('🗼')
-      .onBuild(
-        effect(Types.Stat, StatMethods.ADD)
-          .params(statParams().key(Stat.fortificationStrength).amount(2))
-          .build(),
-      )
-      .onBuild(
-        effect(Types.Stat, StatMethods.ADD)
-          .params(statParams().key(Stat.absorption).amount(0.5))
-          .build(),
-      )
-      .onAttackResolved(
-        effect(Types.Development, DevelopmentMethods.REMOVE)
-          .params(developmentParams().id('watchtower').landId('$landId'))
-          .build(),
-      )
-      .build(),
-    order: 4,
-    focus: 'defense',
-  });
+	registry.add('watchtower', {
+		...development()
+			.id('watchtower')
+			.name('Watchtower')
+			.icon('🗼')
+			.onBuild(
+				effect(Types.Stat, StatMethods.ADD)
+					.params(statParams().key(Stat.fortificationStrength).amount(2))
+					.build(),
+			)
+			.onBuild(
+				effect(Types.Stat, StatMethods.ADD)
+					.params(statParams().key(Stat.absorption).amount(0.5))
+					.build(),
+			)
+			.onAttackResolved(
+				effect(Types.Development, DevelopmentMethods.REMOVE)
+					.params(developmentParams().id('watchtower').landId('$landId'))
+					.build(),
+			)
+			.build(),
+		order: 4,
+		focus: 'defense',
+	});
 
-  registry.add(
-    'garden',
-    development().id('garden').name('Garden').icon('🌿').system().build(),
-  );
+	registry.add(
+		'garden',
+		development().id('garden').name('Garden').icon('🌿').system().build(),
+	);
 
-  return registry;
+	return registry;
 }
 
 export const DEVELOPMENTS = createDevelopmentRegistry();

--- a/packages/contents/src/game.ts
+++ b/packages/contents/src/game.ts
@@ -4,32 +4,32 @@ import { PopulationRole } from './populationRoles';
 import type { StartConfig } from '@kingdom-builder/engine/config/schema';
 
 export const GAME_START: StartConfig = {
-  player: {
-    resources: {
-      [Resource.gold]: 10,
-      [Resource.ap]: 0,
-      [Resource.happiness]: 0,
-      [Resource.castleHP]: 10,
-    },
-    stats: {
-      [Stat.maxPopulation]: 1,
-      [Stat.armyStrength]: 0,
-      [Stat.fortificationStrength]: 0,
-      [Stat.absorption]: 0,
-      [Stat.growth]: 0.25,
-      [Stat.warWeariness]: 0,
-    },
-    population: {
-      [PopulationRole.Council]: 1,
-      [PopulationRole.Legion]: 0,
-      [PopulationRole.Fortifier]: 0,
-      [PopulationRole.Citizen]: 0,
-    },
-    lands: [{ developments: ['farm'] }, {}],
-  },
-  players: {
-    B: {
-      resources: { [Resource.ap]: 1 },
-    },
-  },
+	player: {
+		resources: {
+			[Resource.gold]: 10,
+			[Resource.ap]: 0,
+			[Resource.happiness]: 0,
+			[Resource.castleHP]: 10,
+		},
+		stats: {
+			[Stat.maxPopulation]: 1,
+			[Stat.armyStrength]: 0,
+			[Stat.fortificationStrength]: 0,
+			[Stat.absorption]: 0,
+			[Stat.growth]: 0.25,
+			[Stat.warWeariness]: 0,
+		},
+		population: {
+			[PopulationRole.Council]: 1,
+			[PopulationRole.Legion]: 0,
+			[PopulationRole.Fortifier]: 0,
+			[PopulationRole.Citizen]: 0,
+		},
+		lands: [{ developments: ['farm'] }, {}],
+	},
+	players: {
+		B: {
+			resources: { [Resource.ap]: 1 },
+		},
+	},
 };

--- a/packages/contents/src/land.ts
+++ b/packages/contents/src/land.ts
@@ -1,14 +1,14 @@
 export const LAND_INFO = {
-  icon: '🗺️',
-  label: 'Land',
+	icon: '🗺️',
+	label: 'Land',
 } as const;
 
 export const SLOT_INFO = {
-  icon: '🧩',
-  label: 'Development Slot',
+	icon: '🧩',
+	label: 'Development Slot',
 } as const;
 
 export const DEVELOPMENTS_INFO = {
-  icon: '🏗️',
-  label: 'Developments',
+	icon: '🏗️',
+	label: 'Developments',
 } as const;

--- a/packages/contents/src/modifiers.ts
+++ b/packages/contents/src/modifiers.ts
@@ -1,4 +1,4 @@
 export const MODIFIER_INFO = {
-  cost: { icon: '💲', label: 'Cost Modifier' },
-  result: { icon: '✨', label: 'Result Modifier' },
+	cost: { icon: '💲', label: 'Cost Modifier' },
+	result: { icon: '✨', label: 'Result Modifier' },
 } as const;

--- a/packages/contents/src/passive.ts
+++ b/packages/contents/src/passive.ts
@@ -1,4 +1,4 @@
 export const PASSIVE_INFO = {
-  icon: '♾️',
-  label: 'Passive',
+	icon: '♾️',
+	label: 'Passive',
 } as const;

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -1,107 +1,107 @@
 import { Stat } from './stats';
 import { PopulationRole } from './populationRoles';
 import {
-  effect,
-  Types,
-  StatMethods,
-  phase,
-  step,
-  populationEvaluator,
-  statParams,
-  compareEvaluator,
-  statEvaluator,
-  type PhaseDef,
+	effect,
+	Types,
+	StatMethods,
+	phase,
+	step,
+	populationEvaluator,
+	statParams,
+	compareEvaluator,
+	statEvaluator,
+	type PhaseDef,
 } from './config/builders';
 import {
-  ON_GAIN_AP_STEP,
-  ON_GAIN_INCOME_STEP,
-  ON_PAY_UPKEEP_STEP,
+	ON_GAIN_AP_STEP,
+	ON_GAIN_INCOME_STEP,
+	ON_PAY_UPKEEP_STEP,
 } from './defs';
 
 export const PHASES: PhaseDef[] = [
-  phase('growth')
-    .label('Growth')
-    .icon('🏗️')
-    .step(
-      step('resolve-dynamic-triggers')
-        .title('Resolve dynamic triggers')
-        .triggers('onGrowthPhase'),
-    )
-    .step(
-      step('gain-income')
-        .title('Gain Income')
-        .icon('💰')
-        .triggers(ON_GAIN_INCOME_STEP),
-    )
-    .step(step('gain-ap').title('Gain Action Points').triggers(ON_GAIN_AP_STEP))
-    .step(
-      step('raise-strength')
-        .title('Raise Strength')
-        .effect(
-          effect()
-            .evaluator(populationEvaluator().role(PopulationRole.Legion))
-            .effect(
-              effect(Types.Stat, StatMethods.ADD_PCT)
-                .params(
-                  statParams()
-                    .key(Stat.armyStrength)
-                    .percentFromStat(Stat.growth),
-                )
-                .round('up')
-                .build(),
-            )
-            .build(),
-        )
-        .effect(
-          effect()
-            .evaluator(populationEvaluator().role(PopulationRole.Fortifier))
-            .effect(
-              effect(Types.Stat, StatMethods.ADD_PCT)
-                .params(
-                  statParams()
-                    .key(Stat.fortificationStrength)
-                    .percentFromStat(Stat.growth),
-                )
-                .round('up')
-                .build(),
-            )
-            .build(),
-        ),
-    )
-    .build(),
-  phase('upkeep')
-    .label('Upkeep')
-    .icon('🧹')
-    .step(
-      step('resolve-dynamic-triggers')
-        .title('Resolve dynamic triggers')
-        .triggers('onUpkeepPhase'),
-    )
-    .step(step('pay-upkeep').title('Pay Upkeep').triggers(ON_PAY_UPKEEP_STEP))
-    .step(
-      step('war-recovery')
-        .title('War recovery')
-        .effect(
-          effect()
-            .evaluator(
-              compareEvaluator()
-                .left(statEvaluator().key(Stat.warWeariness))
-                .operator('gt')
-                .right(0),
-            )
-            .effect(
-              effect(Types.Stat, StatMethods.REMOVE)
-                .params(statParams().key(Stat.warWeariness).amount(1))
-                .build(),
-            )
-            .build(),
-        ),
-    )
-    .build(),
-  phase('main')
-    .label('Main')
-    .icon('🎯')
-    .action()
-    .step(step('main').title('Main Phase'))
-    .build(),
+	phase('growth')
+		.label('Growth')
+		.icon('🏗️')
+		.step(
+			step('resolve-dynamic-triggers')
+				.title('Resolve dynamic triggers')
+				.triggers('onGrowthPhase'),
+		)
+		.step(
+			step('gain-income')
+				.title('Gain Income')
+				.icon('💰')
+				.triggers(ON_GAIN_INCOME_STEP),
+		)
+		.step(step('gain-ap').title('Gain Action Points').triggers(ON_GAIN_AP_STEP))
+		.step(
+			step('raise-strength')
+				.title('Raise Strength')
+				.effect(
+					effect()
+						.evaluator(populationEvaluator().role(PopulationRole.Legion))
+						.effect(
+							effect(Types.Stat, StatMethods.ADD_PCT)
+								.params(
+									statParams()
+										.key(Stat.armyStrength)
+										.percentFromStat(Stat.growth),
+								)
+								.round('up')
+								.build(),
+						)
+						.build(),
+				)
+				.effect(
+					effect()
+						.evaluator(populationEvaluator().role(PopulationRole.Fortifier))
+						.effect(
+							effect(Types.Stat, StatMethods.ADD_PCT)
+								.params(
+									statParams()
+										.key(Stat.fortificationStrength)
+										.percentFromStat(Stat.growth),
+								)
+								.round('up')
+								.build(),
+						)
+						.build(),
+				),
+		)
+		.build(),
+	phase('upkeep')
+		.label('Upkeep')
+		.icon('🧹')
+		.step(
+			step('resolve-dynamic-triggers')
+				.title('Resolve dynamic triggers')
+				.triggers('onUpkeepPhase'),
+		)
+		.step(step('pay-upkeep').title('Pay Upkeep').triggers(ON_PAY_UPKEEP_STEP))
+		.step(
+			step('war-recovery')
+				.title('War recovery')
+				.effect(
+					effect()
+						.evaluator(
+							compareEvaluator()
+								.left(statEvaluator().key(Stat.warWeariness))
+								.operator('gt')
+								.right(0),
+						)
+						.effect(
+							effect(Types.Stat, StatMethods.REMOVE)
+								.params(statParams().key(Stat.warWeariness).amount(1))
+								.build(),
+						)
+						.build(),
+				),
+		)
+		.build(),
+	phase('main')
+		.label('Main')
+		.icon('🎯')
+		.action()
+		.step(step('main').title('Main Phase'))
+		.build(),
 ];

--- a/packages/contents/src/population.ts
+++ b/packages/contents/src/population.ts
@@ -1,11 +1,11 @@
 export const POPULATION_INFO = {
-  icon: '👥',
-  label: 'Population',
-  description:
-    'Population represents the people of your kingdom. Manage them wisely and assign roles to benefit your realm.',
+	icon: '👥',
+	label: 'Population',
+	description:
+		'Population represents the people of your kingdom. Manage them wisely and assign roles to benefit your realm.',
 } as const;
 
 export const POPULATION_ARCHETYPE_INFO = {
-  icon: '🎭',
-  label: 'Archetypes',
+	icon: '🎭',
+	label: 'Archetypes',
 } as const;

--- a/packages/contents/src/populationRoles.ts
+++ b/packages/contents/src/populationRoles.ts
@@ -1,48 +1,48 @@
 import {
-  populationRole,
-  type PopulationRoleInfo,
-  toRecord,
+	populationRole,
+	type PopulationRoleInfo,
+	toRecord,
 } from './config/builders';
 
 export const PopulationRole = {
-  Council: 'council',
-  Legion: 'legion',
-  Fortifier: 'fortifier',
-  Citizen: 'citizen',
+	Council: 'council',
+	Legion: 'legion',
+	Fortifier: 'fortifier',
+	Citizen: 'citizen',
 } as const;
 export type PopulationRoleId =
-  (typeof PopulationRole)[keyof typeof PopulationRole];
+	(typeof PopulationRole)[keyof typeof PopulationRole];
 
 const defs: PopulationRoleInfo[] = [
-  populationRole(PopulationRole.Council)
-    .icon('⚖️')
-    .label('Council')
-    .description(
-      'The Council advises the crown and generates Action Points during the Growth phase. Keeping them employed fuels your economy.',
-    )
-    .build(),
-  populationRole(PopulationRole.Legion)
-    .icon('🎖️')
-    .label('Legion')
-    .description(
-      'Legions lead your forces, boosting Army Strength and training troops each Growth phase.',
-    )
-    .build(),
-  populationRole(PopulationRole.Fortifier)
-    .icon('🔧')
-    .label('Fortifier')
-    .description(
-      'Fortifiers reinforce your defenses. They raise Fortification Strength and shore up the castle every Growth phase.',
-    )
-    .build(),
-  populationRole(PopulationRole.Citizen)
-    .icon('👤')
-    .label('Citizen')
-    .description(
-      'Citizens are unassigned populace who await a role. They contribute little on their own but can be trained into specialists.',
-    )
-    .build(),
+	populationRole(PopulationRole.Council)
+		.icon('⚖️')
+		.label('Council')
+		.description(
+			'The Council advises the crown and generates Action Points during the Growth phase. Keeping them employed fuels your economy.',
+		)
+		.build(),
+	populationRole(PopulationRole.Legion)
+		.icon('🎖️')
+		.label('Legion')
+		.description(
+			'Legions lead your forces, boosting Army Strength and training troops each Growth phase.',
+		)
+		.build(),
+	populationRole(PopulationRole.Fortifier)
+		.icon('🔧')
+		.label('Fortifier')
+		.description(
+			'Fortifiers reinforce your defenses. They raise Fortification Strength and shore up the castle every Growth phase.',
+		)
+		.build(),
+	populationRole(PopulationRole.Citizen)
+		.icon('👤')
+		.label('Citizen')
+		.description(
+			'Citizens are unassigned populace who await a role. They contribute little on their own but can be trained into specialists.',
+		)
+		.build(),
 ];
 
 export const POPULATION_ROLES: Record<PopulationRoleId, PopulationRoleInfo> =
-  toRecord(defs) as Record<PopulationRoleId, PopulationRoleInfo>;
+	toRecord(defs) as Record<PopulationRoleId, PopulationRoleInfo>;

--- a/packages/contents/src/resources.ts
+++ b/packages/contents/src/resources.ts
@@ -1,47 +1,47 @@
 import { resource, type ResourceInfo, toRecord } from './config/builders';
 
 export const Resource = {
-  gold: 'gold',
-  ap: 'ap',
-  happiness: 'happiness',
-  castleHP: 'castleHP',
+	gold: 'gold',
+	ap: 'ap',
+	happiness: 'happiness',
+	castleHP: 'castleHP',
 } as const;
 export type ResourceKey = (typeof Resource)[keyof typeof Resource];
 
 const defs: ResourceInfo[] = [
-  resource(Resource.gold)
-    .icon('🪙')
-    .label('Gold')
-    .description(
-      'Gold is the foundational currency of the realm. It is earned through developments and actions and spent to fund buildings, recruit population or pay for powerful plays. A healthy treasury keeps your options open.',
-    )
-    .tag('bankruptcy-check')
-    .build(),
-  resource(Resource.ap)
-    .icon('⚡')
-    .label('Action Points')
-    .description(
-      'Action Points govern how many actions you can perform during your turn. Plan carefully: once you run out of AP, your main phase ends.',
-    )
-    .build(),
-  resource(Resource.happiness)
-    .icon('😊')
-    .label('Happiness')
-    .description(
-      'Happiness measures the contentment of your subjects. High happiness keeps morale up, while low happiness can lead to unrest or negative effects.',
-    )
-    .build(),
-  resource(Resource.castleHP)
-    .icon('🏰')
-    .label('Castle HP')
-    .description(
-      'Castle HP represents the durability of your stronghold. If it ever drops to zero, your kingdom falls and the game is lost.',
-    )
-    .tag('attack-target')
-    .tag('win-condition-zero')
-    .build(),
+	resource(Resource.gold)
+		.icon('🪙')
+		.label('Gold')
+		.description(
+			'Gold is the foundational currency of the realm. It is earned through developments and actions and spent to fund buildings, recruit population or pay for powerful plays. A healthy treasury keeps your options open.',
+		)
+		.tag('bankruptcy-check')
+		.build(),
+	resource(Resource.ap)
+		.icon('⚡')
+		.label('Action Points')
+		.description(
+			'Action Points govern how many actions you can perform during your turn. Plan carefully: once you run out of AP, your main phase ends.',
+		)
+		.build(),
+	resource(Resource.happiness)
+		.icon('😊')
+		.label('Happiness')
+		.description(
+			'Happiness measures the contentment of your subjects. High happiness keeps morale up, while low happiness can lead to unrest or negative effects.',
+		)
+		.build(),
+	resource(Resource.castleHP)
+		.icon('🏰')
+		.label('Castle HP')
+		.description(
+			'Castle HP represents the durability of your stronghold. If it ever drops to zero, your kingdom falls and the game is lost.',
+		)
+		.tag('attack-target')
+		.tag('win-condition-zero')
+		.build(),
 ];
 
 export const RESOURCES: Record<ResourceKey, ResourceInfo> = toRecord(
-  defs,
+	defs,
 ) as Record<ResourceKey, ResourceInfo>;

--- a/packages/contents/src/stats.ts
+++ b/packages/contents/src/stats.ts
@@ -1,67 +1,67 @@
 import { stat, type StatInfo, toRecord } from './config/builders';
 
 export const Stat = {
-  maxPopulation: 'maxPopulation',
-  armyStrength: 'armyStrength',
-  fortificationStrength: 'fortificationStrength',
-  absorption: 'absorption',
-  growth: 'growth',
-  warWeariness: 'warWeariness',
+	maxPopulation: 'maxPopulation',
+	armyStrength: 'armyStrength',
+	fortificationStrength: 'fortificationStrength',
+	absorption: 'absorption',
+	growth: 'growth',
+	warWeariness: 'warWeariness',
 } as const;
 export type StatKey = (typeof Stat)[keyof typeof Stat];
 
 const defs: StatInfo[] = [
-  stat(Stat.maxPopulation)
-    .icon('👥')
-    .label('Max Population')
-    .description(
-      'Max Population determines how many subjects your kingdom can sustain. Expand infrastructure or build houses to increase it.',
-    )
-    .capacity()
-    .addFormat({ prefix: 'Max ' })
-    .build(),
-  stat(Stat.armyStrength)
-    .icon('⚔️')
-    .label('Army Strength')
-    .description(
-      'Army Strength reflects the overall power of your military forces. A higher value makes your attacks more formidable.',
-    )
-    .build(),
-  stat(Stat.fortificationStrength)
-    .icon('🛡️')
-    .label('Fortification Strength')
-    .description(
-      'Fortification Strength measures the resilience of your defenses. It reduces damage taken when enemies assault your castle.',
-    )
-    .build(),
-  stat(Stat.absorption)
-    .icon('🌀')
-    .label('Absorption')
-    .description(
-      'Absorption reduces incoming damage by a percentage. It represents magical barriers or tactical advantages that soften blows.',
-    )
-    .displayAsPercent()
-    .addFormat({ percent: true })
-    .build(),
-  stat(Stat.growth)
-    .icon('📈')
-    .label('Growth')
-    .description(
-      'Growth increases Army and Fortification Strength during the Raise Strength step. Its effect scales with active Legions and Fortifiers—if you lack Legions or Fortifiers, that side will not gain Strength during the Growth phase.',
-    )
-    .displayAsPercent()
-    .addFormat({ percent: true })
-    .build(),
-  stat(Stat.warWeariness)
-    .icon('💤')
-    .label('War Weariness')
-    .description(
-      'War Weariness reflects the fatigue from prolonged conflict. High weariness can sap morale and hinder wartime efforts.',
-    )
-    .build(),
+	stat(Stat.maxPopulation)
+		.icon('👥')
+		.label('Max Population')
+		.description(
+			'Max Population determines how many subjects your kingdom can sustain. Expand infrastructure or build houses to increase it.',
+		)
+		.capacity()
+		.addFormat({ prefix: 'Max ' })
+		.build(),
+	stat(Stat.armyStrength)
+		.icon('⚔️')
+		.label('Army Strength')
+		.description(
+			'Army Strength reflects the overall power of your military forces. A higher value makes your attacks more formidable.',
+		)
+		.build(),
+	stat(Stat.fortificationStrength)
+		.icon('🛡️')
+		.label('Fortification Strength')
+		.description(
+			'Fortification Strength measures the resilience of your defenses. It reduces damage taken when enemies assault your castle.',
+		)
+		.build(),
+	stat(Stat.absorption)
+		.icon('🌀')
+		.label('Absorption')
+		.description(
+			'Absorption reduces incoming damage by a percentage. It represents magical barriers or tactical advantages that soften blows.',
+		)
+		.displayAsPercent()
+		.addFormat({ percent: true })
+		.build(),
+	stat(Stat.growth)
+		.icon('📈')
+		.label('Growth')
+		.description(
+			'Growth increases Army and Fortification Strength during the Raise Strength step. Its effect scales with active Legions and Fortifiers—if you lack Legions or Fortifiers, that side will not gain Strength during the Growth phase.',
+		)
+		.displayAsPercent()
+		.addFormat({ percent: true })
+		.build(),
+	stat(Stat.warWeariness)
+		.icon('💤')
+		.label('War Weariness')
+		.description(
+			'War Weariness reflects the fatigue from prolonged conflict. High weariness can sap morale and hinder wartime efforts.',
+		)
+		.build(),
 ];
 
 export const STATS: Record<StatKey, StatInfo> = toRecord(defs) as Record<
-  StatKey,
-  StatInfo
+	StatKey,
+	StatInfo
 >;

--- a/packages/contents/src/triggers.ts
+++ b/packages/contents/src/triggers.ts
@@ -1,51 +1,51 @@
 import { PHASES } from './phases';
 
 const phaseTriggers = Object.fromEntries(
-  PHASES.map((p) => [
-    `on${p.id.charAt(0).toUpperCase() + p.id.slice(1)}Phase`,
-    {
-      icon: p.icon,
-      future: `On each ${p.label} Phase`,
-      past: `${p.label} Phase`,
-    },
-  ]),
+	PHASES.map((p) => [
+		`on${p.id.charAt(0).toUpperCase() + p.id.slice(1)}Phase`,
+		{
+			icon: p.icon,
+			future: `On each ${p.label} Phase`,
+			past: `${p.label} Phase`,
+		},
+	]),
 );
 
 export const TRIGGER_INFO = {
-  onBuild: {
-    icon: '⚒️',
-    future: 'Until removed',
-    past: 'Build',
-  },
-  onBeforeAttacked: {
-    icon: '🛡️',
-    future: 'Before being attacked',
-    past: 'Before attack',
-  },
-  onAttackResolved: {
-    icon: '⚔️',
-    future: 'After having been attacked',
-    past: 'After attack',
-  },
-  onPayUpkeepStep: {
-    icon: '🧹',
-    future: 'During upkeep step',
-    past: 'Upkeep step',
-  },
-  onGainIncomeStep: {
-    icon: '💰',
-    future: 'During income step',
-    past: 'Income step',
-  },
-  onGainAPStep: {
-    icon: '⚡',
-    future: 'During AP step',
-    past: 'AP step',
-  },
-  mainPhase: {
-    icon: PHASES.find((p) => p.id === 'main')?.icon || '🎯',
-    future: '',
-    past: `${PHASES.find((p) => p.id === 'main')?.label || 'Main'} phase`,
-  },
-  ...phaseTriggers,
+	onBuild: {
+		icon: '⚒️',
+		future: 'Until removed',
+		past: 'Build',
+	},
+	onBeforeAttacked: {
+		icon: '🛡️',
+		future: 'Before being attacked',
+		past: 'Before attack',
+	},
+	onAttackResolved: {
+		icon: '⚔️',
+		future: 'After having been attacked',
+		past: 'After attack',
+	},
+	onPayUpkeepStep: {
+		icon: '🧹',
+		future: 'During upkeep step',
+		past: 'Upkeep step',
+	},
+	onGainIncomeStep: {
+		icon: '💰',
+		future: 'During income step',
+		past: 'Income step',
+	},
+	onGainAPStep: {
+		icon: '⚡',
+		future: 'During AP step',
+		past: 'AP step',
+	},
+	mainPhase: {
+		icon: PHASES.find((p) => p.id === 'main')?.icon || '🎯',
+		future: '',
+		past: `${PHASES.find((p) => p.id === 'main')?.label || 'Main'} phase`,
+	},
+	...phaseTriggers,
 } as const;

--- a/packages/engine/package-lock.json
+++ b/packages/engine/package-lock.json
@@ -1,1536 +1,1536 @@
 {
-  "name": "@kingdom-builder/engine",
-  "version": "0.1.0",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "@kingdom-builder/engine",
-      "version": "0.1.0",
-      "dependencies": {
-        "zod": "^3.23.8"
-      },
-      "devDependencies": {
-        "typescript": "^5.5.4",
-        "vitest": "^3.2.4"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
-      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.49.0.tgz",
-      "integrity": "sha512-rlKIeL854Ed0e09QGYFlmDNbka6I3EQFw7iZuugQjMb11KMpJCLPFL4ZPbMfaEhLADEL1yx0oujGkBQ7+qW3eA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.49.0.tgz",
-      "integrity": "sha512-cqPpZdKUSQYRtLLr6R4X3sD4jCBO1zUmeo3qrWBCqYIeH8Q3KRL4F3V7XJ2Rm8/RJOQBZuqzQGWPjjvFUcYa/w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.49.0.tgz",
-      "integrity": "sha512-99kMMSMQT7got6iYX3yyIiJfFndpojBmkHfTc1rIje8VbjhmqBXE+nb7ZZP3A5skLyujvT0eIUCUsxAe6NjWbw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.49.0.tgz",
-      "integrity": "sha512-y8cXoD3wdWUDpjOLMKLx6l+NFz3NlkWKcBCBfttUn+VGSfgsQ5o/yDUGtzE9HvsodkP0+16N0P4Ty1VuhtRUGg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.49.0.tgz",
-      "integrity": "sha512-3mY5Pr7qv4GS4ZvWoSP8zha8YoiqrU+e0ViPvB549jvliBbdNLrg2ywPGkgLC3cmvN8ya3za+Q2xVyT6z+vZqA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.49.0.tgz",
-      "integrity": "sha512-C9KzzOAQU5gU4kG8DTk+tjdKjpWhVWd5uVkinCwwFub2m7cDYLOdtXoMrExfeBmeRy9kBQMkiyJ+HULyF1yj9w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.49.0.tgz",
-      "integrity": "sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.49.0.tgz",
-      "integrity": "sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.49.0.tgz",
-      "integrity": "sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.49.0.tgz",
-      "integrity": "sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.49.0.tgz",
-      "integrity": "sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.49.0.tgz",
-      "integrity": "sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.49.0.tgz",
-      "integrity": "sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.49.0.tgz",
-      "integrity": "sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.49.0.tgz",
-      "integrity": "sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.49.0.tgz",
-      "integrity": "sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.49.0.tgz",
-      "integrity": "sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.49.0.tgz",
-      "integrity": "sha512-wkNRzfiIGaElC9kXUT+HLx17z7D0jl+9tGYRKwd8r7cUqTL7GYAvgUY++U2hK6Ar7z5Z6IRRoWC8kQxpmM7TDA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.49.0.tgz",
-      "integrity": "sha512-gq5aW/SyNpjp71AAzroH37DtINDcX1Qw2iv9Chyz49ZgdOP3NV8QCyKZUrGsYX9Yyggj5soFiRCgsL3HwD8TdA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.49.0.tgz",
-      "integrity": "sha512-gEtqFbzmZLFk2xKh7g0Rlo8xzho8KrEFEkzvHbfUGkrgXOpZ4XagQ6n+wIZFNh1nTb8UD16J4nFSFKXYgnbdBg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@types/chai": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/deep-eql": "*"
-      }
-    },
-    "node_modules/@types/deep-eql": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "3.2.4",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.9",
-        "@esbuild/android-arm": "0.25.9",
-        "@esbuild/android-arm64": "0.25.9",
-        "@esbuild/android-x64": "0.25.9",
-        "@esbuild/darwin-arm64": "0.25.9",
-        "@esbuild/darwin-x64": "0.25.9",
-        "@esbuild/freebsd-arm64": "0.25.9",
-        "@esbuild/freebsd-x64": "0.25.9",
-        "@esbuild/linux-arm": "0.25.9",
-        "@esbuild/linux-arm64": "0.25.9",
-        "@esbuild/linux-ia32": "0.25.9",
-        "@esbuild/linux-loong64": "0.25.9",
-        "@esbuild/linux-mips64el": "0.25.9",
-        "@esbuild/linux-ppc64": "0.25.9",
-        "@esbuild/linux-riscv64": "0.25.9",
-        "@esbuild/linux-s390x": "0.25.9",
-        "@esbuild/linux-x64": "0.25.9",
-        "@esbuild/netbsd-arm64": "0.25.9",
-        "@esbuild/netbsd-x64": "0.25.9",
-        "@esbuild/openbsd-arm64": "0.25.9",
-        "@esbuild/openbsd-x64": "0.25.9",
-        "@esbuild/openharmony-arm64": "0.25.9",
-        "@esbuild/sunos-x64": "0.25.9",
-        "@esbuild/win32-arm64": "0.25.9",
-        "@esbuild/win32-ia32": "0.25.9",
-        "@esbuild/win32-x64": "0.25.9"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/expect-type": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.18",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
-      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/rollup": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
-      "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.49.0",
-        "@rollup/rollup-android-arm64": "4.49.0",
-        "@rollup/rollup-darwin-arm64": "4.49.0",
-        "@rollup/rollup-darwin-x64": "4.49.0",
-        "@rollup/rollup-freebsd-arm64": "4.49.0",
-        "@rollup/rollup-freebsd-x64": "4.49.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.49.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.49.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.49.0",
-        "@rollup/rollup-linux-arm64-musl": "4.49.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.49.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.49.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.49.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.49.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.49.0",
-        "@rollup/rollup-linux-x64-gnu": "4.49.0",
-        "@rollup/rollup-linux-x64-musl": "4.49.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.49.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.49.0",
-        "@rollup/rollup-win32-x64-msvc": "4.49.0",
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/siginfo": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stackback": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/std-env": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/strip-literal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
-      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/tinybench": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
-      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/vite": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz",
-      "integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/debug": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/why-is-node-running": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "siginfo": "^2.0.0",
-        "stackback": "0.0.2"
-      },
-      "bin": {
-        "why-is-node-running": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    }
-  }
+	"name": "@kingdom-builder/engine",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@kingdom-builder/engine",
+			"version": "0.1.0",
+			"dependencies": {
+				"zod": "^3.23.8"
+			},
+			"devDependencies": {
+				"typescript": "^5.5.4",
+				"vitest": "^3.2.4"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+			"integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+			"integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+			"integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+			"integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+			"integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+			"integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+			"integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+			"integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+			"integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+			"integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+			"integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+			"integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+			"integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+			"integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+			"integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+			"integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+			"integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+			"integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+			"integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+			"integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+			"integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+			"integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+			"integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+			"integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+			"integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+			"integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.49.0.tgz",
+			"integrity": "sha512-rlKIeL854Ed0e09QGYFlmDNbka6I3EQFw7iZuugQjMb11KMpJCLPFL4ZPbMfaEhLADEL1yx0oujGkBQ7+qW3eA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.49.0.tgz",
+			"integrity": "sha512-cqPpZdKUSQYRtLLr6R4X3sD4jCBO1zUmeo3qrWBCqYIeH8Q3KRL4F3V7XJ2Rm8/RJOQBZuqzQGWPjjvFUcYa/w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.49.0.tgz",
+			"integrity": "sha512-99kMMSMQT7got6iYX3yyIiJfFndpojBmkHfTc1rIje8VbjhmqBXE+nb7ZZP3A5skLyujvT0eIUCUsxAe6NjWbw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.49.0.tgz",
+			"integrity": "sha512-y8cXoD3wdWUDpjOLMKLx6l+NFz3NlkWKcBCBfttUn+VGSfgsQ5o/yDUGtzE9HvsodkP0+16N0P4Ty1VuhtRUGg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.49.0.tgz",
+			"integrity": "sha512-3mY5Pr7qv4GS4ZvWoSP8zha8YoiqrU+e0ViPvB549jvliBbdNLrg2ywPGkgLC3cmvN8ya3za+Q2xVyT6z+vZqA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.49.0.tgz",
+			"integrity": "sha512-C9KzzOAQU5gU4kG8DTk+tjdKjpWhVWd5uVkinCwwFub2m7cDYLOdtXoMrExfeBmeRy9kBQMkiyJ+HULyF1yj9w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.49.0.tgz",
+			"integrity": "sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.49.0.tgz",
+			"integrity": "sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.49.0.tgz",
+			"integrity": "sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.49.0.tgz",
+			"integrity": "sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.49.0.tgz",
+			"integrity": "sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.49.0.tgz",
+			"integrity": "sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.49.0.tgz",
+			"integrity": "sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.49.0.tgz",
+			"integrity": "sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.49.0.tgz",
+			"integrity": "sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.49.0.tgz",
+			"integrity": "sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.49.0.tgz",
+			"integrity": "sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.49.0.tgz",
+			"integrity": "sha512-wkNRzfiIGaElC9kXUT+HLx17z7D0jl+9tGYRKwd8r7cUqTL7GYAvgUY++U2hK6Ar7z5Z6IRRoWC8kQxpmM7TDA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.49.0.tgz",
+			"integrity": "sha512-gq5aW/SyNpjp71AAzroH37DtINDcX1Qw2iv9Chyz49ZgdOP3NV8QCyKZUrGsYX9Yyggj5soFiRCgsL3HwD8TdA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.49.0.tgz",
+			"integrity": "sha512-gEtqFbzmZLFk2xKh7g0Rlo8xzho8KrEFEkzvHbfUGkrgXOpZ4XagQ6n+wIZFNh1nTb8UD16J4nFSFKXYgnbdBg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+			"integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vitest/expect": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+			"integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "3.2.4",
+				"@vitest/utils": "3.2.4",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+			"integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.2.4",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+			"integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+			"integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "3.2.4",
+				"pathe": "^2.0.3",
+				"strip-literal": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+			"integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.4",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+			"integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^4.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+			"integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.4",
+				"loupe": "^3.1.4",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/chai": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+			"integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/esbuild": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
+			"integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.25.9",
+				"@esbuild/android-arm": "0.25.9",
+				"@esbuild/android-arm64": "0.25.9",
+				"@esbuild/android-x64": "0.25.9",
+				"@esbuild/darwin-arm64": "0.25.9",
+				"@esbuild/darwin-x64": "0.25.9",
+				"@esbuild/freebsd-arm64": "0.25.9",
+				"@esbuild/freebsd-x64": "0.25.9",
+				"@esbuild/linux-arm": "0.25.9",
+				"@esbuild/linux-arm64": "0.25.9",
+				"@esbuild/linux-ia32": "0.25.9",
+				"@esbuild/linux-loong64": "0.25.9",
+				"@esbuild/linux-mips64el": "0.25.9",
+				"@esbuild/linux-ppc64": "0.25.9",
+				"@esbuild/linux-riscv64": "0.25.9",
+				"@esbuild/linux-s390x": "0.25.9",
+				"@esbuild/linux-x64": "0.25.9",
+				"@esbuild/netbsd-arm64": "0.25.9",
+				"@esbuild/netbsd-x64": "0.25.9",
+				"@esbuild/openbsd-arm64": "0.25.9",
+				"@esbuild/openbsd-x64": "0.25.9",
+				"@esbuild/openharmony-arm64": "0.25.9",
+				"@esbuild/sunos-x64": "0.25.9",
+				"@esbuild/win32-arm64": "0.25.9",
+				"@esbuild/win32-ia32": "0.25.9",
+				"@esbuild/win32-x64": "0.25.9"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+			"integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/loupe": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.18",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+			"integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.6",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
+			"integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.8"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.49.0",
+				"@rollup/rollup-android-arm64": "4.49.0",
+				"@rollup/rollup-darwin-arm64": "4.49.0",
+				"@rollup/rollup-darwin-x64": "4.49.0",
+				"@rollup/rollup-freebsd-arm64": "4.49.0",
+				"@rollup/rollup-freebsd-x64": "4.49.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.49.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.49.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.49.0",
+				"@rollup/rollup-linux-arm64-musl": "4.49.0",
+				"@rollup/rollup-linux-loongarch64-gnu": "4.49.0",
+				"@rollup/rollup-linux-ppc64-gnu": "4.49.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.49.0",
+				"@rollup/rollup-linux-riscv64-musl": "4.49.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.49.0",
+				"@rollup/rollup-linux-x64-gnu": "4.49.0",
+				"@rollup/rollup-linux-x64-musl": "4.49.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.49.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.49.0",
+				"@rollup/rollup-win32-x64-msvc": "4.49.0",
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+			"integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/strip-literal": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+			"integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^9.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.14",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+			"integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.4.4",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+			"integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/vite": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz",
+			"integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.25.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.14"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"lightningcss": "^1.21.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite-node": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.1",
+				"es-module-lexer": "^1.7.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/expect": "3.2.4",
+				"@vitest/mocker": "3.2.4",
+				"@vitest/pretty-format": "^3.2.4",
+				"@vitest/runner": "3.2.4",
+				"@vitest/snapshot": "3.2.4",
+				"@vitest/spy": "3.2.4",
+				"@vitest/utils": "3.2.4",
+				"chai": "^5.2.0",
+				"debug": "^4.4.1",
+				"expect-type": "^1.2.1",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.2",
+				"std-env": "^3.9.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.14",
+				"tinypool": "^1.1.1",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+				"vite-node": "3.2.4",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@vitest/browser": "3.2.4",
+				"@vitest/ui": "3.2.4",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/debug": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		}
+	}
 }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,20 +1,20 @@
 {
-  "name": "@kingdom-builder/engine",
-  "version": "0.1.0",
-  "private": false,
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "test": "vitest run"
-  },
-  "dependencies": {
-    "zod": "^3.23.8"
-  },
-  "devDependencies": {
-    "typescript": "^5.5.4",
-    "vitest": "^3.2.4",
-    "@kingdom-builder/contents": "^0.1.0"
-  }
+	"name": "@kingdom-builder/engine",
+	"version": "0.1.0",
+	"private": false,
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"test": "vitest run"
+	},
+	"dependencies": {
+		"zod": "^3.23.8"
+	},
+	"devDependencies": {
+		"typescript": "^5.5.4",
+		"vitest": "^3.2.4",
+		"@kingdom-builder/contents": "^0.1.0"
+	}
 }

--- a/packages/engine/src/effects/land_add.ts
+++ b/packages/engine/src/effects/land_add.ts
@@ -2,21 +2,21 @@ import { Land } from '../state';
 import type { EffectHandler } from '.';
 
 interface LandAddParams {
-  count?: number;
-  [key: string]: unknown;
+	count?: number;
+	[key: string]: unknown;
 }
 
 export const landAdd: EffectHandler<LandAddParams> = (
-  effect,
-  ctx,
-  mult = 1,
+	effect,
+	ctx,
+	mult = 1,
 ) => {
-  const count = Math.floor(Number(effect.params?.count ?? 1) * mult);
-  for (let index = 0; index < count; index++) {
-    const land = new Land(
-      `${ctx.activePlayer.id}-L${ctx.activePlayer.lands.length + 1}`,
-      ctx.services.rules.slotsPerNewLand,
-    );
-    ctx.activePlayer.lands.push(land);
-  }
+	const count = Math.floor(Number(effect.params?.count ?? 1) * mult);
+	for (let index = 0; index < count; index++) {
+		const land = new Land(
+			`${ctx.activePlayer.id}-L${ctx.activePlayer.lands.length + 1}`,
+			ctx.services.rules.slotsPerNewLand,
+		);
+		ctx.activePlayer.lands.push(land);
+	}
 };

--- a/packages/engine/src/evaluators/compare.ts
+++ b/packages/engine/src/evaluators/compare.ts
@@ -1,42 +1,42 @@
 import { EVALUATORS, type EvaluatorDef, type EvaluatorHandler } from './index';
 
 interface CompareParams extends Record<string, unknown> {
-  left: EvaluatorDef | number;
-  right: EvaluatorDef | number;
-  operator: 'lt' | 'lte' | 'gt' | 'gte' | 'eq' | 'ne';
+	left: EvaluatorDef | number;
+	right: EvaluatorDef | number;
+	operator: 'lt' | 'lte' | 'gt' | 'gte' | 'eq' | 'ne';
 }
 
 function compare(a: number, b: number, op: CompareParams['operator']) {
-  switch (op) {
-    case 'lt':
-      return a < b;
-    case 'lte':
-      return a <= b;
-    case 'gt':
-      return a > b;
-    case 'gte':
-      return a >= b;
-    case 'eq':
-      return a === b;
-    case 'ne':
-      return a !== b;
-    default:
-      return false;
-  }
+	switch (op) {
+		case 'lt':
+			return a < b;
+		case 'lte':
+			return a <= b;
+		case 'gt':
+			return a > b;
+		case 'gte':
+			return a >= b;
+		case 'eq':
+			return a === b;
+		case 'ne':
+			return a !== b;
+		default:
+			return false;
+	}
 }
 
 export const compareEvaluator: EvaluatorHandler<number, CompareParams> = (
-  definition,
-  ctx,
+	definition,
+	ctx,
 ) => {
-  const params = definition.params as CompareParams;
-  const leftVal =
-    typeof params.left === 'number'
-      ? params.left
-      : Number(EVALUATORS.get(params.left.type)(params.left, ctx));
-  const rightVal =
-    typeof params.right === 'number'
-      ? params.right
-      : Number(EVALUATORS.get(params.right.type)(params.right, ctx));
-  return compare(leftVal, rightVal, params.operator) ? 1 : 0;
+	const params = definition.params as CompareParams;
+	const leftVal =
+		typeof params.left === 'number'
+			? params.left
+			: Number(EVALUATORS.get(params.left.type)(params.left, ctx));
+	const rightVal =
+		typeof params.right === 'number'
+			? params.right
+			: Number(EVALUATORS.get(params.right.type)(params.right, ctx));
+	return compare(leftVal, rightVal, params.operator) ? 1 : 0;
 };

--- a/packages/engine/src/evaluators/development.ts
+++ b/packages/engine/src/evaluators/development.ts
@@ -2,18 +2,18 @@ import type { EvaluatorHandler } from './index';
 import type { EngineContext } from '../context';
 
 export interface DevelopmentEvaluatorParams extends Record<string, unknown> {
-  id: string;
+	id: string;
 }
 
 export const developmentEvaluator: EvaluatorHandler<
-  number,
-  DevelopmentEvaluatorParams
+	number,
+	DevelopmentEvaluatorParams
 > = (definition, ctx: EngineContext) => {
-  const { id } = definition.params!;
-  return ctx.activePlayer.lands.reduce(
-    (total, land) =>
-      total +
-      land.developments.filter((development) => development === id).length,
-    0,
-  );
+	const { id } = definition.params!;
+	return ctx.activePlayer.lands.reduce(
+		(total, land) =>
+			total +
+			land.developments.filter((development) => development === id).length,
+		0,
+	);
 };

--- a/packages/engine/src/evaluators/index.ts
+++ b/packages/engine/src/evaluators/index.ts
@@ -6,17 +6,17 @@ import { populationEvaluator } from './population';
 import { statEvaluator } from './stat';
 import { compareEvaluator } from './compare';
 export interface EvaluatorDef<
-  P extends Record<string, unknown> = Record<string, unknown>,
+	P extends Record<string, unknown> = Record<string, unknown>,
 > {
-  type: string;
-  params?: P | undefined;
+	type: string;
+	params?: P | undefined;
 }
 
 export interface EvaluatorHandler<
-  R = unknown,
-  P extends Record<string, unknown> = Record<string, unknown>,
+	R = unknown,
+	P extends Record<string, unknown> = Record<string, unknown>,
 > {
-  (definition: EvaluatorDef<P>, ctx: EngineContext): R;
+	(definition: EvaluatorDef<P>, ctx: EngineContext): R;
 }
 
 export class EvaluatorRegistry extends Registry<EvaluatorHandler> {}
@@ -24,12 +24,12 @@ export class EvaluatorRegistry extends Registry<EvaluatorHandler> {}
 export const EVALUATORS = new EvaluatorRegistry();
 
 export function registerCoreEvaluators(
-  registry: EvaluatorRegistry = EVALUATORS,
+	registry: EvaluatorRegistry = EVALUATORS,
 ) {
-  registry.add('development', developmentEvaluator);
-  registry.add('population', populationEvaluator);
-  registry.add('stat', statEvaluator);
-  registry.add('compare', compareEvaluator);
+	registry.add('development', developmentEvaluator);
+	registry.add('population', populationEvaluator);
+	registry.add('stat', statEvaluator);
+	registry.add('compare', compareEvaluator);
 }
 
 export { developmentEvaluator } from './development';

--- a/packages/engine/src/evaluators/stat.ts
+++ b/packages/engine/src/evaluators/stat.ts
@@ -3,13 +3,13 @@ import type { EngineContext } from '../context';
 import type { StatKey } from '../state';
 
 export interface StatEvaluatorParams extends Record<string, unknown> {
-  key: StatKey;
+	key: StatKey;
 }
 
 export const statEvaluator: EvaluatorHandler<number, StatEvaluatorParams> = (
-  definition,
-  ctx: EngineContext,
+	definition,
+	ctx: EngineContext,
 ) => {
-  const key = definition.params?.key as StatKey;
-  return ctx.activePlayer.stats[key] || 0;
+	const key = definition.params?.key as StatKey;
+	return ctx.activePlayer.stats[key] || 0;
 };

--- a/packages/engine/src/phases.ts
+++ b/packages/engine/src/phases.ts
@@ -1,16 +1,16 @@
 import type { EffectDef } from './effects';
 
 export interface StepDef {
-  id: string;
-  title?: string;
-  effects?: EffectDef[];
-  triggers?: string[];
+	id: string;
+	title?: string;
+	effects?: EffectDef[];
+	triggers?: string[];
 }
 
 export interface PhaseDef {
-  id: string;
-  steps: StepDef[];
-  action?: boolean;
-  icon?: string;
-  label?: string;
+	id: string;
+	steps: StepDef[];
+	action?: boolean;
+	icon?: string;
+	label?: string;
 }

--- a/packages/engine/src/requirements/evaluator_compare.ts
+++ b/packages/engine/src/requirements/evaluator_compare.ts
@@ -2,39 +2,39 @@ import { EVALUATORS, type EvaluatorDef } from '../evaluators';
 import type { RequirementHandler } from './index';
 
 interface CompareParams {
-  left: EvaluatorDef;
-  right: EvaluatorDef | number;
-  operator: 'lt' | 'lte' | 'gt' | 'gte' | 'eq' | 'ne';
+	left: EvaluatorDef;
+	right: EvaluatorDef | number;
+	operator: 'lt' | 'lte' | 'gt' | 'gte' | 'eq' | 'ne';
 }
 
 function compare(a: number, b: number, op: CompareParams['operator']) {
-  switch (op) {
-    case 'lt':
-      return a < b;
-    case 'lte':
-      return a <= b;
-    case 'gt':
-      return a > b;
-    case 'gte':
-      return a >= b;
-    case 'eq':
-      return a === b;
-    case 'ne':
-      return a !== b;
-    default:
-      return false;
-  }
+	switch (op) {
+		case 'lt':
+			return a < b;
+		case 'lte':
+			return a <= b;
+		case 'gt':
+			return a > b;
+		case 'gte':
+			return a >= b;
+		case 'eq':
+			return a === b;
+		case 'ne':
+			return a !== b;
+		default:
+			return false;
+	}
 }
 
 export const evaluatorCompare: RequirementHandler = (req, ctx) => {
-  const params = req.params as unknown as CompareParams;
-  const leftHandler = EVALUATORS.get(params.left.type);
-  const leftVal = leftHandler(params.left, ctx) as number;
-  const rightVal =
-    typeof params.right === 'number'
-      ? params.right
-      : (EVALUATORS.get(params.right.type)(params.right, ctx) as number);
-  return compare(leftVal, rightVal, params.operator)
-    ? true
-    : req.message || 'Requirement failed';
+	const params = req.params as unknown as CompareParams;
+	const leftHandler = EVALUATORS.get(params.left.type);
+	const leftVal = leftHandler(params.left, ctx) as number;
+	const rightVal =
+		typeof params.right === 'number'
+			? params.right
+			: (EVALUATORS.get(params.right.type)(params.right, ctx) as number);
+	return compare(leftVal, rightVal, params.operator)
+		? true
+		: req.message || 'Requirement failed';
 };

--- a/packages/engine/src/requirements/index.ts
+++ b/packages/engine/src/requirements/index.ts
@@ -6,8 +6,8 @@ import type { RequirementConfig } from '../config/schema';
 export type RequirementDef = RequirementConfig;
 
 export type RequirementHandler = (
-  req: RequirementDef,
-  ctx: EngineContext,
+	req: RequirementDef,
+	ctx: EngineContext,
 ) => true | string;
 
 export class RequirementRegistry extends Registry<RequirementHandler> {}
@@ -15,17 +15,17 @@ export class RequirementRegistry extends Registry<RequirementHandler> {}
 export const REQUIREMENTS = new RequirementRegistry();
 
 export function runRequirement(
-  req: RequirementDef,
-  ctx: EngineContext,
+	req: RequirementDef,
+	ctx: EngineContext,
 ): true | string {
-  const handler = REQUIREMENTS.get(`${req.type}:${req.method}`);
-  return handler(req, ctx);
+	const handler = REQUIREMENTS.get(`${req.type}:${req.method}`);
+	return handler(req, ctx);
 }
 
 export function registerCoreRequirements(
-  registry: RequirementRegistry = REQUIREMENTS,
+	registry: RequirementRegistry = REQUIREMENTS,
 ) {
-  registry.add('evaluator:compare', evaluatorCompare);
+	registry.add('evaluator:compare', evaluatorCompare);
 }
 
 export { evaluatorCompare };

--- a/packages/engine/tests/absorption-cap.test.ts
+++ b/packages/engine/tests/absorption-cap.test.ts
@@ -4,16 +4,16 @@ import { createTestEngine } from './helpers.ts';
 import { Resource } from '../src/state/index.ts';
 
 describe('absorption cap', () => {
-  it('caps absorption at 100%', () => {
-    const ctx = createTestEngine();
-    const defender = ctx.game.opponent;
-    defender.absorption = 1.5;
-    const start = defender.resources[Resource.castleHP];
-    const result = resolveAttack(defender, 5, ctx, {
-      type: 'resource',
-      key: Resource.castleHP,
-    });
-    expect(result.damageDealt).toBe(0);
-    expect(defender.resources[Resource.castleHP]).toBe(start);
-  });
+	it('caps absorption at 100%', () => {
+		const ctx = createTestEngine();
+		const defender = ctx.game.opponent;
+		defender.absorption = 1.5;
+		const start = defender.resources[Resource.castleHP];
+		const result = resolveAttack(defender, 5, ctx, {
+			type: 'resource',
+			key: Resource.castleHP,
+		});
+		expect(result.damageDealt).toBe(0);
+		expect(defender.resources[Resource.castleHP]).toBe(start);
+	});
 });

--- a/packages/engine/tests/additive-stat-pct.test.ts
+++ b/packages/engine/tests/additive-stat-pct.test.ts
@@ -4,33 +4,33 @@ import { Stat } from '../src/state/index.ts';
 import { createTestEngine } from './helpers.ts';
 
 describe('stat:add_pct additive scaling', () => {
-  it('adds multiple percentages from the original base in the same step', () => {
-    const ctx = createTestEngine();
-    const base = 10;
-    ctx.activePlayer.stats[Stat.armyStrength] = base;
+	it('adds multiple percentages from the original base in the same step', () => {
+		const ctx = createTestEngine();
+		const base = 10;
+		ctx.activePlayer.stats[Stat.armyStrength] = base;
 
-    const pct1 = 0.2;
-    const pct2 = 0.4;
-    const effects: EffectDef[] = [
-      {
-        type: 'stat',
-        method: 'add_pct',
-        params: { key: Stat.armyStrength, percent: pct1 },
-      },
-      {
-        type: 'stat',
-        method: 'add_pct',
-        params: { key: Stat.armyStrength, percent: pct2 },
-      },
-    ];
+		const pct1 = 0.2;
+		const pct2 = 0.4;
+		const effects: EffectDef[] = [
+			{
+				type: 'stat',
+				method: 'add_pct',
+				params: { key: Stat.armyStrength, percent: pct1 },
+			},
+			{
+				type: 'stat',
+				method: 'add_pct',
+				params: { key: Stat.armyStrength, percent: pct2 },
+			},
+		];
 
-    runEffects(effects, ctx);
+		runEffects(effects, ctx);
 
-    const expected = base * (1 + pct1 + pct2);
-    expect(ctx.activePlayer.stats[Stat.armyStrength]).toBeCloseTo(expected);
-    const sequential = base * (1 + pct1) * (1 + pct2);
-    expect(ctx.activePlayer.stats[Stat.armyStrength]).not.toBeCloseTo(
-      sequential,
-    );
-  });
+		const expected = base * (1 + pct1 + pct2);
+		expect(ctx.activePlayer.stats[Stat.armyStrength]).toBeCloseTo(expected);
+		const sequential = base * (1 + pct1) * (1 + pct2);
+		expect(ctx.activePlayer.stats[Stat.armyStrength]).not.toBeCloseTo(
+			sequential,
+		);
+	});
 });

--- a/packages/engine/tsconfig.json
+++ b/packages/engine/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist",
-    "composite": true,
-    "declaration": true
-  },
-  "include": ["src"],
-  "exclude": ["dist", "tests"]
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"composite": true,
+		"declaration": true
+	},
+	"include": ["src"],
+	"exclude": ["dist", "tests"]
 }

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <html lang="en" class="dark">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Kingdom Builder</title>
-    <link id="favicon" rel="icon" />
-  </head>
-  <body class="bg-slate-100 dark:bg-slate-900 text-gray-900 dark:text-gray-100">
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Kingdom Builder</title>
+		<link id="favicon" rel="icon" />
+	</head>
+	<body class="bg-slate-100 dark:bg-slate-900 text-gray-900 dark:text-gray-100">
+		<div id="root"></div>
+		<script type="module" src="/src/main.tsx"></script>
+	</body>
 </html>

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "@kingdom-builder/web",
-  "version": "0.1.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
-    "preview": "vite preview",
-    "lint": "eslint . --ext .ts,.tsx",
-    "test": "npm run lint && vitest run"
-  },
-  "dependencies": {
-    "@formkit/auto-animate": "^0.8.4",
-    "@kingdom-builder/contents": "^0.1.0",
-    "@kingdom-builder/engine": "^0.1.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
-  },
-  "devDependencies": {
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "@typescript-eslint/eslint-plugin": "^7.14.1",
-    "@typescript-eslint/parser": "^7.14.1",
-    "@vitejs/plugin-react": "^4.3.1",
-    "autoprefixer": "^10.4.21",
-    "eslint": "^8.57.0",
-    "eslint-plugin-unused-imports": "^3.1.0",
-    "postcss": "^8.5.6",
-    "tailwindcss": "^3.4.17",
-    "typescript": "^5.5.4",
-    "vite": "^5.4.0",
-    "vitest": "^3.2.4"
-  }
+	"name": "@kingdom-builder/web",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vite",
+		"build": "tsc -b && vite build",
+		"preview": "vite preview",
+		"lint": "eslint . --ext .ts,.tsx",
+		"test": "npm run lint && vitest run"
+	},
+	"dependencies": {
+		"@formkit/auto-animate": "^0.8.4",
+		"@kingdom-builder/contents": "^0.1.0",
+		"@kingdom-builder/engine": "^0.1.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
+	},
+	"devDependencies": {
+		"@types/react": "^18.3.3",
+		"@types/react-dom": "^18.3.0",
+		"@typescript-eslint/eslint-plugin": "^7.14.1",
+		"@typescript-eslint/parser": "^7.14.1",
+		"@vitejs/plugin-react": "^4.3.1",
+		"autoprefixer": "^10.4.21",
+		"eslint": "^8.57.0",
+		"eslint-plugin-unused-imports": "^3.1.0",
+		"postcss": "^8.5.6",
+		"tailwindcss": "^3.4.17",
+		"typescript": "^5.5.4",
+		"vite": "^5.4.0",
+		"vitest": "^3.2.4"
+	}
 }

--- a/packages/web/postcss.config.cjs
+++ b/packages/web/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+	plugins: {
+		tailwindcss: {},
+		autoprefixer: {},
+	},
 };

--- a/packages/web/src/components/audio/BackgroundMusic.tsx
+++ b/packages/web/src/components/audio/BackgroundMusic.tsx
@@ -70,10 +70,7 @@ export default function BackgroundMusic({ enabled }: { enabled: boolean }) {
 				audio.volume = 0;
 				try {
 					await audio.play();
-					if (
-						playbackRequestRef.current === requestId &&
-						enabledRef.current
-					) {
+					if (playbackRequestRef.current === requestId && enabledRef.current) {
 						fadeTo(BASE_VOLUME);
 					}
 				} catch (error) {
@@ -157,10 +154,7 @@ export default function BackgroundMusic({ enabled }: { enabled: boolean }) {
 			audio.volume = 0;
 			try {
 				await audio.play();
-				if (
-					playbackRequestRef.current === requestId &&
-					enabledRef.current
-				) {
+				if (playbackRequestRef.current === requestId && enabledRef.current) {
 					fadeTo(BASE_VOLUME);
 				}
 			} catch (error) {

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -3,383 +3,435 @@
 @tailwind utilities;
 
 [title] {
-  cursor: help;
+	cursor: help;
 }
 
 @keyframes player-bg-slide {
-  to {
-    background-position: -32px 32px;
-  }
+	to {
+		background-position: -32px 32px;
+	}
 }
 
 @keyframes value-change-up {
-  0% {
-    opacity: 0;
-    transform: translate(-50%, 0) scale(0.9);
-  }
-  18% {
-    opacity: 1;
-    transform: translate(-50%, -0.5rem) scale(1.08);
-  }
-  100% {
-    opacity: 0;
-    transform: translate(-50%, -2.25rem) scale(0.95);
-  }
+	0% {
+		opacity: 0;
+		transform: translate(-50%, 0) scale(0.9);
+	}
+	18% {
+		opacity: 1;
+		transform: translate(-50%, -0.5rem) scale(1.08);
+	}
+	100% {
+		opacity: 0;
+		transform: translate(-50%, -2.25rem) scale(0.95);
+	}
 }
 
 @keyframes value-change-down {
-  0% {
-    opacity: 0;
-    transform: translate(-50%, 0) scale(0.9);
-  }
-  18% {
-    opacity: 1;
-    transform: translate(-50%, 0.5rem) scale(1.08);
-  }
-  100% {
-    opacity: 0;
-    transform: translate(-50%, 2.25rem) scale(0.95);
-  }
+	0% {
+		opacity: 0;
+		transform: translate(-50%, 0) scale(0.9);
+	}
+	18% {
+		opacity: 1;
+		transform: translate(-50%, 0.5rem) scale(1.08);
+	}
+	100% {
+		opacity: 0;
+		transform: translate(-50%, 2.25rem) scale(0.95);
+	}
 }
 
 @layer components {
-  .bar-item {
-    @apply flex items-center gap-1 whitespace-nowrap rounded-full border border-white/40 bg-white/50 px-3 py-1 text-sm font-semibold tabular-nums text-slate-700 shadow-sm shadow-white/30 transition appearance-none dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100;
-  }
-  .info-bar {
-    @apply relative flex w-full flex-wrap items-center gap-2 rounded-full pl-14 pr-3 py-1;
-  }
-  .info-bar::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: 9999px;
-    border: 1px solid rgba(255, 255, 255, 0.45);
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0));
-    opacity: 0.9;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .dark .info-bar::before {
-    border-color: rgba(255, 255, 255, 0.15);
-    background: linear-gradient(135deg, rgba(148, 163, 184, 0.22), rgba(30, 41, 59, 0.05));
-  }
-  .info-bar > * {
-    position: relative;
-    z-index: 1;
-  }
-  .info-bar__icon {
-    @apply absolute left-3 flex h-6 w-6 items-center justify-center rounded-full text-base;
-    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), rgba(251, 191, 36, 0.55));
-    box-shadow: 0 4px 10px rgba(251, 191, 36, 0.25);
-    color: #92400e;
-    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.6);
-  }
-  .dark .info-bar__icon {
-    background: radial-gradient(circle at 30% 30%, rgba(248, 250, 252, 0.9), rgba(234, 179, 8, 0.35));
-    box-shadow: 0 4px 10px rgba(202, 138, 4, 0.35);
-    color: #facc15;
-    text-shadow: 0 1px 2px rgba(17, 24, 39, 0.75);
-  }
-  .hoverable {
-    @apply transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/60 hover:shadow-lg hover:shadow-amber-500/10 dark:hover:bg-white/10 dark:hover:shadow-black/30;
-  }
-  .panel-card {
-    @apply relative overflow-hidden rounded-2xl border border-white/50 bg-white/70 shadow-lg shadow-amber-500/10 dark:border-white/10 dark:bg-slate-900/70 dark:shadow-black/50;
-  }
-  .panel-card::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0));
-    opacity: 0.85;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .dark .panel-card::before {
-    background: linear-gradient(135deg, rgba(148, 163, 184, 0.18), rgba(30, 41, 59, 0.05));
-    opacity: 0.9;
-  }
-  .panel-card > * {
-    position: relative;
-    z-index: 1;
-  }
-  .action-card {
-    display: flex;
-    flex-direction: column;
-    perspective: 1200px;
-    cursor: inherit;
-  }
-  .action-card__inner {
-    position: relative;
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    align-items: stretch;
-    flex: 1;
-    height: 100%;
-    transition: transform 0.6s cubic-bezier(0.25, 0.8, 0.25, 1);
-    transform-style: preserve-3d;
-  }
-  .action-card[data-face='back'] .action-card__inner {
-    transform: rotateY(180deg);
-  }
-  .action-card__face {
-    display: flex;
-    flex-direction: column;
-    backface-visibility: hidden;
-    border-radius: inherit;
-    background: transparent;
-    grid-area: 1 / 1;
-    width: 100%;
-    height: 100%;
-  }
-  .action-card__face--front {
-    transform: rotateY(0deg);
-    cursor: inherit;
-  }
-  .action-card__face--back {
-    transform: rotateY(180deg);
-  }
-  .action-card[data-face='front'] .action-card__face--back,
-  .action-card[data-face='back'] .action-card__face--front {
-    pointer-events: none;
-  }
-  .action-card__face--front > * {
-    width: 100%;
-    height: 100%;
-    border-radius: inherit;
-    background: transparent;
-  }
-  .action-card__badge {
-    position: absolute;
-    top: 0.35rem;
-    left: 0.4rem;
-    z-index: 2;
-  }
-  .action-card__badge-pill {
-    @apply rounded-full bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-amber-600 shadow-sm shadow-amber-400/30 dark:bg-slate-800/70 dark:text-amber-300;
-  }
-  .action-card__multi-step {
-    @apply flex items-center justify-center rounded-md border border-white/20 bg-white/55 p-0.5 text-emerald-700/90 shadow-sm shadow-emerald-200/10 dark:border-white/10 dark:bg-slate-900/70 dark:text-emerald-200/90;
-  }
-  .action-card__multi-step-icon {
-    width: 0.75rem;
-    height: 0.75rem;
-  }
-  .action-card__option {
-    @apply panel-card cursor-pointer border border-white/40 bg-white/70 p-3 text-left text-sm text-slate-700 transition dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100;
-  }
-  .action-card__option--compact {
-    @apply flex min-h-[4.25rem] items-center justify-center gap-2 text-base font-semibold;
-  }
-  .action-card__option--compact .action-card__option-title {
-    @apply text-base font-semibold text-center;
-  }
-  .action-card__option-title {
-    @apply text-base font-semibold;
-  }
-  .action-card__option-summary {
-    @apply text-sm text-slate-600 dark:text-slate-300;
-  }
-  .action-card__option-description {
-    @apply text-xs text-slate-500 dark:text-slate-400;
-  }
-  .action-card__cancel {
-    @apply rounded-full border border-white/50 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-white hover:text-slate-900 dark:border-white/20 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700;
-  }
-  .player-panel .panel-card {
-    @apply border-white/40 bg-white/80 dark:border-white/10 dark:bg-slate-900/60;
-  }
-  .value-change-indicator {
-    @apply pointer-events-none font-black tracking-wide text-sm sm:text-base;
-    left: 50%;
-    position: absolute;
-    text-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
-    white-space: nowrap;
-    z-index: 20;
-    letter-spacing: 0.04em;
-    will-change: transform, opacity;
-  }
-  .value-change-indicator--gain {
-    animation: value-change-up 1.2s ease-out forwards;
-    top: 0;
-    filter: drop-shadow(0 0 6px rgba(16, 185, 129, 0.4));
-  }
-  .value-change-indicator--loss {
-    animation: value-change-down 1.2s ease-out forwards;
-    bottom: 0;
-    filter: drop-shadow(0 0 6px rgba(248, 113, 113, 0.4));
-  }
-  .frosted-surface {
-    position: relative;
-    overflow: hidden;
-    isolation: isolate;
-  }
-  .frosted-surface::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0));
-    opacity: 0.85;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .dark .frosted-surface::before {
-    background: linear-gradient(135deg, rgba(148, 163, 184, 0.18), rgba(30, 41, 59, 0.05));
-    opacity: 0.9;
-  }
-  .frosted-surface > * {
-    position: relative;
-    z-index: 1;
-  }
+	.bar-item {
+		@apply flex items-center gap-1 whitespace-nowrap rounded-full border border-white/40 bg-white/50 px-3 py-1 text-sm font-semibold tabular-nums text-slate-700 shadow-sm shadow-white/30 transition appearance-none dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100;
+	}
+	.info-bar {
+		@apply relative flex w-full flex-wrap items-center gap-2 rounded-full pl-14 pr-3 py-1;
+	}
+	.info-bar::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		border-radius: 9999px;
+		border: 1px solid rgba(255, 255, 255, 0.45);
+		background: linear-gradient(
+			135deg,
+			rgba(255, 255, 255, 0.55),
+			rgba(255, 255, 255, 0)
+		);
+		opacity: 0.9;
+		pointer-events: none;
+		z-index: 0;
+	}
+	.dark .info-bar::before {
+		border-color: rgba(255, 255, 255, 0.15);
+		background: linear-gradient(
+			135deg,
+			rgba(148, 163, 184, 0.22),
+			rgba(30, 41, 59, 0.05)
+		);
+	}
+	.info-bar > * {
+		position: relative;
+		z-index: 1;
+	}
+	.info-bar__icon {
+		@apply absolute left-3 flex h-6 w-6 items-center justify-center rounded-full text-base;
+		background: radial-gradient(
+			circle at 30% 30%,
+			rgba(255, 255, 255, 0.9),
+			rgba(251, 191, 36, 0.55)
+		);
+		box-shadow: 0 4px 10px rgba(251, 191, 36, 0.25);
+		color: #92400e;
+		text-shadow: 0 1px 2px rgba(255, 255, 255, 0.6);
+	}
+	.dark .info-bar__icon {
+		background: radial-gradient(
+			circle at 30% 30%,
+			rgba(248, 250, 252, 0.9),
+			rgba(234, 179, 8, 0.35)
+		);
+		box-shadow: 0 4px 10px rgba(202, 138, 4, 0.35);
+		color: #facc15;
+		text-shadow: 0 1px 2px rgba(17, 24, 39, 0.75);
+	}
+	.hoverable {
+		@apply transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/60 hover:shadow-lg hover:shadow-amber-500/10 dark:hover:bg-white/10 dark:hover:shadow-black/30;
+	}
+	.panel-card {
+		@apply relative overflow-hidden rounded-2xl border border-white/50 bg-white/70 shadow-lg shadow-amber-500/10 dark:border-white/10 dark:bg-slate-900/70 dark:shadow-black/50;
+	}
+	.panel-card::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(
+			135deg,
+			rgba(255, 255, 255, 0.55),
+			rgba(255, 255, 255, 0)
+		);
+		opacity: 0.85;
+		pointer-events: none;
+		z-index: 0;
+	}
+	.dark .panel-card::before {
+		background: linear-gradient(
+			135deg,
+			rgba(148, 163, 184, 0.18),
+			rgba(30, 41, 59, 0.05)
+		);
+		opacity: 0.9;
+	}
+	.panel-card > * {
+		position: relative;
+		z-index: 1;
+	}
+	.action-card {
+		display: flex;
+		flex-direction: column;
+		perspective: 1200px;
+		cursor: inherit;
+	}
+	.action-card__inner {
+		position: relative;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr);
+		align-items: stretch;
+		flex: 1;
+		height: 100%;
+		transition: transform 0.6s cubic-bezier(0.25, 0.8, 0.25, 1);
+		transform-style: preserve-3d;
+	}
+	.action-card[data-face='back'] .action-card__inner {
+		transform: rotateY(180deg);
+	}
+	.action-card__face {
+		display: flex;
+		flex-direction: column;
+		backface-visibility: hidden;
+		border-radius: inherit;
+		background: transparent;
+		grid-area: 1 / 1;
+		width: 100%;
+		height: 100%;
+	}
+	.action-card__face--front {
+		transform: rotateY(0deg);
+		cursor: inherit;
+	}
+	.action-card__face--back {
+		transform: rotateY(180deg);
+	}
+	.action-card[data-face='front'] .action-card__face--back,
+	.action-card[data-face='back'] .action-card__face--front {
+		pointer-events: none;
+	}
+	.action-card__face--front > * {
+		width: 100%;
+		height: 100%;
+		border-radius: inherit;
+		background: transparent;
+	}
+	.action-card__badge {
+		position: absolute;
+		top: 0.35rem;
+		left: 0.4rem;
+		z-index: 2;
+	}
+	.action-card__badge-pill {
+		@apply rounded-full bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-amber-600 shadow-sm shadow-amber-400/30 dark:bg-slate-800/70 dark:text-amber-300;
+	}
+	.action-card__multi-step {
+		@apply flex items-center justify-center rounded-md border border-white/20 bg-white/55 p-0.5 text-emerald-700/90 shadow-sm shadow-emerald-200/10 dark:border-white/10 dark:bg-slate-900/70 dark:text-emerald-200/90;
+	}
+	.action-card__multi-step-icon {
+		width: 0.75rem;
+		height: 0.75rem;
+	}
+	.action-card__option {
+		@apply panel-card cursor-pointer border border-white/40 bg-white/70 p-3 text-left text-sm text-slate-700 transition dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100;
+	}
+	.action-card__option--compact {
+		@apply flex min-h-[4.25rem] items-center justify-center gap-2 text-base font-semibold;
+	}
+	.action-card__option--compact .action-card__option-title {
+		@apply text-base font-semibold text-center;
+	}
+	.action-card__option-title {
+		@apply text-base font-semibold;
+	}
+	.action-card__option-summary {
+		@apply text-sm text-slate-600 dark:text-slate-300;
+	}
+	.action-card__option-description {
+		@apply text-xs text-slate-500 dark:text-slate-400;
+	}
+	.action-card__cancel {
+		@apply rounded-full border border-white/50 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-white hover:text-slate-900 dark:border-white/20 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700;
+	}
+	.player-panel .panel-card {
+		@apply border-white/40 bg-white/80 dark:border-white/10 dark:bg-slate-900/60;
+	}
+	.value-change-indicator {
+		@apply pointer-events-none font-black tracking-wide text-sm sm:text-base;
+		left: 50%;
+		position: absolute;
+		text-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+		white-space: nowrap;
+		z-index: 20;
+		letter-spacing: 0.04em;
+		will-change: transform, opacity;
+	}
+	.value-change-indicator--gain {
+		animation: value-change-up 1.2s ease-out forwards;
+		top: 0;
+		filter: drop-shadow(0 0 6px rgba(16, 185, 129, 0.4));
+	}
+	.value-change-indicator--loss {
+		animation: value-change-down 1.2s ease-out forwards;
+		bottom: 0;
+		filter: drop-shadow(0 0 6px rgba(248, 113, 113, 0.4));
+	}
+	.frosted-surface {
+		position: relative;
+		overflow: hidden;
+		isolation: isolate;
+	}
+	.frosted-surface::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(
+			135deg,
+			rgba(255, 255, 255, 0.55),
+			rgba(255, 255, 255, 0)
+		);
+		opacity: 0.85;
+		pointer-events: none;
+		z-index: 0;
+	}
+	.dark .frosted-surface::before {
+		background: linear-gradient(
+			135deg,
+			rgba(148, 163, 184, 0.18),
+			rgba(30, 41, 59, 0.05)
+		);
+		opacity: 0.9;
+	}
+	.frosted-surface > * {
+		position: relative;
+		z-index: 1;
+	}
 
-  .hover-card-transition {
-    opacity: 0;
-    transform: translateY(4px);
-    transition: opacity 200ms ease, transform 200ms ease;
-  }
+	.hover-card-transition {
+		opacity: 0;
+		transform: translateY(4px);
+		transition:
+			opacity 200ms ease,
+			transform 200ms ease;
+	}
 
-  .hover-card-transition[data-state='enter'] {
-    opacity: 1;
-    transform: translateY(0);
-  }
+	.hover-card-transition[data-state='enter'] {
+		opacity: 1;
+		transform: translateY(0);
+	}
 
-  .hover-card-transition[data-state='exit'] {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-  .land-tile {
-    @apply relative panel-card border border-white/50 p-3 text-center hoverable cursor-help shadow-lg shadow-amber-500/10 dark:border-white/10;
-  }
-  .land-slot {
-    @apply panel-card border border-white/40 p-1.5 text-lg leading-none hoverable cursor-help flex items-center justify-center gap-1 shrink-0 min-w-8 min-h-8 dark:border-white/10;
-  }
-  .player-bg {
-    @apply relative overflow-hidden rounded-3xl border border-white/60 text-slate-900 shadow-xl shadow-slate-900/10 dark:border-white/10 dark:text-slate-100 dark:shadow-black/40;
-    --stripe-color: rgba(255, 255, 255, 0.45);
-    background-color: var(--player-color);
-  }
-  .dark .player-bg {
-    --stripe-color: rgba(15, 23, 42, 0.45);
-  }
-  .player-bg::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-    background-image: linear-gradient(
-      45deg,
-      var(--stripe-color) 25%,
-      transparent 25%,
-      transparent 50%,
-      var(--stripe-color) 50%,
-      var(--stripe-color) 75%,
-      transparent 75%,
-      transparent
-    );
-    background-size: 32px 32px;
-    background-position: 0 0;
-    background-repeat: repeat;
-    opacity: 0.65;
-    will-change: background-position;
-    transition: opacity 150ms ease-in-out;
-  }
-  .player-bg > * {
-    position: relative;
-    z-index: 1;
-  }
-  .player-bg::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(circle at 25% -10%, rgba(255, 255, 255, 0.35), transparent 55%),
-      radial-gradient(circle at 75% 120%, rgba(255, 255, 255, 0.25), transparent 65%);
-    opacity: 0.7;
-    pointer-events: none;
-    z-index: 0;
-  }
-  .dark .player-bg::after {
-    background: radial-gradient(circle at 25% -10%, rgba(148, 163, 184, 0.15), transparent 60%),
-      radial-gradient(circle at 75% 120%, rgba(148, 163, 184, 0.12), transparent 70%);
-    opacity: 0.8;
-  }
-  .player-bg-animated {
-    animation: none;
-  }
-  .player-bg-animated::before {
-    opacity: 1;
-    animation: player-bg-slide 2s linear infinite;
-  }
-  .player-bg-blue {
-    --player-color: rgba(191, 219, 254, 0.75);
-  }
-  .player-bg-blue-active {
-    --player-color: rgba(147, 197, 253, 0.85);
-  }
-  .player-bg-red {
-    --player-color: rgba(254, 205, 211, 0.75);
-  }
-  .player-bg-red-active {
-    --player-color: rgba(251, 182, 206, 0.85);
-  }
-  .dark .player-bg-blue {
-    --player-color: rgba(37, 99, 235, 0.35);
-  }
-  .dark .player-bg-blue-active {
-    --player-color: rgba(96, 165, 250, 0.5);
-  }
-  .dark .player-bg-red {
-    --player-color: rgba(190, 18, 60, 0.35);
-  }
-  .dark .player-bg-red-active {
-    --player-color: rgba(244, 63, 94, 0.5);
-  }
-  .log-entry-a {
-    color: rgb(37, 99, 235);
-  }
-  .log-entry-b {
-    color: rgb(190, 18, 60);
-  }
-  .dark .log-entry-a {
-    color: rgb(191, 219, 254);
-  }
-  .dark .log-entry-b {
-    color: rgb(251, 207, 232);
-  }
+	.hover-card-transition[data-state='exit'] {
+		opacity: 0;
+		transform: translateY(6px);
+	}
+	.land-tile {
+		@apply relative panel-card border border-white/50 p-3 text-center hoverable cursor-help shadow-lg shadow-amber-500/10 dark:border-white/10;
+	}
+	.land-slot {
+		@apply panel-card border border-white/40 p-1.5 text-lg leading-none hoverable cursor-help flex items-center justify-center gap-1 shrink-0 min-w-8 min-h-8 dark:border-white/10;
+	}
+	.player-bg {
+		@apply relative overflow-hidden rounded-3xl border border-white/60 text-slate-900 shadow-xl shadow-slate-900/10 dark:border-white/10 dark:text-slate-100 dark:shadow-black/40;
+		--stripe-color: rgba(255, 255, 255, 0.45);
+		background-color: var(--player-color);
+	}
+	.dark .player-bg {
+		--stripe-color: rgba(15, 23, 42, 0.45);
+	}
+	.player-bg::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		z-index: 0;
+		background-image: linear-gradient(
+			45deg,
+			var(--stripe-color) 25%,
+			transparent 25%,
+			transparent 50%,
+			var(--stripe-color) 50%,
+			var(--stripe-color) 75%,
+			transparent 75%,
+			transparent
+		);
+		background-size: 32px 32px;
+		background-position: 0 0;
+		background-repeat: repeat;
+		opacity: 0.65;
+		will-change: background-position;
+		transition: opacity 150ms ease-in-out;
+	}
+	.player-bg > * {
+		position: relative;
+		z-index: 1;
+	}
+	.player-bg::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background:
+			radial-gradient(
+				circle at 25% -10%,
+				rgba(255, 255, 255, 0.35),
+				transparent 55%
+			),
+			radial-gradient(
+				circle at 75% 120%,
+				rgba(255, 255, 255, 0.25),
+				transparent 65%
+			);
+		opacity: 0.7;
+		pointer-events: none;
+		z-index: 0;
+	}
+	.dark .player-bg::after {
+		background:
+			radial-gradient(
+				circle at 25% -10%,
+				rgba(148, 163, 184, 0.15),
+				transparent 60%
+			),
+			radial-gradient(
+				circle at 75% 120%,
+				rgba(148, 163, 184, 0.12),
+				transparent 70%
+			);
+		opacity: 0.8;
+	}
+	.player-bg-animated {
+		animation: none;
+	}
+	.player-bg-animated::before {
+		opacity: 1;
+		animation: player-bg-slide 2s linear infinite;
+	}
+	.player-bg-blue {
+		--player-color: rgba(191, 219, 254, 0.75);
+	}
+	.player-bg-blue-active {
+		--player-color: rgba(147, 197, 253, 0.85);
+	}
+	.player-bg-red {
+		--player-color: rgba(254, 205, 211, 0.75);
+	}
+	.player-bg-red-active {
+		--player-color: rgba(251, 182, 206, 0.85);
+	}
+	.dark .player-bg-blue {
+		--player-color: rgba(37, 99, 235, 0.35);
+	}
+	.dark .player-bg-blue-active {
+		--player-color: rgba(96, 165, 250, 0.5);
+	}
+	.dark .player-bg-red {
+		--player-color: rgba(190, 18, 60, 0.35);
+	}
+	.dark .player-bg-red-active {
+		--player-color: rgba(244, 63, 94, 0.5);
+	}
+	.log-entry-a {
+		color: rgb(37, 99, 235);
+	}
+	.log-entry-b {
+		color: rgb(190, 18, 60);
+	}
+	.dark .log-entry-a {
+		color: rgb(191, 219, 254);
+	}
+	.dark .log-entry-b {
+		color: rgb(251, 207, 232);
+	}
 }
 
 .no-scrollbar {
-  scrollbar-width: none;
+	scrollbar-width: none;
 }
 
 .no-scrollbar::-webkit-scrollbar {
-  display: none;
+	display: none;
 }
 
 .custom-scrollbar {
-  scrollbar-width: thin;
-  scrollbar-color: rgba(148, 163, 184, 0.6) transparent;
+	scrollbar-width: thin;
+	scrollbar-color: rgba(148, 163, 184, 0.6) transparent;
 }
 
 .custom-scrollbar::-webkit-scrollbar {
-  width: 8px;
+	width: 8px;
 }
 
 .custom-scrollbar::-webkit-scrollbar-track {
-  background: transparent;
+	background: transparent;
 }
 
 .custom-scrollbar::-webkit-scrollbar-thumb {
-  background-color: rgba(148, 163, 184, 0.6);
-  border-radius: 9999px;
-  border: 2px solid transparent;
-  background-clip: content-box;
+	background-color: rgba(148, 163, 184, 0.6);
+	border-radius: 9999px;
+	border: 2px solid transparent;
+	background-clip: content-box;
 }
 
 .dark .custom-scrollbar {
-  scrollbar-color: rgba(148, 163, 184, 0.45) transparent;
+	scrollbar-color: rgba(148, 163, 184, 0.45) transparent;
 }
 
 .dark .custom-scrollbar::-webkit-scrollbar-thumb {
-  background-color: rgba(148, 163, 184, 0.45);
+	background-color: rgba(148, 163, 184, 0.45);
 }

--- a/packages/web/src/translation/content/factory.ts
+++ b/packages/web/src/translation/content/factory.ts
@@ -4,44 +4,44 @@ import type { ContentTranslator, Summary } from './types';
 const TRANSLATORS = new Map<string, ContentTranslator<unknown, unknown>>();
 
 export function registerContentTranslator<T, O>(
-  type: string,
-  translator: ContentTranslator<T, O>,
+	type: string,
+	translator: ContentTranslator<T, O>,
 ): void {
-  TRANSLATORS.set(type, translator as ContentTranslator<unknown, unknown>);
+	TRANSLATORS.set(type, translator as ContentTranslator<unknown, unknown>);
 }
 
 export function summarizeContent<T, O>(
-  type: string,
-  target: T,
-  ctx: EngineContext,
-  opts?: O,
+	type: string,
+	target: T,
+	ctx: EngineContext,
+	opts?: O,
 ): Summary {
-  const translator = TRANSLATORS.get(type) as
-    | ContentTranslator<T, O>
-    | undefined;
-  return translator ? translator.summarize(target, ctx, opts) : [];
+	const translator = TRANSLATORS.get(type) as
+		| ContentTranslator<T, O>
+		| undefined;
+	return translator ? translator.summarize(target, ctx, opts) : [];
 }
 
 export function describeContent<T, O>(
-  type: string,
-  target: T,
-  ctx: EngineContext,
-  opts?: O,
+	type: string,
+	target: T,
+	ctx: EngineContext,
+	opts?: O,
 ): Summary {
-  const translator = TRANSLATORS.get(type) as
-    | ContentTranslator<T, O>
-    | undefined;
-  return translator ? translator.describe(target, ctx, opts) : [];
+	const translator = TRANSLATORS.get(type) as
+		| ContentTranslator<T, O>
+		| undefined;
+	return translator ? translator.describe(target, ctx, opts) : [];
 }
 
 export function logContent<T, O>(
-  type: string,
-  target: T,
-  ctx: EngineContext,
-  opts?: O,
+	type: string,
+	target: T,
+	ctx: EngineContext,
+	opts?: O,
 ): string[] {
-  const translator = TRANSLATORS.get(type) as
-    | ContentTranslator<T, O>
-    | undefined;
-  return translator?.log ? translator.log(target, ctx, opts) : [];
+	const translator = TRANSLATORS.get(type) as
+		| ContentTranslator<T, O>
+		| undefined;
+	return translator?.log ? translator.log(target, ctx, opts) : [];
 }

--- a/packages/web/src/translation/content/land.ts
+++ b/packages/web/src/translation/content/land.ts
@@ -1,46 +1,46 @@
 import type { EngineContext } from '@kingdom-builder/engine';
 import { SLOT_INFO } from '@kingdom-builder/contents';
 import {
-  describeContent,
-  summarizeContent,
-  registerContentTranslator,
+	describeContent,
+	summarizeContent,
+	registerContentTranslator,
 } from './factory';
 import type { ContentTranslator, Land, Summary, SummaryEntry } from './types';
 
 function translate(
-  land: Land,
-  ctx: EngineContext,
-  fn: (
-    type: string,
-    target: unknown,
-    ctx: EngineContext,
-    opts?: Record<string, unknown>,
-  ) => Summary,
+	land: Land,
+	ctx: EngineContext,
+	fn: (
+		type: string,
+		target: unknown,
+		ctx: EngineContext,
+		opts?: Record<string, unknown>,
+	) => Summary,
 ): Summary {
-  const items: SummaryEntry[] = [];
-  for (let i = 0; i < land.slotsMax; i++) {
-    const devId = land.developments[i];
-    if (devId) {
-      items.push({
-        title: `${ctx.developments.get(devId)?.icon || ''} ${
-          ctx.developments.get(devId)?.name || devId
-        }`,
-        items: fn('development', devId, ctx, { installed: true }),
-      });
-    } else {
-      items.push(`${SLOT_INFO.icon} Empty ${SLOT_INFO.label}`);
-    }
-  }
-  return items;
+	const items: SummaryEntry[] = [];
+	for (let i = 0; i < land.slotsMax; i++) {
+		const devId = land.developments[i];
+		if (devId) {
+			items.push({
+				title: `${ctx.developments.get(devId)?.icon || ''} ${
+					ctx.developments.get(devId)?.name || devId
+				}`,
+				items: fn('development', devId, ctx, { installed: true }),
+			});
+		} else {
+			items.push(`${SLOT_INFO.icon} Empty ${SLOT_INFO.label}`);
+		}
+	}
+	return items;
 }
 
 class LandTranslator implements ContentTranslator<Land> {
-  summarize(land: Land, ctx: EngineContext): Summary {
-    return translate(land, ctx, summarizeContent);
-  }
-  describe(land: Land, ctx: EngineContext): Summary {
-    return translate(land, ctx, describeContent);
-  }
+	summarize(land: Land, ctx: EngineContext): Summary {
+		return translate(land, ctx, summarizeContent);
+	}
+	describe(land: Land, ctx: EngineContext): Summary {
+		return translate(land, ctx, describeContent);
+	}
 }
 
 registerContentTranslator('land', new LandTranslator());

--- a/packages/web/src/translation/content/types.ts
+++ b/packages/web/src/translation/content/types.ts
@@ -1,25 +1,26 @@
 import type { EngineContext } from '@kingdom-builder/engine';
 
 export interface Land {
-  id: string;
-  slotsMax: number;
-  slotsUsed: number;
-  slotsFree: number;
-  developments: string[];
+	id: string;
+	slotsMax: number;
+	slotsUsed: number;
+	slotsFree: number;
+	developments: string[];
 }
 
-export type SummaryEntry =
-  | string
-  | {
-      title: string;
-      items: SummaryEntry[];
-      _desc?: true;
-      _hoist?: true;
-    };
+export interface SummaryGroup {
+	title: string;
+	items: SummaryEntry[];
+	_desc?: true;
+	_hoist?: true;
+	[key: string]: unknown;
+}
+
+export type SummaryEntry = string | SummaryGroup;
 export type Summary = SummaryEntry[];
 
 export interface ContentTranslator<T = unknown, O = Record<string, unknown>> {
-  summarize(target: T, ctx: EngineContext, opts?: O): Summary;
-  describe(target: T, ctx: EngineContext, opts?: O): Summary;
-  log?(target: T, ctx: EngineContext, opts?: O): string[];
+	summarize(target: T, ctx: EngineContext, opts?: O): Summary;
+	describe(target: T, ctx: EngineContext, opts?: O): Summary;
+	log?(target: T, ctx: EngineContext, opts?: O): string[];
 }

--- a/packages/web/src/translation/effects/evaluators/development.ts
+++ b/packages/web/src/translation/effects/evaluators/development.ts
@@ -1,39 +1,39 @@
 import { registerEvaluatorFormatter } from '../factory';
 
 registerEvaluatorFormatter('development', {
-  summarize: (ev, sub, ctx) => {
-    const devId = (ev.params as Record<string, string>)['id']!;
-    let def: { name?: string; icon?: string | undefined } | undefined;
-    try {
-      def = ctx.developments.get(devId);
-    } catch {
-      /* ignore */
-    }
-    const icon = def?.icon || devId;
-    const label = def?.name || devId;
-    return sub.map((s) =>
-      typeof s === 'string'
-        ? `${s} per ${icon} ${label}`.trim()
-        : { ...s, title: `${s.title} per ${icon} ${label}`.trim() },
-    );
-  },
-  describe: (ev, sub, ctx) => {
-    const devId = (ev.params as Record<string, string>)['id']!;
-    let def: { name?: string; icon?: string | undefined } | undefined;
-    try {
-      def = ctx.developments.get(devId);
-    } catch {
-      /* ignore */
-    }
-    const icon = def?.icon || '';
-    const label = def?.name || devId;
-    return sub.map((s) =>
-      typeof s === 'string'
-        ? `${s} for each ${icon} ${label}`.trim()
-        : {
-            ...s,
-            title: `${s.title} for each ${icon} ${label}`.trim(),
-          },
-    );
-  },
+	summarize: (ev, sub, ctx) => {
+		const devId = (ev.params as Record<string, string>)['id']!;
+		let def: { name?: string; icon?: string | undefined } | undefined;
+		try {
+			def = ctx.developments.get(devId);
+		} catch {
+			/* ignore */
+		}
+		const icon = def?.icon || devId;
+		const label = def?.name || devId;
+		return sub.map((s) =>
+			typeof s === 'string'
+				? `${s} per ${icon} ${label}`.trim()
+				: { ...s, title: `${s.title} per ${icon} ${label}`.trim() },
+		);
+	},
+	describe: (ev, sub, ctx) => {
+		const devId = (ev.params as Record<string, string>)['id']!;
+		let def: { name?: string; icon?: string | undefined } | undefined;
+		try {
+			def = ctx.developments.get(devId);
+		} catch {
+			/* ignore */
+		}
+		const icon = def?.icon || '';
+		const label = def?.name || devId;
+		return sub.map((s) =>
+			typeof s === 'string'
+				? `${s} for each ${icon} ${label}`.trim()
+				: {
+						...s,
+						title: `${s.title} for each ${icon} ${label}`.trim(),
+					},
+		);
+	},
 });

--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -1,51 +1,51 @@
 import { registerEffectFormatter } from '../factory';
 
 registerEffectFormatter('development', 'add', {
-  summarize: (eff, ctx) => {
-    const id = eff.params?.['id'] as string;
-    let icon = id;
-    try {
-      icon = ctx.developments.get(id).icon || id;
-    } catch {
-      /* ignore */
-    }
-    return `${icon}`;
-  },
-  describe: (eff, ctx) => {
-    const id = eff.params?.['id'] as string;
-    let def: { name: string; icon?: string | undefined } | undefined;
-    try {
-      def = ctx.developments.get(id);
-    } catch {
-      /* ignore */
-    }
-    const label = def?.name || id;
-    const icon = def?.icon || '';
-    return `Add ${icon}${label}`;
-  },
+	summarize: (eff, ctx) => {
+		const id = eff.params?.['id'] as string;
+		let icon = id;
+		try {
+			icon = ctx.developments.get(id).icon || id;
+		} catch {
+			/* ignore */
+		}
+		return `${icon}`;
+	},
+	describe: (eff, ctx) => {
+		const id = eff.params?.['id'] as string;
+		let def: { name: string; icon?: string | undefined } | undefined;
+		try {
+			def = ctx.developments.get(id);
+		} catch {
+			/* ignore */
+		}
+		const label = def?.name || id;
+		const icon = def?.icon || '';
+		return `Add ${icon}${label}`;
+	},
 });
 
 registerEffectFormatter('development', 'remove', {
-  summarize: (eff, ctx) => {
-    const id = eff.params?.['id'] as string;
-    let icon = id;
-    try {
-      icon = ctx.developments.get(id).icon || id;
-    } catch {
-      /* ignore */
-    }
-    return `Remove ${icon}`;
-  },
-  describe: (eff, ctx) => {
-    const id = eff.params?.['id'] as string;
-    let def: { name: string; icon?: string | undefined } | undefined;
-    try {
-      def = ctx.developments.get(id);
-    } catch {
-      /* ignore */
-    }
-    const label = def?.name || id;
-    const icon = def?.icon || '';
-    return `Remove ${icon}${label}`;
-  },
+	summarize: (eff, ctx) => {
+		const id = eff.params?.['id'] as string;
+		let icon = id;
+		try {
+			icon = ctx.developments.get(id).icon || id;
+		} catch {
+			/* ignore */
+		}
+		return `Remove ${icon}`;
+	},
+	describe: (eff, ctx) => {
+		const id = eff.params?.['id'] as string;
+		let def: { name: string; icon?: string | undefined } | undefined;
+		try {
+			def = ctx.developments.get(id);
+		} catch {
+			/* ignore */
+		}
+		const label = def?.name || id;
+		const icon = def?.icon || '';
+		return `Remove ${icon}${label}`;
+	},
 });

--- a/packages/web/src/translation/effects/formatters/land.ts
+++ b/packages/web/src/translation/effects/formatters/land.ts
@@ -3,18 +3,18 @@ import { signed } from '../helpers';
 import { registerEffectFormatter } from '../factory';
 
 registerEffectFormatter('land', 'add', {
-  summarize: (eff) => {
-    const count = Number(eff.params?.['count'] ?? 1);
-    return `${LAND_INFO.icon}${signed(count)}${count}`;
-  },
-  describe: (eff) => {
-    const count = Number(eff.params?.['count'] ?? 1);
-    return `${LAND_INFO.icon} ${signed(count)}${count} ${LAND_INFO.label}`;
-  },
+	summarize: (eff) => {
+		const count = Number(eff.params?.['count'] ?? 1);
+		return `${LAND_INFO.icon}${signed(count)}${count}`;
+	},
+	describe: (eff) => {
+		const count = Number(eff.params?.['count'] ?? 1);
+		return `${LAND_INFO.icon} ${signed(count)}${count} ${LAND_INFO.label}`;
+	},
 });
 
 registerEffectFormatter('land', 'till', {
-  summarize: () => `${SLOT_INFO.icon}+1`,
-  describe: () =>
-    `Till ${LAND_INFO.icon} ${LAND_INFO.label} to unlock ${SLOT_INFO.icon} ${SLOT_INFO.label}`,
+	summarize: () => `${SLOT_INFO.icon}+1`,
+	describe: () =>
+		`Till ${LAND_INFO.icon} ${LAND_INFO.label} to unlock ${SLOT_INFO.icon} ${SLOT_INFO.label}`,
 });

--- a/packages/web/src/translation/effects/formatters/resource.ts
+++ b/packages/web/src/translation/effects/formatters/resource.ts
@@ -4,55 +4,55 @@ import { signed } from '../helpers';
 import { registerEffectFormatter } from '../factory';
 
 registerEffectFormatter('resource', 'add', {
-  summarize: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const res = RESOURCES[key as ResourceKey];
-    const icon = res ? res.icon : key;
-    const amount = Number(eff.params?.['amount']);
-    return `${icon}${signed(amount)}${amount}`;
-  },
-  describe: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const res = RESOURCES[key as ResourceKey];
-    const label = res?.label || key;
-    const icon = res?.icon || key;
-    const amount = Number(eff.params?.['amount']);
-    return `${icon}${signed(amount)}${amount} ${label}`;
-  },
+	summarize: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const res = RESOURCES[key as ResourceKey];
+		const icon = res ? res.icon : key;
+		const amount = Number(eff.params?.['amount']);
+		return `${icon}${signed(amount)}${amount}`;
+	},
+	describe: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const res = RESOURCES[key as ResourceKey];
+		const label = res?.label || key;
+		const icon = res?.icon || key;
+		const amount = Number(eff.params?.['amount']);
+		return `${icon}${signed(amount)}${amount} ${label}`;
+	},
 });
 
 registerEffectFormatter('resource', 'remove', {
-  summarize: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const res = RESOURCES[key as ResourceKey];
-    const icon = res ? res.icon : key;
-    const amount = Number(eff.params?.['amount']);
-    return `${icon}${signed(-amount)}${-amount}`;
-  },
-  describe: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const res = RESOURCES[key as ResourceKey];
-    const label = res?.label || key;
-    const icon = res?.icon || key;
-    const amount = Number(eff.params?.['amount']);
-    return `${icon}${signed(-amount)}${-amount} ${label}`;
-  },
+	summarize: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const res = RESOURCES[key as ResourceKey];
+		const icon = res ? res.icon : key;
+		const amount = Number(eff.params?.['amount']);
+		return `${icon}${signed(-amount)}${-amount}`;
+	},
+	describe: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const res = RESOURCES[key as ResourceKey];
+		const label = res?.label || key;
+		const icon = res?.icon || key;
+		const amount = Number(eff.params?.['amount']);
+		return `${icon}${signed(-amount)}${-amount} ${label}`;
+	},
 });
 
 registerEffectFormatter('resource', 'transfer', {
-  summarize: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const res = RESOURCES[key as ResourceKey];
-    const icon = res?.icon || key;
-    const percent = Number(eff.params?.['percent']);
-    return `Transfer ${percent}% ${icon}`;
-  },
-  describe: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const res = RESOURCES[key as ResourceKey];
-    const label = res?.label || key;
-    const icon = res?.icon || key;
-    const percent = Number(eff.params?.['percent']);
-    return `Transfer ${percent}% of opponent's ${icon}${label} to you`;
-  },
+	summarize: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const res = RESOURCES[key as ResourceKey];
+		const icon = res?.icon || key;
+		const percent = Number(eff.params?.['percent']);
+		return `Transfer ${percent}% ${icon}`;
+	},
+	describe: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const res = RESOURCES[key as ResourceKey];
+		const label = res?.label || key;
+		const icon = res?.icon || key;
+		const percent = Number(eff.params?.['percent']);
+		return `Transfer ${percent}% of opponent's ${icon}${label} to you`;
+	},
 });

--- a/packages/web/src/translation/effects/formatters/stat/index.ts
+++ b/packages/web/src/translation/effects/formatters/stat/index.ts
@@ -3,106 +3,106 @@ import { gainOrLose, increaseOrDecrease, signed } from '../../helpers';
 import { registerEffectFormatter } from '../../factory';
 
 registerEffectFormatter('stat', 'add', {
-  summarize: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const stat = STATS[key as keyof typeof STATS];
-    const icon = stat?.icon || key;
-    const amount = Number(eff.params?.['amount']);
-    const format = stat?.addFormat;
-    const prefix = format?.prefix || '';
-    if (format?.percent) {
-      const pct = amount * 100;
-      return `${prefix}${icon}${signed(pct)}${pct}%`;
-    }
-    return `${prefix}${icon}${signed(amount)}${amount}`;
-  },
-  describe: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const stat = STATS[key as keyof typeof STATS];
-    const label = stat?.label || key;
-    const icon = stat?.icon || '';
-    const amount = Number(eff.params?.['amount']);
-    const format = stat?.addFormat;
-    const prefix = format?.prefix || '';
-    if (format?.percent) {
-      const pct = Math.abs(amount * 100);
-      return `${increaseOrDecrease(amount)} ${icon}${label} by ${pct}%`;
-    }
-    if (prefix) {
-      return `${increaseOrDecrease(amount)} ${prefix}${icon} by ${Math.abs(amount)}`;
-    }
-    return `${gainOrLose(amount)} ${Math.abs(amount)} ${icon} ${label}`;
-  },
+	summarize: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const stat = STATS[key as keyof typeof STATS];
+		const icon = stat?.icon || key;
+		const amount = Number(eff.params?.['amount']);
+		const format = stat?.addFormat;
+		const prefix = format?.prefix || '';
+		if (format?.percent) {
+			const pct = amount * 100;
+			return `${prefix}${icon}${signed(pct)}${pct}%`;
+		}
+		return `${prefix}${icon}${signed(amount)}${amount}`;
+	},
+	describe: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const stat = STATS[key as keyof typeof STATS];
+		const label = stat?.label || key;
+		const icon = stat?.icon || '';
+		const amount = Number(eff.params?.['amount']);
+		const format = stat?.addFormat;
+		const prefix = format?.prefix || '';
+		if (format?.percent) {
+			const pct = Math.abs(amount * 100);
+			return `${increaseOrDecrease(amount)} ${icon}${label} by ${pct}%`;
+		}
+		if (prefix) {
+			return `${increaseOrDecrease(amount)} ${prefix}${icon} by ${Math.abs(amount)}`;
+		}
+		return `${gainOrLose(amount)} ${Math.abs(amount)} ${icon} ${label}`;
+	},
 });
 
 registerEffectFormatter('stat', 'remove', {
-  summarize: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const stat = STATS[key as keyof typeof STATS];
-    const icon = stat?.icon || key;
-    const amount = -Number(eff.params?.['amount']);
-    const format = stat?.addFormat;
-    const prefix = format?.prefix || '';
-    if (format?.percent) {
-      const pct = amount * 100;
-      return `${prefix}${icon}${signed(pct)}${pct}%`;
-    }
-    return `${prefix}${icon}${signed(amount)}${amount}`;
-  },
-  describe: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const stat = STATS[key as keyof typeof STATS];
-    const label = stat?.label || key;
-    const icon = stat?.icon || '';
-    const amount = -Number(eff.params?.['amount']);
-    const format = stat?.addFormat;
-    const prefix = format?.prefix || '';
-    if (format?.percent) {
-      const pct = Math.abs(amount * 100);
-      return `${increaseOrDecrease(amount)} ${icon}${label} by ${pct}%`;
-    }
-    if (prefix) {
-      return `${increaseOrDecrease(amount)} ${prefix}${icon} by ${Math.abs(amount)}`;
-    }
-    return `${gainOrLose(amount)} ${Math.abs(amount)} ${icon} ${label}`;
-  },
+	summarize: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const stat = STATS[key as keyof typeof STATS];
+		const icon = stat?.icon || key;
+		const amount = -Number(eff.params?.['amount']);
+		const format = stat?.addFormat;
+		const prefix = format?.prefix || '';
+		if (format?.percent) {
+			const pct = amount * 100;
+			return `${prefix}${icon}${signed(pct)}${pct}%`;
+		}
+		return `${prefix}${icon}${signed(amount)}${amount}`;
+	},
+	describe: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const stat = STATS[key as keyof typeof STATS];
+		const label = stat?.label || key;
+		const icon = stat?.icon || '';
+		const amount = -Number(eff.params?.['amount']);
+		const format = stat?.addFormat;
+		const prefix = format?.prefix || '';
+		if (format?.percent) {
+			const pct = Math.abs(amount * 100);
+			return `${increaseOrDecrease(amount)} ${icon}${label} by ${pct}%`;
+		}
+		if (prefix) {
+			return `${increaseOrDecrease(amount)} ${prefix}${icon} by ${Math.abs(amount)}`;
+		}
+		return `${gainOrLose(amount)} ${Math.abs(amount)} ${icon} ${label}`;
+	},
 });
 
 registerEffectFormatter('stat', 'add_pct', {
-  summarize: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const stat = STATS[key as keyof typeof STATS];
-    const icon = stat ? stat.icon : key;
-    const percent = eff.params?.['percent'];
-    if (percent !== undefined) {
-      const pct = Number(percent) * 100;
-      return `${icon}${signed(pct)}${pct}%`;
-    }
-    const pctStat = eff.params?.['percentStat'] as string | undefined;
-    if (pctStat) {
-      const pctIcon = STATS[pctStat as keyof typeof STATS]?.icon || pctStat;
-      return `${icon}${pctIcon}`;
-    }
-    return icon;
-  },
-  describe: (eff) => {
-    const key = eff.params?.['key'] as string;
-    const stat = STATS[key as keyof typeof STATS];
-    const label = stat?.label || key;
-    const icon = stat?.icon || '';
-    const percent = eff.params?.['percent'];
-    if (percent !== undefined) {
-      const raw = Number(percent);
-      const pct = raw * 100;
-      return `${increaseOrDecrease(raw)} ${icon}${label} by ${Math.abs(pct)}%`;
-    }
-    const pctStat = eff.params?.['percentStat'] as string | undefined;
-    if (pctStat) {
-      const pctInfo = STATS[pctStat as keyof typeof STATS];
-      const pctIcon = pctInfo?.icon || '';
-      const pctLabel = pctInfo?.label || pctStat;
-      return `Increase ${icon}${label} by ${pctIcon}${pctLabel}`;
-    }
-    return `${increaseOrDecrease(0)} ${icon}${label}`;
-  },
+	summarize: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const stat = STATS[key as keyof typeof STATS];
+		const icon = stat ? stat.icon : key;
+		const percent = eff.params?.['percent'];
+		if (percent !== undefined) {
+			const pct = Number(percent) * 100;
+			return `${icon}${signed(pct)}${pct}%`;
+		}
+		const pctStat = eff.params?.['percentStat'] as string | undefined;
+		if (pctStat) {
+			const pctIcon = STATS[pctStat as keyof typeof STATS]?.icon || pctStat;
+			return `${icon}${pctIcon}`;
+		}
+		return icon;
+	},
+	describe: (eff) => {
+		const key = eff.params?.['key'] as string;
+		const stat = STATS[key as keyof typeof STATS];
+		const label = stat?.label || key;
+		const icon = stat?.icon || '';
+		const percent = eff.params?.['percent'];
+		if (percent !== undefined) {
+			const raw = Number(percent);
+			const pct = raw * 100;
+			return `${increaseOrDecrease(raw)} ${icon}${label} by ${Math.abs(pct)}%`;
+		}
+		const pctStat = eff.params?.['percentStat'] as string | undefined;
+		if (pctStat) {
+			const pctInfo = STATS[pctStat as keyof typeof STATS];
+			const pctIcon = pctInfo?.icon || '';
+			const pctLabel = pctInfo?.label || pctStat;
+			return `Increase ${icon}${label} by ${pctIcon}${pctLabel}`;
+		}
+		return `${increaseOrDecrease(0)} ${icon}${label}`;
+	},
 });

--- a/packages/web/src/utils/isActionPhaseActive.ts
+++ b/packages/web/src/utils/isActionPhaseActive.ts
@@ -1,7 +1,7 @@
 export function isActionPhaseActive(
-  currentPhase: string,
-  actionPhaseId: string | undefined,
-  tabsEnabled: boolean,
+	currentPhase: string,
+	actionPhaseId: string | undefined,
+	tabsEnabled: boolean,
 ): boolean {
-  return tabsEnabled && currentPhase === actionPhaseId;
+	return tabsEnabled && currentPhase === actionPhaseId;
 }

--- a/packages/web/src/utils/useValueChangeIndicators.ts
+++ b/packages/web/src/utils/useValueChangeIndicators.ts
@@ -1,59 +1,59 @@
 import { useEffect, useRef, useState } from 'react';
 
 export interface ValueChangeIndicator {
-  id: number;
-  delta: number;
-  direction: 'gain' | 'loss';
+	id: number;
+	delta: number;
+	direction: 'gain' | 'loss';
 }
 
 const INDICATOR_DURATION = 1200;
 
 export const useValueChangeIndicators = (value: number) => {
-  const previousRef = useRef<number | undefined>();
-  const idRef = useRef(0);
-  const [changes, setChanges] = useState<ValueChangeIndicator[]>([]);
+	const previousRef = useRef<number | undefined>();
+	const idRef = useRef(0);
+	const [changes, setChanges] = useState<ValueChangeIndicator[]>([]);
 
-  useEffect(() => {
-    const previous = previousRef.current;
-    if (previous !== undefined && previous !== value) {
-      const delta = value - previous;
-      if (delta !== 0) {
-        const id = idRef.current;
-        idRef.current += 1;
-        setChanges((existing) => [
-          ...existing,
-          { id, delta, direction: delta > 0 ? 'gain' : 'loss' },
-        ]);
-      }
-    }
-    previousRef.current = value;
-  }, [value]);
+	useEffect(() => {
+		const previous = previousRef.current;
+		if (previous !== undefined && previous !== value) {
+			const delta = value - previous;
+			if (delta !== 0) {
+				const id = idRef.current;
+				idRef.current += 1;
+				setChanges((existing) => [
+					...existing,
+					{ id, delta, direction: delta > 0 ? 'gain' : 'loss' },
+				]);
+			}
+		}
+		previousRef.current = value;
+	}, [value]);
 
-  useEffect(() => {
-    if (changes.length === 0) {
-      return undefined;
-    }
+	useEffect(() => {
+		if (changes.length === 0) {
+			return undefined;
+		}
 
-    if (typeof window === 'undefined') {
-      return undefined;
-    }
+		if (typeof window === 'undefined') {
+			return undefined;
+		}
 
-    const timers = changes.map((change) =>
-      window.setTimeout(() => {
-        setChanges((existing) =>
-          existing.filter((item) => item.id !== change.id),
-        );
-      }, INDICATOR_DURATION),
-    );
+		const timers = changes.map((change) =>
+			window.setTimeout(() => {
+				setChanges((existing) =>
+					existing.filter((item) => item.id !== change.id),
+				);
+			}, INDICATOR_DURATION),
+		);
 
-    return () => {
-      timers.forEach((timer) => window.clearTimeout(timer));
-    };
-  }, [changes]);
+		return () => {
+			timers.forEach((timer) => window.clearTimeout(timer));
+		};
+	}, [changes]);
 
-  return changes;
+	return changes;
 };
 
 export type UseValueChangeIndicatorsReturn = ReturnType<
-  typeof useValueChangeIndicators
+	typeof useValueChangeIndicators
 >;

--- a/packages/web/tailwind.config.cjs
+++ b/packages/web/tailwind.config.cjs
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: 'class',
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
-  theme: { extend: {} },
-  plugins: [],
+	darkMode: 'class',
+	content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+	theme: { extend: {} },
+	plugins: [],
 };

--- a/packages/web/tests/development-summary.test.ts
+++ b/packages/web/tests/development-summary.test.ts
@@ -3,61 +3,61 @@ import { summarizeContent } from '../src/translation/content';
 import type { Summary } from '../src/translation/content';
 import { createEngine } from '@kingdom-builder/engine';
 import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
-  RESOURCES,
-  Resource,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	RESOURCES,
+	Resource,
 } from '@kingdom-builder/contents';
 import type { DevelopmentDef } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
-  return await import('../../engine/src');
+	return await import('../../engine/src');
 });
 
 function flatten(summary: Summary): string[] {
-  const result: string[] = [];
-  for (const entry of summary) {
-    if (typeof entry === 'string') {
-      result.push(entry);
-    } else {
-      result.push(...flatten(entry.items));
-    }
-  }
-  return result;
+	const result: string[] = [];
+	for (const entry of summary) {
+		if (typeof entry === 'string') {
+			result.push(entry);
+		} else {
+			result.push(...flatten(entry.items));
+		}
+	}
+	return result;
 }
 
 describe('development translation', () => {
-  it('includes phase effects for a development', () => {
-    const ctx = createEngine({
-      actions: ACTIONS,
-      buildings: BUILDINGS,
-      developments: DEVELOPMENTS,
-      populations: POPULATIONS,
-      phases: PHASES,
-      start: GAME_START,
-      rules: RULES,
-    });
-    const devEntry = Array.from(
-      (
-        DEVELOPMENTS as unknown as { map: Map<string, DevelopmentDef> }
-      ).map.values(),
-    ).find((d) => d.onGainIncomeStep);
-    const devId = (devEntry as { id: string }).id;
-    const summary = summarizeContent('development', devId, ctx);
-    const flat = flatten(summary);
-    const goldIcon = RESOURCES[Resource.gold].icon;
-    const dev = DEVELOPMENTS.get(devId);
-    const amt =
-      (
-        dev.onGainIncomeStep?.[0]?.effects?.[0]?.params as {
-          amount?: number;
-        }
-      )?.amount ?? 0;
-    expect(flat.some((l) => l.includes(`${goldIcon}+${amt}`))).toBe(true);
-  });
+	it('includes phase effects for a development', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		const devEntry = Array.from(
+			(
+				DEVELOPMENTS as unknown as { map: Map<string, DevelopmentDef> }
+			).map.values(),
+		).find((d) => d.onGainIncomeStep);
+		const devId = (devEntry as { id: string }).id;
+		const summary = summarizeContent('development', devId, ctx);
+		const flat = flatten(summary);
+		const goldIcon = RESOURCES[Resource.gold].icon;
+		const dev = DEVELOPMENTS.get(devId);
+		const amt =
+			(
+				dev.onGainIncomeStep?.[0]?.effects?.[0]?.params as {
+					amount?: number;
+				}
+			)?.amount ?? 0;
+		expect(flat.some((l) => l.includes(`${goldIcon}+${amt}`))).toBe(true);
+	});
 });

--- a/packages/web/tests/land-till-formatter.test.ts
+++ b/packages/web/tests/land-till-formatter.test.ts
@@ -3,61 +3,61 @@ import { summarizeEffects } from '../src/translation/effects';
 import { summarizeContent } from '../src/translation/content';
 import { createEngine } from '@kingdom-builder/engine';
 import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
-  SLOT_INFO,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	SLOT_INFO,
 } from '@kingdom-builder/contents';
 import { LandMethods } from '@kingdom-builder/contents/config/builders';
 
 vi.mock('@kingdom-builder/engine', async () => {
-  return await import('../../engine/src');
+	return await import('../../engine/src');
 });
 
 function createCtx() {
-  return createEngine({
-    actions: ACTIONS,
-    buildings: BUILDINGS,
-    developments: DEVELOPMENTS,
-    populations: POPULATIONS,
-    phases: PHASES,
-    start: GAME_START,
-    rules: RULES,
-  });
+	return createEngine({
+		actions: ACTIONS,
+		buildings: BUILDINGS,
+		developments: DEVELOPMENTS,
+		populations: POPULATIONS,
+		phases: PHASES,
+		start: GAME_START,
+		rules: RULES,
+	});
 }
 
 describe('land till formatter', () => {
-  it('summarizes till effect', () => {
-    const ctx = createCtx();
-    const summary = summarizeEffects(
-      [{ type: 'land', method: LandMethods.TILL }],
-      ctx,
-    );
-    expect(summary).toContain(`${SLOT_INFO.icon}+1`);
-  });
+	it('summarizes till effect', () => {
+		const ctx = createCtx();
+		const summary = summarizeEffects(
+			[{ type: 'land', method: LandMethods.TILL }],
+			ctx,
+		);
+		expect(summary).toContain(`${SLOT_INFO.icon}+1`);
+	});
 
-  it('summarizes till action', () => {
-    const ctx = createCtx();
-    const tillId = Array.from(
-      (
-        ACTIONS as unknown as {
-          map: Map<string, { effects: { type: string; method?: string }[] }>;
-        }
-      ).map.entries(),
-    ).find(([, a]) =>
-      a.effects.some(
-        (e: { type: string; method?: string }) =>
-          e.type === 'land' && e.method === LandMethods.TILL,
-      ),
-    )?.[0] as string;
-    const summary = summarizeContent('action', tillId, ctx);
-    const hasIcon = summary.some(
-      (i) => typeof i === 'string' && i.includes(SLOT_INFO.icon),
-    );
-    expect(hasIcon).toBe(true);
-  });
+	it('summarizes till action', () => {
+		const ctx = createCtx();
+		const tillId = Array.from(
+			(
+				ACTIONS as unknown as {
+					map: Map<string, { effects: { type: string; method?: string }[] }>;
+				}
+			).map.entries(),
+		).find(([, a]) =>
+			a.effects.some(
+				(e: { type: string; method?: string }) =>
+					e.type === 'land' && e.method === LandMethods.TILL,
+			),
+		)?.[0] as string;
+		const summary = summarizeContent('action', tillId, ctx);
+		const hasIcon = summary.some(
+			(i) => typeof i === 'string' && i.includes(SLOT_INFO.icon),
+		);
+		expect(hasIcon).toBe(true);
+	});
 });

--- a/packages/web/tests/phase-history.test.ts
+++ b/packages/web/tests/phase-history.test.ts
@@ -2,21 +2,21 @@ import { describe, it, expect, vi } from 'vitest';
 import { isActionPhaseActive } from '../src/utils/isActionPhaseActive';
 
 vi.mock('@kingdom-builder/engine', async () => {
-  return await import('../../engine/src');
+	return await import('../../engine/src');
 });
 
 // Ensure actions remain enabled when viewing previous phase history.
 // Specifically, the check should depend solely on the provided phase ids.
 
 describe('isActionPhaseActive', () => {
-  const phaseA = 'phaseA';
-  const phaseB = 'phaseB';
+	const phaseA = 'phaseA';
+	const phaseB = 'phaseB';
 
-  it('returns true when game is in action phase regardless of display phase', () => {
-    expect(isActionPhaseActive(phaseA, phaseA, true)).toBe(true);
-  });
+	it('returns true when game is in action phase regardless of display phase', () => {
+		expect(isActionPhaseActive(phaseA, phaseA, true)).toBe(true);
+	});
 
-  it('returns false when not in action phase', () => {
-    expect(isActionPhaseActive(phaseB, phaseA, true)).toBe(false);
-  });
+	it('returns false when not in action phase', () => {
+		expect(isActionPhaseActive(phaseB, phaseA, true)).toBe(false);
+	});
 });

--- a/packages/web/tests/population-summary.test.ts
+++ b/packages/web/tests/population-summary.test.ts
@@ -1,120 +1,120 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
-  summarizeContent,
-  summarizeEffects,
-  describeEffects,
-  type Summary,
+	summarizeContent,
+	summarizeEffects,
+	describeEffects,
+	type Summary,
 } from '../src/translation';
 import { createEngine, PopulationRole } from '@kingdom-builder/engine';
 import {
-  ACTIONS,
-  BUILDINGS,
-  DEVELOPMENTS,
-  POPULATIONS,
-  PHASES,
-  GAME_START,
-  RULES,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
 } from '@kingdom-builder/contents';
 
 vi.mock('@kingdom-builder/engine', async () => {
-  return await import('../../engine/src');
+	return await import('../../engine/src');
 });
 
 function flatten(summary: Summary): string[] {
-  const result: string[] = [];
-  for (const entry of summary) {
-    if (typeof entry === 'string') {
-      result.push(entry);
-    } else {
-      result.push(...flatten(entry.items));
-    }
-  }
-  return result;
+	const result: string[] = [];
+	for (const entry of summary) {
+		if (typeof entry === 'string') {
+			result.push(entry);
+		} else {
+			result.push(...flatten(entry.items));
+		}
+	}
+	return result;
 }
 
 describe('population effect translation', () => {
-  const ctx = createEngine({
-    actions: ACTIONS,
-    buildings: BUILDINGS,
-    developments: DEVELOPMENTS,
-    populations: POPULATIONS,
-    phases: PHASES,
-    start: GAME_START,
-    rules: RULES,
-  });
+	const ctx = createEngine({
+		actions: ACTIONS,
+		buildings: BUILDINGS,
+		developments: DEVELOPMENTS,
+		populations: POPULATIONS,
+		phases: PHASES,
+		start: GAME_START,
+		rules: RULES,
+	});
 
-  it('summarizes population-raising action for specific role', () => {
-    const raiseId = Array.from(
-      (
-        ACTIONS as unknown as {
-          map: Map<string, { effects: { type: string; method?: string }[] }>;
-        }
-      ).map.entries(),
-    ).find(([, a]) =>
-      a.effects.some(
-        (e: { type: string; method?: string }) =>
-          e.type === 'population' && e.method === 'add',
-      ),
-    )?.[0] as string;
-    const summary = summarizeContent('action', raiseId, ctx, {
-      role: PopulationRole.Council,
-    });
-    const flat = flatten(summary);
-    const expected = summarizeEffects(
-      [
-        {
-          type: 'population',
-          method: 'add',
-          params: { role: PopulationRole.Council },
-        },
-      ],
-      ctx,
-    )[0];
-    expect(flat).toContain(expected);
-  });
+	it('summarizes population-raising action for specific role', () => {
+		const raiseId = Array.from(
+			(
+				ACTIONS as unknown as {
+					map: Map<string, { effects: { type: string; method?: string }[] }>;
+				}
+			).map.entries(),
+		).find(([, a]) =>
+			a.effects.some(
+				(e: { type: string; method?: string }) =>
+					e.type === 'population' && e.method === 'add',
+			),
+		)?.[0] as string;
+		const summary = summarizeContent('action', raiseId, ctx, {
+			role: PopulationRole.Council,
+		});
+		const flat = flatten(summary);
+		const expected = summarizeEffects(
+			[
+				{
+					type: 'population',
+					method: 'add',
+					params: { role: PopulationRole.Council },
+				},
+			],
+			ctx,
+		)[0];
+		expect(flat).toContain(expected);
+	});
 
-  it('handles population removal effect', () => {
-    const summary = summarizeEffects(
-      [
-        {
-          type: 'population',
-          method: 'remove',
-          params: { role: PopulationRole.Council },
-        },
-      ],
-      ctx,
-    );
-    const desc = describeEffects(
-      [
-        {
-          type: 'population',
-          method: 'remove',
-          params: { role: PopulationRole.Council },
-        },
-      ],
-      ctx,
-    );
-    const expectedSummary = summarizeEffects(
-      [
-        {
-          type: 'population',
-          method: 'remove',
-          params: { role: PopulationRole.Council },
-        },
-      ],
-      ctx,
-    )[0];
-    const expectedDesc = describeEffects(
-      [
-        {
-          type: 'population',
-          method: 'remove',
-          params: { role: PopulationRole.Council },
-        },
-      ],
-      ctx,
-    )[0];
-    expect(summary).toContain(expectedSummary);
-    expect(desc).toContain(expectedDesc);
-  });
+	it('handles population removal effect', () => {
+		const summary = summarizeEffects(
+			[
+				{
+					type: 'population',
+					method: 'remove',
+					params: { role: PopulationRole.Council },
+				},
+			],
+			ctx,
+		);
+		const desc = describeEffects(
+			[
+				{
+					type: 'population',
+					method: 'remove',
+					params: { role: PopulationRole.Council },
+				},
+			],
+			ctx,
+		);
+		const expectedSummary = summarizeEffects(
+			[
+				{
+					type: 'population',
+					method: 'remove',
+					params: { role: PopulationRole.Council },
+				},
+			],
+			ctx,
+		)[0];
+		const expectedDesc = describeEffects(
+			[
+				{
+					type: 'population',
+					method: 'remove',
+					params: { role: PopulationRole.Council },
+				},
+			],
+			ctx,
+		)[0];
+		expect(summary).toContain(expectedSummary);
+		expect(desc).toContain(expectedDesc);
+	});
 });

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,7 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "composite": true
-  },
-  "include": ["src", "../engine/src", "../contents/src"]
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"composite": true
+	},
+	"include": ["src", "../engine/src", "../contents/src"]
 }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -7,16 +7,16 @@ const rootDir = fileURLToPath(new URL('.', import.meta.url));
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@kingdom-builder/contents': path.resolve(rootDir, '../contents/src'),
-      '@kingdom-builder/engine': path.resolve(rootDir, '../engine/src'),
-    },
-  },
-  build: {
-    rollupOptions: {
-      input: path.resolve(rootDir, 'index.html'),
-    },
-  },
+	plugins: [react()],
+	resolve: {
+		alias: {
+			'@kingdom-builder/contents': path.resolve(rootDir, '../contents/src'),
+			'@kingdom-builder/engine': path.resolve(rootDir, '../engine/src'),
+		},
+	},
+	build: {
+		rollupOptions: {
+			input: path.resolve(rootDir, 'index.html'),
+		},
+	},
 });

--- a/scripts/check-test-content.js
+++ b/scripts/check-test-content.js
@@ -2,58 +2,61 @@ const fs = require('fs');
 const path = require('path');
 
 function collectContentStrings() {
-  const contentDir = path.join(__dirname, '..', 'packages', 'contents', 'src');
-  const strings = new Set();
-  const idRegex = /\.id\(\s*['"]([^'"\s]+)['"]\s*\)/g;
-  const keyValRegex = /([A-Za-z0-9_-]+):\s*['"]\1['"]/g;
+	const contentDir = path.join(__dirname, '..', 'packages', 'contents', 'src');
+	const strings = new Set();
+	const idRegex = /\.id\(\s*['"]([^'"\s]+)['"]\s*\)/g;
+	const keyValRegex = /([A-Za-z0-9_-]+):\s*['"]\1['"]/g;
 
-  function walk(dir) {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && entry.name.endsWith('.ts')) {
-        const text = fs.readFileSync(full, 'utf8');
-        let m;
-        while ((m = idRegex.exec(text)) !== null) {
-          strings.add(m[1]);
-        }
-        while ((m = keyValRegex.exec(text)) !== null) {
-          strings.add(m[1]);
-        }
-      }
-    }
-  }
+	function walk(dir) {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(full);
+			} else if (entry.isFile() && entry.name.endsWith('.ts')) {
+				const text = fs.readFileSync(full, 'utf8');
+				let m;
+				while ((m = idRegex.exec(text)) !== null) {
+					strings.add(m[1]);
+				}
+				while ((m = keyValRegex.exec(text)) !== null) {
+					strings.add(m[1]);
+				}
+			}
+		}
+	}
 
-  walk(contentDir);
-  return strings;
+	walk(contentDir);
+	return strings;
 }
 
 const FORBIDDEN = collectContentStrings();
 
 function checkValue(value, node, context) {
-  if (typeof value === 'string' && FORBIDDEN.has(value)) {
-    context.report({ node, message: `Forbidden content literal "${value}" found in test.` });
-  }
+	if (typeof value === 'string' && FORBIDDEN.has(value)) {
+		context.report({
+			node,
+			message: `Forbidden content literal "${value}" found in test.`,
+		});
+	}
 }
 
 module.exports = {
-  meta: {
-    type: 'problem',
-    docs: {
-      description: 'disallow literals from contents in tests',
-    },
-  },
-  create(context) {
-    return {
-      Literal(node) {
-        checkValue(node.value, node, context);
-      },
-      TemplateLiteral(node) {
-        for (const quasi of node.quasis) {
-          checkValue(quasi.value.cooked, quasi, context);
-        }
-      },
-    };
-  },
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'disallow literals from contents in tests',
+		},
+	},
+	create(context) {
+		return {
+			Literal(node) {
+				checkValue(node.value, node, context);
+			},
+			TemplateLiteral(node) {
+				for (const quasi of node.quasis) {
+					checkValue(quasi.value.cooked, quasi, context);
+				}
+			},
+		};
+	},
 };

--- a/scripts/dependency-cruiser.cjs
+++ b/scripts/dependency-cruiser.cjs
@@ -3,18 +3,14 @@
 module.exports = {
 	forbidden: [],
 	options: {
-		includeOnly: [
-			"^packages/engine",
-			"^packages/contents",
-			"^packages/web"
-		],
+		includeOnly: ['^packages/engine', '^packages/contents', '^packages/web'],
 		doNotFollow: {
-			path: "node_modules"
+			path: 'node_modules',
 		},
 		tsPreCompilationDeps: true,
-		baseDir: ".",
+		baseDir: '.',
 		tsConfig: {
-			fileName: "./tsconfig.base.json"
-		}
-	}
+			fileName: './tsconfig.base.json',
+		},
+	},
 };

--- a/scripts/ensure-dev-dependencies.cjs
+++ b/scripts/ensure-dev-dependencies.cjs
@@ -5,28 +5,39 @@ const { spawnSync } = require('child_process');
 const rootDir = resolve(__dirname, '..');
 
 const dependencies = [
-  {
-    name: 'eslint-plugin-import',
-    path: resolve(rootDir, 'node_modules', 'eslint-plugin-import', 'package.json'),
-  },
-  {
-    name: '@vitest/coverage-v8',
-    path: resolve(rootDir, 'node_modules', '@vitest', 'coverage-v8', 'package.json'),
-  },
+	{
+		name: 'eslint-plugin-import',
+		path: resolve(
+			rootDir,
+			'node_modules',
+			'eslint-plugin-import',
+			'package.json',
+		),
+	},
+	{
+		name: '@vitest/coverage-v8',
+		path: resolve(
+			rootDir,
+			'node_modules',
+			'@vitest',
+			'coverage-v8',
+			'package.json',
+		),
+	},
 ];
 
 const missing = dependencies
-  .filter((dependency) => !existsSync(dependency.path))
-  .map((dependency) => dependency.name);
+	.filter((dependency) => !existsSync(dependency.path))
+	.map((dependency) => dependency.name);
 
 if (missing.length > 0) {
-  const result = spawnSync('npm', ['install', '--no-save', ...missing], {
-    cwd: rootDir,
-    stdio: 'inherit',
-    env: process.env,
-  });
+	const result = spawnSync('npm', ['install', '--no-save', ...missing], {
+		cwd: rootDir,
+		stdio: 'inherit',
+		env: process.env,
+	});
 
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
-  }
+	if (result.status !== 0) {
+		process.exit(result.status ?? 1);
+	}
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,3 +1,3 @@
 {
-  "type": "commonjs"
+	"type": "commonjs"
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,28 +1,28 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "verbatimModuleSyntax": true,
-    "jsx": "react-jsx",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-    "noImplicitOverride": true,
-    "useUnknownInCatchVariables": true,
-    "forceConsistentCasingInFileNames": true,
-    "noPropertyAccessFromIndexSignature": false,
-    "types": ["vitest", "node"],
-    "baseUrl": ".",
-    "paths": {
-      "@kingdom-builder/engine/*": ["packages/engine/src/*"],
-      "@kingdom-builder/contents/*": ["packages/contents/src/*"],
-      "@kingdom-builder/*": ["packages/*/src"]
-    }
-  }
+	"compilerOptions": {
+		"target": "ES2022",
+		"useDefineForClassFields": true,
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"module": "ESNext",
+		"skipLibCheck": true,
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"jsx": "react-jsx",
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
+		"noImplicitOverride": true,
+		"useUnknownInCatchVariables": true,
+		"forceConsistentCasingInFileNames": true,
+		"noPropertyAccessFromIndexSignature": false,
+		"types": ["vitest", "node"],
+		"baseUrl": ".",
+		"paths": {
+			"@kingdom-builder/engine/*": ["packages/engine/src/*"],
+			"@kingdom-builder/contents/*": ["packages/contents/src/*"],
+			"@kingdom-builder/*": ["packages/*/src"]
+		}
+	}
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,14 @@
 {
-  "extends": "./tsconfig.base.json",
-  "include": ["**/*.ts", "**/*.tsx", "**/*.d.ts"],
-  "exclude": ["dist", "node_modules"]
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"allowJs": true
+	},
+	"include": [
+		"**/*.ts",
+		"**/*.tsx",
+		"**/*.d.ts",
+		"scripts/**/*.js",
+		"scripts/**/*.cjs"
+	],
+	"exclude": ["dist", "node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "files": [],
-  "references": [{ "path": "packages/engine" }, { "path": "packages/web" }]
+	"files": [],
+	"references": [{ "path": "packages/engine" }, { "path": "packages/web" }]
 }


### PR DESCRIPTION
## Summary
- format the repository with Prettier to align all configs, scripts, and sources with the tabbed house style
- add a prettier check script, update the aggregate check gate, and widen lint-staged coverage for prettier
- adjust lint-staged ESLint targets plus eslint/tsconfig settings so JavaScript tooling files no longer break pre-commit checks

## Testing
- CI=1 npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e17a5583cc83258666a6c8483c4aa0