### PR TITLE
Refactor game context helpers into modular hooks

### DIFF
--- a/packages/web/src/state/GameContext.types.ts
+++ b/packages/web/src/state/GameContext.types.ts
@@ -1,0 +1,45 @@
+import type { EngineContext } from '@kingdom-builder/engine';
+import type { ResourceKey } from '@kingdom-builder/contents';
+import type { Action } from './actionTypes';
+import type { PhaseStep } from './phaseTypes';
+import type { TimeScale } from './useTimeScale';
+import type { HoverCard } from './useHoverCard';
+import type { LogEntry } from './useGameLog';
+import type { ErrorToast } from './useErrorToasts';
+
+export interface GameEngineContextValue {
+	ctx: EngineContext;
+	log: LogEntry[];
+	logOverflowed: boolean;
+	hoverCard: HoverCard | null;
+	handleHoverCard: (data: HoverCard) => void;
+	clearHoverCard: () => void;
+	phaseSteps: PhaseStep[];
+	setPhaseSteps: React.Dispatch<React.SetStateAction<PhaseStep[]>>;
+	phaseTimer: number;
+	mainApStart: number;
+	displayPhase: string;
+	setDisplayPhase: (id: string) => void;
+	phaseHistories: Record<string, PhaseStep[]>;
+	tabsEnabled: boolean;
+	actionCostResource: ResourceKey;
+	handlePerform: (
+		action: Action,
+		params?: Record<string, unknown>,
+	) => Promise<void>;
+	runUntilActionPhase: () => Promise<void>;
+	handleEndTurn: () => Promise<void>;
+	updateMainPhaseStep: (apStartOverride?: number) => void;
+	onExit?: () => void;
+	darkMode: boolean;
+	onToggleDark: () => void;
+	musicEnabled: boolean;
+	onToggleMusic: () => void;
+	soundEnabled: boolean;
+	onToggleSound: () => void;
+	timeScale: TimeScale;
+	setTimeScale: (value: TimeScale) => void;
+	errorToasts: ErrorToast[];
+	pushErrorToast: (message: string) => void;
+	dismissErrorToast: (id: number) => void;
+}

--- a/packages/web/src/state/actionTypes.ts
+++ b/packages/web/src/state/actionTypes.ts
@@ -1,0 +1,5 @@
+export interface Action {
+	id: string;
+	name: string;
+	system?: boolean;
+}

--- a/packages/web/src/state/phaseTypes.ts
+++ b/packages/web/src/state/phaseTypes.ts
@@ -1,0 +1,5 @@
+export type PhaseStep = {
+	title: string;
+	items: { text: string; italic?: boolean; done?: boolean }[];
+	active: boolean;
+};

