### PR TITLE
Fix royal decree option hover behaviour

### DIFF
--- a/packages/engine/src/evaluators/development.ts
+++ b/packages/engine/src/evaluators/development.ts
@@ -13,9 +13,7 @@ export const developmentEvaluator: EvaluatorHandler<
 	return ctx.activePlayer.lands.reduce(
 		(total, land) =>
 			total +
-			land.developments.filter(
-				(development) => development === id,
-			).length,
+			land.developments.filter((development) => development === id).length,
 		0,
 	);
 };

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -178,6 +178,7 @@ function OptionCard({ option }: { option: ActionCardOption }) {
 			className={optionClass}
 			onClick={option.disabled ? undefined : option.onSelect}
 			disabled={option.disabled}
+			style={{ cursor: option.disabled ? 'not-allowed' : 'pointer' }}
 			onMouseEnter={option.onMouseEnter}
 			onMouseLeave={option.onMouseLeave}
 			aria-label={ariaLabel}

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -330,6 +330,7 @@ export default function ActionCard({
 									onClick={onCancel}
 									aria-label="Cancel selection"
 									title="Cancel selection"
+									style={{ cursor: 'pointer' }}
 								>
 									×
 								</button>

--- a/packages/web/src/components/actions/useEffectGroupOptions.ts
+++ b/packages/web/src/components/actions/useEffectGroupOptions.ts
@@ -78,7 +78,10 @@ function buildHoverDetails(
 		describedSummary,
 		'describe',
 	);
-	const { effects, description } = splitSummary(describedSummary);
+	const translatedSummary = Array.isArray(described.entry)
+		? described.entry
+		: [described.entry];
+	const { effects, description } = splitSummary(translatedSummary);
 	const requirements = getActionRequirements(
 		option.actionId,
 		context,

--- a/packages/web/src/components/actions/useEffectGroupOptions.ts
+++ b/packages/web/src/components/actions/useEffectGroupOptions.ts
@@ -12,10 +12,7 @@ import {
 } from '../../translation';
 import { type ActionCardOption } from './ActionCard';
 import type { HoverCardData } from './types';
-import {
-	buildActionOptionTranslation,
-	deriveActionOptionLabel,
-} from '../../translation/effects/optionLabel';
+import { deriveActionOptionLabel } from '../../translation/effects/optionLabel';
 
 type ResolveParams = Record<string, unknown> | undefined;
 
@@ -65,30 +62,22 @@ function buildHoverDetails(
 	context: EngineContext,
 	formatRequirement: (requirement: string) => string,
 	hoverBackground: string,
+	optionLabel: string,
 ): HoverCardData {
-	const describedSummary = describeContent(
+	const hoverSummary = describeContent(
 		'action',
 		option.actionId,
 		context,
 		mergedParams,
 	);
-	const described = buildActionOptionTranslation(
-		option,
-		context,
-		describedSummary,
-		'describe',
-	);
-	const translatedSummary = Array.isArray(described.entry)
-		? described.entry
-		: [described.entry];
-	const { effects, description } = splitSummary(translatedSummary);
+	const { effects, description } = splitSummary(hoverSummary);
 	const requirements = getActionRequirements(
 		option.actionId,
 		context,
 		mergedParams,
 	).map(formatRequirement);
 	return {
-		title: described.label.trim() || option.label,
+		title: optionLabel.trim() || option.label,
 		effects,
 		...(description && { description }),
 		requirements,
@@ -152,6 +141,7 @@ export function useEffectGroupOptions({
 					context,
 					formatRequirement,
 					hoverBackground,
+					optionLabel,
 				);
 				handleHoverCard(hoverDetails);
 			};

--- a/packages/web/src/components/actions/useEffectGroupOptions.ts
+++ b/packages/web/src/components/actions/useEffectGroupOptions.ts
@@ -66,15 +66,19 @@ function buildHoverDetails(
 	formatRequirement: (requirement: string) => string,
 	hoverBackground: string,
 ): HoverCardData {
+	const describedSummary = describeContent(
+		'action',
+		option.actionId,
+		context,
+		mergedParams,
+	);
 	const described = buildActionOptionTranslation(
 		option,
 		context,
-		describeContent('action', option.actionId, context, mergedParams),
+		describedSummary,
 		'describe',
 	);
-	const hoverSummary =
-		typeof described.entry === 'string' ? [described.entry] : [described.entry];
-	const { effects, description } = splitSummary(hoverSummary);
+	const { effects, description } = splitSummary(describedSummary);
 	const requirements = getActionRequirements(
 		option.actionId,
 		context,

--- a/packages/web/src/components/actions/useEffectGroupOptions.ts
+++ b/packages/web/src/components/actions/useEffectGroupOptions.ts
@@ -70,12 +70,29 @@ function buildHoverDetails(
 		context,
 		mergedParams,
 	);
-	const { effects, description } = splitSummary(hoverSummary);
+	const { effects: baseEffects, description } = splitSummary(hoverSummary);
 	const requirements = getActionRequirements(
 		option.actionId,
 		context,
 		mergedParams,
 	).map(formatRequirement);
+	let effects = baseEffects;
+	const developmentId = mergedParams?.id;
+	if (typeof developmentId === 'string') {
+		try {
+			const developmentSummary = describeContent(
+				'development',
+				developmentId,
+				context,
+			);
+			const { effects: developmentEffects } = splitSummary(developmentSummary);
+			if (developmentEffects.length > 0) {
+				effects = developmentEffects;
+			}
+		} catch {
+			/* ignore missing development summaries */
+		}
+	}
 	return {
 		title: optionLabel.trim() || option.label,
 		effects,

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -240,7 +240,7 @@
 		@apply rounded-full border border-rose-500 bg-rose-500 px-3 py-1 text-xs;
 		@apply font-semibold uppercase tracking-wide text-white transition;
 		@apply hover:border-rose-600 hover:bg-rose-600 dark:border-rose-400;
-		@apply dark:bg-rose-500 dark:hover:bg-rose-400;
+		@apply dark:bg-rose-500 dark:hover:bg-rose-400 cursor-pointer;
 	}
 	.player-panel .panel-card {
 		@apply border-white/40 bg-white/80 dark:border-white/10 dark:bg-slate-900/60;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -237,7 +237,10 @@
 		padding-left: 1rem;
 	}
 	.action-card__cancel {
-		@apply rounded-full border border-white/50 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-white hover:text-slate-900 dark:border-white/20 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700;
+		@apply rounded-full border border-rose-500 bg-rose-500 px-3 py-1 text-xs;
+		@apply font-semibold uppercase tracking-wide text-white transition;
+		@apply hover:border-rose-600 hover:bg-rose-600 dark:border-rose-400;
+		@apply dark:bg-rose-500 dark:hover:bg-rose-400;
 	}
 	.player-panel .panel-card {
 		@apply border-white/40 bg-white/80 dark:border-white/10 dark:bg-slate-900/60;

--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -1,3 +1,4 @@
+import { describeContent } from '../../content';
 import { registerEffectFormatter } from '../factory';
 
 registerEffectFormatter('development', 'add', {
@@ -22,7 +23,29 @@ registerEffectFormatter('development', 'add', {
 		const label = def?.name || id;
 		const icon = def?.icon || '';
 		const decoratedLabel = [icon, label].filter(Boolean).join(' ').trim();
-		return `Add ${decoratedLabel}`.trim();
+		const details = describeContent('development', id, ctx);
+		if (!details.length) {
+			const addition = `Add ${decoratedLabel}`.trim();
+			return addition;
+		}
+		const title = decoratedLabel.length > 0 ? decoratedLabel : label || id;
+		const detailItems = details.slice();
+		const normalizedTitle = title.trim();
+		if (
+			normalizedTitle.length > 0 &&
+			!detailItems.some(
+				(entry) =>
+					typeof entry === 'string' && entry.trim() === normalizedTitle,
+			)
+		) {
+			detailItems.unshift(normalizedTitle);
+		}
+		return [
+			{
+				title,
+				items: detailItems,
+			},
+		];
 	},
 });
 

--- a/packages/web/src/translation/effects/formatters/development.ts
+++ b/packages/web/src/translation/effects/formatters/development.ts
@@ -1,4 +1,3 @@
-import { describeContent } from '../../content';
 import { registerEffectFormatter } from '../factory';
 
 registerEffectFormatter('development', 'add', {
@@ -23,29 +22,7 @@ registerEffectFormatter('development', 'add', {
 		const label = def?.name || id;
 		const icon = def?.icon || '';
 		const decoratedLabel = [icon, label].filter(Boolean).join(' ').trim();
-		const details = describeContent('development', id, ctx);
-		if (!details.length) {
-			const addition = `Add ${decoratedLabel}`.trim();
-			return addition;
-		}
-		const title = decoratedLabel.length > 0 ? decoratedLabel : label || id;
-		const detailItems = details.slice();
-		const normalizedTitle = title.trim();
-		if (
-			normalizedTitle.length > 0 &&
-			!detailItems.some(
-				(entry) =>
-					typeof entry === 'string' && entry.trim() === normalizedTitle,
-			)
-		) {
-			detailItems.unshift(normalizedTitle);
-		}
-		return [
-			{
-				title,
-				items: detailItems,
-			},
-		];
+		return `Add ${decoratedLabel}`.trim();
 	},
 });
 


### PR DESCRIPTION
## Summary
- ensure Royal Decree option buttons show the pointer cursor like other actionable buttons
- reuse the full action description for effect-group hover cards and drop cost display for free Royal Decree options
- tint the Royal Decree option cancel control red for a clearer destructive affordance
- run Prettier on the development evaluator helper to satisfy repository formatting rules

## Testing
- `npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68e2354e52708325abce194f64fa2eee