### PR TITLE
Refine attack summaries with icon bullets

### DIFF
--- a/packages/web/src/translation/effects/formatters/attack/building.ts
+++ b/packages/web/src/translation/effects/formatters/attack/building.ts
@@ -6,6 +6,7 @@ import {
 	formatPercent,
 	iconLabel,
 } from './shared';
+import { buildAttackSummaryBullet } from './summary';
 import {
 	buildDescribeEntry,
 	buildingFortificationItems,
@@ -44,18 +45,16 @@ const buildingFormatter: AttackTargetFormatter<{
 	},
 	buildBaseEntry(context) {
 		if (context.mode === 'summarize') {
-			const power = context.stats.power;
-			const powerDisplay = power ? power.icon || power.label : 'Attack';
-			return `${powerDisplay} destroy opponent's ${context.targetLabel}`;
+			return buildAttackSummaryBullet(context);
 		}
 		return buildDescribeEntry(context, buildingFortificationItems(context));
 	},
 	buildOnDamageTitle(mode, { info, targetLabel }) {
-		const summaryTarget = info.icon || info.label;
-		const describeTarget = targetLabel;
-		return mode === 'summarize'
-			? `On opponent ${summaryTarget} destruction`
-			: `On opponent ${describeTarget} destruction`;
+		const summaryTarget = info.icon || info.label || targetLabel;
+		if (mode === 'summarize') {
+			return `${summaryTarget}💥`;
+		}
+		return `On opponent ${targetLabel} destruction`;
 	},
 	buildEvaluationEntry(log, context) {
 		const { stats, targetLabel } = context;

--- a/packages/web/src/translation/effects/formatters/attack/resource.ts
+++ b/packages/web/src/translation/effects/formatters/attack/resource.ts
@@ -5,6 +5,7 @@ import {
 } from '@kingdom-builder/contents';
 import type { AttackLog } from '@kingdom-builder/engine';
 import { formatDiffCommon, iconLabel } from './shared';
+import { buildAttackSummaryBullet } from './summary';
 import {
 	buildDescribeEntry,
 	buildStandardEvaluationEntry,
@@ -41,16 +42,16 @@ const resourceFormatter: AttackTargetFormatter<{
 	},
 	buildBaseEntry(context) {
 		if (context.mode === 'summarize') {
-			const power = context.stats.power;
-			const powerDisplay = power ? power.icon || power.label : 'Attack';
-			return `${powerDisplay} vs opponent's ${context.targetLabel}`;
+			return buildAttackSummaryBullet(context);
 		}
 		return buildDescribeEntry(context, defaultFortificationItems(context));
 	},
-	buildOnDamageTitle(mode, { info }) {
-		return mode === 'summarize'
-			? `On opponent ${info.icon} damage`
-			: `On opponent ${info.icon} ${info.label} damage`;
+	buildOnDamageTitle(mode, { info, targetLabel }) {
+		const summaryTarget = info.icon || info.label || targetLabel;
+		if (mode === 'summarize') {
+			return `${summaryTarget}💥`;
+		}
+		return `On opponent ${info.icon} ${info.label} damage`;
 	},
 	buildEvaluationEntry(log, context) {
 		return buildStandardEvaluationEntry(log, context, false);

--- a/packages/web/src/translation/effects/formatters/attack/stat.ts
+++ b/packages/web/src/translation/effects/formatters/attack/stat.ts
@@ -1,6 +1,7 @@
 import { STATS, type StatKey } from '@kingdom-builder/contents';
 import type { AttackLog } from '@kingdom-builder/engine';
 import { formatDiffCommon, iconLabel } from './shared';
+import { buildAttackSummaryBullet } from './summary';
 import {
 	buildDescribeEntry,
 	buildStandardEvaluationEntry,
@@ -41,16 +42,16 @@ const statFormatter: AttackTargetFormatter<{
 	},
 	buildBaseEntry(context) {
 		if (context.mode === 'summarize') {
-			const power = context.stats.power;
-			const powerDisplay = power ? power.icon || power.label : 'Attack';
-			return `${powerDisplay} vs opponent's ${context.targetLabel}`;
+			return buildAttackSummaryBullet(context);
 		}
 		return buildDescribeEntry(context, defaultFortificationItems(context));
 	},
-	buildOnDamageTitle(mode, { info }) {
-		return mode === 'summarize'
-			? `On opponent ${info.icon} damage`
-			: `On opponent ${info.icon} ${info.label} damage`;
+	buildOnDamageTitle(mode, { info, targetLabel }) {
+		const summaryTarget = info.icon || info.label || targetLabel;
+		if (mode === 'summarize') {
+			return `${summaryTarget}💥`;
+		}
+		return `On opponent ${info.icon} ${info.label} damage`;
 	},
 	buildEvaluationEntry(log, context) {
 		return buildStandardEvaluationEntry(log, context, true);

--- a/packages/web/src/translation/effects/formatters/attack/summary.ts
+++ b/packages/web/src/translation/effects/formatters/attack/summary.ts
@@ -1,0 +1,75 @@
+import type { SummaryEntry } from '../../../content';
+import {
+	DEFAULT_ATTACK_STAT_LABELS,
+	type AttackTarget,
+	type BaseEntryContext,
+	type AttackStatDescriptor,
+} from './types';
+
+const FALLBACK_ATTACK_ICON = '⚔️';
+const DEFENDER_ICON = '🛡️';
+
+function statIconOrLabel(
+	descriptor: AttackStatDescriptor | undefined,
+	fallbackLabel: string,
+): string {
+	if (descriptor?.icon) {
+		return descriptor.icon;
+	}
+	if (descriptor?.label) {
+		return descriptor.label;
+	}
+	return fallbackLabel;
+}
+
+function targetIconOrLabel<TTarget extends AttackTarget>(
+	context: BaseEntryContext<TTarget>,
+): string {
+	if (context.info.icon) {
+		return context.info.icon;
+	}
+	return context.info.label;
+}
+
+export function buildAttackSummaryBullet<TTarget extends AttackTarget>(
+	context: BaseEntryContext<TTarget>,
+): SummaryEntry {
+	const powerIcon = statIconOrLabel(
+		context.stats.power,
+		DEFAULT_ATTACK_STAT_LABELS.power,
+	);
+	const targetIcon = targetIconOrLabel(context);
+	const parts: string[] = [powerIcon, targetIcon];
+	if (context.ignoreAbsorption && context.stats.absorption) {
+		parts.push(
+			`🚫${statIconOrLabel(
+				context.stats.absorption,
+				DEFAULT_ATTACK_STAT_LABELS.absorption,
+			)}`,
+		);
+	}
+	if (context.ignoreFortification && context.stats.fortification) {
+		parts.push(
+			`🚫${statIconOrLabel(
+				context.stats.fortification,
+				DEFAULT_ATTACK_STAT_LABELS.fortification,
+			)}`,
+		);
+	}
+	return parts.join('');
+}
+
+export function ownerSummaryIcon(owner: 'attacker' | 'defender'): string {
+	return owner === 'attacker' ? FALLBACK_ATTACK_ICON : DEFENDER_ICON;
+}
+
+export function prefixOwnerSummary(
+	owner: 'attacker' | 'defender',
+	entry: SummaryEntry,
+): SummaryEntry {
+	const prefix = ownerSummaryIcon(owner);
+	if (typeof entry === 'string') {
+		return `${prefix}${entry}`;
+	}
+	return { ...entry, title: `${prefix}${entry.title}` };
+}

--- a/packages/web/tests/army-attack-translation.test.ts
+++ b/packages/web/tests/army-attack-translation.test.ts
@@ -381,15 +381,16 @@ describe('army attack translation', () => {
 		);
 		const warAmt = (warRes?.params as { amount?: number })?.amount ?? 0;
 		const summary = summarizeContent('action', attack.id, ctx);
-		const targetDisplay = iconLabel(castle.icon, castle.label, castle.id);
+		const powerSummary = powerStat.icon ?? powerStat.label ?? 'Attack Power';
+		const targetSummary = castle.icon || castle.label;
 		expect(summary).toEqual([
-			`${powerStat.icon ?? powerStat.label} vs opponent's ${targetDisplay}`,
+			`${powerSummary}${targetSummary}`,
 			{
-				title: `On opponent ${castle.icon} damage`,
+				title: `${targetSummary}💥`,
 				items: [
-					`${happiness.icon}${defenderAmt} for opponent`,
-					`${happiness.icon}${attackerAmt >= 0 ? '+' : ''}${attackerAmt} for you`,
-					`${plunder.icon} ${plunder.name}`,
+					`🛡️${happiness.icon}${defenderAmt}`,
+					`⚔️${happiness.icon}${attackerAmt >= 0 ? '+' : ''}${attackerAmt}`,
+					`⚔️${plunder.icon} ${plunder.name}`,
 				],
 			},
 			`${warWeariness.icon}${warAmt >= 0 ? '+' : ''}${warAmt}`,
@@ -497,9 +498,9 @@ describe('army attack translation', () => {
 		const targetDisplay = iconLabel(castle.icon, castle.label, castle.id);
 
 		const summary = summarizeContent('action', attack.id, ctx);
-		expect(summary).toEqual([
-			`${powerStat.icon ?? powerStat.label} vs opponent's ${targetDisplay}`,
-		]);
+		const powerSummary = powerStat.icon ?? powerStat.label ?? 'Attack Power';
+		const targetSummary = castle.icon || castle.label;
+		expect(summary).toEqual([`${powerSummary}${targetSummary}`]);
 
 		const description = describeContent('action', attack.id, ctx);
 		expect(description).toEqual([
@@ -549,14 +550,7 @@ describe('army attack translation', () => {
 		const { ctx, buildingAttack, building } = createSyntheticCtx();
 		const powerStat = getStat(SYNTH_POWER_STAT_KEY)!;
 		const gold = RESOURCES[Resource.gold];
-		const buildingDisplay = iconLabel(
-			building.icon,
-			building.name,
-			building.id,
-		);
-		const summaryTitle = building.icon
-			? `On opponent ${building.icon} destruction`
-			: `On opponent ${building.name ?? building.id} destruction`;
+		const summaryTarget = building.icon || building.name || building.id;
 		const attackEffect = buildingAttack.effects.find(
 			(e: EffectDef) => e.type === 'attack',
 		);
@@ -572,11 +566,12 @@ describe('army attack translation', () => {
 			(rewardEffect?.params as { amount?: number })?.amount ?? 0;
 
 		const summary = summarizeContent('action', buildingAttack.id, ctx);
+		const powerSummary = powerStat.icon ?? powerStat.label ?? 'Attack Power';
 		expect(summary).toEqual([
-			`${powerStat.icon ?? powerStat.label} destroy opponent's ${buildingDisplay}`,
+			`${powerSummary}${summaryTarget}`,
 			{
-				title: summaryTitle,
-				items: [`${gold.icon}+${rewardAmount} for you`],
+				title: `${summaryTarget}💥`,
+				items: [`⚔️${gold.icon}+${rewardAmount}`],
 			},
 		]);
 	});


### PR DESCRIPTION
## Summary
- add an attack summary helper that emits compact icon-based bullets for effect targets
- switch resource/stat/building attack formatters and on-damage summaries to the shared helper and icon titles
- update army attack translation tests to match the icon summary format

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e249f130108325abfc6fca32846b29