### PR TITLE
Fix main phase history tabs while action phase is active

### DIFF
--- a/packages/web/src/state/useMainPhaseTracker.ts
+++ b/packages/web/src/state/useMainPhaseTracker.ts
@@ -12,6 +12,7 @@ interface MainPhaseTrackerOptions {
 		React.SetStateAction<Record<string, PhaseStep[]>>
 	>;
 	setDisplayPhase: (phase: string) => void;
+	getDisplayPhase: () => string;
 }
 
 export function useMainPhaseTracker({
@@ -21,6 +22,7 @@ export function useMainPhaseTracker({
 	setPhaseSteps,
 	setPhaseHistories,
 	setDisplayPhase,
+	getDisplayPhase,
 }: MainPhaseTrackerOptions) {
 	const [mainApStart, setMainApStart] = useState(0);
 
@@ -52,13 +54,21 @@ export function useMainPhaseTracker({
 					active: remaining > 0,
 				},
 			];
-			setPhaseSteps(steps);
+			const currentDisplay = getDisplayPhase();
+			const shouldShowAction = actionPhaseId
+				? currentDisplay === actionPhaseId
+				: currentDisplay === snapshot.game.currentPhase;
+			if (shouldShowAction) {
+				setPhaseSteps(steps);
+			}
 			if (actionPhaseId) {
 				setPhaseHistories((prev) => ({
 					...prev,
 					[actionPhaseId]: steps,
 				}));
-				setDisplayPhase(actionPhaseId);
+				if (shouldShowAction) {
+					setDisplayPhase(actionPhaseId);
+				}
 			} else {
 				setDisplayPhase(snapshot.game.currentPhase);
 			}
@@ -71,6 +81,7 @@ export function useMainPhaseTracker({
 			setDisplayPhase,
 			setPhaseHistories,
 			setPhaseSteps,
+			getDisplayPhase,
 		],
 	);
 

--- a/packages/web/src/state/usePhaseProgress.ts
+++ b/packages/web/src/state/usePhaseProgress.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
 	type EngineSession,
 	type EngineSessionSnapshot,
@@ -48,6 +48,13 @@ export function usePhaseProgress({
 		Record<string, PhaseStep[]>
 	>({});
 	const [tabsEnabled, setTabsEnabled] = useState(false);
+	const displayPhaseRef = useRef(displayPhase);
+
+	useEffect(() => {
+		displayPhaseRef.current = displayPhase;
+	}, [displayPhase]);
+
+	const getDisplayPhase = useCallback(() => displayPhaseRef.current, []);
 
 	const { mainApStart, setMainApStart, updateMainPhaseStep } =
 		useMainPhaseTracker({
@@ -57,6 +64,7 @@ export function usePhaseProgress({
 			setPhaseSteps,
 			setPhaseHistories,
 			setDisplayPhase,
+			getDisplayPhase,
 		});
 
 	const { runDelay, runStepDelay } = usePhaseDelays({

--- a/packages/web/src/state/usePhaseProgress.ts
+++ b/packages/web/src/state/usePhaseProgress.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type SetStateAction,
+} from 'react';
 import {
 	type EngineSession,
 	type EngineSessionSnapshot,
@@ -41,18 +47,24 @@ export function usePhaseProgress({
 }: PhaseProgressOptions) {
 	const [phaseSteps, setPhaseSteps] = useState<PhaseStep[]>([]);
 	const [phaseTimer, setPhaseTimer] = useState(0);
-	const [displayPhase, setDisplayPhase] = useState(
+	const [displayPhaseState, setDisplayPhaseState] = useState(
 		sessionState.game.currentPhase,
 	);
 	const [phaseHistories, setPhaseHistories] = useState<
 		Record<string, PhaseStep[]>
 	>({});
 	const [tabsEnabled, setTabsEnabled] = useState(false);
-	const displayPhaseRef = useRef(displayPhase);
+	const displayPhaseRef = useRef(displayPhaseState);
 
-	useEffect(() => {
-		displayPhaseRef.current = displayPhase;
-	}, [displayPhase]);
+	const setDisplayPhase = useCallback((next: SetStateAction<string>) => {
+		setDisplayPhaseState((prev) => {
+			const resolved = typeof next === 'function' ? next(prev) : next;
+			displayPhaseRef.current = resolved;
+			return resolved;
+		});
+	}, []);
+
+	const displayPhase = displayPhaseState;
 
 	const getDisplayPhase = useCallback(() => displayPhaseRef.current, []);
 

--- a/packages/web/src/state/usePhaseProgress.ts
+++ b/packages/web/src/state/usePhaseProgress.ts
@@ -57,11 +57,10 @@ export function usePhaseProgress({
 	const displayPhaseRef = useRef(displayPhaseState);
 
 	const setDisplayPhase = useCallback((next: SetStateAction<string>) => {
-		setDisplayPhaseState((prev) => {
-			const resolved = typeof next === 'function' ? next(prev) : next;
-			displayPhaseRef.current = resolved;
-			return resolved;
-		});
+		const resolved =
+			typeof next === 'function' ? next(displayPhaseRef.current) : next;
+		displayPhaseRef.current = resolved;
+		setDisplayPhaseState(resolved);
 	}, []);
 
 	const displayPhase = displayPhaseState;


### PR DESCRIPTION
## Summary
* Track the currently displayed phase in `usePhaseProgress` so manual tab selections persist while main-phase progress updates run.【F:packages/web/src/state/usePhaseProgress.ts†L42-L68】
* Gate `useMainPhaseTracker` step updates on the active tab so action phase recalculations stop overwriting previously resolved phase histories.【F:packages/web/src/state/useMainPhaseTracker.ts†L45-L74】

## Text formatting audit (required)
1. **Translator/formatter reuse:** No translators or formatters were modified; existing behaviour is unchanged.【F:packages/web/src/state/usePhaseProgress.ts†L1-L160】
2. **Canonical keywords/icons/helpers touched:** None of the canonical keywords, icons, or helpers were touched in this change set.【F:packages/web/src/state/useMainPhaseTracker.ts†L1-L88】
3. **Voice review:** No player-facing text was added or updated, so no voice review was required.【F:packages/web/src/state/usePhaseProgress.ts†L1-L160】

## Standards compliance (required)
1. **File length limits respected:** `usePhaseProgress.ts` and `useMainPhaseTracker.ts` remain well under the 250-line limit, topping out at 160 and 88 lines respectively.【F:packages/web/src/state/usePhaseProgress.ts†L1-L160】【F:packages/web/src/state/useMainPhaseTracker.ts†L1-L88】
2. **Line length limits respected:** `npm run check` (which includes `format:check`) passed, confirming compliance with the repository’s formatting rules including the 80-character limit.【b8d5aa†L1-L19】
3. **Domain separation upheld:** Changes are limited to the web state layer and do not introduce cross-domain dependencies.【F:packages/web/src/state/usePhaseProgress.ts†L42-L140】【F:packages/web/src/state/useMainPhaseTracker.ts†L45-L74】
4. **Code standards satisfied:** `npm run check` succeeded, covering linting and style enforcement for the modified files.【b8d5aa†L1-L19】
5. **Tests updated:** Existing tests already cover the interaction; the targeted `phase-history` suite continues to pass with these changes.【ec685d†L1-L17】
6. **Documentation updated:** No documentation changes were required for this behavioural fix.【F:packages/web/src/state/usePhaseProgress.ts†L42-L68】
7. **`npm run check` results:** See `npm run check` output showing successful completion.【b8d5aa†L1-L19】
8. **`npm run test:coverage` results:** See `npm run test:coverage` output with coverage summary.【ccf25a†L1-L19】

## Testing
* `npm run check`
* `npm run test:coverage`
* `npm run test -- packages/web/tests/phase-history.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e255b7dc848325a4d0256f341c87ba