### PR TITLE
refactor: extract population helpers for actions panel

### DIFF
--- a/packages/web/src/components/actions/populationHelpers.ts
+++ b/packages/web/src/components/actions/populationHelpers.ts
@@ -1,0 +1,101 @@
+import {
+	POPULATION_ROLES,
+	type PopulationRoleId,
+} from '@kingdom-builder/contents';
+
+export interface PopulationDefinition {
+	id: string;
+	name: string;
+	icon?: string;
+	upkeep?: Record<string, number>;
+	onAssigned?: unknown[];
+	onUnassigned?: unknown[];
+	onGrowthPhase?: unknown[];
+	onUpkeepPhase?: unknown[];
+	onPayUpkeepStep?: unknown[];
+	onGainIncomeStep?: unknown[];
+	onGainAPStep?: unknown[];
+}
+
+export type EffectConfig = {
+	type?: string;
+	method?: string;
+	params?: Record<string, unknown>;
+	effects?: EffectConfig[];
+};
+
+export interface PopulationRegistryLike {
+	get(id: string): PopulationDefinition;
+	entries(): [string, PopulationDefinition][];
+}
+
+export function isHirablePopulation(
+	population: PopulationDefinition | undefined,
+): boolean {
+	if (!population) {
+		return false;
+	}
+	if (population.upkeep && Object.keys(population.upkeep).length > 0) {
+		return true;
+	}
+	const effectLists: (keyof PopulationDefinition)[] = [
+		'onAssigned',
+		'onUnassigned',
+		'onGrowthPhase',
+		'onUpkeepPhase',
+		'onPayUpkeepStep',
+		'onGainIncomeStep',
+		'onGainAPStep',
+	];
+	return effectLists.some((key) => {
+		const effects = population[key];
+		return Array.isArray(effects) && effects.length > 0;
+	});
+}
+
+export function collectPopulationRolesFromEffects(
+	effects: EffectConfig[] | undefined,
+	explicitRoles: Set<string>,
+): boolean {
+	let usesPlaceholder = false;
+	for (const effect of effects ?? []) {
+		if (effect.type === 'population' && effect.method === 'add') {
+			const role = effect.params?.['role'];
+			if (typeof role === 'string') {
+				if (role.startsWith('$')) {
+					usesPlaceholder = true;
+				} else {
+					explicitRoles.add(role);
+				}
+			}
+		}
+		if (effect.effects?.length) {
+			if (collectPopulationRolesFromEffects(effect.effects, explicitRoles)) {
+				usesPlaceholder = true;
+			}
+		}
+	}
+	return usesPlaceholder;
+}
+
+export function getPopulationIconFromRole(
+	role: string,
+	populations: PopulationRegistryLike,
+): string {
+	if (!role) {
+		return '';
+	}
+	const infoIcon = POPULATION_ROLES[role as PopulationRoleId]?.icon;
+	if (infoIcon) {
+		return infoIcon;
+	}
+	try {
+		const population = populations.get(role);
+		if (typeof population?.icon === 'string') {
+			return population.icon;
+		}
+	} catch {
+		// Ignore missing population entries when deriving icons.
+	}
+	return '';
+}


### PR DESCRIPTION
## Summary
- extract population helper utilities into a dedicated populationHelpers module
- update ActionsPanel to consume the shared helpers instead of inline implementations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e231e83f688325be52301fb37ce3c9