### PR TITLE
Display current happiness value in hover card

### DIFF
--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -80,6 +80,7 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 		handleHoverCard({
 			title: `${info.icon} ${info.label}`,
 			effects: entries,
+			description: [`Current value: ${value}`],
 			effectsTitle: `Tiers (Current: ${value})`,
 			requirements: [],
 			bgClass: PLAYER_INFO_CARD_BG,


### PR DESCRIPTION
## Summary
- add the current happiness total to the hover card description so the UI and tests stay in sync

## Testing
- npm run check
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68e18c7318388325bff504a9c2b3cc84