### PR TITLE
Refactor phase naming across web modules

### DIFF
--- a/packages/contents/src/triggers.ts
+++ b/packages/contents/src/triggers.ts
@@ -1,14 +1,19 @@
 import { PHASES } from './phases';
 
 const phaseTriggers = Object.fromEntries(
-	PHASES.map((p) => [
-		`on${p.id.charAt(0).toUpperCase() + p.id.slice(1)}Phase`,
-		{
-			icon: p.icon,
-			future: `On each ${p.label} Phase`,
-			past: `${p.label} Phase`,
-		},
-	]),
+	PHASES.map((phaseDefinition) => {
+		const phaseId = phaseDefinition.id;
+		const capitalizedPhaseId =
+			phaseId.charAt(0).toUpperCase() + phaseId.slice(1);
+		return [
+			`on${capitalizedPhaseId}Phase`,
+			{
+				icon: phaseDefinition.icon,
+				future: `On each ${phaseDefinition.label} Phase`,
+				past: `${phaseDefinition.label} Phase`,
+			},
+		];
+	}),
 );
 
 export const TRIGGER_INFO = {
@@ -43,9 +48,14 @@ export const TRIGGER_INFO = {
 		past: 'AP step',
 	},
 	mainPhase: {
-		icon: PHASES.find((p) => p.id === 'main')?.icon || '🎯',
+		icon:
+			PHASES.find((phaseDefinition) => phaseDefinition.id === 'main')?.icon ||
+			'🎯',
 		future: '',
-		past: `${PHASES.find((p) => p.id === 'main')?.label || 'Main'} phase`,
+		past: `${
+			PHASES.find((phaseDefinition) => phaseDefinition.id === 'main')?.label ||
+			'Main'
+		} phase`,
 	},
 	...phaseTriggers,
 } as const;

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -85,11 +85,11 @@ function GameLayout() {
 			}
 		};
 	}, [ctx.game.players.length]);
