### PR TITLE
Fix multi-step action selection and styling

### DIFF
--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -100,8 +100,6 @@ export interface ActionCardProps {
 }
 
 function StepBadge({
-	stepIndex,
-	stepCount,
 	stepLabel,
 	variant,
 	multiStep,
@@ -112,10 +110,11 @@ function StepBadge({
 	variant: ActionCardVariant;
 	multiStep: boolean | undefined;
 }) {
-	if (variant === 'back' && stepCount && stepCount > 0) {
-		const current = stepIndex && stepIndex > 0 ? stepIndex : 1;
-		const label =
-			stepLabel ?? `Step ${Math.min(current, stepCount)} of ${stepCount}`;
+	if (variant === 'back') {
+		const label = stepLabel?.trim();
+		if (!label) {
+			return null;
+		}
 		return (
 			<div className="action-card__badge">
 				<span className="action-card__badge-pill">{label}</span>

--- a/packages/web/src/components/actions/GenericActionCard.tsx
+++ b/packages/web/src/components/actions/GenericActionCard.tsx
@@ -29,6 +29,7 @@ interface GenericActionCardProps {
 	handleOptionSelect: (
 		group: ActionEffectGroup,
 		option: ActionEffectGroupOption,
+		resolvedParams?: Record<string, unknown>,
 	) => void;
 	context: EngineContext;
 	actionCostResource: ResourceKey;

--- a/packages/web/src/components/actions/GenericActions.tsx
+++ b/packages/web/src/components/actions/GenericActions.tsx
@@ -92,7 +92,11 @@ function GenericActions({
 	);
 
 	const handleOptionSelect = useCallback(
-		(group: ActionEffectGroup, option: ActionEffectGroupOption) => {
+		(
+			group: ActionEffectGroup,
+			option: ActionEffectGroupOption,
+			resolvedParams?: Record<string, unknown>,
+		) => {
 			setPending((previous) => {
 				if (!previous) {
 					return previous;
@@ -101,19 +105,25 @@ function GenericActions({
 				if (!currentGroup || currentGroup.id !== group.id) {
 					return previous;
 				}
+				const mergedParams = resolvedParams
+					? { ...previous.params, ...resolvedParams }
+					: previous.params;
 				const nextChoices: ActionEffectGroupChoiceMap = {
 					...previous.choices,
-					[group.id]: { optionId: option.id },
+					[group.id]: resolvedParams
+						? { optionId: option.id, params: resolvedParams }
+						: { optionId: option.id },
 				};
 				if (previous.step + 1 < previous.groups.length) {
 					return {
 						...previous,
 						step: previous.step + 1,
+						params: mergedParams,
 						choices: nextChoices,
 					};
 				}
 				void handlePerform(previous.action, {
-					...previous.params,
+					...mergedParams,
 					choices: nextChoices,
 				});
 				return null;

--- a/packages/web/src/components/actions/useEffectGroupOptions.ts
+++ b/packages/web/src/components/actions/useEffectGroupOptions.ts
@@ -25,6 +25,7 @@ type BuildOptionsParams = {
 	handleOptionSelect: (
 		group: ActionEffectGroup,
 		option: ActionEffectGroupOption,
+		resolvedParams?: Record<string, unknown>,
 	) => void;
 	clearHoverCard: () => void;
 	handleHoverCard: (data: HoverCardData) => void;
@@ -125,7 +126,7 @@ export function useEffectGroupOptions({
 				label: optionLabel,
 				onSelect: () => {
 					clearHoverCard();
-					handleOptionSelect(currentGroup, option);
+					handleOptionSelect(currentGroup, option, resolved);
 				},
 				compact: currentGroup.layout === 'compact',
 			};

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -191,22 +191,22 @@
 		height: 0.75rem;
 	}
 	.action-card__option {
-		@apply panel-card cursor-pointer border border-white/40 bg-white/70 p-3 text-left text-sm text-slate-700 transition dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100;
+		@apply panel-card flex h-full w-full cursor-pointer flex-col items-start gap-2 overflow-hidden border border-white/40 bg-white/70 p-3 text-left text-sm leading-snug text-slate-700 transition dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100;
 	}
 	.action-card__option--compact {
-		@apply flex min-h-[4.25rem] items-center justify-center gap-2 text-base font-semibold;
-	}
-	.action-card__option--compact .action-card__option-title {
-		@apply text-base font-semibold text-center;
+		@apply min-h-[4.25rem] flex-row flex-wrap items-center justify-center gap-2 text-base font-semibold text-center;
 	}
 	.action-card__option-title {
-		@apply text-base font-semibold;
+		@apply w-full break-words text-base font-semibold;
+	}
+	.action-card__option--compact .action-card__option-title {
+		@apply text-center;
 	}
 	.action-card__option-summary {
-		@apply text-sm text-slate-600 dark:text-slate-300;
+		@apply w-full break-words text-sm text-slate-600 dark:text-slate-300;
 	}
 	.action-card__option-description {
-		@apply text-xs text-slate-500 dark:text-slate-400;
+		@apply w-full break-words text-xs text-slate-500 dark:text-slate-400;
 	}
 	.action-card__cancel {
 		@apply rounded-full border border-white/50 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-white hover:text-slate-900 dark:border-white/20 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700;

--- a/packages/web/src/translation/effects/optionLabel.ts
+++ b/packages/web/src/translation/effects/optionLabel.ts
@@ -57,6 +57,7 @@ function resolveOptionTargetLabel(
 function normalizeEntryLabel(
 	label: string,
 	targetLabel: string | undefined,
+	preserveVerb: boolean,
 ): string {
 	if (!targetLabel) {
 		return label.trim();
@@ -69,7 +70,7 @@ function normalizeEntryLabel(
 	if (normalizedTarget.startsWith(trimmedLabel)) {
 		return normalizedTarget;
 	}
-	if (trimmedLabel.startsWith('Add ')) {
+	if (!preserveVerb && trimmedLabel.startsWith('Add ')) {
 		const withoutAdd = trimmedLabel.slice(4).trim();
 		if (normalizedTarget.startsWith(withoutAdd)) {
 			return normalizedTarget;
@@ -157,21 +158,27 @@ export function buildActionOptionTranslation(
 	}
 	const restEntries = translated.slice(1).map(cloneSummaryEntry);
 	if (typeof first === 'string') {
-		const normalizedFirst = normalizeEntryLabel(first, targetLabel);
+		const normalizedFirst = normalizeEntryLabel(
+			first,
+			targetLabel,
+			mode === 'describe',
+		);
 		const title = combineLabels(actionLabel, normalizedFirst, fallback);
-		const detailEntries =
-			restEntries.length > 0
-				? restEntries
-				: mode === 'describe'
-					? [normalizedFirst]
-					: [];
+		const includeFirstDetail = mode === 'describe' && restEntries.length > 0;
+		const detailEntries = includeFirstDetail
+			? [normalizedFirst, ...restEntries]
+			: restEntries;
 		if (detailEntries.length === 0) {
 			return { label: title, entry: title };
 		}
 		return { label: title, entry: { title, items: detailEntries } };
 	}
 	const firstObject = cloneSummaryEntry(first) as ObjectSummaryEntry;
-	const normalizedTitle = normalizeEntryLabel(firstObject.title, targetLabel);
+	const normalizedTitle = normalizeEntryLabel(
+		firstObject.title,
+		targetLabel,
+		mode === 'describe',
+	);
 	const combinedTitle = combineLabels(actionLabel, normalizedTitle, fallback);
 	const entry: ObjectSummaryEntry = {
 		...firstObject,


### PR DESCRIPTION
## Summary
- hide the back-of-card step pill when no custom label is provided and tidy multi-step badges
- ensure multi-step choice resolution forwards option parameters so complex actions complete without errors
- polish action option styling and keep descriptive verbs in option translations for nested actions

## Testing
- `npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`
- `npx vitest run packages/web/tests/royal-decree-translation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e17ef26c988325836ad107ebbe7c58