### PR TITLE
Refactor engine session hooks to use snapshots

### DIFF
--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -109,7 +109,7 @@ export function GameProvider({
 	});
 
 	const { log, logOverflowed, addLog, logWithEffectDelay } = useGameLog({
-		ctx,
+		sessionState,
 		mountedRef,
 		timeScaleRef,
 		setTrackedTimeout,
@@ -131,7 +131,8 @@ export function GameProvider({
 		updateMainPhaseStep,
 		setPhaseHistories,
 	} = usePhaseProgress({
-		ctx,
+		session,
+		sessionState,
 		actionPhaseId,
 		actionCostResource,
 		addLog,
@@ -148,10 +149,15 @@ export function GameProvider({
 		setTrackedTimeout,
 	});
 
-	useCompensationLogger({ ctx, addLog, resourceKeys: RESOURCE_KEYS });
+	useCompensationLogger({
+		session,
+		sessionState,
+		addLog,
+		resourceKeys: RESOURCE_KEYS,
+	});
 
 	const { handlePerform, performRef } = useActionPerformer({
-		ctx,
+		session,
 		actionCostResource,
 		addLog,
 		logWithEffectDelay,
@@ -165,7 +171,8 @@ export function GameProvider({
 	});
 
 	useAiRunner({
-		ctx,
+		session,
+		sessionState,
 		runUntilActionPhaseCore,
 		setPhaseHistories,
 		performRef,

--- a/packages/web/src/state/usePhaseProgress.helpers.ts
+++ b/packages/web/src/state/usePhaseProgress.helpers.ts
@@ -1,0 +1,184 @@
+import {
+	type EngineAdvanceResult,
+	type EngineSession,
+	type PlayerStateSnapshot,
+} from '@kingdom-builder/engine';
+import { type ResourceKey, type StepDef } from '@kingdom-builder/contents';
+import { diffStepSnapshots, snapshotPlayer } from '../translation';
+import { describeSkipEvent } from '../utils/describeSkipEvent';
+import type { PhaseStep } from './phaseTypes';
+
+interface AdvanceToActionPhaseOptions {
+	session: EngineSession;
+	actionCostResource: ResourceKey;
+	resourceKeys: ResourceKey[];
+	runDelay: (total: number) => Promise<void>;
+	runStepDelay: () => Promise<void>;
+	mountedRef: React.MutableRefObject<boolean>;
+	setPhaseSteps: React.Dispatch<React.SetStateAction<PhaseStep[]>>;
+	setPhaseHistories: React.Dispatch<
+		React.SetStateAction<Record<string, PhaseStep[]>>
+	>;
+	setPhaseTimer: (value: number) => void;
+	setDisplayPhase: (phase: string) => void;
+	setTabsEnabled: (value: boolean) => void;
+	setMainApStart: (value: number) => void;
+	updateMainPhaseStep: (value: number) => void;
+	addLog: (entry: string | string[], player?: PlayerStateSnapshot) => void;
+	refresh: () => void;
+}
+
+export async function advanceToActionPhase({
+	session,
+	actionCostResource,
+	resourceKeys,
+	runDelay,
+	runStepDelay,
+	mountedRef,
+	setPhaseSteps,
+	setPhaseHistories,
+	setPhaseTimer,
+	setDisplayPhase,
+	setTabsEnabled,
+	setMainApStart,
+	updateMainPhaseStep,
+	addLog,
+	refresh,
+}: AdvanceToActionPhaseOptions) {
+	let snapshot = session.getSnapshot();
+	const context = session.getLegacyContext();
+	if (snapshot.phases[snapshot.game.phaseIndex]?.action) {
+		if (!mountedRef.current) {
+			return;
+		}
+		setPhaseTimer(0);
+		setTabsEnabled(true);
+		setDisplayPhase(snapshot.game.currentPhase);
+		return;
+	}
+	setTabsEnabled(false);
+	setPhaseSteps([]);
+	setDisplayPhase(snapshot.game.currentPhase);
+	setPhaseHistories({});
+	let ranSteps = false;
+	let lastPhase: string | null = null;
+	while (!snapshot.phases[snapshot.game.phaseIndex]?.action) {
+		ranSteps = true;
+		const activePlayerBefore = snapshot.game.players.find(
+			(player) => player.id === snapshot.game.activePlayerId,
+		);
+		if (!activePlayerBefore) {
+			break;
+		}
+		const before = snapshotPlayer(activePlayerBefore);
+		const { phase, step, player, effects, skipped }: EngineAdvanceResult =
+			session.advancePhase();
+		const phaseDef = snapshot.phases.find(
+			(phaseDefinition) => phaseDefinition.id === phase,
+		);
+		if (!phaseDef) {
+			break;
+		}
+		const stepDef = phaseDef.steps.find(
+			(stepDefinition) => stepDefinition.id === step,
+		);
+		if (phase !== lastPhase) {
+			await runDelay(1500);
+			if (!mountedRef.current) {
+				return;
+			}
+			setPhaseSteps([]);
+			setDisplayPhase(phase);
+			addLog(`${phaseDef.icon} ${phaseDef.label} Phase`, player);
+			lastPhase = phase;
+		}
+		const phaseId = phase;
+		let entry: PhaseStep;
+		if (skipped) {
+			const summary = describeSkipEvent(skipped, phaseDef, stepDef);
+			addLog(summary.logLines, player);
+			entry = {
+				title: summary.history.title,
+				items: summary.history.items,
+				active: true,
+			};
+		} else {
+			const after = snapshotPlayer(player);
+			const stepWithEffects: StepDef | undefined = stepDef
+				? ({ ...(stepDef as StepDef), effects } as StepDef)
+				: undefined;
+			const changes = diffStepSnapshots(
+				before,
+				after,
+				stepWithEffects,
+				context,
+				resourceKeys,
+			);
+			if (changes.length) {
+				addLog(
+					changes.map((change) => `  ${change}`),
+					player,
+				);
+			}
+			entry = {
+				title: stepDef?.title || step,
+				items:
+					changes.length > 0
+						? changes.map((text) => ({ text }))
+						: [{ text: 'No effect', italic: true }],
+				active: true,
+			};
+		}
+		setPhaseSteps((prev) => [...prev, entry]);
+		setPhaseHistories((prev) => ({
+			...prev,
+			[phaseId]: [...(prev[phaseId] ?? []), entry],
+		}));
+		await runStepDelay();
+		if (!mountedRef.current) {
+			return;
+		}
+		const finalized = { ...entry, active: false };
+		setPhaseSteps((prev) => {
+			if (!prev.length) {
+				return prev;
+			}
+			const next = [...prev];
+			next[next.length - 1] = finalized;
+			return next;
+		});
+		setPhaseHistories((prev) => {
+			const history = prev[phaseId];
+			if (!history?.length) {
+				return prev;
+			}
+			const nextHistory = [...history];
+			nextHistory[nextHistory.length - 1] = finalized;
+			return { ...prev, [phaseId]: nextHistory };
+		});
+		snapshot = session.getSnapshot();
+	}
+	if (ranSteps) {
+		await runDelay(1500);
+		if (!mountedRef.current) {
+			return;
+		}
+	} else if (!mountedRef.current) {
+		return;
+	} else {
+		setPhaseTimer(0);
+	}
+	const refreshed = session.getSnapshot();
+	const activeAtAction = refreshed.game.players.find(
+		(player) => player.id === refreshed.game.activePlayerId,
+	);
+	const start = activeAtAction?.resources[actionCostResource] ?? 0;
+	if (!mountedRef.current) {
+		return;
+	}
+	setMainApStart(start);
+	updateMainPhaseStep(start);
+	setDisplayPhase(refreshed.game.currentPhase);
+	setTabsEnabled(true);
+	refresh();
+}

--- a/packages/web/src/translation/log/snapshots.ts
+++ b/packages/web/src/translation/log/snapshots.ts
@@ -3,6 +3,7 @@ import {
 	type PassiveSummary,
 	type PlayerId,
 	type PlayerStateSnapshot,
+	type PlayerSnapshot as EnginePlayerSnapshot,
 } from '@kingdom-builder/engine';
 import { type ResourceKey } from '@kingdom-builder/contents';
 import { type Land } from '../content';
@@ -37,8 +38,13 @@ interface LegacyPlayerSnapshot {
 	passives?: PassiveSummary[];
 }
 
+type SnapshotInput =
+	| PlayerStateSnapshot
+	| LegacyPlayerSnapshot
+	| EnginePlayerSnapshot;
+
 export function snapshotPlayer(
-	playerState: PlayerStateSnapshot | LegacyPlayerSnapshot,
+	playerState: SnapshotInput,
 	context?: EngineContext,
 ): PlayerSnapshot {
 	const buildingList = Array.isArray(playerState.buildings)
@@ -50,9 +56,10 @@ export function snapshotPlayer(
 		slotsUsed: land.slotsUsed,
 		developments: [...land.developments],
 	}));
-	const passives = playerState.passives
-		? [...playerState.passives]
-		: context
+	const hasPassives = 'passives' in playerState && playerState.passives;
+	const passives = hasPassives
+		? [...playerState.passives!]
+		: context && 'id' in playerState
 			? context.passives.list(playerState.id as PlayerId)
 			: [];
 	return {


### PR DESCRIPTION
## Summary
- refactor GameContext to pass EngineSession plus snapshots into game state hooks
- update phase/action/AI hooks to drive effects through the session facade and immutable snapshots
- extend log snapshot utilities and add a helper to advance phases via the session API

## Testing
- npm run lint
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e249ba44908325971d410d686bbea8