### PR TITLE
Add compare requirement helper and enrich development descriptions

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -9,7 +9,7 @@ import {
 import {
 	action,
 	effect,
-	requirement,
+	requirementEvaluatorCompare,
 	Types,
 	LandMethods,
 	ResourceMethods,
@@ -164,10 +164,10 @@ export function createActionRegistry() {
 			.cost(Resource.ap, 1)
 			.cost(Resource.gold, 5)
 			.requirement(
-				requirement('evaluator', 'compare')
-					.param('left', populationEvaluator().build())
-					.param('operator', 'lt')
-					.param('right', statEvaluator().key(Stat.maxPopulation).build())
+				requirementEvaluatorCompare()
+					.left(populationEvaluator().build())
+					.operator('lt')
+					.right(statEvaluator().key(Stat.maxPopulation).build())
 					.message('Free space for 👥')
 					.build(),
 			)
@@ -260,13 +260,10 @@ export function createActionRegistry() {
 			.icon('🗡️')
 			.cost(Resource.ap, 1)
 			.requirement(
-				requirement('evaluator', 'compare')
-					.param('left', statEvaluator().key(Stat.warWeariness).build())
-					.param('operator', 'lt')
-					.param(
-						'right',
-						populationEvaluator().role(PopulationRole.Legion).build(),
-					)
+				requirementEvaluatorCompare()
+					.left(statEvaluator().key(Stat.warWeariness).build())
+					.operator('lt')
+					.right(populationEvaluator().role(PopulationRole.Legion).build())
 					.message(
 						`${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be lower than ${POPULATION_ROLES[PopulationRole.Legion].icon} ${POPULATION_ROLES[PopulationRole.Legion].label}`,
 					)
@@ -316,10 +313,10 @@ export function createActionRegistry() {
 			.cost(Resource.ap, 1)
 			.cost(Resource.gold, 3)
 			.requirement(
-				requirement('evaluator', 'compare')
-					.param('left', statEvaluator().key(Stat.warWeariness).build())
-					.param('operator', 'eq')
-					.param('right', 0)
+				requirementEvaluatorCompare()
+					.left(statEvaluator().key(Stat.warWeariness).build())
+					.operator('eq')
+					.right(0)
 					.message(
 						`${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be 0`,
 					)

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -41,6 +41,10 @@ export const Types = {
 	Stat: 'stat',
 } as const;
 
+export const RequirementTypes = {
+	Evaluator: 'evaluator',
+} as const;
+
 export const LandMethods = {
 	ADD: 'add',
 	TILL: 'till',
@@ -1537,6 +1541,29 @@ export class RequirementBuilder<P extends Params = Params> {
 	}
 }
 
+class RequirementEvaluatorCompareBuilder extends RequirementBuilder {
+	constructor() {
+		super();
+		this.type(RequirementTypes.Evaluator);
+		this.method('compare');
+	}
+
+	left(value: unknown) {
+		this.param('left', value);
+		return this;
+	}
+
+	operator(value: string) {
+		this.param('operator', value);
+		return this;
+	}
+
+	right(value: unknown) {
+		this.param('right', value);
+		return this;
+	}
+}
+
 export function requirement(type?: string, method?: string) {
 	const builder = new RequirementBuilder();
 	if (type) {
@@ -1546,6 +1573,10 @@ export function requirement(type?: string, method?: string) {
 		builder.method(method);
 	}
 	return builder;
+}
+
+export function requirementEvaluatorCompare() {
+	return new RequirementEvaluatorCompareBuilder();
 }
 
 class BaseBuilder<T extends { id: string; name: string }> {

--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -22,7 +22,19 @@ registerEffectFormatter('development', 'add', {
 		}
 		const label = def?.name || id;
 		const icon = def?.icon || '';
-		return `Add ${icon}${label}`;
+		const details = describeContent('development', id, ctx);
+		const combined = [icon, label].filter(Boolean).join(' ').trim();
+		const addLabel = combined.length > 0 ? `Add ${combined}` : 'Add';
+		if (!details.length) {
+			return addLabel;
+		}
+		return [
+			addLabel,
+			{
+				title: combined || label,
+				items: details,
+			},
+		];
 	},
 });
 


### PR DESCRIPTION
## Summary
- add a `RequirementTypes` constant with a dedicated compare helper for evaluator requirements
- switch the content actions that perform population and war-weariness checks to use the new helper
- extend development effect descriptions to surface nested development details when adding structures

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e180ef4aa48325ae2ed7303f69620c