--- a/packages/web/src/state/useActionPerformer.ts
+++ b/packages/web/src/state/useActionPerformer.ts
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useRef } from 'react';
+import {
+	getActionCosts,
+	performAction,
+	resolveActionEffects,
+	simulateAction,
+	type ActionParams,
+	type EngineContext,
+} from '@kingdom-builder/engine';
+import { RESOURCES, type ResourceKey } from '@kingdom-builder/contents';
+import { diffStepSnapshots, logContent, snapshotPlayer } from '../translation';
+import type { Action } from './actionTypes';
+
+interface UseActionPerformerOptions {
+	ctx: EngineContext;
+	actionCostResource: ResourceKey;
+	addLog: (
+		entry: string | string[],
+		player?: EngineContext['activePlayer'],
+	) => void;
+	logWithEffectDelay: (
+		lines: string[],
+		player: EngineContext['activePlayer'],
+	) => Promise<void>;
+	updateMainPhaseStep: (apStartOverride?: number) => void;
+	refresh: () => void;
+	pushErrorToast: (message: string) => void;
+	mountedRef: React.MutableRefObject<boolean>;
+	endTurn: () => Promise<void>;
+	enqueue: <T>(task: () => Promise<T> | T) => Promise<T>;
+	resourceKeys: ResourceKey[];
+}
+
+export function useActionPerformer({
+	ctx,
+	actionCostResource,
+	addLog,
+	logWithEffectDelay,
+	updateMainPhaseStep,
+	refresh,
+	pushErrorToast,
+	mountedRef,
+	endTurn,
+	enqueue,
+	resourceKeys,
+}: UseActionPerformerOptions) {
+	const perform = useCallback(
+		async (action: Action, params?: ActionParams<string>) => {
+			const player = ctx.activePlayer;
+			const before = snapshotPlayer(player, ctx);
+			const costs = getActionCosts(action.id, ctx, params);
+			try {
+				simulateAction(action.id, ctx, params);
+				const traces = performAction(action.id, ctx, params);
+
+				const after = snapshotPlayer(player, ctx);
+				const stepDef = ctx.actions.get(action.id);
+				const resolvedStep = resolveActionEffects(stepDef, params);
+				const changes = diffStepSnapshots(
+					before,
+					after,
+					resolvedStep,
+					ctx,
+					resourceKeys,
+				);
+				const messages = logContent('action', action.id, ctx, params);
+				const costLines: string[] = [];
+				for (const key of Object.keys(costs) as (keyof typeof RESOURCES)[]) {
+					const amt = costs[key] ?? 0;
+					if (!amt) {
+						continue;
+					}
+					const info = RESOURCES[key];
+					const icon = info?.icon ? `${info.icon} ` : '';
+					const label = info?.label ?? key;
+					const beforeAmount = before.resources[key] ?? 0;
+					const afterAmount = beforeAmount - amt;
+					costLines.push(
+						`    ${icon}${label} -${amt} (${beforeAmount}→${afterAmount})`,
+					);
+				}
+				if (costLines.length) {
+					messages.splice(1, 0, '  💲 Action cost', ...costLines);
+				}
+
+				const normalize = (line: string) =>
+					(line.split(' (')[0] ?? '').replace(/\s[+-]?\d+$/, '').trim();
+
+				const subLines: string[] = [];
+				for (const trace of traces) {
+					const subStep = ctx.actions.get(trace.id);
+					const subResolved = resolveActionEffects(subStep);
+					const subChanges = diffStepSnapshots(
+						trace.before,
+						trace.after,
+						subResolved,
+						ctx,
+						resourceKeys,
+					);
+					if (!subChanges.length) {
+						continue;
+					}
+					subLines.push(...subChanges);
+					const icon = ctx.actions.get(trace.id)?.icon || '';
+					const name = ctx.actions.get(trace.id).name;
+					const line = `  ${icon} ${name}`;
+					const index = messages.indexOf(line);
+					if (index !== -1) {
+						messages.splice(index + 1, 0, ...subChanges.map((c) => `    ${c}`));
+					}
+				}
+
+				const subPrefixes = subLines.map(normalize);
+				const messagePrefixes = new Set<string>();
+				for (const line of messages) {
+					const trimmed = line.trim();
+					if (!trimmed.startsWith('You:') && !trimmed.startsWith('Opponent:')) {
+						continue;
+					}
+					const body = trimmed.slice(trimmed.indexOf(':') + 1).trim();
+					const normalized = normalize(body);
+					if (normalized) {
+						messagePrefixes.add(normalized);
+					}
+				}
+
+				const costLabels = new Set(
+					Object.keys(costs) as (keyof typeof RESOURCES)[],
+				);
+				const filtered = changes.filter((line) => {
+					const normalizedLine = normalize(line);
+					if (messagePrefixes.has(normalizedLine)) {
+						return false;
+					}
+					if (subPrefixes.includes(normalizedLine)) {
+						return false;
+					}
+					for (const key of costLabels) {
+						const info = RESOURCES[key];
+						const prefix = info?.icon
+							? `${info.icon} ${info.label}`
+							: info.label;
+						if (line.startsWith(prefix)) {
+							return false;
+						}
+					}
+					return true;
+				});
+				const logLines = [...messages, ...filtered.map((c) => `  ${c}`)];
+
+				updateMainPhaseStep();
+				refresh();
+
+				await logWithEffectDelay(logLines, player);
+
+				if (!mountedRef.current) {
+					return;
+				}
+				if (
+					ctx.game.devMode &&
+					(ctx.activePlayer.resources[actionCostResource] ?? 0) <= 0
+				) {
+					await endTurn();
+				}
+			} catch (error) {
+				const icon = ctx.actions.get(action.id)?.icon || '';
+				const message = (error as Error).message || 'Action failed';
+				pushErrorToast(message);
+				addLog(`Failed to play ${icon} ${action.name}: ${message}`, player);
+				return;
+			}
+		},
+		[
+			addLog,
+			ctx,
+			endTurn,
+			logWithEffectDelay,
+			mountedRef,
+			pushErrorToast,
+			refresh,
+			resourceKeys,
+			updateMainPhaseStep,
+		],
+	);
+
+	const handlePerform = useCallback(
+		(action: Action, params?: ActionParams<string>) =>
+			enqueue(() => perform(action, params)),
+		[enqueue, perform],
+	);
+
+	const performRef = useRef<typeof perform>(perform);
+	useEffect(() => {
+		performRef.current = perform;
+	}, [perform]);
+
+	return { handlePerform, performRef };
+}

