### PR TITLE
Refine favicon setup helpers

### DIFF
--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -4,16 +4,34 @@ import App from './App';
 import { PRIMARY_ICON_ID, RESOURCES } from '@kingdom-builder/contents';
 import { resolvePrimaryIcon } from './startup/resolvePrimaryIcon';
 
+const createFaviconSvg = (emoji: string): string =>
+	[
+		'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">',
+		'<text y=".9em" font-size="90">',
+		emoji,
+		'</text>',
+		'</svg>',
+	].join('');
+
+const ensureFaviconLink = (): HTMLLinkElement => {
+	const existing = document.querySelector<HTMLLinkElement>('#favicon');
+	if (existing) {
+		return existing;
+	}
+	const link = document.createElement('link');
+	link.id = 'favicon';
+	return link;
+};
+
 const icon = resolvePrimaryIcon(RESOURCES, PRIMARY_ICON_ID);
 if (icon) {
-	const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">${icon}</text></svg>`;
-	const link =
-		document.querySelector<HTMLLinkElement>('#favicon') ??
-		document.createElement('link');
-	link.id = 'favicon';
+	const svg = createFaviconSvg(icon);
+	const link = ensureFaviconLink();
 	link.rel = 'icon';
 	link.href = `data:image/svg+xml,${encodeURIComponent(svg)}`;
-	document.head.appendChild(link);
+	if (!link.parentElement) {
+		document.head.appendChild(link);
+	}
 } else {
 	console.warn('Unable to resolve favicon icon from content.');
 }


### PR DESCRIPTION
## Summary
- extract helpers to build the favicon SVG markup within the 80 character limit
- centralize link creation logic and only append a new favicon element when needed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e231e33df483258df8d7feadd74339