### PR TITLE
Revise happiness passive presentation

### DIFF
--- a/packages/contents/src/happinessHelpers.ts
+++ b/packages/contents/src/happinessHelpers.ts
@@ -62,6 +62,8 @@ type TierPassiveEffectOptions = {
 	removalDetail: string;
 	params: ReturnType<typeof passiveParams>;
 	effects?: EffectConfig[];
+	icon?: string;
+	name?: string;
 };
 
 export function createTierPassiveEffect({
@@ -71,13 +73,22 @@ export function createTierPassiveEffect({
 	removalDetail,
 	params,
 	effects = [],
+	icon,
+	name,
 }: TierPassiveEffectOptions) {
 	params.detail(summaryToken ?? summary);
+	if (name) {
+		params.name(name);
+	}
+	if (icon) {
+		params.icon(icon);
+	}
 	params.meta({
 		source: {
 			type: 'tiered-resource',
 			id: tierId,
 			...(summaryToken ? { labelToken: summaryToken } : {}),
+			...(icon ? { icon } : {}),
 		},
 		removal: {
 			token: removalDetail,

--- a/packages/contents/src/rules.ts
+++ b/packages/contents/src/rules.ts
@@ -15,6 +15,28 @@ import { happinessTier, passiveParams } from './config/builders';
 import { Resource } from './resources';
 import { formatPassiveRemoval } from './text';
 
+const HAPPINESS_TIER_ICONS = {
+	despair: '😡',
+	misery: '😠',
+	grim: '😟',
+	unrest: '🙁',
+	steady: '😐',
+	content: '🙂',
+	joyful: '😊',
+	elated: '😄',
+	ecstatic: '🤩',
+} as const;
+
+type HappinessTierSlug = keyof typeof HAPPINESS_TIER_ICONS;
+
+function formatTierName(slug: HappinessTierSlug) {
+	return slug
+		.split(/[-_]/g)
+		.filter(Boolean)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ');
+}
+
 const happinessSummaryToken = (slug: string) =>
 	`happiness.tier.summary.${slug}`;
 
@@ -24,6 +46,7 @@ const TIER_CONFIGS = [
 	{
 		id: 'happiness:tier:despair',
 		passiveId: 'passive:happiness:despair',
+		slug: 'despair',
 		range: { min: -10 },
 		incomeMultiplier: 0.5,
 		disableGrowth: true,
@@ -41,6 +64,7 @@ const TIER_CONFIGS = [
 	{
 		id: 'happiness:tier:misery',
 		passiveId: 'passive:happiness:misery',
+		slug: 'misery',
 		range: { min: -9, max: -8 },
 		incomeMultiplier: 0.5,
 		disableGrowth: true,
@@ -56,6 +80,7 @@ const TIER_CONFIGS = [
 	{
 		id: 'happiness:tier:grim',
 		passiveId: 'passive:happiness:grim',
+		slug: 'grim',
 		range: { min: -7, max: -5 },
 		incomeMultiplier: 0.75,
 		disableGrowth: true,
@@ -71,6 +96,7 @@ const TIER_CONFIGS = [
 	{
 		id: 'happiness:tier:unrest',
 		passiveId: 'passive:happiness:unrest',
+		slug: 'unrest',
 		range: { min: -4, max: -3 },
 		incomeMultiplier: 0.75,
 		summaryToken: happinessSummaryToken('unrest'),
@@ -80,6 +106,7 @@ const TIER_CONFIGS = [
 	},
 	{
 		id: 'happiness:tier:steady',
+		slug: 'steady',
 		range: { min: -2, max: 2 },
 		incomeMultiplier: 1,
 		summaryToken: happinessSummaryToken('steady'),
@@ -89,6 +116,7 @@ const TIER_CONFIGS = [
 	{
 		id: 'happiness:tier:content',
 		passiveId: 'passive:happiness:content',
+		slug: 'content',
 		range: { min: 3, max: 4 },
 		incomeMultiplier: 1.25,
 		summaryToken: happinessSummaryToken('content'),
@@ -99,6 +127,7 @@ const TIER_CONFIGS = [
 	{
 		id: 'happiness:tier:joyful',
 		passiveId: 'passive:happiness:joyful',
+		slug: 'joyful',
 		range: { min: 5, max: 7 },
 		incomeMultiplier: 1.25,
 		buildingDiscountPct: 0.2,
@@ -116,6 +145,7 @@ const TIER_CONFIGS = [
 	{
 		id: 'happiness:tier:elated',
 		passiveId: 'passive:happiness:elated',
+		slug: 'elated',
 		range: { min: 8, max: 9 },
 		incomeMultiplier: 1.5,
 		buildingDiscountPct: 0.2,
@@ -133,6 +163,7 @@ const TIER_CONFIGS = [
 	{
 		id: 'happiness:tier:ecstatic',
 		passiveId: 'passive:happiness:ecstatic',
+		slug: 'ecstatic',
 		range: { min: 10 },
 		incomeMultiplier: 1.5,
 		buildingDiscountPct: 0.2,
@@ -156,6 +187,8 @@ type TierConfig = (typeof TIER_CONFIGS)[number] & {
 };
 
 function buildTierDefinition(config: TierConfig): HappinessTierDefinition {
+	const icon = HAPPINESS_TIER_ICONS[config.slug as HappinessTierSlug];
+	const name = formatTierName(config.slug as HappinessTierSlug);
 	const builder = happinessTier(config.id)
 		.range(config.range.min, config.range.max)
 		.incomeMultiplier(config.incomeMultiplier)
@@ -167,7 +200,8 @@ function buildTierDefinition(config: TierConfig): HappinessTierDefinition {
 		.display((display) =>
 			display
 				.summaryToken(config.summaryToken)
-				.removalCondition(config.removal),
+				.removalCondition(config.removal)
+				.icon(icon),
 		);
 	if (config.passiveId) {
 		const params = passiveParams().id(config.passiveId);
@@ -182,6 +216,8 @@ function buildTierDefinition(config: TierConfig): HappinessTierDefinition {
 			removalDetail: config.removal,
 			params,
 			...(config.effects ? { effects: config.effects } : {}),
+			icon,
+			name,
 		});
 		builder.passive(passive);
 	}

--- a/packages/engine/src/evaluators/development.ts
+++ b/packages/engine/src/evaluators/development.ts
@@ -13,9 +13,7 @@ export const developmentEvaluator: EvaluatorHandler<
 	return ctx.activePlayer.lands.reduce(
 		(total, land) =>
 			total +
-			land.developments.filter(
-				(development) => development === id,
-			).length,
+			land.developments.filter((development) => development === id).length,
 		0,
 	);
 };

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -75,13 +75,12 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 	const tiers = ctx.services.rules.tierDefinitions;
 	const showHappinessCard = (value: number) => {
 		const activeTier = ctx.services.tieredResource.definition(value);
-		const entries = buildTierEntries(tiers, activeTier?.id, ctx);
+		const { entries } = buildTierEntries(tiers, activeTier?.id, ctx);
 		const info = RESOURCES[happinessKey];
 		handleHoverCard({
 			title: `${info.icon} ${info.label}`,
 			effects: entries,
-			description: [`Current value: ${value}`],
-			effectsTitle: `Tiers (Current: ${value})`,
+			effectsTitle: `Thresholds (Current value: ${value})`,
 			requirements: [],
 			bgClass: PLAYER_INFO_CARD_BG,
 		});

--- a/packages/web/src/components/player/buildTierEntries.ts
+++ b/packages/web/src/components/player/buildTierEntries.ts
@@ -1,6 +1,7 @@
 import { PASSIVE_INFO } from '@kingdom-builder/contents';
 import type { EngineContext } from '@kingdom-builder/engine';
 import { summarizeContent, splitSummary } from '../../translation';
+import type { SummaryGroup } from '../../translation/content';
 
 export const MAX_TIER_SUMMARY_LINES = 4;
 
@@ -9,10 +10,25 @@ export type TierDefinition =
 
 type TierSummaryEntry = TierDefinition & { active: boolean };
 
+type TierSummaryGroup = SummaryGroup & { className?: string };
+
+export interface TierEntriesResult {
+	entries: TierSummaryGroup[];
+	activeEntry?: {
+		entry: TierSummaryGroup;
+		icon: string;
+		name: string;
+		rangeLabel: string;
+	};
+}
+
 function formatTierRange(tier: TierDefinition) {
 	const { min, max } = tier.range;
 	if (max === undefined) {
-		return `${min}`;
+		if (min >= 0) {
+			return `${min}+`;
+		}
+		return `≤ ${min}`;
 	}
 	if (min === max) {
 		return `${min}`;
@@ -20,11 +36,42 @@ function formatTierRange(tier: TierDefinition) {
 	return `${min} to ${max}`;
 }
 
+function extractTierSlug(value: string | undefined) {
+	if (!value) {
+		return undefined;
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+	for (const delimiter of ['.', ':', '/']) {
+		if (trimmed.includes(delimiter)) {
+			const slug = trimmed.slice(trimmed.lastIndexOf(delimiter) + 1);
+			if (slug && slug !== trimmed) {
+				return slug;
+			}
+		}
+	}
+	return trimmed;
+}
+
+function formatTierName(value: string | undefined) {
+	const slug = extractTierSlug(value);
+	if (!slug) {
+		return 'Tier';
+	}
+	return slug
+		.split(/[-_]/g)
+		.filter(Boolean)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ');
+}
+
 export function buildTierEntries(
 	tiers: TierDefinition[],
 	activeId: string | undefined,
 	ctx: EngineContext,
-) {
+): TierEntriesResult {
 	const getRangeStart = (tier: TierDefinition) =>
 		tier.range.min ?? Number.NEGATIVE_INFINITY;
 	const orderedTiers = [...tiers].sort(
@@ -34,12 +81,14 @@ export function buildTierEntries(
 		...tier,
 		active: tier.id === activeId,
 	}));
-	return entries.map((entry) => {
+	const summaries = entries.map((entry) => {
 		const { display, active } = entry;
 		const rangeLabel = formatTierRange(entry);
-		const statusIcon = active ? '🟢' : '⚪';
 		const icon = display?.icon ?? PASSIVE_INFO.icon ?? '';
-		const titleParts = [statusIcon, icon, rangeLabel].filter(
+		const labelToken = display?.summaryToken ?? entry.text?.summary;
+		const name = formatTierName(labelToken ?? entry.id);
+		const formattedRange = rangeLabel.length ? `(${rangeLabel})` : undefined;
+		const titleParts = [icon, name, formattedRange].filter(
 			(part) => part && String(part).trim().length > 0,
 		);
 		const title = titleParts.join(' ').trim();
@@ -47,6 +96,29 @@ export function buildTierEntries(
 		const summary = summarizeContent('tier', entry, ctx);
 		const { effects } = splitSummary(summary);
 		const items = effects.slice(0, MAX_TIER_SUMMARY_LINES);
-		return { title, items };
+		const group: TierSummaryGroup = { title, items };
+		if (active) {
+			group.className = 'text-emerald-600 dark:text-emerald-300';
+		}
+		return {
+			entry: group,
+			active,
+			icon,
+			name,
+			rangeLabel,
+		};
 	});
+	const activeEntry = summaries.find((entry) => entry.active);
+	const result: TierEntriesResult = {
+		entries: summaries.map((entry) => entry.entry),
+	};
+	if (activeEntry) {
+		result.activeEntry = {
+			entry: activeEntry.entry,
+			icon: activeEntry.icon,
+			name: activeEntry.name,
+			rangeLabel: activeEntry.rangeLabel,
+		};
+	}
+	return result;
 }

--- a/packages/web/src/translation/content/index.ts
+++ b/packages/web/src/translation/content/index.ts
@@ -1,4 +1,10 @@
-export type { Land, Summary, SummaryEntry, ContentTranslator } from './types';
+export type {
+	Land,
+	Summary,
+	SummaryEntry,
+	SummaryGroup,
+	ContentTranslator,
+} from './types';
 export {
 	registerContentTranslator,
 	summarizeContent,

--- a/packages/web/src/translation/content/types.ts
+++ b/packages/web/src/translation/content/types.ts
@@ -13,6 +13,7 @@ export interface SummaryGroup {
 	items: SummaryEntry[];
 	_desc?: true;
 	_hoist?: true;
+	className?: string;
 	[key: string]: unknown;
 }
 

--- a/packages/web/src/translation/render.tsx
+++ b/packages/web/src/translation/render.tsx
@@ -19,9 +19,9 @@ export function renderSummary(summary: Summary | undefined): React.ReactNode {
 			);
 		}
 		return (
-			<li key={i}>
+			<li key={i} className={e.className}>
 				<span className="font-semibold">{e.title}</span>
-				<ul className="pl-4 space-y-1">{renderSummary(e.items)}</ul>
+				<ul className="pl-4 space-y-1 list-disc">{renderSummary(e.items)}</ul>
 			</li>
 		);
 	});

--- a/packages/web/tests/resource-bar.test.tsx
+++ b/packages/web/tests/resource-bar.test.tsx
@@ -90,15 +90,20 @@ describe('<ResourceBar /> happiness hover card', () => {
 		const hoverCard = handleHoverCard.mock.calls.at(-1)?.[0];
 		expect(hoverCard).toBeTruthy();
 		expect(hoverCard?.title).toBe(`${resourceInfo.icon} ${resourceInfo.label}`);
-		expect(hoverCard?.description).toEqual([`Current value: ${resourceValue}`]);
+		expect(hoverCard?.description).toBeUndefined();
+		expect(hoverCard?.effectsTitle).toBe(
+			`Thresholds (Current value: ${resourceValue})`,
+		);
 		const tierEntries = hoverCard?.effects ?? [];
 		expect(tierEntries).toHaveLength(ctx.services.rules.tierDefinitions.length);
-		const activeEntry = tierEntries.find(
-			(entry: unknown) =>
-				typeof entry !== 'string' &&
-				Boolean((entry as { title?: string }).title?.includes('🟢')),
-		) as { items: unknown[] } | undefined;
-		expect(activeEntry).toBeTruthy();
+		const activeEntries = tierEntries.filter((entry: unknown) => {
+			if (typeof entry === 'string') {
+				return false;
+			}
+			const className = (entry as { className?: string }).className;
+			return className?.includes('text-emerald-600');
+		});
+		expect(activeEntries).toHaveLength(1);
 		const tiers = ctx.services.rules.tierDefinitions;
 		const getRangeStart = (tier: TierDefinition) =>
 			tier.range.min ?? Number.NEGATIVE_INFINITY;


### PR DESCRIPTION
## Summary
- add distinct icons and labels for each happiness tier passive and propagate them to passive metadata
- rework the happiness hover card to highlight the active threshold with shared formatting and remove redundant descriptions
- align passive hover details with the tier summaries, update related tests, and tidy evaluator formatting

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e23313c28c8325bcd4dd5e64481c4b