### PR TITLE
Refactor development formatter helper

### DIFF
--- a/docs/text-formatting.md
+++ b/docs/text-formatting.md
@@ -139,6 +139,11 @@ suffixes like "per 🧩 Development" (see
   output the icon-first bullets and sentence-case gain/lose copy used across
   action summaries, descriptions, and logs. Reuse them instead of hardcoding
   unlock/remove phrasing.
+- **Development slots** — `renderDevelopmentChange` in
+  [`effects/formatters/development.ts`](../packages/web/src/translation/effects/formatters/development.ts)
+  centralises icon-first summaries, full-sentence descriptions, and log copy
+  for adding or removing developments. Import it when formatting new
+  development effects to keep the verbs consistent.
 - **Result modifier clauses** — The modifier helpers in
   [`effects/formatters/modifier_helpers.ts`](../packages/web/src/translation/effects/formatters/modifier_helpers.ts)
   standardise phrases such as "Whenever it grants resources" and handle

--- a/packages/web/tests/development-summary.test.ts
+++ b/packages/web/tests/development-summary.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { summarizeContent } from '../src/translation/content';
 import type { Summary } from '../src/translation/content';
+import {
+	logEffects,
+	describeEffects,
+	summarizeEffects,
+} from '../src/translation/effects';
 import { createEngine } from '@kingdom-builder/engine';
 import {
 	ACTIONS,
@@ -59,5 +64,49 @@ describe('development translation', () => {
 				}
 			)?.amount ?? 0;
 		expect(flat.some((l) => l.includes(`${goldIcon}+${amt}`))).toBe(true);
+	});
+
+	it('uses shared helper for add and remove effects', () => {
+		const ctx = createEngine({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+		});
+		const devId = DEVELOPMENTS.keys()[0] as string;
+		const development = ctx.developments.get(devId);
+		const display =
+			[development?.icon ?? '', development?.name ?? devId]
+				.filter(Boolean)
+				.join(' ')
+				.trim() || devId;
+		const addSummary = summarizeEffects(
+			[{ type: 'development', method: 'add', params: { id: devId } }],
+			ctx,
+		);
+		expect(flatten(addSummary)).toContain(display);
+		const addDescription = describeEffects(
+			[{ type: 'development', method: 'add', params: { id: devId } }],
+			ctx,
+		);
+		expect(flatten(addDescription)).toContain(`Add ${display}`);
+		const removeSummary = summarizeEffects(
+			[{ type: 'development', method: 'remove', params: { id: devId } }],
+			ctx,
+		);
+		expect(flatten(removeSummary)).toContain(display);
+		const removeDescription = describeEffects(
+			[{ type: 'development', method: 'remove', params: { id: devId } }],
+			ctx,
+		);
+		expect(flatten(removeDescription)).toContain(`Remove ${display}`);
+		const removeLog = logEffects(
+			[{ type: 'development', method: 'remove', params: { id: devId } }],
+			ctx,
+		);
+		expect(removeLog).toContain(`Removed ${display}`);
 	});
 });


### PR DESCRIPTION
## Summary
- add a shared `renderDevelopmentChange` helper so development add/remove effects produce icon-first summaries, full descriptions, and log copy
- extend the development summary tests to assert the shared helper output across summarize, describe, and log modes
- link the new helper from the text-formatting guide to steer future development effect phrasing

## Testing
- npm run test:quick >/tmp/unit.log 2>&1 && tail -n 100 /tmp/unit.log

------
https://chatgpt.com/codex/tasks/task_e_68e249e1d4e08325bd13271cf88a5b29