--- a/packages/web/src/state/useAiRunner.ts
+++ b/packages/web/src/state/useAiRunner.ts
@@ -1,0 +1,78 @@
+import { useEffect } from 'react';
+import {
+	advance,
+	type ActionParams,
+	type EngineContext,
+} from '@kingdom-builder/engine';
+import type { Dispatch, SetStateAction } from 'react';
+import type { Action } from './actionTypes';
+import type { PhaseStep } from './phaseTypes';
+
+interface UseAiRunnerOptions {
+	ctx: EngineContext;
+	runUntilActionPhaseCore: () => Promise<void>;
+	setPhaseHistories: Dispatch<SetStateAction<Record<string, PhaseStep[]>>>;
+	performRef: React.MutableRefObject<
+		(action: Action, params?: ActionParams<string>) => Promise<void>
+	>;
+	mountedRef: React.MutableRefObject<boolean>;
+}
+
+export function useAiRunner({
+	ctx,
+	runUntilActionPhaseCore,
+	setPhaseHistories,
+	performRef,
+	mountedRef,
+}: UseAiRunnerOptions) {
+	useEffect(() => {
+		const phaseDefinition = ctx.phases[ctx.game.phaseIndex];
+		if (!phaseDefinition?.action) {
+			return;
+		}
+		const aiSystem = ctx.aiSystem;
+		const activeId = ctx.activePlayer.id;
+		if (!aiSystem?.has(activeId)) {
+			return;
+		}
+		void ctx.enqueue(async () => {
+			await aiSystem.run(activeId, ctx, {
+				performAction: async (
+					actionId: string,
+					engineCtx: EngineContext,
+					params?: ActionParams<string>,
+				) => {
+					const definition = engineCtx.actions.get(actionId);
+					if (!definition) {
+						throw new Error(`Unknown action ${String(actionId)} for AI`);
+					}
+					const action: Action = {
+						id: definition.id,
+						name: definition.name,
+					};
+					if (definition.system !== undefined) {
+						action.system = definition.system;
+					}
+					await performRef.current(action, params as Record<string, unknown>);
+				},
+				advance: (engineCtx: EngineContext) => {
+					advance(engineCtx);
+				},
+			});
+			if (!mountedRef.current) {
+				return;
+			}
+			setPhaseHistories({});
+			await runUntilActionPhaseCore();
+		});
+	}, [
+		ctx.activePlayer.id,
+		ctx.aiSystem,
+		ctx.game.phaseIndex,
+		runUntilActionPhaseCore,
+		setPhaseHistories,
+		performRef,
+		ctx,
+		mountedRef,
+	]);
+}

