### PR TITLE
Refactor tier summaries to use shared translators

### DIFF
--- a/packages/web/src/translation/content/index.ts
+++ b/packages/web/src/translation/content/index.ts
@@ -15,3 +15,4 @@ import './action';
 import './development';
 import './building';
 import './land';
+import './tier';

--- a/packages/web/src/translation/content/tier.ts
+++ b/packages/web/src/translation/content/tier.ts
@@ -1,0 +1,96 @@
+import { formatPassiveRemoval } from '@kingdom-builder/contents';
+import type { HappinessTierDefinition } from '@kingdom-builder/engine/services';
+import type { EngineContext } from '@kingdom-builder/engine';
+import { summarizeEffects } from '../effects';
+import { translateTierSummary } from './tierSummaries';
+import { registerContentTranslator } from './factory';
+import type { ContentTranslator, Summary, SummaryEntry } from './types';
+
+function splitLines(text: string | undefined): string[] {
+	if (!text) {
+		return [];
+	}
+	return text
+		.split(/\r?\n/u)
+		.map((line) => line.replace(/^[-•–]\s*/u, '').trim())
+		.filter((line) => line.length > 0);
+}
+
+function appendUnique(target: string[], values: string[]): void {
+	for (const value of values) {
+		if (!value) {
+			continue;
+		}
+		if (target.includes(value)) {
+			continue;
+		}
+		target.push(value);
+	}
+}
+
+function flattenSummary(entries: Summary): string[] {
+	const lines: string[] = [];
+	const queue: SummaryEntry[] = [...entries];
+	while (queue.length) {
+		const entry = queue.shift();
+		if (entry === undefined) {
+			continue;
+		}
+		if (typeof entry === 'string') {
+			const trimmed = entry.trim();
+			if (trimmed.length && !lines.includes(trimmed)) {
+				lines.push(trimmed);
+			}
+			continue;
+		}
+		const title = entry.title.trim();
+		if (title.length && !lines.includes(title)) {
+			lines.push(title);
+		}
+		if (entry.items?.length) {
+			queue.unshift(...entry.items);
+		}
+	}
+	return lines;
+}
+
+class TierTranslator
+	implements ContentTranslator<HappinessTierDefinition, Record<string, never>>
+{
+	summarize(tier: HappinessTierDefinition, ctx: EngineContext): Summary {
+		const summaryLines: string[] = [];
+		const translated = translateTierSummary(tier.display?.summaryToken);
+		appendUnique(summaryLines, splitLines(translated ?? tier.text?.summary));
+		if (!summaryLines.length && tier.preview?.effects?.length) {
+			const effectSummaries = summarizeEffects(tier.preview.effects, ctx);
+			appendUnique(summaryLines, flattenSummary(effectSummaries));
+		}
+		if (!summaryLines.length) {
+			summaryLines.push('No effect');
+		}
+		const summary: Summary = [...summaryLines];
+
+		const descriptionLines: string[] = [];
+		appendUnique(descriptionLines, splitLines(tier.text?.description));
+		const removal =
+			tier.text?.removal ??
+			(tier.display?.removalCondition
+				? formatPassiveRemoval(tier.display.removalCondition)
+				: undefined);
+		appendUnique(descriptionLines, splitLines(removal));
+		if (descriptionLines.length) {
+			summary.push({
+				title: 'Details',
+				items: descriptionLines,
+				_desc: true,
+			});
+		}
+		return summary;
+	}
+
+	describe(tier: HappinessTierDefinition, ctx: EngineContext): Summary {
+		return this.summarize(tier, ctx);
+	}
+}
+
+registerContentTranslator('tier', new TierTranslator());

--- a/packages/web/tests/tier-content-summary.test.ts
+++ b/packages/web/tests/tier-content-summary.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { createEngine } from '@kingdom-builder/engine';
+import {
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+} from '@kingdom-builder/contents';
+import {
+	summarizeContent,
+	splitSummary,
+	translateTierSummary,
+} from '../src/translation';
+
+function splitLines(text: string | undefined): string[] {
+	if (!text) {
+		return [];
+	}
+	return text
+		.split(/\r?\n/u)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+}
+
+function flattenSummary(entries: unknown[] | undefined): string[] {
+	if (!entries) {
+		return [];
+	}
+	const lines: string[] = [];
+	const queue = [...entries];
+	while (queue.length) {
+		const entry = queue.shift();
+		if (entry === undefined) {
+			continue;
+		}
+		if (typeof entry === 'string') {
+			lines.push(entry);
+			continue;
+		}
+		if (entry && typeof entry === 'object') {
+			const group = entry as { title?: string; items?: unknown[] };
+			if (group.title) {
+				lines.push(group.title);
+			}
+			if (Array.isArray(group.items)) {
+				queue.unshift(...group.items);
+			}
+		}
+	}
+	return lines;
+}
+
+describe('tier content summaries', () => {
+	it('summarizes tiers using canonical translators', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		ctx.services.rules.tierDefinitions.forEach((tier) => {
+			const summary = summarizeContent('tier', tier, ctx);
+			const { effects, description } = splitSummary(summary);
+			const effectLines = flattenSummary(effects);
+			const descriptionLines = flattenSummary(description);
+			const translated = translateTierSummary(tier.display?.summaryToken);
+			const expectedLines = splitLines(translated ?? tier.text?.summary);
+			if (expectedLines.length) {
+				expectedLines.forEach((line) => {
+					expect(effectLines).toContain(line);
+				});
+			} else {
+				expect(effectLines).toContain('No effect');
+			}
+			if (tier.text?.removal) {
+				expect(effectLines).not.toContain(tier.text.removal);
+				expect(descriptionLines).toContain(tier.text.removal);
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- use the shared summarizeContent/splitSummary helpers when building tier hover entries and expose the shared max line constant
- add a tier content translator that derives summary, description, and "No effect" fallbacks from tokens, previews, and removal text
- refresh the ResourceBar tier tests and add coverage for the translator to assert effect/description separation

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e22c0044bc8325894c68aacfd4c57e