### PR TITLE
Run coverage in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,3 +3,4 @@
 set -e
 
 npm run check
+npm run test:coverage


### PR DESCRIPTION
## Summary
- update the Husky pre-push hook to run coverage after the existing check step so pushes fail on coverage regressions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2514c55bc83259e524db00f4028a2