--- a/packages/web/src/state/useCompensationLogger.ts
+++ b/packages/web/src/state/useCompensationLogger.ts
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import type { EngineContext } from '@kingdom-builder/engine';
+import type { ResourceKey } from '@kingdom-builder/contents';
+import {
+	diffStepSnapshots,
+	snapshotPlayer,
+	type PlayerSnapshot,
+} from '../translation';
+
+interface UseCompensationLoggerOptions {
+	ctx: EngineContext;
+	addLog: (
+		entry: string | string[],
+		player?: EngineContext['activePlayer'],
+	) => void;
+	resourceKeys: ResourceKey[];
+}
+
+export function useCompensationLogger({
+	ctx,
+	addLog,
+	resourceKeys,
+}: UseCompensationLoggerOptions) {
+	useEffect(() => {
+		ctx.game.players.forEach((player) => {
+			const compensation = ctx.compensations[player.id];
+			if (
+				!compensation ||
+				(Object.keys(compensation.resources || {}).length === 0 &&
+					Object.keys(compensation.stats || {}).length === 0)
+			) {
+				return;
+			}
+			const after: PlayerSnapshot = snapshotPlayer(player, ctx);
+			const before: PlayerSnapshot = {
+				...after,
+				resources: { ...after.resources },
+				stats: { ...after.stats },
+				buildings: [...after.buildings],
+				lands: after.lands.map((land) => ({
+					...land,
+					developments: [...land.developments],
+				})),
+				passives: [...after.passives],
+			};
+			for (const [resourceKey, resourceDelta] of Object.entries(
+				compensation.resources || {},
+			)) {
+				before.resources[resourceKey] =
+					(before.resources[resourceKey] || 0) - (resourceDelta ?? 0);
+			}
+			for (const [statKey, statDelta] of Object.entries(
+				compensation.stats || {},
+			)) {
+				before.stats[statKey] = (before.stats[statKey] || 0) - (statDelta ?? 0);
+			}
+			const lines = diffStepSnapshots(
+				before,
+				after,
+				undefined,
+				ctx,
+				resourceKeys,
+			);
+			if (lines.length) {
+				addLog(
+					['Last-player compensation:', ...lines.map((line) => `  ${line}`)],
+					player,
+				);
+			}
+		});
+	}, [addLog, ctx, resourceKeys]);
+}

--- a/packages/web/src/state/useErrorToasts.ts
+++ b/packages/web/src/state/useErrorToasts.ts
@@ -1,0 +1,34 @@
+import { useCallback, useRef, useState } from 'react';
+
+export type ErrorToast = {
+	id: number;
+	message: string;
+};
+
+interface UseErrorToastsOptions {
+	setTrackedTimeout: (callback: () => void, delay: number) => number;
+}
+
+export function useErrorToasts({ setTrackedTimeout }: UseErrorToastsOptions) {
+	const nextToastId = useRef(0);
+	const [errorToasts, setErrorToasts] = useState<ErrorToast[]>([]);
+
+	const dismissErrorToast = useCallback((id: number) => {
+		setErrorToasts((prev) => prev.filter((toast) => toast.id !== id));
+	}, []);
+
+	const pushErrorToast = useCallback(
+		(message: string) => {
+			const id = nextToastId.current++;
+			const trimmed = message.trim();
+			const normalized = trimmed || 'Action failed';
+			setErrorToasts((prev) => [...prev, { id, message: normalized }]);
+			setTrackedTimeout(() => {
+				dismissErrorToast(id);
+			}, 5000);
+		},
+		[dismissErrorToast, setTrackedTimeout],
+	);
+
+	return { errorToasts, pushErrorToast, dismissErrorToast };
+}

