### PR TITLE
Improve action option descriptions in translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
 	},
 	"lint-staged": {
 		"*.{js,jsx,ts,tsx,json,md,cjs}": "prettier --write",
-		"*.{ts,tsx}": "eslint --max-warnings=0 --rulesdir scripts",
-		"*.{ts,tsx}": "bash -c 'tsc --noEmit'"
+		"*.{ts,tsx}": [
+			"eslint --max-warnings=0 --rulesdir scripts",
+			"bash -c 'tsc --noEmit'"
+		]
 	}
 }

--- a/packages/web/src/translation/effects/factory.ts
+++ b/packages/web/src/translation/effects/factory.ts
@@ -244,7 +244,12 @@ function buildOptionEntry(
 			? summarizeContent('action', option.actionId, context, mergedParams)
 			: describeContent('action', option.actionId, context, mergedParams);
 
-	const { entry } = buildActionOptionTranslation(option, context, translated);
+	const { entry } = buildActionOptionTranslation(
+		option,
+		context,
+		translated,
+		mode,
+	);
 	return entry;
 }
 

--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -1,6 +1,4 @@
 import { registerEffectFormatter } from '../factory';
-import { describeContent } from '../../content';
-
 registerEffectFormatter('development', 'add', {
 	summarize: (eff, ctx) => {
 		const id = eff.params?.['id'] as string;
@@ -22,7 +20,8 @@ registerEffectFormatter('development', 'add', {
 		}
 		const label = def?.name || id;
 		const icon = def?.icon || '';
-		return `Add ${icon}${label}`;
+		const decoratedLabel = [icon, label].filter(Boolean).join(' ').trim();
+		return `Add ${decoratedLabel}`.trim();
 	},
 });
 
@@ -47,6 +46,7 @@ registerEffectFormatter('development', 'remove', {
 		}
 		const label = def?.name || id;
 		const icon = def?.icon || '';
-		return `Remove ${icon}${label}`;
+		const decoratedLabel = [icon, label].filter(Boolean).join(' ').trim();
+		return `Remove ${decoratedLabel}`.trim();
 	},
 });

--- a/packages/web/src/translation/effects/optionLabel.ts
+++ b/packages/web/src/translation/effects/optionLabel.ts
@@ -137,10 +137,13 @@ export interface ActionOptionTranslationResult {
 	entry: SummaryEntry;
 }
 
+type EffectGroupMode = 'summarize' | 'describe' | 'log';
+
 export function buildActionOptionTranslation(
 	option: ActionEffectGroupOption,
 	context: EngineContext,
 	translated: SummaryEntry[],
+	mode: EffectGroupMode,
 ): ActionOptionTranslationResult {
 	const fallback = fallbackOptionLabel(option);
 	const actionLabel = resolveActionLabel(option, context) || fallback;
@@ -156,10 +159,16 @@ export function buildActionOptionTranslation(
 	if (typeof first === 'string') {
 		const normalizedFirst = normalizeEntryLabel(first, targetLabel);
 		const title = combineLabels(actionLabel, normalizedFirst, fallback);
-		if (restEntries.length === 0) {
+		const detailEntries =
+			restEntries.length > 0
+				? restEntries
+				: mode === 'describe'
+					? [normalizedFirst]
+					: [];
+		if (detailEntries.length === 0) {
 			return { label: title, entry: title };
 		}
-		return { label: title, entry: { title, items: restEntries } };
+		return { label: title, entry: { title, items: detailEntries } };
 	}
 	const firstObject = cloneSummaryEntry(first) as ObjectSummaryEntry;
 	const normalizedTitle = normalizeEntryLabel(firstObject.title, targetLabel);
@@ -177,5 +186,6 @@ export function deriveActionOptionLabel(
 	context: EngineContext,
 	translated: SummaryEntry[],
 ): string {
-	return buildActionOptionTranslation(option, context, translated).label;
+	return buildActionOptionTranslation(option, context, translated, 'summarize')
+		.label;
 }


### PR DESCRIPTION
## Summary
- ensure action effect groups pass the render mode into the option translation helper so describe mode can build nested entries
- normalize development add/remove descriptions to include decorated labels
- wrap describe-mode option translations in nested entries when string details are returned

## Testing
- npm run test:coverage
- npx vitest run packages/web/tests/royal-decree-translation.test.ts --reporter verbose

------
https://chatgpt.com/codex/tasks/task_e_68e183439b0c83258bb5f7e25a02983c