### PR TITLE
Refactor test indentation and wrap long lines

### DIFF
--- a/packages/web/tests/ActionsPanel.test.tsx
+++ b/packages/web/tests/ActionsPanel.test.tsx
@@ -66,41 +66,45 @@ beforeEach(() => {
 });
 
 describe('<ActionsPanel />', () => {
-	it('renders hire options for generated population roles with derived requirement icons', () => {
-		render(<ActionsPanel />);
-		const raiseAction = metadata.actions.raise;
-		expect(requirementIconsMock).toHaveBeenCalledWith(
-			raiseAction.id,
-			expect.anything(),
-		);
-		const baseIcons = metadata.requirementIcons.get(raiseAction.id) ?? [];
-		const hireButtons = screen.getAllByRole('button', {
-			name: /Hire\s*:/,
-		});
-		const requirementTexts = hireButtons.map(
-			(button) => within(button).getByText(/^Req/).textContent ?? '',
-		);
-		for (const role of metadata.populationRoles) {
-			expect(
-				requirementTexts.some((text) => {
-					if (!text.includes('Req')) {
-						return false;
-					}
-					if (baseIcons.some((icon) => !text.includes(icon))) {
-						return false;
-					}
-					if (
-						metadata.populationInfoIcon &&
-						!text.includes(metadata.populationInfoIcon)
-					) {
-						return false;
-					}
-					return role.icon ? text.includes(role.icon) : true;
-				}),
-			).toBe(true);
-		}
-		expect(hireButtons).toHaveLength(metadata.populationRoles.length);
-	});
+	it(
+		'renders hire options for generated population roles ' +
+			'with derived requirement icons',
+		() => {
+			render(<ActionsPanel />);
+			const raiseAction = metadata.actions.raise;
+			expect(requirementIconsMock).toHaveBeenCalledWith(
+				raiseAction.id,
+				expect.anything(),
+			);
+			const baseIcons = metadata.requirementIcons.get(raiseAction.id) ?? [];
+			const hireButtons = screen.getAllByRole('button', {
+				name: /Hire\s*:/,
+			});
+			const requirementTexts = hireButtons.map(
+				(button) => within(button).getByText(/^Req/).textContent ?? '',
+			);
+			for (const role of metadata.populationRoles) {
+				expect(
+					requirementTexts.some((text) => {
+						if (!text.includes('Req')) {
+							return false;
+						}
+						if (baseIcons.some((icon) => !text.includes(icon))) {
+							return false;
+						}
+						if (
+							metadata.populationInfoIcon &&
+							!text.includes(metadata.populationInfoIcon)
+						) {
+							return false;
+						}
+						return role.icon ? text.includes(role.icon) : true;
+					}),
+				).toBe(true);
+			}
+			expect(hireButtons).toHaveLength(metadata.populationRoles.length);
+		},
+	);
 
 	it('falls back to requirement helper icons for building cards', () => {
 		setScenario({ showBuilding: true });
@@ -123,17 +127,26 @@ describe('<ActionsPanel />', () => {
 		});
 		const requirementText =
 			within(buildingButton).getByText(/^Req/).textContent ?? '';
-		expect(icons.every((icon) => requirementText.includes(icon))).toBe(true);
+		const allIconsPresent = icons.every((icon) => {
+			return requirementText.includes(icon);
+		});
+		expect(allIconsPresent).toBe(true);
 	});
 
-	it('omits the hire section when the helper supplies a non-population action category', () => {
-		setScenario({ actionCategories: { population: 'custom-population' } });
-		expect(metadata.actions.raise.category).toBe('custom-population');
-		render(<ActionsPanel />);
-		expect(screen.queryAllByRole('button', { name: /Hire\s*:/ })).toHaveLength(
-			0,
-		);
-	});
+	it(
+		'omits the hire section when the helper supplies a non-population ' +
+			'action category',
+		() => {
+			setScenario({
+				actionCategories: { population: 'custom-population' },
+			});
+			expect(metadata.actions.raise.category).toBe('custom-population');
+			render(<ActionsPanel />);
+			expect(
+				screen.queryAllByRole('button', { name: /Hire\s*:/ }),
+			).toHaveLength(0);
+		},
+	);
 
 	it('renders requirement icons for custom generated population roles', () => {
 		setScenario({

--- a/packages/web/tests/development-translation.test.ts
+++ b/packages/web/tests/development-translation.test.ts
@@ -81,35 +81,46 @@ function findSelfReferentialDevelopment(
 }
 
 describe('development translation', () => {
-	it('replaces self-referential placeholders when describing developments', () => {
-		const id = findSelfReferentialDevelopment(DEVELOPMENTS.entries());
-		const summary = summarizeContent('development', id, ctx as EngineContext);
-		const description = describeContent(
-			'development',
-			id,
-			ctx as EngineContext,
+		it(
+			'replaces self-referential placeholders when describing developments',
+			() => {
+				const id = findSelfReferentialDevelopment(DEVELOPMENTS.entries());
+				const summary = summarizeContent('development', id, ctx as EngineContext);
+				const description = describeContent(
+					'development',
+					id,
+					ctx as EngineContext,
+				);
+				const strings = [...flatten(summary), ...flatten(description)];
+
+				expect(strings.some((line) => line.includes('$id'))).toBe(false);
+
+				const def = ctx.developments.get(id);
+				const icon = def.icon || '';
+
+				const hasIncomeLine = strings.some((line) => {
+					return /During income step/.test(line);
+				});
+				expect(hasIncomeLine).toBe(true);
+
+				expect(strings.some((line) => /\+2/.test(line))).toBe(true);
+				expect(strings.some((line) => /Gold/.test(line))).toBe(true);
+				const prohibited = strings.filter(
+					(line) =>
+						line.includes(`per ${icon} ${def.name}`) ||
+						line.includes(`for each ${icon} ${def.name}`),
+				);
+				expect(prohibited).toHaveLength(0);
+
+				const logEntry = logContent(
+					'development',
+					id,
+					ctx as EngineContext,
+				);
+				expect(logEntry.some((line) => line.includes(def.name))).toBe(true);
+				if (icon) {
+					expect(logEntry.some((line) => line.includes(icon))).toBe(true);
+				}
+			},
 		);
-		const strings = [...flatten(summary), ...flatten(description)];
-
-		expect(strings.some((line) => line.includes('$id'))).toBe(false);
-
-		const def = ctx.developments.get(id);
-		const icon = def.icon || '';
-
-		expect(strings.some((line) => /During income step/.test(line))).toBe(true);
-		expect(strings.some((line) => /\+2/.test(line))).toBe(true);
-		expect(strings.some((line) => /Gold/.test(line))).toBe(true);
-		const prohibited = strings.filter(
-			(line) =>
-				line.includes(`per ${icon} ${def.name}`) ||
-				line.includes(`for each ${icon} ${def.name}`),
-		);
-		expect(prohibited).toHaveLength(0);
-
-		const logEntry = logContent('development', id, ctx as EngineContext);
-		expect(logEntry.some((line) => line.includes(def.name))).toBe(true);
-		if (icon) {
-			expect(logEntry.some((line) => line.includes(icon))).toBe(true);
-		}
-	});
 });


### PR DESCRIPTION
## Summary
- restyle the ActionsPanel test suite with tab indentation, wrapped descriptions, and helper variables for resource checks
- reformat the development translation test to use tabbed indentation and extracted expectations for long regex checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e231dbe78c83258ea92ce6d362b357