### PR TITLE
Update PR template to require test command evidence

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,9 @@
 4. **Code standards satisfied:** <!-- Cite linting or review evidence that code standards remain satisfied. -->
 5. **Tests updated:** <!-- Link to new or updated tests that cover the changes and include their results. -->
 6. **Documentation updated:** <!-- Point to required documentation updates or explain why none were needed. -->
+7. **`npm run check` results:** <!-- Provide a link or pastebin showing the full output. -->
+8. **`npm run test:coverage` results:** <!-- Provide a link or pastebin showing the full output. -->
 
 ## Testing
 
-<!-- List the tests you ran and their results. -->
+<!-- List the tests you ran and their results. Include both `npm run check` and `npm run test:coverage`, marking their status (pass/fail) alongside any additional commands. -->


### PR DESCRIPTION
## Summary
- add checklist items to capture links or pastebins for `npm run check` and `npm run test:coverage`
- remind authors in the Testing section to report both commands with their statuses

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e25152163883258f124e1a37e5ba46