### PR TITLE
Extract ActionCard helpers into utilities

### DIFF
--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -1,60 +1,9 @@
 import React from 'react';
+import type { Focus } from '@kingdom-builder/contents';
 import { type Summary } from '../../translation';
 import { renderSummary, renderCosts } from '../../translation/render';
-import type { Focus } from '@kingdom-builder/contents';
-
-const FOCUS_GRADIENTS: Record<Focus, string> & { default: string } = {
-	economy:
-		'from-emerald-200/70 to-emerald-100/40 dark:from-emerald-900/40 dark:to-emerald-800/20',
-	aggressive:
-		'from-amber-200/70 to-orange-100/40 dark:from-amber-900/40 dark:to-orange-900/20',
-	defense:
-		'from-blue-200/70 to-sky-100/40 dark:from-blue-900/40 dark:to-sky-900/20',
-	other:
-		'from-rose-200/70 to-rose-100/40 dark:from-rose-900/40 dark:to-rose-800/20',
-	default:
-		'from-rose-200/70 to-rose-100/40 dark:from-rose-900/40 dark:to-rose-800/20',
-};
-
-function stripSummary(
-	summary: Summary | undefined,
-	requirements: readonly string[],
-): Summary | undefined {
-	const first = summary?.[0];
-	const baseSummary = !first
-		? summary
-		: typeof first === 'string'
-			? summary
-			: first.items;
-	if (!baseSummary) {
-		return baseSummary;
-	}
-	if (requirements.length === 0) {
-		return baseSummary;
-	}
-	const requirementSet = new Set(
-		requirements.map((req) => req.trim()).filter((req) => req.length > 0),
-	);
-	const filterEntries = (entries: Summary): Summary => {
-		const filtered: Summary = [];
-		for (const entry of entries) {
-			if (typeof entry === 'string') {
-				if (requirementSet.has(entry.trim())) {
-					continue;
-				}
-				filtered.push(entry);
-			} else {
-				const nested = filterEntries(entry.items);
-				if (nested.length > 0) {
-					filtered.push({ ...entry, items: nested });
-				}
-			}
-		}
-		return filtered;
-	};
-	const filtered = filterEntries(baseSummary);
-	return filtered.length > 0 ? filtered : undefined;
-}
+import { FOCUS_GRADIENTS } from './focusGradients';
+import { stripSummary } from './stripSummary';
 
 export type ActionCardOption = {
 	id: string;

--- a/packages/web/src/components/actions/focusGradients.ts
+++ b/packages/web/src/components/actions/focusGradients.ts
@@ -1,0 +1,30 @@
+import type { Focus } from '@kingdom-builder/contents';
+
+type GradientMap = Record<Focus, string> & { default: string };
+
+function joinGradient(parts: readonly string[]): string {
+	return parts.join(' ');
+}
+
+export const FOCUS_GRADIENTS: GradientMap = {
+	economy: joinGradient([
+		'from-emerald-200/70 to-emerald-100/40',
+		'dark:from-emerald-900/40 dark:to-emerald-800/20',
+	]),
+	aggressive: joinGradient([
+		'from-amber-200/70 to-orange-100/40',
+		'dark:from-amber-900/40 dark:to-orange-900/20',
+	]),
+	defense: joinGradient([
+		'from-blue-200/70 to-sky-100/40',
+		'dark:from-blue-900/40 dark:to-sky-900/20',
+	]),
+	other: joinGradient([
+		'from-rose-200/70 to-rose-100/40',
+		'dark:from-rose-900/40 dark:to-rose-800/20',
+	]),
+	default: joinGradient([
+		'from-rose-200/70 to-rose-100/40',
+		'dark:from-rose-900/40 dark:to-rose-800/20',
+	]),
+};

--- a/packages/web/src/components/actions/stripSummary.ts
+++ b/packages/web/src/components/actions/stripSummary.ts
@@ -1,0 +1,45 @@
+import { type Summary } from '../../translation';
+
+function createRequirementSet(requirements: readonly string[]): Set<string> {
+	const trimmed = requirements.map((requirement) => requirement.trim());
+	return new Set(trimmed.filter((requirement) => requirement.length > 0));
+}
+
+function filterEntries(entries: Summary, requirementSet: Set<string>): Summary {
+	const filtered: Summary = [];
+	for (const entry of entries) {
+		if (typeof entry === 'string') {
+			if (requirementSet.has(entry.trim())) {
+				continue;
+			}
+			filtered.push(entry);
+			continue;
+		}
+		const nested = filterEntries(entry.items, requirementSet);
+		if (nested.length > 0) {
+			filtered.push({ ...entry, items: nested });
+		}
+	}
+	return filtered;
+}
+
+export function stripSummary(
+	summary: Summary | undefined,
+	requirements: readonly string[],
+): Summary | undefined {
+	const first = summary?.[0];
+	const baseSummary = !first
+		? summary
+		: typeof first === 'string'
+			? summary
+			: first.items;
+	if (!baseSummary) {
+		return baseSummary;
+	}
+	if (requirements.length === 0) {
+		return baseSummary;
+	}
+	const requirementSet = createRequirementSet(requirements);
+	const filtered = filterEntries(baseSummary, requirementSet);
+	return filtered.length > 0 ? filtered : undefined;
+}


### PR DESCRIPTION
## Summary
- move the focus gradient definitions into a dedicated utility next to ActionCard
- extract the summary filtering helper into its own module and reuse it from ActionCard
- keep ActionCard focused on rendering by importing the extracted helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2527cf9b08325b70f7f78aedf7a94