### PR TITLE
Fix evaluation modifier lint and normalize royal decree translation expectations

### DIFF
--- a/packages/engine/src/services/evaluation_modifier_service.ts
+++ b/packages/engine/src/services/evaluation_modifier_service.ts
@@ -1,7 +1,6 @@
 import type { EngineContext } from '../context';
 import type {
 	EvaluationModifier,
-	EvaluationModifierResult,
 	ResourceGain,
 	RoundingInstruction,
 	RoundingMode,
@@ -84,10 +83,7 @@ export class EvaluationModifierService {
 		const perResourcePercent: Partial<Record<string, number>> = {};
 		const rounding: Partial<Record<string, RoundingMode>> = {};
 		for (const modifier of modifierMap.values()) {
-			const result = modifier(
-				context,
-				gains,
-			) as EvaluationModifierResult | void;
+			const result = modifier(context, gains);
 			if (!result || result.percent === undefined) {
 				if (result && 'round' in result) {
 					mergeRoundInstruction(rounding, result.round);


### PR DESCRIPTION
## Summary
- remove an unnecessary type assertion from the evaluation modifier service
- normalize royal decree translation expectations to handle trimmed labels

## Testing
- npm run check
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68e1878a61c88325a1b88876f36ce7f7