-	const playerPanels = ctx.game.players.map((p, i) => {
-		const isActive = p.id === ctx.activePlayer.id;
-		const sideClass = i === 0 ? 'pr-6' : 'pl-6';
+	const playerPanels = ctx.game.players.map((player, index) => {
+		const isActive = player.id === ctx.activePlayer.id;
+		const sideClass = index === 0 ? 'pr-6' : 'pl-6';
 		const colorClass =
-			i === 0
+			index === 0
 				? isActive
 					? 'player-bg-blue-active'
 					: 'player-bg-blue'
@@ -106,8 +106,8 @@ function GameLayout() {
 			.join(' ');
 		return (
 			<PlayerPanel
-				key={p.id}
-				player={p}
+				key={player.id}
+				player={player}
 				className={`grow basis-[calc(50%-1rem)] max-w-[calc(50%-1rem)] p-4 ${bgClass}`}
 				isActive={isActive}
 			/>

--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import TimerCircle from '../TimerCircle';
-import { useGameEngine } from '../../state/GameContext';
+import { useGameEngine, type PhaseStep } from '../../state/GameContext';
 import { isActionPhaseActive } from '../../utils/isActionPhaseActive';
 import { useAnimate } from '../../utils/useAutoAnimate';
 import Button from '../common/Button';
@@ -23,10 +23,12 @@ const PhasePanel = React.forwardRef<HTMLDivElement, PhasePanelProps>(
 			handleEndTurn,
 		} = useGameEngine();
 
-		const actionPhaseId = useMemo(
-			() => ctx.phases.find((p) => p.action)?.id,
-			[ctx],
-		);
+		const actionPhaseId = useMemo(() => {
+			const phaseWithAction = ctx.phases.find(
+				(phaseDefinition) => phaseDefinition.action,
+			);
+			return phaseWithAction?.id;
+		}, [ctx]);
 		const isActionPhase = isActionPhaseActive(
 			ctx.game.currentPhase,
 			actionPhaseId,
@@ -43,6 +45,136 @@ const PhasePanel = React.forwardRef<HTMLDivElement, PhasePanelProps>(
 			el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
 		}, [phaseSteps]);
 
+		const phaseTabs = ctx.phases.map((phase) => {
+			const isSelected = displayPhase === phase.id;
+			const baseTabClassSegments = [
+				'relative flex items-center gap-2 rounded-full',
+				'px-4 py-2 text-sm transition-all',
+			];
+			const selectedTabSegments = [
+				'bg-gradient-to-r from-blue-500/90 to-indigo-500/90',
+				'text-white shadow-lg shadow-blue-500/30',
+			];
+			const idleTabSegments = [
+				'text-slate-600 hover:bg-white/60 hover:text-slate-800',
+				'dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-slate-100',
+			];
+			const tabSegments = isSelected ? selectedTabSegments : idleTabSegments;
+			const tabClasses = [
+				...baseTabClassSegments,
+				...tabSegments,
+				tabsEnabled ? null : 'opacity-60',
+			]
+				.filter(Boolean)
+				.join(' ');
+			const handleSelectPhase = () => {
+				if (!tabsEnabled) {
+					return;
+				}
+				setDisplayPhase(phase.id);
+				const nextSteps: PhaseStep[] = phaseHistories[phase.id] ?? [];
+				setPhaseSteps(nextSteps);
+			};
+			return (
+				<Button
+					key={phase.id}
+					type="button"
+					disabled={!tabsEnabled}
+					onClick={handleSelectPhase}
+					variant="ghost"
+					className={tabClasses}
+				>
+					<span className="text-lg leading-none">{phase.icon}</span>
+					<span className="text-xs font-semibold uppercase tracking-[0.2em]">
+						{phase.label}
+					</span>
+				</Button>
+			);
+		});
+
+		const renderedPhaseSteps = phaseSteps.map((stepEntry, stepIndex) => {
+			const stepBaseClasses = [
+				'rounded-2xl border px-4 py-3 shadow-sm transition-all',
+			];
+			const stepStateClasses = stepEntry.active
+				? [
+						'border-blue-500/50',
+						'bg-gradient-to-r from-blue-500/20 to-indigo-500/20',
+						'text-slate-800 shadow-blue-500/30',
+						'dark:border-indigo-400/40',
+						'dark:from-blue-500/30 dark:to-indigo-500/30',
+						'dark:text-slate-50',
+					]
+				: [
+						'border-white/40 bg-white/60 text-slate-600',
+						'dark:border-white/10 dark:bg-slate-900/40',
+						'dark:text-slate-200',
+					];
+			const stepClassSegments = [...stepBaseClasses, ...stepStateClasses];
+			const stepClasses = stepClassSegments.join(' ');
+			const titleClasses = [
+				'text-sm font-semibold',
+				stepEntry.active
+					? 'text-slate-900 dark:text-white'
+					: 'text-slate-700 dark:text-slate-100',
+			].join(' ');
+			const itemClassName = (item: PhaseStep['items'][number]) =>
+				[
+					item.italic ? 'italic' : '',
+					item.done
+						? 'font-semibold text-emerald-600 dark:text-emerald-400'
+						: '',
+				]
+					.filter(Boolean)
+					.join(' ');
+			const stepItems = stepEntry.items.length ? (
+				stepEntry.items.map((item, itemIndex) => (
+					<li key={itemIndex} className={itemClassName(item)}>
+						{item.text}
+						{item.done && <span className="ml-1">✔️</span>}
+					</li>
+				))
+			) : (
+				<li className="italic text-slate-400 dark:text-slate-500">...</li>
+			);
+			return (
+				<li key={stepIndex} className={stepClasses}>
+					<div className={titleClasses}>{stepEntry.title}</div>
+					<ul
+						className={[
+							'mt-2 space-y-1 pl-4 text-[0.85rem] leading-snug',
+							'list-disc list-inside',
+							stepEntry.active
+								? 'text-slate-700 dark:text-slate-100'
+								: 'text-slate-600 dark:text-slate-300',
+						].join(' ')}
+					>
+						{stepItems}
+					</ul>
+				</li>
+			);
+		});
+
+		const actionPhaseHasActiveSteps =
+			actionPhaseId &&
+			phaseHistories[actionPhaseId]?.some(
+				(stepHistoryEntry) => stepHistoryEntry.active,
+			);
+		const shouldDisableEndTurn = Boolean(actionPhaseHasActiveSteps);
+		const timerCircle = <TimerCircle progress={phaseTimer} />;
+		const handleEndTurnClick = () => {
+			void handleEndTurn();
+		};
+		const endTurnButton = (
+			<Button
+				variant="primary"
+				disabled={shouldDisableEndTurn}
+				onClick={handleEndTurnClick}
+			>
+				Next Turn
+			</Button>
+		);
+
 		const panelHeight = Math.max(320, height ?? 0);
 
 		return (
@@ -57,121 +189,21 @@ const PhasePanel = React.forwardRef<HTMLDivElement, PhasePanelProps>(
 					</span>
 				</div>
 				<div className="flex flex-wrap gap-2 border-b border-white/40 pb-2 dark:border-white/10">
-					{ctx.phases.map((p) => {
-						const isSelected = displayPhase === p.id;
-						const tabClasses = [
-							'relative flex items-center gap-2 rounded-full px-4 py-2 text-sm transition-all',
-							isSelected
-								? 'bg-gradient-to-r from-blue-500/90 to-indigo-500/90 text-white shadow-lg shadow-blue-500/30'
-								: 'text-slate-600 hover:bg-white/60 hover:text-slate-800 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-slate-100',
-							tabsEnabled ? '' : 'opacity-60',
-						]
-							.filter(Boolean)
-							.join(' ');
-						return (
-							<Button
-								key={p.id}
-								type="button"
-								disabled={!tabsEnabled}
-								onClick={() => {
-									if (!tabsEnabled) {
-										return;
-									}
-									setDisplayPhase(p.id);
-									setPhaseSteps(phaseHistories[p.id] ?? []);
-								}}
-								variant="ghost"
-								className={tabClasses}
-							>
-								<span className="text-lg leading-none">{p.icon}</span>
-								<span className="text-xs font-semibold uppercase tracking-[0.2em]">
-									{p.label}
-								</span>
-							</Button>
-						);
-					})}
+					{phaseTabs}
 				</div>
 				<ul
 					ref={phaseStepsRef}
 					className="flex-1 space-y-3 overflow-y-auto text-left text-sm custom-scrollbar"
 				>
-					{phaseSteps.map((s, i) => {
-						const stepClasses = [
-							'rounded-2xl border px-4 py-3 shadow-sm transition-all',
-							s.active
-								? 'border-blue-500/50 bg-gradient-to-r from-blue-500/20 to-indigo-500/20 text-slate-800 shadow-blue-500/30 dark:border-indigo-400/40 dark:from-blue-500/30 dark:to-indigo-500/30 dark:text-slate-50'
-								: 'border-white/40 bg-white/60 text-slate-600 dark:border-white/10 dark:bg-slate-900/40 dark:text-slate-200',
-						]
-							.filter(Boolean)
-							.join(' ');
-						const titleClasses = [
-							'text-sm font-semibold',
-							s.active
-								? 'text-slate-900 dark:text-white'
-								: 'text-slate-700 dark:text-slate-100',
-						]
-							.filter(Boolean)
-							.join(' ');
-						return (
-							<li key={i} className={stepClasses}>
-								<div className={titleClasses}>{s.title}</div>
-								<ul
-									className={[
-										'mt-2 space-y-1 pl-4 text-[0.85rem] leading-snug list-disc list-inside',
-										s.active
-											? 'text-slate-700 dark:text-slate-100'
-											: 'text-slate-600 dark:text-slate-300',
-									]
-										.filter(Boolean)
-										.join(' ')}
-								>
-									{s.items.length > 0 ? (
-										s.items.map((it, j) => (
-											<li
-												key={j}
-												className={[
-													it.italic ? 'italic' : '',
-													it.done
-														? 'font-semibold text-emerald-600 dark:text-emerald-400'
-														: '',
-												]
-													.filter(Boolean)
-													.join(' ')}
-											>
-												{it.text}
-												{it.done && <span className="ml-1">✔️</span>}
-											</li>
-										))
-									) : (
-										<li className="italic text-slate-400 dark:text-slate-500">
-											...
-										</li>
-									)}
-								</ul>
-							</li>
-						);
-					})}
+					{renderedPhaseSteps}
 				</ul>
 				{(!isActionPhase || phaseTimer > 0) && (
 					<div className="absolute right-3 top-3 flex items-center gap-2 rounded-full border border-white/60 bg-white/80 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-slate-600 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-200">
-						<div className="h-9 w-9">
-							<TimerCircle progress={phaseTimer} />
-						</div>
+						<div className="h-9 w-9">{timerCircle}</div>
 					</div>
 				)}
 				{isActionPhase && (
-					<div className="mt-2 text-right">
-						<Button
-							variant="primary"
-							disabled={Boolean(
-								actionPhaseId &&
-									phaseHistories[actionPhaseId]?.some((s) => s.active),
-							)}
-							onClick={() => void handleEndTurn()}
-						>
-							Next Turn
-						</Button>
-					</div>
+					<div className="mt-2 text-right">{endTurnButton}</div>
 				)}
 			</section>
 		);

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -219,7 +219,7 @@ export default function PassiveDisplay({
 				const summaryText = resolveSummaryText(passive, def);
 				const items = describeEffects(def.effects || [], ctx);
 				const upkeepLabel =
-					PHASES.find((p) => p.id === 'upkeep')?.label || 'Upkeep';
+					PHASES.find((phase) => phase.id === 'upkeep')?.label || 'Upkeep';
 				const sections = def.onUpkeepPhase
 					? [{ title: `Until your next ${upkeepLabel} Phase`, items }]
 					: items;

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -74,7 +74,7 @@ interface HoverCard {
 	bgClass?: string;
 }
 
-type PhaseStep = {
+export type PhaseStep = {
 	title: string;
 	items: { text: string; italic?: boolean; done?: boolean }[];
 	active: boolean;
@@ -207,21 +207,24 @@ export function GameProvider({
 		};
 	}, [clearTrackedTimeout]);
 
-	const actionPhaseId = useMemo(
-		() => ctx.phases.find((p) => p.action)?.id,
-		[ctx],
-	);
+	const actionPhaseId = useMemo(() => {
+		const phaseWithAction = ctx.phases.find(
+			(phaseDefinition) => phaseDefinition.action,
+		);
+		return phaseWithAction?.id;
+	}, [ctx]);
 
 	const addLog = (
 		entry: string | string[],
 		player?: EngineContext['activePlayer'],
 	) => {
-		const p = player ?? ctx.activePlayer;
+		const logPlayer = player ?? ctx.activePlayer;
 		setLog((prev) => {
-			const items = (Array.isArray(entry) ? entry : [entry]).map((text) => ({
+			const messages = Array.isArray(entry) ? entry : [entry];
+			const items = messages.map((text) => ({
 				time: new Date().toLocaleTimeString(),
-				text: `[${p.name}] ${text}`,
-				playerId: p.id,
+				text: `[${logPlayer.name}] ${text}`,
+				playerId: logPlayer.id,
 			}));
 			const combined = [...prev, ...items];
 			const next = combined.slice(-MAX_LOG_ENTRIES);
@@ -377,8 +380,12 @@ export function GameProvider({
 			ranSteps = true;
 			const before = snapshotPlayer(ctx.activePlayer, ctx);
 			const { phase, step, player, effects, skipped } = advance(ctx);
-			const phaseDef = ctx.phases.find((p) => p.id === phase)!;
-			const stepDef = phaseDef.steps.find((s) => s.id === step);
+			const phaseDef = ctx.phases.find(
+				(phaseDefinition) => phaseDefinition.id === phase,
+			)!;
+			const stepDef = phaseDef.steps.find(
+				(stepDefinition) => stepDefinition.id === step,
+			);
 			if (phase !== lastPhase) {
 				await runDelay(1500);
 				if (!mountedRef.current) {

--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -1,5 +1,4 @@
 import { registerEffectFormatter } from '../factory';
-import { describeContent } from '../../content';
 
 registerEffectFormatter('development', 'add', {
 	summarize: (eff, ctx) => {

--- a/packages/web/tests/fixtures/syntheticFestival.ts
+++ b/packages/web/tests/fixtures/syntheticFestival.ts
@@ -198,11 +198,13 @@ export const getSyntheticFestivalDetails = (
 		ctx.phases.find((phase) =>
 			phase.steps.some((step) => step.triggers?.includes('onUpkeepPhase')),
 		) ??
-		PHASES.find((phase) =>
-			phase.steps.some((step) => step.triggers?.includes('onUpkeepPhase')),
+		PHASES.find((phaseDefinition) =>
+			phaseDefinition.steps.some((step) =>
+				step.triggers?.includes('onUpkeepPhase'),
+			),
 		) ??
-		ctx.phases.find((p) => p.id === 'upkeep') ??
-		PHASES.find((p) => p.id === 'upkeep');
+		ctx.phases.find((phaseDefinition) => phaseDefinition.id === 'upkeep') ??
+		PHASES.find((phaseDefinition) => phaseDefinition.id === 'upkeep');
 	const upkeepLabel = upkeepPhase?.label || 'Upkeep';
 	const upkeepIcon = upkeepPhase?.icon;
 

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -56,7 +56,7 @@ describe('log resource sources', () => {
 		ctx.game.currentPlayerIndex = 0;
 
 		const growthPhase = ctx.phases.find(
-			(p) => p.id === SYNTHETIC_PHASE_IDS.growth,
+			(phase) => phase.id === SYNTHETIC_PHASE_IDS.growth,
 		);
 		const step = growthPhase?.steps.find(
 			(s) => s.id === SYNTHETIC_STEP_IDS.gainIncome,
@@ -154,7 +154,7 @@ describe('log resource sources', () => {
 			ctx,
 		);
 		const upkeepPhase = ctx.phases.find(
-			(p) => p.id === SYNTHETIC_PHASE_IDS.upkeep,
+			(phase) => phase.id === SYNTHETIC_PHASE_IDS.upkeep,
 		);
 		const step = upkeepPhase?.steps.find(
 			(s) => s.id === SYNTHETIC_STEP_IDS.payUpkeep,


### PR DESCRIPTION
## Summary
- rename phase selection and logging helpers to use descriptive identifiers
- refactor the phase panel to compute tab and step content with readable variable names and shorter lines
- update content utilities and related tests to replace `p` aliases and drop unused imports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e181c999888325a23d1b13efb5061e