### PR TITLE
Fix multi-step option selection handling

### DIFF
--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -163,6 +163,7 @@ function StepBadge({
 function OptionCard({ option }: { option: ActionCardOption }) {
 	const icon = option.icon?.trim();
 	const label = option.label.trim();
+	const ariaLabel = label.length > 0 ? label : option.id;
 	const optionClass = [
 		'action-card__option',
 		option.compact ? 'action-card__option--compact' : '',
@@ -170,6 +171,7 @@ function OptionCard({ option }: { option: ActionCardOption }) {
 	]
 		.filter(Boolean)
 		.join(' ');
+	const compactVisual = icon || (label.length > 0 ? label[0] : '–');
 	return (
 		<button
 			type="button"
@@ -178,25 +180,42 @@ function OptionCard({ option }: { option: ActionCardOption }) {
 			disabled={option.disabled}
 			onMouseEnter={option.onMouseEnter}
 			onMouseLeave={option.onMouseLeave}
+			aria-label={ariaLabel}
+			title={option.compact ? ariaLabel : undefined}
 		>
-			<span className="action-card__option-header">
-				{icon ? (
-					<span aria-hidden="true" className="action-card__option-icon">
-						{icon}
+			{option.compact ? (
+				<>
+					<span
+						aria-hidden="true"
+						className="action-card__option-compact-visual"
+					>
+						{compactVisual}
 					</span>
-				) : null}
-				<span className="action-card__option-title">{label}</span>
-			</span>
-			{!option.compact && option.summary && (
-				<p className="action-card__option-summary">{option.summary}</p>
-			)}
-			{!option.compact && option.description && (
-				<p className="action-card__option-description">{option.description}</p>
+					<span className="sr-only">{ariaLabel}</span>
+				</>
+			) : (
+				<>
+					<span className="action-card__option-header">
+						{icon ? (
+							<span aria-hidden="true" className="action-card__option-icon">
+								{icon}
+							</span>
+						) : null}
+						<span className="action-card__option-title">{label}</span>
+					</span>
+					{option.summary ? (
+						<p className="action-card__option-summary">{option.summary}</p>
+					) : null}
+					{option.description ? (
+						<p className="action-card__option-description">
+							{option.description}
+						</p>
+					) : null}
+				</>
 			)}
 		</button>
 	);
 }
-
 export default function ActionCard({
 	title,
 	costs,

--- a/packages/web/src/components/actions/GenericActions.tsx
+++ b/packages/web/src/components/actions/GenericActions.tsx
@@ -75,6 +75,12 @@ function GenericActions({
 			if (placeholders.has('playerId')) {
 				params.playerId = context.activePlayer.id;
 			}
+			for (const placeholder of placeholders) {
+				if (placeholder in params) {
+					continue;
+				}
+				params[placeholder] = undefined;
+			}
 			clearHoverCard();
 			setPending({
 				action: targetAction,
@@ -124,15 +130,23 @@ function GenericActions({
 					...previous.choices,
 					[group.id]: choice,
 				};
-				const mergedParams = resolvedParams
-					? { ...previous.params, ...resolvedParams }
+				const forwardedEntries = resolvedParams
+					? Object.entries(resolvedParams).filter(([key]) =>
+							Object.prototype.hasOwnProperty.call(previous.params, key),
+						)
+					: [];
+				const mergedParams = forwardedEntries.length
+					? {
+							...previous.params,
+							...Object.fromEntries(forwardedEntries),
+						}
 					: previous.params;
 				if (previous.step + 1 < previous.groups.length) {
 					return {
 						...previous,
 						step: previous.step + 1,
 						choices: nextChoices,
-						params: resolvedParams ? mergedParams : previous.params,
+						params: mergedParams,
 					};
 				}
 				void handlePerform(previous.action, {

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -208,14 +208,10 @@
 		min-width: 0;
 	}
 	.action-card__option--compact {
-		@apply min-h-[4.25rem] items-center gap-2 text-base text-center;
+		@apply min-h-[4.25rem] items-center justify-center gap-0 text-base text-center;
 	}
-	.action-card__option--compact .action-card__option-header {
-		@apply flex flex-col items-center justify-center gap-1 text-center;
-	}
-	.action-card__option--compact .action-card__option-title {
-		@apply text-base font-semibold text-center;
-		width: 100%;
+	.action-card__option-compact-visual {
+		@apply flex h-12 w-12 items-center justify-center text-3xl leading-none;
 	}
 	.action-card__option-summary {
 		@apply text-xs text-left text-slate-600 leading-snug dark:text-slate-300;

--- a/packages/web/src/translation/effects/optionLabel.ts
+++ b/packages/web/src/translation/effects/optionLabel.ts
@@ -159,10 +159,14 @@ export function buildActionOptionTranslation(
 	if (typeof first === 'string') {
 		const normalizedFirst = normalizeEntryLabel(first, targetLabel);
 		const title = combineLabels(actionLabel, normalizedFirst, fallback);
+		const shouldIncludeFirstDetail =
+			restEntries.length > 0
+				? true
+				: mode === 'describe' && normalizedFirst !== targetLabel;
 		const detailEntries =
 			restEntries.length > 0
 				? restEntries
-				: mode === 'describe'
+				: shouldIncludeFirstDetail
 					? [normalizedFirst]
 					: [];
 		if (detailEntries.length === 0) {


### PR DESCRIPTION
## Summary
- center compact multi-step action choices on their icon and hide redundant labels
- ensure pending multi-step selections only forward placeholder parameters to prevent unknown-id errors
- stop duplicating effect group detail text in action descriptions for grouped effects

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e22f0878c4832590cd365e81bfa375