### PR TITLE
Add turn indicator to phase panel

### DIFF
--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -95,6 +95,15 @@ const PhasePanel = React.forwardRef<HTMLDivElement, PhasePanelProps>(
 			);
 		});
 
+		const turnIndicator = (
+			<div className="flex items-center gap-3 rounded-full border border-white/60 bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-700 shadow-sm dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-200">
+				<span>Turn {ctx.game.turn}</span>
+				<span className="rounded-full bg-white/60 px-2 py-1 text-[0.65rem] font-medium tracking-[0.2em] text-slate-500 dark:bg-white/10 dark:text-slate-300">
+					{ctx.activePlayer.name}
+				</span>
+			</div>
+		);
+
 		const renderedPhaseSteps = phaseSteps.map((stepEntry, stepIndex) => {
 			const stepBaseClasses = [
 				'rounded-2xl border px-4 py-3 shadow-sm transition-all',
@@ -186,13 +195,9 @@ const PhasePanel = React.forwardRef<HTMLDivElement, PhasePanelProps>(
 				className="relative flex min-h-[320px] w-full flex-col gap-3 overflow-hidden rounded-3xl border border-white/60 bg-white/75 px-6 py-6 shadow-2xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/50 frosted-surface"
 				style={{ height: `${panelHeight}px` }}
 			>
-				<div className="absolute -top-6 left-4 rounded-full border border-white/60 bg-white/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-700 shadow-sm dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-200 frosted-surface">
-					<span>
-						Turn {ctx.game.turn} · {ctx.activePlayer.name}
-					</span>
-				</div>
-				<div className="flex flex-wrap gap-2 border-b border-white/40 pb-2 dark:border-white/10">
-					{phaseTabs}
+				<div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/40 pb-2 dark:border-white/10">
+					{turnIndicator}
+					<div className="flex flex-wrap gap-2">{phaseTabs}</div>
 				</div>
 				<ul
 					ref={phaseStepsRef}

--- a/packages/web/tests/PhasePanel.test.tsx
+++ b/packages/web/tests/PhasePanel.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeAll } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import PhasePanel from '../src/components/phases/PhasePanel';
@@ -66,16 +66,15 @@ beforeAll(() => {
 describe('<PhasePanel />', () => {
 	it('displays current turn and phases', () => {
 		render(<PhasePanel />);
-		expect(
-			screen.getByText((content) => {
-				const turnText = `Turn ${ctx.game.turn}`;
-				return (
-					typeof content === 'string' &&
-					content.includes(turnText) &&
-					content.includes(ctx.activePlayer.name)
-				);
-			}),
-		).toBeInTheDocument();
+		const turnText = `Turn ${ctx.game.turn}`;
+		const turnElement = screen.getByText(turnText);
+		const turnContainer = turnElement.closest('div');
+		expect(turnContainer).toBeTruthy();
+		if (turnContainer) {
+			expect(
+				within(turnContainer).getByText(ctx.activePlayer.name),
+			).toBeInTheDocument();
+		}
 		const firstPhase = ctx.phases[0];
 		const phaseLabel = `${firstPhase.icon} ${firstPhase.label}`;
 		expect(


### PR DESCRIPTION
## Summary
- add an engine-sourced turn indicator to the phase panel header alongside the phase tabs
- update the PhasePanel test to verify the new turn display and active player label

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e24b97f3008325be940f340c206d52