### PR TITLE
Refine evaluation result modifier naming

### DIFF
--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -1,5 +1,4 @@
 import { registerEffectFormatter } from '../factory';
-import { describeContent } from '../../content';
 
 registerEffectFormatter('development', 'add', {
 	summarize: (eff, ctx) => {


### PR DESCRIPTION
## Summary
- refactor the evaluation modifier handler in `result_mod` to use descriptive gain variable names and typed callback helpers
- remove an unused import from the development effect formatter to satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e181c317a88325be8386b626dc90f5