### PR TITLE
Allow placeholder population roles

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -27,6 +27,7 @@ import {
 	passiveParams,
 	costModParams,
 	developmentEvaluator,
+	populationParams,
 	populationEvaluator,
 	statEvaluator,
 	attackParams,
@@ -171,7 +172,7 @@ export function createActionRegistry() {
 			)
 			.effect(
 				effect(Types.Population, PopulationMethods.ADD)
-					.param('role', '$role')
+					.params(populationParams().role('$role'))
 					.build(),
 			)
 			.effect(

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -1112,9 +1112,11 @@ export function resultModParams() {
 }
 
 class PopulationEffectParamsBuilder extends ParamsBuilder<{
-	role?: PopulationRoleId;
+	// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+	role?: PopulationRoleId | string;
 }> {
-	role(role: PopulationRoleId) {
+	// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+	role(role: PopulationRoleId | string) {
 		return this.set(
 			'role',
 			role,

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -12,6 +12,7 @@ import {
 	happinessTier,
 	Types,
 	PassiveMethods,
+	populationParams,
 } from '../src/config/builders';
 import { RESOURCES, type ResourceKey } from '../src/resources';
 import { STATS, type StatKey } from '../src/stats';
@@ -192,6 +193,13 @@ describe('content builder safeguards', () => {
 			passiveParams().id('passive:test').skipStep('', 'step'),
 		).toThrowError(
 			'Passive params skipStep(...) requires both phaseId and stepId. Provide both values when calling skipStep().',
+		);
+	});
+	it('supports placeholder strings in population params while requiring role()', () => {
+		const params = populationParams().role('$role').build();
+		expect(params).toEqual({ role: '$role' });
+		expect(() => populationParams().build()).toThrowError(
+			'Population effect is missing role(). Call role(PopulationRole.yourChoice) to choose who is affected.',
 		);
 	});
 });


### PR DESCRIPTION
## Summary
- allow `PopulationEffectParamsBuilder.role` to accept placeholder strings for dynamic population selections while keeping duplicate-call validation
- switch the `raise_pop` action to configure its population effect with the population params builder
- extend builder validation tests to cover placeholder roles and ensure role selection remains required

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e24374d4b48325bb729f076801bd93