### PR TITLE
Update format script to use Prettier write mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,9 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.
   descriptive identifiers, and the ~250-line limit for new modules. Missing
   plugins such as `eslint-plugin-import` are auto-installed; if tooling fails,
   install with `npm install --no-save eslint-plugin-import`.
-- `npm run format` applies Prettier with **tab indentation** and an 80-character
-  print width across TypeScript, JSON, Markdown, etc.
+- `npm run format` runs `prettier . --write` to apply Prettier with **tab
+  indentation** and an 80-character print width across TypeScript, JSON,
+  Markdown, etc.
 - Legacy files above 250 lines remain until refactored; new code should respect
   the limit.
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"pretest:coverage": "node scripts/ensure-dev-dependencies.cjs",
 		"test:coverage": "vitest run --coverage",
 		"test:ci": "npm run test:coverage",
-		"format": "prettier .",
+		"format": "prettier . --write",
 		"prepare": "husky install",
 		"lint:deps": "dependency-cruiser packages/engine packages/contents packages/web --config scripts/dependency-cruiser.cjs --output-type text"
 	},


### PR DESCRIPTION
## Summary
- update the format npm script to invoke Prettier with --write
- document the updated format command in AGENTS.md so contributors use the correct invocation

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e22f8c4634832586570f73854c4cc5