### PR TITLE
Add action effect parameter builder and update content usage

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -22,6 +22,7 @@ import {
 	resourceParams,
 	statParams,
 	developmentParams,
+	actionParams,
 	resultModParams,
 	passiveParams,
 	costModParams,
@@ -193,13 +194,12 @@ export function createActionRegistry() {
 			.cost(Resource.gold, 12)
 			.effect(
 				effect(Types.Action, ActionMethods.PERFORM)
-					.param('id', 'expand')
+					.params(actionParams().id('expand'))
 					.build(),
 			)
 			.effect(
 				effect(Types.Action, ActionMethods.PERFORM)
-					.param('id', 'till')
-					.param('landId', '$landId')
+					.params(actionParams().id('till').landId('$landId'))
 					.build(),
 			)
 			.effectGroup(
@@ -210,32 +210,28 @@ export function createActionRegistry() {
 							.label('Raise a House')
 							.icon('🏠')
 							.action('develop')
-							.param('landId', '$landId')
-							.param('id', 'house'),
+							.params(actionParams().id('house').landId('$landId')),
 					)
 					.option(
 						actionEffectGroupOption('royal_decree_farm')
 							.label('Establish a Farm')
 							.icon('🌾')
 							.action('develop')
-							.param('landId', '$landId')
-							.param('id', 'farm'),
+							.params(actionParams().id('farm').landId('$landId')),
 					)
 					.option(
 						actionEffectGroupOption('royal_decree_outpost')
 							.label('Fortify with an Outpost')
 							.icon('🏹')
 							.action('develop')
-							.param('landId', '$landId')
-							.param('id', 'outpost'),
+							.params(actionParams().id('outpost').landId('$landId')),
 					)
 					.option(
 						actionEffectGroupOption('royal_decree_watchtower')
 							.label('Raise a Watchtower')
 							.icon('🗼')
 							.action('develop')
-							.param('landId', '$landId')
-							.param('id', 'watchtower'),
+							.params(actionParams().id('watchtower').landId('$landId')),
 					),
 			)
 			.effect(
@@ -279,7 +275,7 @@ export function createActionRegistry() {
 									.params(resourceParams().key(Resource.happiness).amount(1))
 									.build(),
 								effect(Types.Action, ActionMethods.PERFORM)
-									.param('id', 'plunder')
+									.params(actionParams().id('plunder'))
 									.build(),
 							)
 							.onDamageDefender(
@@ -393,11 +389,13 @@ export function createActionRegistry() {
 			.cost(Resource.gold, 6)
 			.effect(
 				effect(Types.Action, ActionMethods.PERFORM)
-					.param('id', 'expand')
+					.params(actionParams().id('expand'))
 					.build(),
 			)
 			.effect(
-				effect(Types.Action, ActionMethods.PERFORM).param('id', 'till').build(),
+				effect(Types.Action, ActionMethods.PERFORM)
+					.params(actionParams().id('till'))
+					.build(),
 			)
 			.effect(
 				effect(Types.Passive, PassiveMethods.ADD)

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -17,6 +17,7 @@ import {
 	PassiveMethods,
 	StatMethods,
 	resourceParams,
+	actionParams,
 	resultModParams,
 	evaluationTarget,
 	developmentTarget,
@@ -114,7 +115,9 @@ export function createBuildingRegistry() {
 			.icon('🏭')
 			.cost(Resource.gold, 10)
 			.onBuild(
-				effect(Types.Action, ActionMethods.ADD).param('id', 'plow').build(),
+				effect(Types.Action, ActionMethods.ADD)
+					.params(actionParams().id('plow'))
+					.build(),
 			)
 			.build(),
 		focus: 'economy',

--- a/packages/contents/tests/action-effect-group-builders.test.ts
+++ b/packages/contents/tests/action-effect-group-builders.test.ts
@@ -3,6 +3,7 @@ import {
 	action,
 	actionEffectGroup,
 	actionEffectGroupOption,
+	actionParams,
 	building,
 } from '../src/config/builders';
 import type { ActionEffectGroupDef } from '../src/config/builders';
@@ -83,8 +84,7 @@ describe('action effect group builder safeguards', () => {
 						actionEffectGroupOption('farm')
 							.label('Farm')
 							.action('develop')
-							.param('id', 'farm')
-							.param('landId', '$landId'),
+							.params(actionParams().id('farm').landId('$landId')),
 					),
 			)
 			.build();

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -2,6 +2,7 @@ import {
 	action,
 	resourceParams,
 	statParams,
+	actionParams,
 	effect,
 	requirement,
 	compareRequirement,
@@ -36,6 +37,22 @@ describe('content builder safeguards', () => {
 	it('blocks duplicate action ids', () => {
 		expect(() => action().id('demo').id('again')).toThrowError(
 			'Action already has an id(). Remove the extra id() call.',
+		);
+	});
+
+	it('requires action params to declare an id', () => {
+		expect(() => actionParams().build()).toThrowError(
+			'Action effect params is missing id(). Call id("your-action-id") before build().',
+		);
+	});
+
+	it('prevents duplicate action param setters', () => {
+		const builder = actionParams().id('develop');
+		expect(() => builder.id('again')).toThrowError(
+			'Action effect params already set id(). Remove the extra id() call.',
+		);
+		expect(() => actionParams().landId('$land').landId('$land')).toThrowError(
+			'Action effect params already set landId(). Remove the extra landId() call.',
 		);
 	});
 


### PR DESCRIPTION
## Summary
- add an ActionEffectParamsBuilder with duplicate-set safeguards and a params(...) helper for action effect group options
- update action and building content definitions to populate action params via the new builder factory
- extend builder validation tests to cover action params requirements and duplicate setter protection

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e23dd069fc8325ace244161a800b6b