### PR TITLE
Clarify PR template usage in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,17 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.
 - Legacy files above 250 lines remain until refactored; new code should respect
   the limit.
 
+### 2.3 Pull Request Submission Protocol
+
+- Every time you call the `make_pr` tool, copy the full contents of
+  `.github/PULL_REQUEST_TEMPLATE.md` into the PR body and replace every
+  placeholder with the specific information for the current change set.
+- Do not trim sections from the template or leave HTML comments/placeholder
+  markers in place; fill out each required section completely.
+- Reviewers will immediately bounce any PR whose description omits a section
+  from the template or leaves placeholders unaddressed, so confirm compliance
+  before invoking `make_pr`.
+
 #### Coding Standards Checklist
 
 - [ ] Wrap every conditional or loop body in braces, even for single statements.
@@ -93,7 +104,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.
 - [ ] Use descriptive, human-readable identifiers instead of abbreviations.
 - [ ] Indent code with tabs to preserve consistent formatting.
 
-### 2.3 Code Standards & Naming
+### 2.4 Code Standards & Naming
 
 - Prefer descriptive names; avoid one-letter identifiers except for familiar
   generic parameters.
@@ -105,7 +116,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.
 - Documentation (`*.md`) and non-runtime tooling (e.g., `overview.tsx`) may
   adopt context-specific formatting.
 
-### 2.4 Testing Workflow
+### 2.5 Testing Workflow
 
 - Tests reside in `packages/engine/tests` (unit) and `tests/integration`
   (integration).


### PR DESCRIPTION
## Summary
- Document a new pull request submission protocol in `AGENTS.md` that requires pasting the entire `.github/PULL_REQUEST_TEMPLATE.md` when calling `make_pr` and completing every section.
- Note that reviewers will reject PRs missing template sections or containing leftover placeholders.
- Renumber the subsequent workflow headings to keep section numbering consistent.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Documentation-only update; no translators or formatters were touched.
2. **Canonical keywords/icons/helpers touched:** None; no canonical keyword, icon, or helper references were modified.
3. **Voice review:** Confirmed repository guidance tone remains consistent within the updated documentation.

## Standards compliance (required)
1. **File length limits respected:** `AGENTS.md` remains under the documented limits after the edits.
2. **Line length limits respected:** All added lines stay within the 80-character guideline.
3. **Domain separation upheld:** Change is limited to documentation and does not impact engine, web, content, or protocol code.
4. **Code standards satisfied:** Documentation-only update; no runtime code was introduced or modified.
5. **Tests updated:** No tests required for documentation updates.
6. **Documentation updated:** `AGENTS.md` updated with the new PR submission instructions.
7. **`npm run check` results:** Not run; documentation-only change with no code impact.
8. **`npm run test:coverage` results:** Not run; documentation-only change with no code impact.

## Testing
- Not run (documentation-only change).


------
https://chatgpt.com/codex/tasks/task_e_68e2522ead48832581d797d6e9bf2632