### PR TITLE
Refactor action formatter copy and document helper

### DIFF
--- a/docs/text-formatting.md
+++ b/docs/text-formatting.md
@@ -134,6 +134,11 @@ suffixes like "per 🧩 Development" (see
   [`effects/helpers.ts`](../packages/web/src/translation/effects/helpers.ts)
   produce the preferred wording for deltas. Always pipe numeric changes through
   these helpers before concatenating strings.
+- **Action labels** — `formatActionLabel` and `formatActionChangeSentence` in
+  [`effects/formatters/action.ts`](../packages/web/src/translation/effects/formatters/action.ts)
+  output the icon-first bullets and sentence-case gain/lose copy used across
+  action summaries, descriptions, and logs. Reuse them instead of hardcoding
+  unlock/remove phrasing.
 - **Result modifier clauses** — The modifier helpers in
   [`effects/formatters/modifier_helpers.ts`](../packages/web/src/translation/effects/formatters/modifier_helpers.ts)
   standardise phrases such as "Whenever it grants resources" and handle

--- a/packages/web/src/translation/effects/formatters/action.ts
+++ b/packages/web/src/translation/effects/formatters/action.ts
@@ -54,6 +54,7 @@ registerEffectFormatter('action', 'add', {
 		const { label, system } = getActionPresentation(id, ctx);
 		const card = describeContent('action', id, ctx);
 		return [
+			label,
 			formatActionChangeSentence('gain', label, 'describe'),
 			{
 				title: label,
@@ -88,7 +89,7 @@ registerEffectFormatter('action', 'remove', {
 			return null;
 		}
 		const { label } = getActionPresentation(id, ctx);
-		return formatActionChangeSentence('lose', label, 'describe');
+		return [label, formatActionChangeSentence('lose', label, 'describe')];
 	},
 	log: (eff, ctx) => {
 		const id = eff.params?.['id'] as string;

--- a/packages/web/src/translation/effects/formatters/action.ts
+++ b/packages/web/src/translation/effects/formatters/action.ts
@@ -5,17 +5,36 @@ import {
 import { describeContent } from '../../content';
 import { registerEffectFormatter, logEffects } from '../factory';
 
-function getActionLabel(id: string, ctx: EngineContext) {
+function formatActionLabel(icon: string, name: string) {
+	return [icon, name].filter(Boolean).join(' ').trim();
+}
+
+function formatActionChangeSentence(
+	change: 'gain' | 'lose',
+	label: string,
+	mode: 'describe' | 'log',
+) {
+	const verbs = {
+		gain: { describe: 'Gain', log: 'Unlocked' },
+		lose: { describe: 'Lose', log: 'Lost' },
+	} as const;
+	return `${verbs[change][mode]} the ${label} action`;
+}
+
+function getActionPresentation(id: string, ctx: EngineContext) {
 	let name = id;
 	let icon = '';
+	let system = false;
 	try {
 		const def = ctx.actions.get(id);
 		name = def.name;
 		icon = def.icon || '';
+		system = !!def.system;
 	} catch {
 		// ignore missing action
 	}
-	return { icon, name };
+	const label = formatActionLabel(icon, name) || id;
+	return { icon, name, system, label };
 }
 
 registerEffectFormatter('action', 'add', {
@@ -24,29 +43,23 @@ registerEffectFormatter('action', 'add', {
 		if (!id) {
 			return null;
 		}
-		const { icon, name } = getActionLabel(id, ctx);
-		return `Gain action ${icon} ${name}`;
+		const { label } = getActionPresentation(id, ctx);
+		return label;
 	},
 	describe: (eff, ctx) => {
 		const id = eff.params?.['id'] as string;
 		if (!id) {
 			return null;
 		}
-		const { icon, name } = getActionLabel(id, ctx);
+		const { label, system } = getActionPresentation(id, ctx);
 		const card = describeContent('action', id, ctx);
-		let isSystem = false;
-		try {
-			isSystem = !!ctx.actions.get(id).system;
-		} catch {
-			// ignore missing action
-		}
 		return [
-			`Gain action ${icon} ${name}`,
+			formatActionChangeSentence('gain', label, 'describe'),
 			{
-				title: `${icon} ${name}`,
+				title: label,
 				items: card,
 				_hoist: true,
-				...(isSystem && { _desc: true }),
+				...(system && { _desc: true }),
 			},
 		];
 	},
@@ -55,8 +68,8 @@ registerEffectFormatter('action', 'add', {
 		if (!id) {
 			return null;
 		}
-		const { icon, name } = getActionLabel(id, ctx);
-		return `Unlocked ${icon} ${name}`;
+		const { label } = getActionPresentation(id, ctx);
+		return formatActionChangeSentence('gain', label, 'log');
 	},
 });
 
@@ -66,24 +79,24 @@ registerEffectFormatter('action', 'remove', {
 		if (!id) {
 			return null;
 		}
-		const { icon, name } = getActionLabel(id, ctx);
-		return `Lose ${icon} ${name}`;
+		const { label } = getActionPresentation(id, ctx);
+		return label;
 	},
 	describe: (eff, ctx) => {
 		const id = eff.params?.['id'] as string;
 		if (!id) {
 			return null;
 		}
-		const { icon, name } = getActionLabel(id, ctx);
-		return `Lose action ${icon} ${name}`;
+		const { label } = getActionPresentation(id, ctx);
+		return formatActionChangeSentence('lose', label, 'describe');
 	},
 	log: (eff, ctx) => {
 		const id = eff.params?.['id'] as string;
 		if (!id) {
 			return null;
 		}
-		const { icon, name } = getActionLabel(id, ctx);
-		return `Lost ${icon} ${name}`;
+		const { label } = getActionPresentation(id, ctx);
+		return formatActionChangeSentence('lose', label, 'log');
 	},
 });
 
@@ -93,19 +106,19 @@ registerEffectFormatter('action', 'perform', {
 		if (!id) {
 			return null;
 		}
-		const { icon, name } = getActionLabel(id, ctx);
-		return `${icon} ${name}`;
+		const { label } = getActionPresentation(id, ctx);
+		return label;
 	},
 	describe: (eff, ctx) => {
 		const id = eff.params?.['id'] as string;
 		if (!id) {
 			return null;
 		}
-		const { icon, name } = getActionLabel(id, ctx);
+		const { label } = getActionPresentation(id, ctx);
 		const summary = describeContent('action', id, ctx);
 		return [
 			{
-				title: `${icon} ${name}`,
+				title: label,
 				items: summary,
 			},
 		];
@@ -115,10 +128,10 @@ registerEffectFormatter('action', 'perform', {
 		if (!id) {
 			return null;
 		}
-		const { icon, name } = getActionLabel(id, ctx);
+		const { label } = getActionPresentation(id, ctx);
 		const def = ctx.actions.get(id);
 		const resolved = resolveActionEffects(def);
 		const sub = logEffects(resolved.effects, ctx);
-		return [{ title: `${icon} ${name}`, items: sub }];
+		return [{ title: label, items: sub }];
 	},
 });

--- a/packages/web/tests/plow-workshop-translation.test.ts
+++ b/packages/web/tests/plow-workshop-translation.test.ts
@@ -28,7 +28,7 @@ describe('plow workshop translation', () => {
 		expect(effects).toHaveLength(1);
 		const build = effects[0] as { title: string; items?: unknown[] };
 		expect(build.items?.[0]).toBe(
-			`Gain action ${synthetic.plow.icon} ${synthetic.plow.name}`,
+			`${synthetic.plow.icon} ${synthetic.plow.name}`,
 		);
 		expect(description).toBeDefined();
 		const actionCard = (description as Summary)[0] as { title: string };


### PR DESCRIPTION
## Summary
- refactor the action effect formatter to emit shared icon-first labels and sentence-case gain/loss copy
- update the plow workshop translation test expectations to align with the new formatter output
- document the action label helper in the text-formatting guide for reuse in future formatters

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e243653a088325a425f28911f731b9