### PR TITLE
Fix Royal Decree option translations

### DIFF
--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -1,51 +1,69 @@
 import { registerEffectFormatter } from '../factory';
+import { describeContent } from '../../content';
 
 registerEffectFormatter('development', 'add', {
-  summarize: (eff, ctx) => {
-    const id = eff.params?.['id'] as string;
-    let icon = id;
-    try {
-      icon = ctx.developments.get(id).icon || id;
-    } catch {
-      /* ignore */
-    }
-    return `${icon}`;
-  },
-  describe: (eff, ctx) => {
-    const id = eff.params?.['id'] as string;
-    let def: { name: string; icon?: string | undefined } | undefined;
-    try {
-      def = ctx.developments.get(id);
-    } catch {
-      /* ignore */
-    }
-    const label = def?.name || id;
-    const icon = def?.icon || '';
-    return `Add ${icon}${label}`;
-  },
+	summarize: (effect, context) => {
+		const id = effect.params?.['id'] as string;
+		let definition:
+			| { icon?: string | undefined; name?: string | undefined }
+			| undefined;
+		try {
+			definition = context.developments.get(id);
+		} catch {
+			/* ignore */
+		}
+		const icon = definition?.icon || '';
+		const name = definition?.name || id;
+		return [icon, name].filter(Boolean).join(' ').trim() || id;
+	},
+	describe: (effect, context) => {
+		const id = effect.params?.['id'] as string;
+		let definition:
+			| { name?: string | undefined; icon?: string | undefined }
+			| undefined;
+		try {
+			definition = context.developments.get(id);
+		} catch {
+			/* ignore */
+		}
+		const label = definition?.name || id;
+		const icon = definition?.icon || '';
+		const details = describeContent('development', id, context);
+		if (details.length === 0) {
+			return `${icon}${label}`.trim() || id;
+		}
+		return [
+			{
+				title: [icon, label].filter(Boolean).join(' ').trim(),
+				items: details,
+			},
+		];
+	},
 });
 
 registerEffectFormatter('development', 'remove', {
-  summarize: (eff, ctx) => {
-    const id = eff.params?.['id'] as string;
-    let icon = id;
-    try {
-      icon = ctx.developments.get(id).icon || id;
-    } catch {
-      /* ignore */
-    }
-    return `Remove ${icon}`;
-  },
-  describe: (eff, ctx) => {
-    const id = eff.params?.['id'] as string;
-    let def: { name: string; icon?: string | undefined } | undefined;
-    try {
-      def = ctx.developments.get(id);
-    } catch {
-      /* ignore */
-    }
-    const label = def?.name || id;
-    const icon = def?.icon || '';
-    return `Remove ${icon}${label}`;
-  },
+	summarize: (effect, context) => {
+		const id = effect.params?.['id'] as string;
+		let icon = id;
+		try {
+			icon = context.developments.get(id).icon || id;
+		} catch {
+			/* ignore */
+		}
+		return `Remove ${icon}`;
+	},
+	describe: (effect, context) => {
+		const id = effect.params?.['id'] as string;
+		let definition:
+			| { name?: string | undefined; icon?: string | undefined }
+			| undefined;
+		try {
+			definition = context.developments.get(id);
+		} catch {
+			/* ignore */
+		}
+		const label = definition?.name || id;
+		const icon = definition?.icon || '';
+		return `Remove ${icon}${label}`;
+	},
 });

