### PR TITLE
Restore phase history tab selection in main phase

### DIFF
--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -74,7 +74,7 @@ const PhasePanel = React.forwardRef<HTMLDivElement, PhasePanelProps>(
 				if (!tabsEnabled) {
 					return;
 				}
-				setDisplayPhase(phase.id);
+				setDisplayPhase(phase.id, { manual: true });
 				const nextSteps: PhaseStep[] = phaseHistories[phase.id] ?? [];
 				setPhaseSteps(nextSteps);
 			};

--- a/packages/web/src/state/GameContext.types.ts
+++ b/packages/web/src/state/GameContext.types.ts
@@ -26,7 +26,7 @@ export interface GameEngineContextValue {
 	phaseTimer: number;
 	mainApStart: number;
 	displayPhase: string;
-	setDisplayPhase: (id: string) => void;
+	setDisplayPhase: (id: string, options?: { manual?: boolean }) => void;
 	phaseHistories: Record<string, PhaseStep[]>;
 	tabsEnabled: boolean;
 	actionCostResource: ResourceKey;

--- a/packages/web/src/state/useMainPhaseTracker.ts
+++ b/packages/web/src/state/useMainPhaseTracker.ts
@@ -11,7 +11,8 @@ interface MainPhaseTrackerOptions {
 	setPhaseHistories: React.Dispatch<
 		React.SetStateAction<Record<string, PhaseStep[]>>
 	>;
-	setDisplayPhase: (phase: string) => void;
+	setDisplayPhase: (phase: string, options?: { manual?: boolean }) => void;
+	isManualPhasePinned: (phase: string) => boolean;
 }
 
 export function useMainPhaseTracker({
@@ -21,6 +22,7 @@ export function useMainPhaseTracker({
 	setPhaseSteps,
 	setPhaseHistories,
 	setDisplayPhase,
+	isManualPhasePinned,
 }: MainPhaseTrackerOptions) {
 	const [mainApStart, setMainApStart] = useState(0);
 
@@ -45,15 +47,22 @@ export function useMainPhaseTracker({
 					active: remaining > 0,
 				},
 			];
-			setPhaseSteps(steps);
 			if (actionPhaseId) {
 				setPhaseHistories((prev) => ({
 					...prev,
 					[actionPhaseId]: steps,
 				}));
-				setDisplayPhase(actionPhaseId);
-			} else {
-				setDisplayPhase(ctx.game.currentPhase);
+			}
+			const shouldDeferUpdate = Boolean(
+				actionPhaseId && isManualPhasePinned(actionPhaseId),
+			);
+			if (!shouldDeferUpdate) {
+				setPhaseSteps(steps);
+				if (actionPhaseId) {
+					setDisplayPhase(actionPhaseId);
+				} else {
+					setDisplayPhase(ctx.game.currentPhase);
+				}
 			}
 		},
 		[
@@ -62,6 +71,7 @@ export function useMainPhaseTracker({
 			ctx,
 			mainApStart,
 			setDisplayPhase,
+			isManualPhasePinned,
 			setPhaseHistories,
 			setPhaseSteps,
 		],

--- a/packages/web/src/state/usePhaseDisplay.ts
+++ b/packages/web/src/state/usePhaseDisplay.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface PhaseDisplayOptions {
+	manual?: boolean;
+}
+
+export function usePhaseDisplay(initialPhase: string) {
+	const [displayPhase, setDisplayPhase] = useState(initialPhase);
+	const [tabsEnabled, setTabsEnabled] = useState(false);
+	const manualPhaseRef = useRef<string | null>(null);
+	const tabsEnabledRef = useRef(tabsEnabled);
+
+	useEffect(() => {
+		tabsEnabledRef.current = tabsEnabled;
+		if (!tabsEnabled) {
+			manualPhaseRef.current = null;
+		}
+	}, [tabsEnabled]);
+
+	const updateDisplayPhase = useCallback(
+		(phase: string, options?: PhaseDisplayOptions) => {
+			if (options?.manual && tabsEnabledRef.current) {
+				manualPhaseRef.current = phase;
+			} else if (
+				tabsEnabledRef.current &&
+				manualPhaseRef.current &&
+				manualPhaseRef.current !== phase
+			) {
+				return;
+			} else {
+				manualPhaseRef.current = null;
+			}
+			setDisplayPhase(phase);
+		},
+		[],
+	);
+
+	const isManualPhasePinned = useCallback((phase: string) => {
+		if (!tabsEnabledRef.current) {
+			return false;
+		}
+		const manualPhase = manualPhaseRef.current;
+		if (!manualPhase) {
+			return false;
+		}
+		return manualPhase !== phase;
+	}, []);
+
+	return {
+		displayPhase,
+		setDisplayPhase: updateDisplayPhase,
+		tabsEnabled,
+		setTabsEnabled,
+		isManualPhasePinned,
+	};
+}

--- a/packages/web/src/state/usePhaseProgress.ts
+++ b/packages/web/src/state/usePhaseProgress.ts
@@ -6,7 +6,7 @@ import { describeSkipEvent } from '../utils/describeSkipEvent';
 import type { PhaseStep } from './phaseTypes';
 import { usePhaseDelays } from './usePhaseDelays';
 import { useMainPhaseTracker } from './useMainPhaseTracker';
-
+import { usePhaseDisplay } from './usePhaseDisplay';
 interface PhaseProgressOptions {
 	ctx: EngineContext;
 	actionPhaseId: string | undefined;
@@ -23,7 +23,6 @@ interface PhaseProgressOptions {
 	resourceKeys: ResourceKey[];
 	enqueue: <T>(task: () => Promise<T> | T) => Promise<T>;
 }
-
 export function usePhaseProgress({
 	ctx,
 	actionPhaseId,
@@ -39,12 +38,16 @@ export function usePhaseProgress({
 }: PhaseProgressOptions) {
 	const [phaseSteps, setPhaseSteps] = useState<PhaseStep[]>([]);
 	const [phaseTimer, setPhaseTimer] = useState(0);
-	const [displayPhase, setDisplayPhase] = useState(ctx.game.currentPhase);
 	const [phaseHistories, setPhaseHistories] = useState<
 		Record<string, PhaseStep[]>
 	>({});
-	const [tabsEnabled, setTabsEnabled] = useState(false);
-
+	const {
+		displayPhase,
+		setDisplayPhase,
+		tabsEnabled,
+		setTabsEnabled,
+		isManualPhasePinned,
+	} = usePhaseDisplay(ctx.game.currentPhase);
 	const { mainApStart, setMainApStart, updateMainPhaseStep } =
 		useMainPhaseTracker({
 			ctx,
@@ -53,8 +56,8 @@ export function usePhaseProgress({
 			setPhaseSteps,
 			setPhaseHistories,
 			setDisplayPhase,
+			isManualPhasePinned,
 		});
-
 	const { runDelay, runStepDelay } = usePhaseDelays({
 		mountedRef,
 		timeScaleRef,
@@ -62,7 +65,6 @@ export function usePhaseProgress({
 		clearTrackedInterval,
 		setPhaseTimer,
 	});
-
 	const runUntilActionPhaseCore = useCallback(async () => {
 		if (ctx.phases[ctx.game.phaseIndex]?.action) {
 			if (!mountedRef.current) {
@@ -196,7 +198,6 @@ export function usePhaseProgress({
 		runStepDelay,
 		updateMainPhaseStep,
 	]);
-
 	const runUntilActionPhase = useCallback(
 		() => enqueue(runUntilActionPhaseCore),
 		[enqueue, runUntilActionPhaseCore],


### PR DESCRIPTION
## Summary
- add a dedicated phase display hook that tracks manual tab selections and preserves them while the main phase is active
- update the phase panel and phase progress tracking to respect manual history browsing and avoid resetting the view during action updates
- extend the main phase tracker and context types to allow conditional tab updates when a manual selection is pinned

## Testing
- npm run test:quick

------
https://chatgpt.com/codex/tasks/task_e_68e25012f7e48325ad18b7bc4d82fb7e