--- a/packages/web/src/state/useHoverCard.ts
+++ b/packages/web/src/state/useHoverCard.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Summary } from '../translation';
+
+export interface HoverCard {
+	title: string;
+	effects: Summary;
+	requirements: string[];
+	costs?: Record<string, number>;
+	upkeep?: Record<string, number> | undefined;
+	description?: string | Summary;
+	descriptionTitle?: string;
+	descriptionClass?: string;
+	effectsTitle?: string;
+	bgClass?: string;
+}
+
+interface HoverCardOptions {
+	setTrackedTimeout: (callback: () => void, delay: number) => number;
+	clearTrackedTimeout: (id: number) => void;
+}
+
+export function useHoverCard({
+	setTrackedTimeout,
+	clearTrackedTimeout,
+}: HoverCardOptions) {
+	const [hoverCard, setHoverCard] = useState<HoverCard | null>(null);
+	const hoverTimeout = useRef<number>();
+
+	useEffect(() => {
+		return () => {
+			if (hoverTimeout.current) {
+				clearTrackedTimeout(hoverTimeout.current);
+			}
+			hoverTimeout.current = undefined;
+		};
+	}, [clearTrackedTimeout]);
+
+	const handleHoverCard = useCallback(
+		(data: HoverCard) => {
+			if (hoverTimeout.current) {
+				clearTrackedTimeout(hoverTimeout.current);
+			}
+			hoverTimeout.current = setTrackedTimeout(() => {
+				hoverTimeout.current = undefined;
+				setHoverCard(data);
+			}, 300);
+		},
+		[clearTrackedTimeout, setTrackedTimeout],
+	);
+
+	const clearHoverCard = useCallback(() => {
+		if (hoverTimeout.current) {
+			clearTrackedTimeout(hoverTimeout.current);
+			hoverTimeout.current = undefined;
+		}
+		setHoverCard(null);
+	}, [clearTrackedTimeout]);
+
+	return { hoverCard, handleHoverCard, clearHoverCard };
+}

--- a/packages/web/src/state/useMainPhaseTracker.ts
+++ b/packages/web/src/state/useMainPhaseTracker.ts
@@ -1,0 +1,71 @@
+import { useCallback, useState } from 'react';
+import { RESOURCES, type ResourceKey } from '@kingdom-builder/contents';
+import type { EngineContext } from '@kingdom-builder/engine';
+import type { PhaseStep } from './phaseTypes';
+
+interface MainPhaseTrackerOptions {
+	ctx: EngineContext;
+	actionCostResource: ResourceKey;
+	actionPhaseId: string | undefined;
+	setPhaseSteps: React.Dispatch<React.SetStateAction<PhaseStep[]>>;
+	setPhaseHistories: React.Dispatch<
+		React.SetStateAction<Record<string, PhaseStep[]>>
+	>;
+	setDisplayPhase: (phase: string) => void;
+}
+
+export function useMainPhaseTracker({
+	ctx,
+	actionCostResource,
+	actionPhaseId,
+	setPhaseSteps,
+	setPhaseHistories,
+	setDisplayPhase,
+}: MainPhaseTrackerOptions) {
+	const [mainApStart, setMainApStart] = useState(0);
+
+	const updateMainPhaseStep = useCallback(
+		(apStartOverride?: number) => {
+			const total = apStartOverride ?? mainApStart;
+			const remaining = ctx.activePlayer.resources[actionCostResource] ?? 0;
+			const spent = total - remaining;
+			const resourceInfo = RESOURCES[actionCostResource];
+			const costLabel = resourceInfo?.label ?? '';
+			const costIcon = resourceInfo?.icon ?? '';
+			const costSummary = `${costIcon} ${spent}/${total} spent`;
+			const steps: PhaseStep[] = [
+				{
+					title: `Step 1 - Spend all ${costLabel}`,
+					items: [
+						{
+							text: costSummary,
+							done: remaining === 0,
+						},
+					],
+					active: remaining > 0,
+				},
+			];
+			setPhaseSteps(steps);
+			if (actionPhaseId) {
+				setPhaseHistories((prev) => ({
+					...prev,
+					[actionPhaseId]: steps,
+				}));
+				setDisplayPhase(actionPhaseId);
+			} else {
+				setDisplayPhase(ctx.game.currentPhase);
+			}
+		},
+		[
+			actionCostResource,
+			actionPhaseId,
+			ctx,
+			mainApStart,
+			setDisplayPhase,
+			setPhaseHistories,
+			setPhaseSteps,
+		],
+	);
+
+	return { mainApStart, setMainApStart, updateMainPhaseStep };
+}

