### PR TITLE
Refactor GameContext to use engine sessions

### DIFF
--- a/packages/engine/src/runtime/session.ts
+++ b/packages/engine/src/runtime/session.ts
@@ -2,6 +2,7 @@ import {
 	createEngine,
 	type EngineCreationOptions,
 } from '../setup/create_engine';
+import type { EngineContext } from '../context';
 import { performAction as runAction } from '../actions/action_execution';
 import { advance as runAdvance } from '../phases/advance';
 import { getActionEffectGroups } from '../actions/effect_groups';
@@ -20,6 +21,13 @@ export interface EngineSession {
 	advancePhase(): EngineAdvanceResult;
 	getSnapshot(): EngineSessionSnapshot;
 	getActionOptions(actionId: string): ReturnType<typeof cloneActionOptions>;
+	enqueue<T>(taskFactory: () => Promise<T> | T): Promise<T>;
+	setDevMode(enabled: boolean): void;
+	/**
+	 * @deprecated Temporary escape hatch while the web layer migrates to
+	 * snapshots. Avoid new usage and prefer the session facade instead.
+	 */
+	getLegacyContext(): EngineContext;
 }
 
 export type {
@@ -51,6 +59,15 @@ export function createEngineSession(
 		getActionOptions(actionId) {
 			const groups = getActionEffectGroups(actionId, context);
 			return cloneActionOptions(groups);
+		},
+		enqueue(taskFactory) {
+			return context.enqueue(taskFactory);
+		},
+		setDevMode(enabled) {
+			context.game.devMode = enabled;
+		},
+		getLegacyContext() {
+			return context;
 		},
 	};
 }

--- a/packages/web/src/state/GameContext.types.ts
+++ b/packages/web/src/state/GameContext.types.ts
@@ -1,4 +1,8 @@
-import type { EngineContext } from '@kingdom-builder/engine';
+import type {
+	EngineContext,
+	EngineSession,
+	EngineSessionSnapshot,
+} from '@kingdom-builder/engine';
 import type { ResourceKey } from '@kingdom-builder/contents';
 import type { Action } from './actionTypes';
 import type { PhaseStep } from './phaseTypes';
@@ -8,6 +12,9 @@ import type { LogEntry } from './useGameLog';
 import type { ErrorToast } from './useErrorToasts';
 
 export interface GameEngineContextValue {
+	session: EngineSession;
+	sessionState: EngineSessionSnapshot;
+	/** @deprecated Use `session` and `sessionState` instead. */
 	ctx: EngineContext;
 	log: LogEntry[];
 	logOverflowed: boolean;


### PR DESCRIPTION
## Summary
- extend the engine runtime session with helpers to enqueue work, toggle dev mode, and retrieve the legacy context for transitional consumers
- migrate the web GameProvider to build an EngineSession facade, surface session snapshots, and refresh derived state from the new facade
- expand GameEngineContextValue to expose session data while marking the raw context as deprecated for downstream migration

## Testing
- npm run lint
- npm run test:quick


------
https://chatgpt.com/codex/tasks/task_e_68e2432177c88325aeec15598b7ff637