--- a/packages/web/tests/generic-actions-effect-group.test.tsx
+++ b/packages/web/tests/generic-actions-effect-group.test.tsx
@@ -117,6 +117,12 @@ describe('GenericActions effect group handling', () => {
 		getActionCostsMock.mockImplementation(() => ({ ap: 1, gold: 12 }));
 		getActionRequirementsMock.mockImplementation(() => []);
 		getRequirementIconsMock.mockImplementation(() => []);
+		summarizeContentMock.mockImplementation((type: unknown, id: unknown) => {
+			if (type === 'action' && id === 'develop') {
+				return ['🏠 House'];
+			}
+			return [];
+		});
 		getActionEffectGroupsMock.mockImplementation((actionId: string) => {
 			if (actionId !== 'royal_decree') {
 				return [];
@@ -162,7 +168,7 @@ describe('GenericActions effect group handling', () => {
 		fireEvent.click(actionButton);
 
 		const optionButton = await screen.findByRole('button', {
-			name: /Raise a House/,
+			name: /Develop - 🏠 House/,
 		});
 		fireEvent.click(optionButton);
 

--- a/packages/web/tests/royal-decree-translation.test.ts
+++ b/packages/web/tests/royal-decree-translation.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	createEngine,
+	getActionEffectGroups,
+	type EngineContext,
+} from '@kingdom-builder/engine';
+import {
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+} from '@kingdom-builder/contents';
+import {
+	describeContent,
+	summarizeContent,
+	type SummaryEntry,
+} from '../src/translation';
+
+vi.mock('@kingdom-builder/engine', async () => {
+	return await import('../../engine/src');
+});
+
+const context = createEngine({
+	actions: ACTIONS,
+	buildings: BUILDINGS,
+	developments: DEVELOPMENTS,
+	populations: POPULATIONS,
+	phases: PHASES,
+	start: GAME_START,
+	rules: RULES,
+});
+
+function combineLabels(left: string, right: string): string {
+	const base = left.trim();
+	const entry = right.trim();
+	if (entry.length === 0) {
+		return base;
+	}
+	if (base.length === 0) {
+		return entry;
+	}
+	return `${base} - ${entry}`;
+}
+
+function findGroupEntry(
+	entries: SummaryEntry[],
+): Extract<SummaryEntry, { title: string; items: SummaryEntry[] }> {
+	const group = entries.find(
+		(
+			entry,
+		): entry is Extract<
+			SummaryEntry,
+			{ title: string; items: SummaryEntry[] }
+		> => typeof entry === 'object' && entry.title.includes('Choose one'),
+	);
+	if (!group) {
+		throw new Error('Expected effect group entry');
+	}
+	return group;
+}
+
+describe('royal decree translation', () => {
+	const actionId = 'royal_decree';
+	const developAction = context.actions.get('develop');
+	const developLabel = combineLabels(
+		`${developAction.icon ?? ''} ${developAction.name ?? ''}`,
+		'',
+	);
+	const effectGroups = getActionEffectGroups(
+		actionId,
+		context as EngineContext,
+	);
+	const developGroup = effectGroups.find(
+		(group) => group.id === 'royal_decree_develop',
+	);
+	if (!developGroup) {
+		throw new Error('Expected royal decree develop group');
+	}
+	const developmentOptions = developGroup.options.map((option) => {
+		const params = option.params as { id?: string } | undefined;
+		return params?.id ?? '';
+	});
+
+	it('summarizes options using develop action label', () => {
+		const summary = summarizeContent(
+			'action',
+			actionId,
+			context as EngineContext,
+		);
+		const group = findGroupEntry(summary);
+		expect(group.items).toHaveLength(developmentOptions.length);
+		for (const id of developmentOptions) {
+			const development = context.developments.get(id);
+			const developmentLabel = combineLabels(
+				`${development.icon ?? ''} ${development.name ?? ''}`,
+				'',
+			);
+			const expectedTitle = combineLabels(developLabel, developmentLabel);
+			const entry = group.items.find((item) =>
+				typeof item === 'string'
+					? item === expectedTitle
+					: item.title === expectedTitle,
+			);
+			expect(entry).toBeDefined();
+			expect(typeof entry).toBe('string');
+		}
+	});
+
+	it('describes options with nested develop effects', () => {
+		const description = describeContent(
+			'action',
+			actionId,
+			context as EngineContext,
+		);
+		const group = findGroupEntry(description);
+		expect(group.items).toHaveLength(developmentOptions.length);
+		for (const id of developmentOptions) {
+			const development = context.developments.get(id);
+			const developmentLabel = combineLabels(
+				`${development.icon ?? ''} ${development.name ?? ''}`,
+				'',
+			);
+			const expectedTitle = combineLabels(developLabel, developmentLabel);
+			const entry = group.items.find((item) =>
+				typeof item === 'string'
+					? item === expectedTitle
+					: item.title === expectedTitle,
+			) as
+				| Extract<SummaryEntry, { title: string; items: SummaryEntry[] }>
+				| undefined;
+			expect(entry).toBeDefined();
+			if (!entry) {
+				continue;
+			}
+			expect(typeof entry).toBe('object');
+			expect(entry.items.length).toBeGreaterThan(0);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- derive effect group option labels from translated action summaries so Royal Decree options show the develop target
- reuse the new option label helper when formatting effect groups and ensure development translations surface nested descriptions
- add a Royal Decree translation regression test and update the generic actions test to assert the new label format

## Testing
- npm test -- royal-decree-translation generic-actions-effect-group

------
https://chatgpt.com/codex/tasks/task_e_68e176d128308325865b9fe95c171990