--- a/packages/web/src/state/usePhaseDelays.ts
+++ b/packages/web/src/state/usePhaseDelays.ts
@@ -1,0 +1,61 @@
+import { useCallback } from 'react';
+
+interface PhaseDelayOptions {
+	mountedRef: React.MutableRefObject<boolean>;
+	timeScaleRef: React.MutableRefObject<number>;
+	setTrackedInterval: (callback: () => void, delay: number) => number;
+	clearTrackedInterval: (id: number) => void;
+	setPhaseTimer: (value: number) => void;
+}
+
+export function usePhaseDelays({
+	mountedRef,
+	timeScaleRef,
+	setTrackedInterval,
+	clearTrackedInterval,
+	setPhaseTimer,
+}: PhaseDelayOptions) {
+	const runDelay = useCallback(
+		(total: number) => {
+			const scale = timeScaleRef.current || 1;
+			const adjustedTotal = total / scale;
+			if (adjustedTotal <= 0) {
+				if (mountedRef.current) {
+					setPhaseTimer(0);
+				}
+				return Promise.resolve();
+			}
+			const tick = Math.max(16, Math.min(100, adjustedTotal / 10));
+			if (mountedRef.current) {
+				setPhaseTimer(0);
+			}
+			return new Promise<void>((resolve) => {
+				let elapsed = 0;
+				const interval = setTrackedInterval(() => {
+					elapsed += tick;
+					if (mountedRef.current) {
+						setPhaseTimer(Math.min(1, elapsed / adjustedTotal));
+					}
+					if (elapsed >= adjustedTotal) {
+						clearTrackedInterval(interval);
+						if (mountedRef.current) {
+							setPhaseTimer(0);
+						}
+						resolve();
+					}
+				}, tick);
+			});
+		},
+		[
+			clearTrackedInterval,
+			mountedRef,
+			setTrackedInterval,
+			setPhaseTimer,
+			timeScaleRef,
+		],
+	);
+
+	const runStepDelay = useCallback(() => runDelay(1000), [runDelay]);
+
+	return { runDelay, runStepDelay };
+}

