### PR TITLE
Add evaluator requirement builder and update resource hover card

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -9,7 +9,7 @@ import {
 import {
 	action,
 	effect,
-	requirement,
+	requirementEvaluatorCompare,
 	Types,
 	LandMethods,
 	ResourceMethods,
@@ -164,10 +164,10 @@ export function createActionRegistry() {
 			.cost(Resource.ap, 1)
 			.cost(Resource.gold, 5)
 			.requirement(
-				requirement('evaluator', 'compare')
-					.param('left', populationEvaluator().build())
-					.param('operator', 'lt')
-					.param('right', statEvaluator().key(Stat.maxPopulation).build())
+				requirementEvaluatorCompare()
+					.left(populationEvaluator())
+					.operator('lt')
+					.right(statEvaluator().key(Stat.maxPopulation))
 					.message('Free space for 👥')
 					.build(),
 			)
@@ -260,13 +260,10 @@ export function createActionRegistry() {
 			.icon('🗡️')
 			.cost(Resource.ap, 1)
 			.requirement(
-				requirement('evaluator', 'compare')
-					.param('left', statEvaluator().key(Stat.warWeariness).build())
-					.param('operator', 'lt')
-					.param(
-						'right',
-						populationEvaluator().role(PopulationRole.Legion).build(),
-					)
+				requirementEvaluatorCompare()
+					.left(statEvaluator().key(Stat.warWeariness))
+					.operator('lt')
+					.right(populationEvaluator().role(PopulationRole.Legion))
 					.message(
 						`${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be lower than ${POPULATION_ROLES[PopulationRole.Legion].icon} ${POPULATION_ROLES[PopulationRole.Legion].label}`,
 					)
@@ -316,10 +313,10 @@ export function createActionRegistry() {
 			.cost(Resource.ap, 1)
 			.cost(Resource.gold, 3)
 			.requirement(
-				requirement('evaluator', 'compare')
-					.param('left', statEvaluator().key(Stat.warWeariness).build())
-					.param('operator', 'eq')
-					.param('right', 0)
+				requirementEvaluatorCompare()
+					.left(statEvaluator().key(Stat.warWeariness))
+					.operator('eq')
+					.right(0)
 					.message(
 						`${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be 0`,
 					)

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -98,6 +98,10 @@ export const StatMethods = {
 	REMOVE: 'remove',
 } as const;
 
+export const RequirementTypes = {
+	Evaluator: 'evaluator',
+} as const;
+
 type Params = Record<string, unknown>;
 
 abstract class ParamsBuilder<P extends Params = Params> {
@@ -1546,6 +1550,41 @@ export function requirement(type?: string, method?: string) {
 		builder.method(method);
 	}
 	return builder;
+}
+
+class RequirementEvaluatorCompareBuilder extends RequirementBuilder<{
+	left?: CompareValue;
+	right?: CompareValue;
+	operator?: 'lt' | 'lte' | 'gt' | 'gte' | 'eq' | 'ne';
+}> {
+	constructor() {
+		super();
+		this.type(RequirementTypes.Evaluator);
+		this.method('compare');
+	}
+
+	private normalize(value: CompareValue) {
+		if (value instanceof EvaluatorBuilder) {
+			return value.build();
+		}
+		return value;
+	}
+
+	left(value: CompareValue) {
+		return this.param('left', this.normalize(value));
+	}
+
+	right(value: CompareValue) {
+		return this.param('right', this.normalize(value));
+	}
+
+	operator(op: 'lt' | 'lte' | 'gt' | 'gte' | 'eq' | 'ne') {
+		return this.param('operator', op);
+	}
+}
+
+export function requirementEvaluatorCompare() {
+	return new RequirementEvaluatorCompareBuilder();
 }
 
 class BaseBuilder<T extends { id: string; name: string }> {

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -79,7 +79,6 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 		const info = RESOURCES[happinessKey];
 		handleHoverCard({
 			title: `${info.icon} ${info.label}`,
-			description: [`Current value: ${value}`],
 			effects: entries,
 			effectsTitle: `Tiers (Current: ${value})`,
 			requirements: [],

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -79,6 +79,7 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 		const info = RESOURCES[happinessKey];
 		handleHoverCard({
 			title: `${info.icon} ${info.label}`,
+			description: [`Current value: ${value}`],
 			effects: entries,
 			effectsTitle: `Tiers (Current: ${value})`,
 			requirements: [],


### PR DESCRIPTION
## Summary
- add a dedicated `requirementEvaluatorCompare` helper and `RequirementTypes` constant in the contents builders
- switch the action requirement definitions to use the typed compare builder
- surface the current happiness value in the hover card description for the resource bar

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e18c0839e0832596691578bcc3580e