### PR TITLE
Rename evaluator parameter to descriptive name

### DIFF
--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -1,5 +1,4 @@
 import { registerEffectFormatter } from '../factory';
-import { describeContent } from '../../content';
 
 registerEffectFormatter('development', 'add', {
 	summarize: (eff, ctx) => {

--- a/packages/web/src/translation/log/resourceSources/evaluators.ts
+++ b/packages/web/src/translation/log/resourceSources/evaluators.ts
@@ -3,38 +3,42 @@ import { POPULATION_ROLES, POPULATION_INFO } from '@kingdom-builder/contents';
 import { type ResourceSourceEntry } from './types';
 
 export type EvaluatorIconRenderer = (
-	ev: { type: string; params?: Record<string, unknown> },
+	evaluatorDefinition: { type: string; params?: Record<string, unknown> },
 	entry: ResourceSourceEntry,
 	context: EngineContext,
 ) => void;
 
 function evaluateCount(
-	ev: { type: string; params?: Record<string, unknown> },
+	evaluatorDefinition: { type: string; params?: Record<string, unknown> },
 	context: EngineContext,
 ): number {
-	const handler = EVALUATORS.get(ev.type);
-	return Number(handler(ev, context));
+	const handler = EVALUATORS.get(evaluatorDefinition.type);
+	return Number(handler(evaluatorDefinition, context));
 }
 
 function renderDevelopmentIcons(
-	ev: { type: string; params?: Record<string, unknown> },
+	evaluatorDefinition: { type: string; params?: Record<string, unknown> },
 	entry: ResourceSourceEntry,
 	context: EngineContext,
 ): void {
-	const count = evaluateCount(ev, context);
-	const params = ev.params as Record<string, string> | undefined;
+	const count = evaluateCount(evaluatorDefinition, context);
+	const params = evaluatorDefinition.params as
+		| Record<string, string>
+		| undefined;
 	const id = params?.['id'];
 	const icon = id ? context.developments.get(id)?.icon || '' : '';
 	entry.icons += icon.repeat(count);
 }
 
 function renderPopulationIcons(
-	ev: { type: string; params?: Record<string, unknown> },
+	evaluatorDefinition: { type: string; params?: Record<string, unknown> },
 	entry: ResourceSourceEntry,
 	context: EngineContext,
 ): void {
-	const count = evaluateCount(ev, context);
-	const params = ev.params as Record<string, string> | undefined;
+	const count = evaluateCount(evaluatorDefinition, context);
+	const params = evaluatorDefinition.params as
+		| Record<string, string>
+		| undefined;
 	const role = params?.['role'] as keyof typeof POPULATION_ROLES | undefined;
 	const icon = role
 		? POPULATION_ROLES[role]?.icon || role


### PR DESCRIPTION
## Summary
- rename the resource source evaluator parameter and usages to use a descriptive identifier
- wrap parameter type assertions for line-length compliance and drop an unused formatter import caught by lint

## Testing
- npm run lint
- npx prettier --check packages/web/src/translation/log/resourceSources/evaluators.ts packages/web/src/translation/effects/formatters/development.ts
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e181c8e6bc83258c8f421c06b9f2dd