### PR TITLE
Fix multi-step action prompts and option styling

### DIFF
--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -100,8 +100,8 @@ export interface ActionCardProps {
 }
 
 function StepBadge({
-	stepIndex,
-	stepCount,
+	stepIndex: _stepIndex,
+	stepCount: _stepCount,
 	stepLabel,
 	variant,
 	multiStep,
@@ -112,10 +112,11 @@ function StepBadge({
 	variant: ActionCardVariant;
 	multiStep: boolean | undefined;
 }) {
-	if (variant === 'back' && stepCount && stepCount > 0) {
-		const current = stepIndex && stepIndex > 0 ? stepIndex : 1;
-		const label =
-			stepLabel ?? `Step ${Math.min(current, stepCount)} of ${stepCount}`;
+	if (variant === 'back') {
+		const label = stepLabel?.trim();
+		if (!label) {
+			return null;
+		}
 		return (
 			<div className="action-card__badge">
 				<span className="action-card__badge-pill">{label}</span>

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -161,7 +161,8 @@ function StepBadge({
 }
 
 function OptionCard({ option }: { option: ActionCardOption }) {
-	const label = [option.icon, option.label].filter(Boolean).join(' ').trim();
+	const icon = option.icon?.trim();
+	const label = option.label.trim();
 	const optionClass = [
 		'action-card__option',
 		option.compact ? 'action-card__option--compact' : '',
@@ -178,7 +179,14 @@ function OptionCard({ option }: { option: ActionCardOption }) {
 			onMouseEnter={option.onMouseEnter}
 			onMouseLeave={option.onMouseLeave}
 		>
-			<span className="action-card__option-title">{label}</span>
+			<span className="action-card__option-header">
+				{icon ? (
+					<span aria-hidden="true" className="action-card__option-icon">
+						{icon}
+					</span>
+				) : null}
+				<span className="action-card__option-title">{label}</span>
+			</span>
 			{!option.compact && option.summary && (
 				<p className="action-card__option-summary">{option.summary}</p>
 			)}
@@ -274,9 +282,7 @@ export default function ActionCard({
 							{renderCosts(costs, playerResources, actionCostResource, upkeep)}
 							{requirementBadge}
 						</div>
-						<ul className="text-sm list-disc pl-4 text-left">
-							{renderedSummary}
-						</ul>
+						<ul className="action-card__summary">{renderedSummary}</ul>
 					</div>
 				</button>
 				<div className="action-card__face action-card__face--back">

--- a/packages/web/src/components/actions/GenericActionCard.tsx
+++ b/packages/web/src/components/actions/GenericActionCard.tsx
@@ -29,6 +29,7 @@ interface GenericActionCardProps {
 	handleOptionSelect: (
 		group: ActionEffectGroup,
 		option: ActionEffectGroupOption,
+		params?: Record<string, unknown>,
 	) => void;
 	context: EngineContext;
 	actionCostResource: ResourceKey;

--- a/packages/web/src/components/actions/useEffectGroupOptions.ts
+++ b/packages/web/src/components/actions/useEffectGroupOptions.ts
@@ -25,6 +25,7 @@ type BuildOptionsParams = {
 	handleOptionSelect: (
 		group: ActionEffectGroup,
 		option: ActionEffectGroupOption,
+		params?: Record<string, unknown>,
 	) => void;
 	clearHoverCard: () => void;
 	handleHoverCard: (data: HoverCardData) => void;
@@ -125,7 +126,7 @@ export function useEffectGroupOptions({
 				label: optionLabel,
 				onSelect: () => {
 					clearHoverCard();
-					handleOptionSelect(currentGroup, option);
+					handleOptionSelect(currentGroup, option, resolved);
 				},
 				compact: currentGroup.layout === 'compact',
 			};

--- a/packages/web/src/components/actions/useEffectGroupOptions.ts
+++ b/packages/web/src/components/actions/useEffectGroupOptions.ts
@@ -36,22 +36,27 @@ function resolveOptionParams(
 	option: ActionEffectGroupOption,
 	pendingParams: Record<string, unknown> | undefined,
 ): Record<string, unknown> {
-	const base: Record<string, unknown> = {};
+	const resolved: Record<string, unknown> = {};
 	const params: ResolveParams = option.params;
 	if (!params) {
-		return base;
+		return resolved;
 	}
 	for (const [key, value] of Object.entries(params)) {
-		if (typeof value === 'string' && value.startsWith('$') && pendingParams) {
-			const placeholder = value.slice(1);
-			if (placeholder in pendingParams) {
-				base[key] = pendingParams[placeholder];
-				continue;
-			}
+		if (typeof value !== 'string') {
+			continue;
 		}
-		base[key] = value;
+		if (!value.startsWith('$')) {
+			continue;
+		}
+		if (!pendingParams) {
+			continue;
+		}
+		const placeholder = value.slice(1);
+		if (placeholder in pendingParams) {
+			resolved[key] = pendingParams[placeholder];
+		}
 	}
-	return base;
+	return resolved;
 }
 
 function buildHoverDetails(
@@ -124,9 +129,12 @@ export function useEffectGroupOptions({
 			const card: ActionCardOption = {
 				id: option.id,
 				label: optionLabel,
+				...(option.icon ? { icon: option.icon } : {}),
 				onSelect: () => {
 					clearHoverCard();
-					handleOptionSelect(currentGroup, option, resolved);
+					const selectionParams =
+						Object.keys(resolved).length > 0 ? resolved : undefined;
+					handleOptionSelect(currentGroup, option, selectionParams);
 				},
 				compact: currentGroup.layout === 'compact',
 			};

--- a/packages/web/src/components/actions/useEffectGroupOptions.ts
+++ b/packages/web/src/components/actions/useEffectGroupOptions.ts
@@ -42,19 +42,17 @@ function resolveOptionParams(
 		return resolved;
 	}
 	for (const [key, value] of Object.entries(params)) {
-		if (typeof value !== 'string') {
+		if (typeof value === 'string' && value.startsWith('$')) {
+			if (!pendingParams) {
+				continue;
+			}
+			const placeholder = value.slice(1);
+			if (placeholder in pendingParams) {
+				resolved[key] = pendingParams[placeholder];
+			}
 			continue;
 		}
-		if (!value.startsWith('$')) {
-			continue;
-		}
-		if (!pendingParams) {
-			continue;
-		}
-		const placeholder = value.slice(1);
-		if (placeholder in pendingParams) {
-			resolved[key] = pendingParams[placeholder];
-		}
+		resolved[key] = value;
 	}
 	return resolved;
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -192,21 +192,42 @@
 	}
 	.action-card__option {
 		@apply panel-card w-full cursor-pointer border border-white/40 bg-white/70 p-3 text-left text-sm text-slate-700 transition whitespace-normal break-words dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
 	}
-	.action-card__option--compact {
-		@apply flex min-h-[4.25rem] items-center justify-center gap-2 text-base font-semibold text-center whitespace-normal break-words;
+	.action-card__option-header {
+		@apply flex items-start gap-2 text-left;
 	}
-	.action-card__option--compact .action-card__option-title {
-		@apply block text-base font-semibold text-center whitespace-normal break-words;
+	.action-card__option-icon {
+		@apply text-lg leading-none;
 	}
 	.action-card__option-title {
-		@apply block text-base font-semibold leading-snug whitespace-normal break-words;
+		@apply text-left font-semibold;
+	}
+	.action-card__option--compact {
+		@apply min-h-[4.25rem] items-center gap-2 text-base text-center;
+	}
+	.action-card__option--compact .action-card__option-header {
+		@apply flex flex-col items-center justify-center gap-1 text-center;
+	}
+	.action-card__option--compact .action-card__option-title {
+		@apply text-base font-semibold text-center;
 	}
 	.action-card__option-summary {
-		@apply text-sm text-slate-600 dark:text-slate-300;
+		@apply text-xs text-left text-slate-600 leading-snug dark:text-slate-300;
 	}
 	.action-card__option-description {
-		@apply text-xs text-slate-500 dark:text-slate-400;
+		@apply text-xs text-left text-slate-500 leading-snug dark:text-slate-400;
+	}
+	.action-card__summary {
+		@apply text-sm list-disc pl-4 text-left space-y-1;
+	}
+	.action-card__summary .list-disc {
+		@apply list-none pl-4 space-y-1;
+	}
+	.action-card__summary .list-disc > li {
+		@apply pl-0;
 	}
 	.action-card__cancel {
 		@apply rounded-full border border-white/50 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-white hover:text-slate-900 dark:border-white/20 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -191,16 +191,16 @@
 		height: 0.75rem;
 	}
 	.action-card__option {
-		@apply panel-card cursor-pointer border border-white/40 bg-white/70 p-3 text-left text-sm text-slate-700 transition dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100;
+		@apply panel-card w-full cursor-pointer border border-white/40 bg-white/70 p-3 text-left text-sm text-slate-700 transition whitespace-normal break-words dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100;
 	}
 	.action-card__option--compact {
-		@apply flex min-h-[4.25rem] items-center justify-center gap-2 text-base font-semibold;
+		@apply flex min-h-[4.25rem] items-center justify-center gap-2 text-base font-semibold text-center whitespace-normal break-words;
 	}
 	.action-card__option--compact .action-card__option-title {
-		@apply text-base font-semibold text-center;
+		@apply block text-base font-semibold text-center whitespace-normal break-words;
 	}
 	.action-card__option-title {
-		@apply text-base font-semibold;
+		@apply block text-base font-semibold leading-snug whitespace-normal break-words;
 	}
 	.action-card__option-summary {
 		@apply text-sm text-slate-600 dark:text-slate-300;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -204,6 +204,8 @@
 	}
 	.action-card__option-title {
 		@apply text-left font-semibold;
+		flex: 1 1 auto;
+		min-width: 0;
 	}
 	.action-card__option--compact {
 		@apply min-h-[4.25rem] items-center gap-2 text-base text-center;
@@ -213,6 +215,7 @@
 	}
 	.action-card__option--compact .action-card__option-title {
 		@apply text-base font-semibold text-center;
+		width: 100%;
 	}
 	.action-card__option-summary {
 		@apply text-xs text-left text-slate-600 leading-snug dark:text-slate-300;
@@ -221,13 +224,21 @@
 		@apply text-xs text-left text-slate-500 leading-snug dark:text-slate-400;
 	}
 	.action-card__summary {
-		@apply text-sm list-disc pl-4 text-left space-y-1;
+		font-size: 0.875rem;
+		list-style: disc;
+		padding-left: 1rem;
+		text-align: left;
 	}
-	.action-card__summary .list-disc {
-		@apply list-none pl-4 space-y-1;
+	.action-card__summary > li {
+		margin-bottom: 0.25rem;
 	}
-	.action-card__summary .list-disc > li {
-		@apply pl-0;
+	.action-card__summary > li:last-child {
+		margin-bottom: 0;
+	}
+	.action-card__summary ul {
+		list-style: none;
+		margin: 0.25rem 0 0;
+		padding-left: 1rem;
 	}
 	.action-card__cancel {
 		@apply rounded-full border border-white/50 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-white hover:text-slate-900 dark:border-white/20 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700;

--- a/packages/web/src/translation/render.tsx
+++ b/packages/web/src/translation/render.tsx
@@ -12,7 +12,7 @@ export function renderSummary(summary: Summary | undefined): React.ReactNode {
 		) : (
 			<li key={i}>
 				<span className="font-semibold">{e.title}</span>
-				<ul className="list-disc pl-4">{renderSummary(e.items)}</ul>
+				<ul className="pl-4 space-y-1">{renderSummary(e.items)}</ul>
 			</li>
 		),
 	);


### PR DESCRIPTION
## Summary
- stop rendering the fallback "Step X of Y" badge on action prompts and keep the icon-only front badge
- carry resolved option parameters forward when resolving multi-step actions so the engine receives the correct choice metadata
- update action option card styles so long labels wrap cleanly within their buttons

## Testing
- npm run test:quick *(fails: resource-bar hover card expectation currently broken upstream)*

------
https://chatgpt.com/codex/tasks/task_e_68e18c666f288325a7a135e4231f86e2