### PR TITLE
Handle unknown action traces for Royal Decree

### DIFF
--- a/packages/web/src/state/useActionPerformer.ts
+++ b/packages/web/src/state/useActionPerformer.ts
@@ -88,7 +88,12 @@ export function useActionPerformer({
 
 				const subLines: string[] = [];
 				for (const trace of traces) {
-					const subStep = ctx.actions.get(trace.id);
+					let subStep;
+					try {
+						subStep = ctx.actions.get(trace.id);
+					} catch {
+						continue;
+					}
 					const subResolved = resolveActionEffects(subStep);
 					const subChanges = diffStepSnapshots(
 						trace.before,
@@ -101,8 +106,8 @@ export function useActionPerformer({
 						continue;
 					}
 					subLines.push(...subChanges);
-					const icon = ctx.actions.get(trace.id)?.icon || '';
-					const name = ctx.actions.get(trace.id).name;
+					const icon = typeof subStep.icon === 'string' ? subStep.icon : '';
+					const name = subStep.name;
 					const line = `  ${icon} ${name}`;
 					const index = messages.indexOf(line);
 					if (index !== -1) {

--- a/packages/web/tests/useActionPerformer.test.ts
+++ b/packages/web/tests/useActionPerformer.test.ts
@@ -1,0 +1,127 @@
+/** @vitest-environment jsdom */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useActionPerformer } from '../src/state/useActionPerformer';
+import type { Action } from '../src/state/actionTypes';
+import type { EngineContext } from '@kingdom-builder/engine';
+
+const mockSnapshot = {
+	resources: {},
+	stats: {},
+	buildings: [],
+	lands: [],
+	passives: [],
+};
+
+const getActionCostsMock = vi.fn(() => ({}));
+const performActionMock = vi.fn(() => [
+	{ id: 'house', before: mockSnapshot, after: mockSnapshot },
+]);
+const resolveActionEffectsMock = vi.fn(() => ({
+	effects: [],
+	groups: [],
+	choices: {},
+	missingSelections: [],
+	params: {},
+	steps: [],
+}));
+const simulateActionMock = vi.fn();
+
+vi.mock('@kingdom-builder/engine', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		getActionCosts: (...args: unknown[]) => getActionCostsMock(...args),
+		performAction: (...args: unknown[]) => performActionMock(...args),
+		resolveActionEffects: (...args: unknown[]) =>
+			resolveActionEffectsMock(...args),
+		simulateAction: (...args: unknown[]) => simulateActionMock(...args),
+	};
+});
+
+const diffStepSnapshotsMock = vi.fn(() => []);
+const logContentMock = vi.fn(() => []);
+const snapshotPlayerMock = vi.fn(() => mockSnapshot);
+
+vi.mock('../src/translation', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		diffStepSnapshots: (...args: unknown[]) => diffStepSnapshotsMock(...args),
+		logContent: (...args: unknown[]) => logContentMock(...args),
+		snapshotPlayer: (...args: unknown[]) => snapshotPlayerMock(...args),
+	};
+});
+
+describe('useActionPerformer', () => {
+	beforeEach(() => {
+		getActionCostsMock.mockClear();
+		performActionMock.mockClear();
+		resolveActionEffectsMock.mockClear();
+		simulateActionMock.mockClear();
+		diffStepSnapshotsMock.mockClear();
+		logContentMock.mockClear();
+		snapshotPlayerMock.mockClear();
+	});
+
+	it('skips trace logging when the referenced action is unknown', async () => {
+		const action: Action = { id: 'royal_decree', name: 'Royal Decree' };
+		const actions = new Map([
+			[
+				action.id,
+				{ id: action.id, name: action.name, icon: '📜', effects: [] },
+			],
+		]);
+		const ctx = {
+			actions: {
+				get(id: string) {
+					const definition = actions.get(id);
+					if (!definition) {
+						throw new Error(`Unknown id: ${id}`);
+					}
+					return definition;
+				},
+				map: actions,
+			},
+			activePlayer: {
+				id: 'A',
+				resources: { ap: 3 },
+				lands: [],
+			},
+			game: { devMode: false },
+		} as unknown as EngineContext;
+		const addLog = vi.fn();
+		const logWithEffectDelay = vi.fn(() => Promise.resolve(undefined));
+		const updateMainPhaseStep = vi.fn();
+		const refresh = vi.fn();
+		const pushErrorToast = vi.fn();
+		const mountedRef = { current: true };
+		const endTurn = vi.fn(() => Promise.resolve(undefined));
+		const enqueue = vi.fn(async (task: () => Promise<void> | void) => {
+			return await task();
+		});
+
+		const { result } = renderHook(() =>
+			useActionPerformer({
+				ctx,
+				actionCostResource: 'ap',
+				addLog,
+				logWithEffectDelay,
+				updateMainPhaseStep,
+				refresh,
+				pushErrorToast,
+				mountedRef,
+				endTurn,
+				enqueue,
+				resourceKeys: [],
+			}),
+		);
+
+		await act(async () => {
+			await result.current.handlePerform(action);
+		});
+
+		expect(pushErrorToast).not.toHaveBeenCalled();
+		expect(logWithEffectDelay).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- guard action trace logging in the web action performer so effect group selections without registered nested actions no longer fail
- add a regression test covering Royal Decree to ensure unknown nested traces are ignored during log generation

## Testing
- npm test -- useActionPerformer
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e251a1705483259f4c88c4847c7c8e