### PR TITLE
feat(contents): add start config builder

### DIFF
--- a/packages/contents/src/game.ts
+++ b/packages/contents/src/game.ts
@@ -1,35 +1,37 @@
+import { startConfig, playerStart } from './config/builders';
 import { Resource } from './resources';
 import { Stat } from './stats';
 import { PopulationRole } from './populationRoles';
 import type { StartConfig } from '@kingdom-builder/protocol';
 
-export const GAME_START: StartConfig = {
-	player: {
-		resources: {
-			[Resource.gold]: 10,
-			[Resource.ap]: 0,
-			[Resource.happiness]: 0,
-			[Resource.castleHP]: 10,
-		},
-		stats: {
-			[Stat.maxPopulation]: 1,
-			[Stat.armyStrength]: 0,
-			[Stat.fortificationStrength]: 0,
-			[Stat.absorption]: 0,
-			[Stat.growth]: 0.25,
-			[Stat.warWeariness]: 0,
-		},
-		population: {
-			[PopulationRole.Council]: 1,
-			[PopulationRole.Legion]: 0,
-			[PopulationRole.Fortifier]: 0,
-			[PopulationRole.Citizen]: 0,
-		},
-		lands: [{ developments: ['farm'] }, {}],
-	},
-	players: {
-		B: {
-			resources: { [Resource.ap]: 1 },
-		},
-	},
-};
+export const GAME_START: StartConfig = startConfig()
+	.player(
+		playerStart()
+			.resources({
+				[Resource.gold]: 10,
+				[Resource.ap]: 0,
+				[Resource.happiness]: 0,
+				[Resource.castleHP]: 10,
+			})
+			.stats({
+				[Stat.maxPopulation]: 1,
+				[Stat.armyStrength]: 0,
+				[Stat.fortificationStrength]: 0,
+				[Stat.absorption]: 0,
+				[Stat.growth]: 0.25,
+				[Stat.warWeariness]: 0,
+			})
+			.population({
+				[PopulationRole.Council]: 1,
+				[PopulationRole.Legion]: 0,
+				[PopulationRole.Fortifier]: 0,
+				[PopulationRole.Citizen]: 0,
+			})
+			.lands([{ developments: ['farm'] }, {}]),
+	)
+	.playerOverride('B', (player) =>
+		player.resources({
+			[Resource.ap]: 1,
+		}),
+	)
+	.build();

--- a/packages/contents/tests/start-config-builder-validations.test.ts
+++ b/packages/contents/tests/start-config-builder-validations.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { startConfig, playerStart } from '../src/config/builders';
+import { RESOURCES, type ResourceKey } from '../src/resources';
+import { STATS, type StatKey } from '../src/stats';
+
+const firstResourceKey = Object.keys(RESOURCES)[0] as ResourceKey;
+const firstStatKey = Object.keys(STATS)[0] as StatKey;
+
+describe('start config builder safeguards', () => {
+	it('requires player start to configure each section', () => {
+		expect(() =>
+			playerStart()
+				.stats({ [firstStatKey]: 0 })
+				.population({ demo: 0 })
+				.lands([])
+				.build(),
+		).toThrowError(
+			'Player start is missing resources(). Call resources(...) before build().',
+		);
+	});
+
+	it('prevents duplicate player start resource setters', () => {
+		expect(() =>
+			playerStart()
+				.resources({ [firstResourceKey]: 1 })
+				.resources({ [firstResourceKey]: 2 }),
+		).toThrowError(
+			'Player start already set resources(). Remove the extra resources() call.',
+		);
+	});
+
+	it('demands a base player when building start configs', () => {
+		expect(() => startConfig().build()).toThrowError(
+			'Start config is missing player(...). Configure the base player first.',
+		);
+	});
+
+	it('rejects duplicate player registrations in start configs', () => {
+		expect(() =>
+			startConfig()
+				.player(
+					playerStart()
+						.resources({
+							[firstResourceKey]: 1,
+						})
+						.stats({ [firstStatKey]: 1 })
+						.population({ demo: 1 })
+						.lands([]),
+				)
+				.player(
+					playerStart()
+						.resources({
+							[firstResourceKey]: 1,
+						})
+						.stats({ [firstStatKey]: 1 })
+						.population({ demo: 1 })
+						.lands([]),
+				),
+		).toThrowError(
+			'Start config already set player(...). Remove the extra player() call.',
+		);
+	});
+
+	it('blocks duplicate player overrides in start configs', () => {
+		expect(() =>
+			startConfig()
+				.player(
+					playerStart()
+						.resources({
+							[firstResourceKey]: 1,
+						})
+						.stats({ [firstStatKey]: 1 })
+						.population({ demo: 1 })
+						.lands([]),
+				)
+				.playerOverride('B', (player) =>
+					player.resources({
+						[firstResourceKey]: 0,
+					}),
+				)
+				.playerOverride('B', (player) =>
+					player.resources({
+						[firstResourceKey]: 0,
+					}),
+				),
+		).toThrowError(
+			'Start config already set playerOverride(B). Remove the extra call.',
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- add startConfig/playerStart builders with validation for player setups and overrides
- update GAME_START to use the new builder for clearer configuration
- cover the builder with dedicated start-config validation tests

## Testing
- npm run test -- packages/contents/tests/builder-validations.test.ts packages/contents/tests/start-config-builder-validations.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e248bdd39083258e187f61a0966abb