### PR TITLE
Improve resource identifier naming

### DIFF
--- a/packages/web/src/components/player/PopulationInfo.tsx
+++ b/packages/web/src/components/player/PopulationInfo.tsx
@@ -67,9 +67,17 @@ interface PopulationInfoProps {
 
 const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
 	const { handleHoverCard, clearHoverCard, ctx } = useGameEngine();
-	const popEntries = Object.entries(player.population).filter(([, v]) => v > 0);
-	const currentPop = popEntries.reduce((sum, [, v]) => sum + v, 0);
-	const popDetails = popEntries.map(([role, count]) => ({ role, count }));
+	const popEntries = Object.entries(player.population).filter(
+		([, populationCount]) => populationCount > 0,
+	);
+	const currentPop = popEntries.reduce(
+		(sum, [, populationCount]) => sum + populationCount,
+		0,
+	);
+	const popDetails = popEntries.map(([populationRole, populationCount]) => ({
+		role: populationRole,
+		count: populationCount,
+	}));
 
 	const showGeneralStatCard = () =>
 		handleHoverCard({
@@ -201,16 +209,19 @@ const PopulationInfo: React.FC<PopulationInfoProps> = ({ player }) => {
 				)}
 			</div>
 			{Object.entries(player.stats)
-				.filter(([k, v]) => {
-					const info = STATS[k as keyof typeof STATS];
-					return !info.capacity && (v !== 0 || player.statsHistory?.[k]);
+				.filter(([statKey, statValue]) => {
+					const info = STATS[statKey as keyof typeof STATS];
+					return (
+						!info.capacity &&
+						(statValue !== 0 || player.statsHistory?.[statKey])
+					);
 				})
-				.map(([k, v]) => (
+				.map(([statKey, statValue]) => (
 					<StatButton
-						key={k}
-						statKey={k as keyof typeof STATS}
-						value={v}
-						onShow={() => showStatCard(k)}
+						key={statKey}
+						statKey={statKey as keyof typeof STATS}
+						value={statValue}
+						onShow={() => showStatCard(statKey)}
 						onHide={clearHoverCard}
 					/>
 				))}

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -108,27 +108,27 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 			>
 				{GENERAL_RESOURCE_ICON}
 			</button>
-			{resourceKeys.map((k) => {
-				const info = RESOURCES[k];
-				const v = player.resources[k] ?? 0;
+			{resourceKeys.map((resourceKey) => {
+				const resourceInfo = RESOURCES[resourceKey];
+				const resourceValue = player.resources[resourceKey] ?? 0;
 				const showResourceCard = () => {
-					if (k === happinessKey) {
-						showHappinessCard(v);
+					if (resourceKey === happinessKey) {
+						showHappinessCard(resourceValue);
 						return;
 					}
 					handleHoverCard({
-						title: `${info.icon} ${info.label}`,
+						title: `${resourceInfo.icon} ${resourceInfo.label}`,
 						effects: [],
 						requirements: [],
-						description: info.description,
+						description: resourceInfo.description,
 						bgClass: PLAYER_INFO_CARD_BG,
 					});
 				};
 				return (
 					<ResourceButton
-						key={k}
-						resourceKey={k}
-						value={v}
+						key={resourceKey}
+						resourceKey={resourceKey}
+						value={resourceValue}
 						onShow={showResourceCard}
 						onHide={clearHoverCard}
 					/>

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -254,11 +254,14 @@ export function GameProvider({
 				})),
 				passives: [...after.passives],
 			};
-			for (const [k, v] of Object.entries(comp.resources || {})) {
-				before.resources[k] = (before.resources[k] || 0) - (v ?? 0);
+			for (const [resourceKey, resourceDelta] of Object.entries(
+				comp.resources || {},
+			)) {
+				before.resources[resourceKey] =
+					(before.resources[resourceKey] || 0) - (resourceDelta ?? 0);
 			}
-			for (const [k, v] of Object.entries(comp.stats || {})) {
-				before.stats[k] = (before.stats[k] || 0) - (v ?? 0);
+			for (const [statKey, statDelta] of Object.entries(comp.stats || {})) {
+				before.stats[statKey] = (before.stats[statKey] || 0) - (statDelta ?? 0);
 			}
 			const lines = diffStepSnapshots(
 				before,

--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -1,5 +1,4 @@
 import { registerEffectFormatter } from '../factory';
-import { describeContent } from '../../content';
 
 registerEffectFormatter('development', 'add', {
 	summarize: (eff, ctx) => {

--- a/packages/web/tests/resource-bar.test.tsx
+++ b/packages/web/tests/resource-bar.test.tsx
@@ -73,18 +73,18 @@ describe('<ResourceBar /> happiness hover card', () => {
 			clearHoverCard,
 		} as MockGame;
 		render(<ResourceBar player={ctx.activePlayer} />);
-		const info = RESOURCES[happinessKey];
-		const value = ctx.activePlayer.resources[happinessKey] ?? 0;
+		const resourceInfo = RESOURCES[happinessKey];
+		const resourceValue = ctx.activePlayer.resources[happinessKey] ?? 0;
 		const button = screen.getByRole('button', {
-			name: `${info.label}: ${value}`,
+			name: `${resourceInfo.label}: ${resourceValue}`,
 		});
 		fireEvent.mouseEnter(button);
 		expect(handleHoverCard).toHaveBeenCalled();
-		const call = handleHoverCard.mock.calls.at(-1)?.[0];
-		expect(call).toBeTruthy();
-		expect(call?.title).toBe(`${info.icon} ${info.label}`);
-		expect(call?.description).toEqual([`Current value: ${value}`]);
-		const tierEntries = call?.effects ?? [];
+		const hoverCard = handleHoverCard.mock.calls.at(-1)?.[0];
+		expect(hoverCard).toBeTruthy();
+		expect(hoverCard?.title).toBe(`${resourceInfo.icon} ${resourceInfo.label}`);
+		expect(hoverCard?.description).toEqual([`Current value: ${resourceValue}`]);
+		const tierEntries = hoverCard?.effects ?? [];
 		expect(tierEntries).toHaveLength(ctx.services.rules.tierDefinitions.length);
 		const activeEntry = tierEntries.find(
 			(entry: unknown) =>


### PR DESCRIPTION
## Summary
- rename destructured compensation resource and stat entries to descriptive identifiers in the game context
- update player resource and population UI (and its test) to use resourceKey/resourceValue-style naming
- remove an unused translation import discovered during linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e181ca15808325ac29669add8d63d2