### PR TITLE
Adjust happiness thresholds and presentation

### DIFF
--- a/packages/contents/src/happinessHelpers.ts
+++ b/packages/contents/src/happinessHelpers.ts
@@ -58,6 +58,7 @@ export const growthBonusEffect = (amount: number) =>
 type TierPassiveEffectOptions = {
 	tierId: string;
 	summary: string;
+	summaryToken?: string;
 	removalDetail: string;
 	params: ReturnType<typeof passiveParams>;
 	effects?: EffectConfig[];
@@ -66,13 +67,18 @@ type TierPassiveEffectOptions = {
 export function createTierPassiveEffect({
 	tierId,
 	summary,
+	summaryToken,
 	removalDetail,
 	params,
 	effects = [],
 }: TierPassiveEffectOptions) {
-	params.detail(summary);
+	params.detail(summaryToken ?? summary);
 	params.meta({
-		source: { type: 'tiered-resource', id: tierId },
+		source: {
+			type: 'tiered-resource',
+			id: tierId,
+			...(summaryToken ? { labelToken: summaryToken } : {}),
+		},
 		removal: {
 			token: removalDetail,
 			text: formatPassiveRemoval(removalDetail),

--- a/packages/contents/src/rules.ts
+++ b/packages/contents/src/rules.ts
@@ -83,18 +83,18 @@ const TIER_CONFIGS = [
 		range: { min: -2, max: 2 },
 		incomeMultiplier: 1,
 		summaryToken: happinessSummaryToken('steady'),
-		summary: 'No tier bonuses active.',
+		summary: 'No effect',
 		removal: 'happiness stays between -2 and +2',
 	},
 	{
 		id: 'happiness:tier:content',
 		passiveId: 'passive:happiness:content',
 		range: { min: 3, max: 4 },
-		incomeMultiplier: 1.2,
+		incomeMultiplier: 1.25,
 		summaryToken: happinessSummaryToken('content'),
-		summary: 'During income step, gain 20% more 🪙 gold (rounded up).',
+		summary: 'During income step, gain 25% more 🪙 gold (rounded up).',
 		removal: 'happiness stays between +3 and +4',
-		effects: [incomeModifier('happiness:content:income', 0.2)],
+		effects: [incomeModifier('happiness:content:income', 0.25)],
 	},
 	{
 		id: 'happiness:tier:joyful',
@@ -136,12 +136,11 @@ const TIER_CONFIGS = [
 		range: { min: 10 },
 		incomeMultiplier: 1.5,
 		buildingDiscountPct: 0.2,
-		growthBonusPct: 0.2,
 		summaryToken: happinessSummaryToken('ecstatic'),
 		summary: joinSummary(
 			'During income step, gain 50% more 🪙 gold (rounded up).',
 			'Build action costs 20% less 🪙 gold (rounded up).',
-			'During Growth phase, gain 20% more 📈 Growth.',
+			'Gain +20% 📈 Growth.',
 		),
 		removal: 'happiness is +10 or higher',
 		effects: [
@@ -152,7 +151,9 @@ const TIER_CONFIGS = [
 	},
 ];
 
-type TierConfig = (typeof TIER_CONFIGS)[number];
+type TierConfig = (typeof TIER_CONFIGS)[number] & {
+	growthBonusPct?: number;
+};
 
 function buildTierDefinition(config: TierConfig): HappinessTierDefinition {
 	const builder = happinessTier(config.id)
@@ -177,6 +178,7 @@ function buildTierDefinition(config: TierConfig): HappinessTierDefinition {
 		const passive = createTierPassiveEffect({
 			tierId: config.id,
 			summary: config.summary,
+			summaryToken: config.summaryToken,
 			removalDetail: config.removal,
 			params,
 			...(config.effects ? { effects: config.effects } : {}),
@@ -189,7 +191,7 @@ function buildTierDefinition(config: TierConfig): HappinessTierDefinition {
 	if (config.buildingDiscountPct) {
 		builder.buildingDiscountPct(config.buildingDiscountPct);
 	}
-	if (config.growthBonusPct) {
+	if ('growthBonusPct' in config && config.growthBonusPct) {
 		builder.growthBonusPct(config.growthBonusPct);
 	}
 	return builder.build();

--- a/packages/web/src/components/player/PassiveDisplay.tsx
+++ b/packages/web/src/components/player/PassiveDisplay.tsx
@@ -227,7 +227,7 @@ export default function PassiveDisplay({
 				return (
 					<div
 						key={passive.id}
-						className="hoverable cursor-pointer rounded-xl border border-white/50 bg-white/60 p-3 shadow-sm transition hover:border-blue-400/70 hover:bg-white/80 dark:border-white/10 dark:bg-slate-900/50 dark:hover:border-blue-300/60 dark:hover:bg-slate-900/70"
+						className="hoverable cursor-help rounded-xl border border-white/50 bg-white/60 p-3 shadow-sm transition hover:border-blue-400/70 hover:bg-white/80 dark:border-white/10 dark:bg-slate-900/50 dark:hover:border-blue-300/60 dark:hover:bg-slate-900/70"
 						onMouseEnter={() => {
 							const { effects, description } = splitSummary(sections);
 							const descriptionEntries = [...(description ?? [])] as ReturnType<

--- a/packages/web/src/components/player/buildTierEntries.ts
+++ b/packages/web/src/components/player/buildTierEntries.ts
@@ -131,7 +131,7 @@ export function buildTierEntries(
 		}
 
 		if (!items.length) {
-			items.push('No tier bonuses active.');
+			items.push('No effect');
 		}
 
 		return { title, items };

--- a/packages/web/src/translation/render.tsx
+++ b/packages/web/src/translation/render.tsx
@@ -4,18 +4,27 @@ import type { ResourceKey } from '@kingdom-builder/contents';
 import type { Summary } from './content';
 
 export function renderSummary(summary: Summary | undefined): React.ReactNode {
-	return summary?.map((e, i) =>
-		typeof e === 'string' ? (
-			<li key={i} className="whitespace-pre-line">
-				{e}
-			</li>
-		) : (
+	return summary?.map((e, i) => {
+		if (typeof e === 'string') {
+			const trimmed = e.trim();
+			const isNoEffect = trimmed === 'No effect';
+			const baseClass = 'whitespace-pre-line';
+			const className = isNoEffect
+				? `${baseClass} italic text-slate-500 dark:text-slate-300`
+				: baseClass;
+			return (
+				<li key={i} className={className}>
+					{trimmed}
+				</li>
+			);
+		}
+		return (
 			<li key={i}>
 				<span className="font-semibold">{e.title}</span>
 				<ul className="list-disc pl-4">{renderSummary(e.items)}</ul>
 			</li>
-		),
-	);
+		);
+	});
 }
 
 export function renderCosts(

--- a/tests/integration/happiness-tier-content.test.ts
+++ b/tests/integration/happiness-tier-content.test.ts
@@ -58,7 +58,7 @@ describe('content happiness tiers', () => {
       {
         "id": "passive:happiness:content",
         "removalToken": "happiness stays between +3 and +4",
-        "summary": "During income step, gain 20% more 🪙 gold (rounded up).",
+        "summary": "During income step, gain 25% more 🪙 gold (rounded up).",
         "summaryToken": "happiness.tier.summary.content",
       },
     ],
@@ -94,7 +94,7 @@ describe('content happiness tiers', () => {
       {
         "id": "passive:happiness:ecstatic",
         "removalToken": "happiness is +10 or higher",
-        "summary": "During income step, gain 50% more 🪙 gold (rounded up).\nBuild action costs 20% less 🪙 gold (rounded up).\nDuring Growth phase, gain 20% more 📈 Growth.",
+        "summary": "During income step, gain 50% more 🪙 gold (rounded up).\nBuild action costs 20% less 🪙 gold (rounded up).\nGain +20% 📈 Growth.",
         "summaryToken": "happiness.tier.summary.ecstatic",
       },
     ],


### PR DESCRIPTION
## Summary
- correct the +3 to +4 happiness tier to award a 25% income bonus and refresh the +10 tier growth copy
- align passive hover details with tier summary translations and show “No effect” as an italicized fallback
- present passives with the help cursor when hovered for clearer affordance

## Testing
- `npm run test:quick`

------
https://chatgpt.com/codex/tasks/task_e_68e1859f1a7c83259e4d96dede04aa24