### PR TITLE
feat(contents): add compare requirement helper

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -6,7 +6,7 @@ import { actionSchema, type ActionConfig } from '@kingdom-builder/protocol';
 import {
 	action,
 	effect,
-	requirementEvaluatorCompare,
+	compareRequirement,
 	Types,
 	LandMethods,
 	ResourceMethods,
@@ -161,7 +161,7 @@ export function createActionRegistry() {
 			.cost(Resource.ap, 1)
 			.cost(Resource.gold, 5)
 			.requirement(
-				requirementEvaluatorCompare()
+				compareRequirement()
 					.left(populationEvaluator())
 					.operator('lt')
 					.right(statEvaluator().key(Stat.maxPopulation))
@@ -257,7 +257,7 @@ export function createActionRegistry() {
 			.icon('🗡️')
 			.cost(Resource.ap, 1)
 			.requirement(
-				requirementEvaluatorCompare()
+				compareRequirement()
 					.left(statEvaluator().key(Stat.warWeariness))
 					.operator('lt')
 					.right(populationEvaluator().role(PopulationRole.Legion))
@@ -310,7 +310,7 @@ export function createActionRegistry() {
 			.cost(Resource.ap, 1)
 			.cost(Resource.gold, 3)
 			.requirement(
-				requirementEvaluatorCompare()
+				compareRequirement()
 					.left(statEvaluator().key(Stat.warWeariness))
 					.operator('eq')
 					.right(0)

--- a/packages/contents/tests/action-effect-group-builders.test.ts
+++ b/packages/contents/tests/action-effect-group-builders.test.ts
@@ -1,0 +1,109 @@
+import {
+	ActionBuilder,
+	action,
+	actionEffectGroup,
+	actionEffectGroupOption,
+	building,
+} from '../src/config/builders';
+import type { ActionEffectGroupDef } from '../src/config/builders';
+import { describe, expect, it } from 'vitest';
+
+describe('action effect group builder safeguards', () => {
+	it('requires action effect groups to include options', () => {
+		const group = actionEffectGroup('choose').title('Pick a project');
+		expect(() => group.build()).toThrowError(
+			'Action effect group needs at least one option(). Add option(...) before build().',
+		);
+	});
+
+	it('prevents duplicate option ids within an effect group', () => {
+		const group = actionEffectGroup('choose')
+			.title('Pick a project')
+			.option(actionEffectGroupOption('farm').label('Farm').action('develop'));
+
+		expect(() =>
+			group.option(
+				actionEffectGroupOption('farm').label('House').action('develop'),
+			),
+		).toThrowError(
+			'Action effect group option id "farm" already exists. Use unique option ids within a group.',
+		);
+	});
+
+	it('prevents duplicate effect group ids on an action', () => {
+		const builder = action().id('has_group').name('Has Group');
+		builder.effectGroup(
+			actionEffectGroup('choose')
+				.title('Pick a project')
+				.option(
+					actionEffectGroupOption('farm').label('Farm').action('develop'),
+				),
+		);
+
+		expect(() =>
+			builder.effectGroup(
+				actionEffectGroup('choose')
+					.title('Pick again')
+					.option(
+						actionEffectGroupOption('house').label('House').action('develop'),
+					),
+			),
+		).toThrowError(
+			'Action effect group id "choose" already exists on this action. Use unique group ids.',
+		);
+	});
+
+	it('blocks attaching effect groups to non-action builders', () => {
+		const buildingBuilder = building();
+		const group = actionEffectGroup('choose')
+			.title('Pick a project')
+			.option(actionEffectGroupOption('farm').label('Farm').action('develop'));
+
+		expect(() =>
+			(
+				ActionBuilder.prototype.effectGroup as (
+					this: ActionBuilder,
+					group: unknown,
+				) => ActionBuilder
+			).call(buildingBuilder as unknown as ActionBuilder, group),
+		).toThrowError(
+			'Action effect groups can only be used on actions. Use action().effectGroup(...).',
+		);
+	});
+
+	it('builds actions with effect groups', () => {
+		const built = action()
+			.id('group_action')
+			.name('Group Action')
+			.effectGroup(
+				actionEffectGroup('choose')
+					.title('Pick a project')
+					.summary('Choose one follow-up action to resolve immediately.')
+					.option(
+						actionEffectGroupOption('farm')
+							.label('Farm')
+							.action('develop')
+							.param('id', 'farm')
+							.param('landId', '$landId'),
+					),
+			)
+			.build();
+
+		expect(built.effects).toHaveLength(1);
+		expect('options' in built.effects[0]).toBe(true);
+		const group = built.effects[0] as ActionEffectGroupDef;
+		expect(group).toEqual({
+			id: 'choose',
+			title: 'Pick a project',
+			summary: 'Choose one follow-up action to resolve immediately.',
+			options: [
+				{
+					id: 'farm',
+					label: 'Farm',
+					actionId: 'develop',
+					params: { id: 'farm', landId: '$landId' },
+				},
+			],
+		});
+	});
+});

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -1,13 +1,10 @@
 import {
-	ActionBuilder,
 	action,
-	actionEffectGroup,
-	actionEffectGroupOption,
-	building,
 	resourceParams,
 	statParams,
 	effect,
 	requirement,
+	compareRequirement,
 	passiveParams,
 	attackParams,
 	transferParams,
@@ -15,7 +12,6 @@ import {
 	Types,
 	PassiveMethods,
 } from '../src/config/builders';
-import type { ActionEffectGroupDef } from '../src/config/builders';
 import { RESOURCES, type ResourceKey } from '../src/resources';
 import { STATS, type StatKey } from '../src/stats';
 import { describe, expect, it } from 'vitest';
@@ -49,104 +45,6 @@ describe('content builder safeguards', () => {
 		);
 	});
 
-	it('requires action effect groups to include options', () => {
-		const group = actionEffectGroup('choose').title('Pick a project');
-		expect(() => group.build()).toThrowError(
-			'Action effect group needs at least one option(). Add option(...) before build().',
-		);
-	});
-
-	it('prevents duplicate option ids within an effect group', () => {
-		const group = actionEffectGroup('choose')
-			.title('Pick a project')
-			.option(actionEffectGroupOption('farm').label('Farm').action('develop'));
-
-		expect(() =>
-			group.option(
-				actionEffectGroupOption('farm').label('House').action('develop'),
-			),
-		).toThrowError(
-			'Action effect group option id "farm" already exists. Use unique option ids within a group.',
-		);
-	});
-
-	it('prevents duplicate effect group ids on an action', () => {
-		const builder = action().id('has_group').name('Has Group');
-		builder.effectGroup(
-			actionEffectGroup('choose')
-				.title('Pick a project')
-				.option(
-					actionEffectGroupOption('farm').label('Farm').action('develop'),
-				),
-		);
-
-		expect(() =>
-			builder.effectGroup(
-				actionEffectGroup('choose')
-					.title('Pick again')
-					.option(
-						actionEffectGroupOption('house').label('House').action('develop'),
-					),
-			),
-		).toThrowError(
-			'Action effect group id "choose" already exists on this action. Use unique group ids.',
-		);
-	});
-
-	it('blocks attaching effect groups to non-action builders', () => {
-		const buildingBuilder = building();
-		const group = actionEffectGroup('choose')
-			.title('Pick a project')
-			.option(actionEffectGroupOption('farm').label('Farm').action('develop'));
-
-		expect(() =>
-			(
-				ActionBuilder.prototype.effectGroup as (
-					this: ActionBuilder,
-					group: unknown,
-				) => ActionBuilder
-			).call(buildingBuilder as unknown as ActionBuilder, group),
-		).toThrowError(
-			'Action effect groups can only be used on actions. Use action().effectGroup(...).',
-		);
-	});
-
-	it('builds actions with effect groups', () => {
-		const built = action()
-			.id('group_action')
-			.name('Group Action')
-			.effectGroup(
-				actionEffectGroup('choose')
-					.title('Pick a project')
-					.summary('Choose one follow-up action to resolve immediately.')
-					.option(
-						actionEffectGroupOption('farm')
-							.label('Farm')
-							.action('develop')
-							.param('id', 'farm')
-							.param('landId', '$landId'),
-					),
-			)
-			.build();
-
-		expect(built.effects).toHaveLength(1);
-		expect('options' in built.effects[0]).toBe(true);
-		const group = built.effects[0] as ActionEffectGroupDef;
-		expect(group).toEqual({
-			id: 'choose',
-			title: 'Pick a project',
-			summary: 'Choose one follow-up action to resolve immediately.',
-			options: [
-				{
-					id: 'farm',
-					label: 'Farm',
-					actionId: 'develop',
-					params: { id: 'farm', landId: '$landId' },
-				},
-			],
-		});
-	});
-
 	it('prevents mixing amount and percent for resource changes', () => {
 		const params = resourceParams().key(firstResourceKey).amount(2);
 		expect(() => params.percent(10)).toThrowError(
@@ -176,6 +74,37 @@ describe('content builder safeguards', () => {
 	it('guides requirement configuration mistakes', () => {
 		expect(() => requirement().method('compare').build()).toThrowError(
 			'Requirement is missing type(). Call type("your-requirement") before build().',
+		);
+		expect(() =>
+			compareRequirement().operator('lt').right(5).build(),
+		).toThrowError(
+			'Compare requirement is missing left(). Call left(...) before build().',
+		);
+		expect(() =>
+			compareRequirement().left(1).operator('lt').build(),
+		).toThrowError(
+			'Compare requirement is missing right(). Call right(...) before build().',
+		);
+		expect(() => compareRequirement().left(1).right(2).build()).toThrowError(
+			'Compare requirement is missing operator(). Call operator(...) before build().',
+		);
+		expect(() => {
+			const builder = compareRequirement().left(1);
+			builder.left(2);
+		}).toThrowError(
+			'Compare requirement already set left(). Remove the extra left() call.',
+		);
+		expect(() => {
+			const builder = compareRequirement().right(2);
+			builder.right(3);
+		}).toThrowError(
+			'Compare requirement already set right(). Remove the extra right() call.',
+		);
+		expect(() => {
+			const builder = compareRequirement().operator('lt');
+			builder.operator('gt');
+		}).toThrowError(
+			'Compare requirement already set operator(). Remove the extra operator() call.',
 		);
 	});
 

--- a/packages/engine/src/evaluators/development.ts
+++ b/packages/engine/src/evaluators/development.ts
@@ -13,9 +13,7 @@ export const developmentEvaluator: EvaluatorHandler<
 	return ctx.activePlayer.lands.reduce(
 		(total, land) =>
 			total +
-			land.developments.filter(
-				(development) => development === id,
-			).length,
+			land.developments.filter((development) => development === id).length,
 		0,
 	);
 };

--- a/packages/web/tests/development-translation.test.ts
+++ b/packages/web/tests/development-translation.test.ts
@@ -81,46 +81,39 @@ function findSelfReferentialDevelopment(
 }
 
 describe('development translation', () => {
-		it(
-			'replaces self-referential placeholders when describing developments',
-			() => {
-				const id = findSelfReferentialDevelopment(DEVELOPMENTS.entries());
-				const summary = summarizeContent('development', id, ctx as EngineContext);
-				const description = describeContent(
-					'development',
-					id,
-					ctx as EngineContext,
-				);
-				const strings = [...flatten(summary), ...flatten(description)];
-
-				expect(strings.some((line) => line.includes('$id'))).toBe(false);
-
-				const def = ctx.developments.get(id);
-				const icon = def.icon || '';
-
-				const hasIncomeLine = strings.some((line) => {
-					return /During income step/.test(line);
-				});
-				expect(hasIncomeLine).toBe(true);
-
-				expect(strings.some((line) => /\+2/.test(line))).toBe(true);
-				expect(strings.some((line) => /Gold/.test(line))).toBe(true);
-				const prohibited = strings.filter(
-					(line) =>
-						line.includes(`per ${icon} ${def.name}`) ||
-						line.includes(`for each ${icon} ${def.name}`),
-				);
-				expect(prohibited).toHaveLength(0);
-
-				const logEntry = logContent(
-					'development',
-					id,
-					ctx as EngineContext,
-				);
-				expect(logEntry.some((line) => line.includes(def.name))).toBe(true);
-				if (icon) {
-					expect(logEntry.some((line) => line.includes(icon))).toBe(true);
-				}
-			},
+	it('replaces self-referential placeholders when describing developments', () => {
+		const id = findSelfReferentialDevelopment(DEVELOPMENTS.entries());
+		const summary = summarizeContent('development', id, ctx as EngineContext);
+		const description = describeContent(
+			'development',
+			id,
+			ctx as EngineContext,
 		);
+		const strings = [...flatten(summary), ...flatten(description)];
+
+		expect(strings.some((line) => line.includes('$id'))).toBe(false);
+
+		const def = ctx.developments.get(id);
+		const icon = def.icon || '';
+
+		const hasIncomeLine = strings.some((line) => {
+			return /During income step/.test(line);
+		});
+		expect(hasIncomeLine).toBe(true);
+
+		expect(strings.some((line) => /\+2/.test(line))).toBe(true);
+		expect(strings.some((line) => /Gold/.test(line))).toBe(true);
+		const prohibited = strings.filter(
+			(line) =>
+				line.includes(`per ${icon} ${def.name}`) ||
+				line.includes(`for each ${icon} ${def.name}`),
+		);
+		expect(prohibited).toHaveLength(0);
+
+		const logEntry = logContent('development', id, ctx as EngineContext);
+		expect(logEntry.some((line) => line.includes(def.name))).toBe(true);
+		if (icon) {
+			expect(logEntry.some((line) => line.includes(icon))).toBe(true);
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- add a compareRequirement builder that presets evaluator/compare configuration and enforces required params
- switch action requirements to the helper and expand requirement tests while moving action effect group checks into their own suite
- format touched engine/web files to satisfy prettier and keep the repo passing checks

## Testing
- npm run test:quick
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e2361d77b88325a950e01e37dbdb09