### PR TITLE
Standardize land change log formatting and coverage

### DIFF
--- a/packages/web/src/translation/content/building.ts
+++ b/packages/web/src/translation/content/building.ts
@@ -18,7 +18,8 @@ class BuildingCore implements ContentTranslator<string> {
 	}
 	log(id: string, ctx: EngineContext): string[] {
 		const { name, icon } = resolveBuildingDisplay(id, ctx);
-		return [`${icon}${name}`];
+		const display = [icon, name].filter(Boolean).join(' ').trim();
+		return [display || name];
 	}
 }
 

--- a/packages/web/src/translation/content/development.ts
+++ b/packages/web/src/translation/content/development.ts
@@ -147,8 +147,10 @@ class DevelopmentCore implements ContentTranslator<string> {
 	}
 	log(id: string, ctx: EngineContext): string[] {
 		const def = ctx.developments.get(id);
-		const icon = def.icon || '';
-		return [`${icon}${def.name}`];
+		const name = def?.name ?? id;
+		const icon = def?.icon ?? '';
+		const display = [icon, name].filter(Boolean).join(' ').trim();
+		return [display || name];
 	}
 }
 

--- a/packages/web/src/translation/log/buildingLandChanges.ts
+++ b/packages/web/src/translation/log/buildingLandChanges.ts
@@ -1,0 +1,53 @@
+import { type EngineContext } from '@kingdom-builder/engine';
+import { LAND_INFO } from '@kingdom-builder/contents';
+import { logContent } from '../content';
+import {
+	formatIconLabel,
+	formatLogHeadline,
+	LOG_KEYWORDS,
+} from './logMessages';
+import { type PlayerSnapshot } from './snapshots';
+
+export function appendBuildingChanges(
+	changes: string[],
+	before: PlayerSnapshot,
+	after: PlayerSnapshot,
+	context: EngineContext,
+): void {
+	const previous = new Set(before.buildings);
+	const next = new Set(after.buildings);
+	for (const id of next) {
+		if (previous.has(id)) {
+			continue;
+		}
+		const label = logContent('building', id, context)[0] ?? id;
+		changes.push(formatLogHeadline(LOG_KEYWORDS.built, label));
+	}
+}
+
+export function appendLandChanges(
+	changes: string[],
+	before: PlayerSnapshot,
+	after: PlayerSnapshot,
+	context: EngineContext,
+): void {
+	for (const land of after.lands) {
+		const previous = before.lands.find((item) => item.id === land.id);
+		if (!previous) {
+			const landLabel =
+				formatIconLabel(LAND_INFO.icon, LAND_INFO.label) ||
+				LAND_INFO.label ||
+				'Land';
+			changes.push(formatLogHeadline(LOG_KEYWORDS.gained, landLabel));
+			continue;
+		}
+		for (const development of land.developments) {
+			if (previous.developments.includes(development)) {
+				continue;
+			}
+			const info = logContent('development', development, context);
+			const label = info[0] ?? development;
+			changes.push(formatLogHeadline(LOG_KEYWORDS.developed, label));
+		}
+	}
+}

--- a/packages/web/src/translation/log/diffSections.ts
+++ b/packages/web/src/translation/log/diffSections.ts
@@ -3,12 +3,10 @@ import {
 	RESOURCES,
 	STATS,
 	POPULATION_ROLES,
-	LAND_INFO,
 	SLOT_INFO,
 	type ResourceKey,
 } from '@kingdom-builder/contents';
 import { formatStatValue, statDisplaysAsPercent } from '../../utils/stats';
-import { logContent } from '../content';
 import { findStatPctBreakdown, type StepEffects } from './statBreakdown';
 import { resolvePassivePresentation } from './passives';
 import {
@@ -21,6 +19,10 @@ import {
 	type SignedDelta,
 } from './diffFormatting';
 import { type PlayerSnapshot } from './snapshots';
+export {
+	appendBuildingChanges,
+	appendLandChanges,
+} from './buildingLandChanges';
 
 function describeResourceChange(
 	key: ResourceKey,
@@ -122,44 +124,6 @@ export function appendStatChanges(
 			changes.push(`${line}${breakdown}`);
 		} else {
 			changes.push(line);
-		}
-	}
-}
-export function appendBuildingChanges(
-	changes: string[],
-	before: PlayerSnapshot,
-	after: PlayerSnapshot,
-	context: EngineContext,
-) {
-	const previous = new Set(before.buildings);
-	const next = new Set(after.buildings);
-	for (const id of next) {
-		if (previous.has(id)) {
-			continue;
-		}
-		const label = logContent('building', id, context)[0] ?? id;
-		changes.push(`${label} built`);
-	}
-}
-export function appendLandChanges(
-	changes: string[],
-	before: PlayerSnapshot,
-	after: PlayerSnapshot,
-	context: EngineContext,
-) {
-	for (const land of after.lands) {
-		const previous = before.lands.find((item) => item.id === land.id);
-		if (!previous) {
-			changes.push(`${LAND_INFO.icon} +1 ${LAND_INFO.label}`);
-			continue;
-		}
-		for (const development of land.developments) {
-			if (previous.developments.includes(development)) {
-				continue;
-			}
-			const info = logContent('development', development, context);
-			const label = info[0] ?? development;
-			changes.push(`${LAND_INFO.icon} +${label}`);
 		}
 	}
 }

