### PR TITLE
refactor: normalize tab indentation in evaluator helpers

### DIFF
--- a/packages/engine/src/evaluators/compare.ts
+++ b/packages/engine/src/evaluators/compare.ts
@@ -25,18 +25,20 @@ function compare(a: number, b: number, op: CompareParams['operator']) {
 	}
 }
 
+const getValue = (
+	value: EvaluatorDef | number,
+	ctx: Parameters<EvaluatorHandler<number, CompareParams>>[1],
+) =>
+	typeof value === 'number'
+		? value
+		: Number(EVALUATORS.get(value.type)(value, ctx));
+
 export const compareEvaluator: EvaluatorHandler<number, CompareParams> = (
 	definition,
 	ctx,
 ) => {
 	const params = definition.params as CompareParams;
-	const leftVal =
-		typeof params.left === 'number'
-			? params.left
-			: Number(EVALUATORS.get(params.left.type)(params.left, ctx));
-	const rightVal =
-		typeof params.right === 'number'
-			? params.right
-			: Number(EVALUATORS.get(params.right.type)(params.right, ctx));
+	const leftVal = getValue(params.left, ctx);
+	const rightVal = getValue(params.right, ctx);
 	return compare(leftVal, rightVal, params.operator) ? 1 : 0;
 };

--- a/packages/engine/src/evaluators/development.ts
+++ b/packages/engine/src/evaluators/development.ts
@@ -13,7 +13,9 @@ export const developmentEvaluator: EvaluatorHandler<
 	return ctx.activePlayer.lands.reduce(
 		(total, land) =>
 			total +
-			land.developments.filter((development) => development === id).length,
+			land.developments.filter(
+				(development) => development === id,
+			).length,
 		0,
 	);
 };

--- a/packages/engine/src/requirements/evaluator_compare.ts
+++ b/packages/engine/src/requirements/evaluator_compare.ts
@@ -26,14 +26,19 @@ function compare(a: number, b: number, op: CompareParams['operator']) {
 	}
 }
 
+const getValue = (
+	value: EvaluatorDef | number,
+	ctx: Parameters<RequirementHandler>[1],
+) =>
+	typeof value === 'number'
+		? value
+		: (EVALUATORS.get(value.type)(value, ctx) as number);
+
 export const evaluatorCompare: RequirementHandler = (req, ctx) => {
 	const params = req.params as unknown as CompareParams;
 	const leftHandler = EVALUATORS.get(params.left.type);
 	const leftVal = leftHandler(params.left, ctx) as number;
-	const rightVal =
-		typeof params.right === 'number'
-			? params.right
-			: (EVALUATORS.get(params.right.type)(params.right, ctx) as number);
+	const rightVal = getValue(params.right, ctx);
 	return compare(leftVal, rightVal, params.operator)
 		? true
 		: req.message || 'Requirement failed';


### PR DESCRIPTION
## Summary
- re-indent compare-based evaluator and requirement helpers with tabs and extract shared value lookup helpers
- wrap evaluator development filtering to keep lines under 80 characters while maintaining logic

## Testing
- npm run lint -- --fix

------
https://chatgpt.com/codex/tasks/task_e_68e22f92d61083258e66152db439e3f9