--- a/packages/web/src/state/usePhaseProgress.ts
+++ b/packages/web/src/state/usePhaseProgress.ts
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useState } from 'react';
+import { advance, type EngineContext } from '@kingdom-builder/engine';
+import { type ResourceKey, type StepDef } from '@kingdom-builder/contents';
+import { diffStepSnapshots, snapshotPlayer } from '../translation';
+import { describeSkipEvent } from '../utils/describeSkipEvent';
+import type { PhaseStep } from './phaseTypes';
+import { usePhaseDelays } from './usePhaseDelays';
+import { useMainPhaseTracker } from './useMainPhaseTracker';
+
+interface PhaseProgressOptions {
+	ctx: EngineContext;
+	actionPhaseId: string | undefined;
+	actionCostResource: ResourceKey;
+	addLog: (
+		entry: string | string[],
+		player?: EngineContext['activePlayer'],
+	) => void;
+	mountedRef: React.MutableRefObject<boolean>;
+	timeScaleRef: React.MutableRefObject<number>;
+	setTrackedInterval: (callback: () => void, delay: number) => number;
+	clearTrackedInterval: (id: number) => void;
+	refresh: () => void;
+	resourceKeys: ResourceKey[];
+	enqueue: <T>(task: () => Promise<T> | T) => Promise<T>;
+}
+
+export function usePhaseProgress({
+	ctx,
+	actionPhaseId,
+	actionCostResource,
+	addLog,
+	mountedRef,
+	timeScaleRef,
+	setTrackedInterval,
+	clearTrackedInterval,
+	refresh,
+	resourceKeys,
+	enqueue,
+}: PhaseProgressOptions) {
+	const [phaseSteps, setPhaseSteps] = useState<PhaseStep[]>([]);
+	const [phaseTimer, setPhaseTimer] = useState(0);
+	const [displayPhase, setDisplayPhase] = useState(ctx.game.currentPhase);
+	const [phaseHistories, setPhaseHistories] = useState<
+		Record<string, PhaseStep[]>
+	>({});
+	const [tabsEnabled, setTabsEnabled] = useState(false);
+
+	const { mainApStart, setMainApStart, updateMainPhaseStep } =
+		useMainPhaseTracker({
+			ctx,
+			actionCostResource,
+			actionPhaseId,
+			setPhaseSteps,
+			setPhaseHistories,
+			setDisplayPhase,
+		});
+
+	const { runDelay, runStepDelay } = usePhaseDelays({
+		mountedRef,
+		timeScaleRef,
+		setTrackedInterval,
+		clearTrackedInterval,
+		setPhaseTimer,
+	});
+
+	const runUntilActionPhaseCore = useCallback(async () => {
+		if (ctx.phases[ctx.game.phaseIndex]?.action) {
+			if (!mountedRef.current) {
+				return;
+			}
+			setPhaseTimer(0);
+			setTabsEnabled(true);
+			setDisplayPhase(ctx.game.currentPhase);
+			return;
+		}
+		setTabsEnabled(false);
+		setPhaseSteps([]);
+		setDisplayPhase(ctx.game.currentPhase);
+		setPhaseHistories({});
+		let ranSteps = false;
+		let lastPhase: string | null = null;
+		while (!ctx.phases[ctx.game.phaseIndex]?.action) {
+			ranSteps = true;
+			const before = snapshotPlayer(ctx.activePlayer, ctx);
+			const { phase, step, player, effects, skipped } = advance(ctx);
+			const phaseDef = ctx.phases.find(
+				(phaseDefinition) => phaseDefinition.id === phase,
+			)!;
+			const stepDef = phaseDef.steps.find(
+				(stepDefinition) => stepDefinition.id === step,
+			);
+			if (phase !== lastPhase) {
+				await runDelay(1500);
+				if (!mountedRef.current) {
+					return;
+				}
+				setPhaseSteps([]);
+				setDisplayPhase(phase);
+				addLog(`${phaseDef.icon} ${phaseDef.label} Phase`, player);
+				lastPhase = phase;
+			}
+			const phaseId = phase;
+			let entry: PhaseStep;
+			if (skipped) {
+				const summary = describeSkipEvent(skipped, phaseDef, stepDef);
+				addLog(summary.logLines, player);
+				entry = {
+					title: summary.history.title,
+					items: summary.history.items,
+					active: true,
+				};
+			} else {
+				const after = snapshotPlayer(player, ctx);
+				const stepWithEffects: StepDef | undefined = stepDef
+					? ({ ...(stepDef as StepDef), effects } as StepDef)
+					: undefined;
+				const changes = diffStepSnapshots(
+					before,
+					after,
+					stepWithEffects,
+					ctx,
+					resourceKeys,
+				);
+				if (changes.length) {
+					addLog(
+						changes.map((change) => `  ${change}`),
+						player,
+					);
+				}
+				entry = {
+					title: stepDef?.title || step,
+					items:
+						changes.length > 0
+							? changes.map((text) => ({ text }))
+							: [{ text: 'No effect', italic: true }],
+					active: true,
+				};
+			}
+			setPhaseSteps((prev) => [...prev, entry]);
+			setPhaseHistories((prev) => ({
+				...prev,
+				[phaseId]: [...(prev[phaseId] ?? []), entry],
+			}));
+			await runStepDelay();
+			if (!mountedRef.current) {
+				return;
+			}
+			const finalized = { ...entry, active: false };
+			setPhaseSteps((prev) => {
+				if (!prev.length) {
+					return prev;
+				}
+				const next = [...prev];
+				next[next.length - 1] = finalized;
+				return next;
+			});
+			setPhaseHistories((prev) => {
+				const history = prev[phaseId];
+				if (!history?.length) {
+					return prev;
+				}
+				const nextHistory = [...history];
+				nextHistory[nextHistory.length - 1] = finalized;
+				return { ...prev, [phaseId]: nextHistory };
+			});
+		}
+		if (ranSteps) {
+			await runDelay(1500);
+			if (!mountedRef.current) {
+				return;
+			}
+		} else {
+			if (!mountedRef.current) {
+				return;
+			}
+			setPhaseTimer(0);
+		}
+		const start = ctx.activePlayer.resources[actionCostResource] as number;
+		if (!mountedRef.current) {
+			return;
+		}
+		setMainApStart(start);
+		updateMainPhaseStep(start);
+		setDisplayPhase(ctx.game.currentPhase);
+		setTabsEnabled(true);
+		refresh();
+	}, [
+		actionCostResource,
+		actionPhaseId,
+		addLog,
+		ctx,
+		mountedRef,
+		refresh,
+		resourceKeys,
+		runDelay,
+		runStepDelay,
+		updateMainPhaseStep,
+	]);
+
+	const runUntilActionPhase = useCallback(
+		() => enqueue(runUntilActionPhaseCore),
+		[enqueue, runUntilActionPhaseCore],
+	);
+
+	const endTurn = useCallback(async () => {
+		const phaseDef = ctx.phases[ctx.game.phaseIndex];
+		if (!phaseDef?.action) {
+			return;
+		}
+		if ((ctx.activePlayer.resources[actionCostResource] ?? 0) > 0) {
+			return;
+		}
+		advance(ctx);
+		setPhaseHistories({});
+		await runUntilActionPhaseCore();
+	}, [actionCostResource, ctx, runUntilActionPhaseCore]);
+
+	const handleEndTurn = useCallback(() => enqueue(endTurn), [enqueue, endTurn]);
+
+	useEffect(() => {
+		if (!tabsEnabled) {
+			return;
+		}
+		if (!ctx.phases[ctx.game.phaseIndex]?.action) {
+			return;
+		}
+		const start = ctx.activePlayer.resources[actionCostResource] as number;
+		setMainApStart(start);
+		updateMainPhaseStep(start);
+	}, [actionCostResource, ctx, tabsEnabled, updateMainPhaseStep]);
+
+	return {
+		phaseSteps,
+		setPhaseSteps,
+		phaseTimer,
+		mainApStart,
+		displayPhase,
+		setDisplayPhase,
+		phaseHistories,
+		tabsEnabled,
+		runUntilActionPhase,
+		runUntilActionPhaseCore,
+		handleEndTurn,
+		endTurn,
+		updateMainPhaseStep,
+		setPhaseHistories,
+		setTabsEnabled,
+	};
+}


### PR DESCRIPTION
## Summary
- extract hover card, logging, AI runner, and action performer logic into dedicated hooks used by `GameContext`
- split phase progression responsibilities into `usePhaseProgress`, `usePhaseDelays`, and `useMainPhaseTracker` to keep files under lint limits
- update context exports and wiring to use the new utilities while preserving existing behaviour

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e23604649083258f203766189502f1