--- a/packages/web/src/translation/log/logMessages.ts
+++ b/packages/web/src/translation/log/logMessages.ts
@@ -1,0 +1,26 @@
+export const LOG_KEYWORDS = {
+	built: 'Built',
+	gained: 'Gained',
+	developed: 'Developed',
+} as const;
+
+export function formatIconLabel(
+	icon: string | undefined,
+	label: string | undefined,
+): string {
+	const normalizedIcon = icon?.trim() ?? '';
+	const normalizedLabel = label?.trim() ?? '';
+	if (normalizedIcon && normalizedLabel) {
+		return `${normalizedIcon} ${normalizedLabel}`;
+	}
+	return normalizedIcon || normalizedLabel;
+}
+
+export function formatLogHeadline(keyword: string, label: string): string {
+	const normalizedKeyword = keyword.trim();
+	const normalizedLabel = label.trim();
+	if (!normalizedLabel) {
+		return normalizedKeyword;
+	}
+	return `${normalizedKeyword} ${normalizedLabel}`;
+}

--- a/packages/web/tests/land-change-log.test.ts
+++ b/packages/web/tests/land-change-log.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createEngine, runEffects } from '@kingdom-builder/engine';
+import {
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	LAND_INFO,
+} from '@kingdom-builder/contents';
+import { logContent } from '../src/translation/content';
+import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
+import {
+	formatIconLabel,
+	formatLogHeadline,
+	LOG_KEYWORDS,
+} from '../src/translation/log/logMessages';
+
+vi.mock('@kingdom-builder/engine', async () => {
+	return await import('../../engine/src');
+});
+
+function createTestContext() {
+	return createEngine({
+		actions: ACTIONS,
+		buildings: BUILDINGS,
+		developments: DEVELOPMENTS,
+		populations: POPULATIONS,
+		phases: PHASES,
+		start: GAME_START,
+		rules: RULES,
+	});
+}
+
+describe('land change log formatting', () => {
+	it('logs gained land entries with icon and label', () => {
+		const ctx = createTestContext();
+		const before = snapshotPlayer(ctx.activePlayer, ctx);
+		runEffects(
+			[
+				{
+					type: 'land',
+					method: 'add',
+				},
+			],
+			ctx,
+		);
+		const after = snapshotPlayer(ctx.activePlayer, ctx);
+		const lines = diffStepSnapshots(before, after, undefined, ctx);
+		const landLine = lines.find((line) => {
+			return line.startsWith(LOG_KEYWORDS.gained);
+		});
+		expect(landLine).toBeTruthy();
+		if (!landLine) {
+			return;
+		}
+		const landLabel =
+			formatIconLabel(LAND_INFO.icon, LAND_INFO.label) ||
+			LAND_INFO.label ||
+			'Land';
+		const expectedLine = formatLogHeadline(LOG_KEYWORDS.gained, landLabel);
+		expect(landLine).toBe(expectedLine);
+	});
+
+	it('logs developed entries for new land improvements', () => {
+		const ctx = createTestContext();
+		runEffects(
+			[
+				{
+					type: 'land',
+					method: 'add',
+				},
+			],
+			ctx,
+		);
+		const targetLand =
+			ctx.activePlayer.lands.at(-1) ?? ctx.activePlayer.lands[0];
+		expect(targetLand).toBeTruthy();
+		if (!targetLand) {
+			return;
+		}
+		const developmentEntries = ctx.developments.entries();
+		const developmentEntry = developmentEntries.find(([, def]) => {
+			return Boolean(def?.icon) && Boolean(def?.name);
+		});
+		const fallbackDevelopment = developmentEntries[0];
+		const [developmentId] = developmentEntry ?? fallbackDevelopment ?? [];
+		expect(developmentId).toBeTruthy();
+		if (!developmentId) {
+			return;
+		}
+		const before = snapshotPlayer(ctx.activePlayer, ctx);
+		runEffects(
+			[
+				{
+					type: 'development',
+					method: 'add',
+					params: {
+						id: developmentId,
+						landId: targetLand.id,
+					},
+				},
+			],
+			ctx,
+		);
+		const after = snapshotPlayer(ctx.activePlayer, ctx);
+		const lines = diffStepSnapshots(before, after, undefined, ctx);
+		const developmentLine = lines.find((line) => {
+			return line.startsWith(LOG_KEYWORDS.developed);
+		});
+		expect(developmentLine).toBeTruthy();
+		if (!developmentLine) {
+			return;
+		}
+		const developmentContent = logContent('development', developmentId, ctx);
+		const developmentLabel = developmentContent[0] ?? developmentId;
+		const expectedLine = formatLogHeadline(
+			LOG_KEYWORDS.developed,
+			developmentLabel,
+		);
+		expect(developmentLine).toBe(expectedLine);
+	});
+});


### PR DESCRIPTION
## Summary
- Format building and land change diffs with shared headline helpers so logs reuse canonical keywords and icon+label strings.
- Publish reusable log keyword and icon formatting utilities alongside updated building/development translators that surface icon-prefixed log entries.
- Tighten the land change regression spec to assert the exact icon-and-headline output for gained land and new developments.

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e2316505208325a4082bb19becf3eb