### PR TITLE
Clarify result modifier gain iteration naming

### DIFF
--- a/packages/engine/src/effects/result_mod.ts
+++ b/packages/engine/src/effects/result_mod.ts
@@ -53,19 +53,19 @@ export const resultMod: EffectHandler<ResultModParams> = (effect, ctx) => {
 						runEffects(effects, innerContext);
 					}
 					if (adjust !== undefined) {
-						for (const g of gains) {
-							g.amount += adjust;
+						for (const gainEntry of gains) {
+							gainEntry.amount += adjust;
 						}
 					}
 					if (amount !== undefined) {
-						for (const g of gains) {
-							if (g.amount > 0) {
+						for (const gainEntry of gains) {
+							if (gainEntry.amount > 0) {
 								runEffects(
 									[
 										{
 											type: 'resource',
 											method: 'add',
-											params: { key: g.key, amount },
+											params: { key: gainEntry.key, amount },
 										},
 									],
 									innerContext,


### PR DESCRIPTION
## Summary
- rename the loop variable in the result modifier gain adjustments to the descriptive `gainEntry`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e18bf93c0c8325901a9709f052c40f