### PR TITLE
refactor: extract builder shared primitives

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -7,18 +7,6 @@ import {
 	action,
 	effect,
 	compareRequirement,
-	Types,
-	LandMethods,
-	ResourceMethods,
-	DevelopmentMethods,
-	PopulationMethods,
-	ActionMethods,
-	AttackMethods,
-	PassiveMethods,
-	CostModMethods,
-	ResultModMethods,
-	BuildingMethods,
-	StatMethods,
 	resourceParams,
 	statParams,
 	developmentParams,
@@ -35,6 +23,20 @@ import {
 	actionEffectGroup,
 	actionEffectGroupOption,
 } from './config/builders';
+import {
+	Types,
+	LandMethods,
+	ResourceMethods,
+	DevelopmentMethods,
+	PopulationMethods,
+	ActionMethods,
+	AttackMethods,
+	PassiveMethods,
+	CostModMethods,
+	ResultModMethods,
+	BuildingMethods,
+	StatMethods,
+} from './config/builderShared';
 import type { Focus } from './defs';
 
 export interface ActionDef extends ActionConfig {

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -9,13 +9,6 @@ import { Stat } from './stats';
 import {
 	building,
 	effect,
-	Types,
-	CostModMethods,
-	ResultModMethods,
-	ResourceMethods,
-	ActionMethods,
-	PassiveMethods,
-	StatMethods,
 	resourceParams,
 	actionParams,
 	resultModParams,
@@ -25,6 +18,15 @@ import {
 	costModParams,
 	statParams,
 } from './config/builders';
+import {
+	Types,
+	CostModMethods,
+	ResultModMethods,
+	ResourceMethods,
+	ActionMethods,
+	PassiveMethods,
+	StatMethods,
+} from './config/builderShared';
 import type { BuildingDef } from './defs';
 
 export type { BuildingDef } from './defs';

--- a/packages/contents/src/config/builderShared.ts
+++ b/packages/contents/src/config/builderShared.ts
@@ -1,0 +1,106 @@
+export const Types = {
+	Land: 'land',
+	Resource: 'resource',
+	Building: 'building',
+	Development: 'development',
+	Passive: 'passive',
+	CostMod: 'cost_mod',
+	ResultMod: 'result_mod',
+	Population: 'population',
+	Action: 'action',
+	Attack: 'attack',
+	Stat: 'stat',
+} as const;
+
+export const LandMethods = {
+	ADD: 'add',
+	TILL: 'till',
+} as const;
+
+export const ResourceMethods = {
+	ADD: 'add',
+	REMOVE: 'remove',
+	TRANSFER: 'transfer',
+} as const;
+
+export const BuildingMethods = {
+	ADD: 'add',
+	REMOVE: 'remove',
+} as const;
+
+export const DevelopmentMethods = {
+	ADD: 'add',
+	REMOVE: 'remove',
+} as const;
+
+export const PassiveMethods = {
+	ADD: 'add',
+	REMOVE: 'remove',
+} as const;
+
+export const CostModMethods = {
+	ADD: 'add',
+	REMOVE: 'remove',
+} as const;
+
+export const ResultModMethods = {
+	ADD: 'add',
+	REMOVE: 'remove',
+} as const;
+
+export const PopulationMethods = {
+	ADD: 'add',
+	REMOVE: 'remove',
+} as const;
+
+export const ActionMethods = {
+	ADD: 'add',
+	REMOVE: 'remove',
+	PERFORM: 'perform',
+} as const;
+
+export const AttackMethods = {
+	PERFORM: 'perform',
+} as const;
+
+export const StatMethods = {
+	ADD: 'add',
+	ADD_PCT: 'add_pct',
+	REMOVE: 'remove',
+} as const;
+
+export const RequirementTypes = {
+	Evaluator: 'evaluator',
+} as const;
+
+export type Params = Record<string, unknown>;
+
+export abstract class ParamsBuilder<P extends Params = Params> {
+	protected params: P;
+	private readonly assigned = new Set<keyof P>();
+
+	constructor(initial?: P) {
+		this.params = initial ?? ({} as P);
+	}
+
+	protected wasSet(key: keyof P) {
+		return this.assigned.has(key);
+	}
+
+	protected set<K extends keyof P>(key: K, value: P[K], message?: string) {
+		if (this.assigned.has(key)) {
+			throw new Error(
+				message ??
+					`You already set ${String(key)} for this configuration. ` +
+						`Remove the extra ${String(key)} call.`,
+			);
+		}
+		this.params[key] = value;
+		this.assigned.add(key);
+		return this;
+	}
+
+	build(): P {
+		return this.params;
+	}
+}

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -26,114 +26,13 @@ import type { ResourceKey } from '../resources';
 import type { StatKey } from '../stats';
 import type { PopulationRoleId } from '../populationRoles';
 import type { TriggerKey } from '../defs';
-
-export const Types = {
-	Land: 'land',
-	Resource: 'resource',
-	Building: 'building',
-	Development: 'development',
-	Passive: 'passive',
-	CostMod: 'cost_mod',
-	ResultMod: 'result_mod',
-	Population: 'population',
-	Action: 'action',
-	Attack: 'attack',
-	Stat: 'stat',
-} as const;
-
-export const LandMethods = {
-	ADD: 'add',
-	TILL: 'till',
-} as const;
-
-export const ResourceMethods = {
-	ADD: 'add',
-	REMOVE: 'remove',
-	TRANSFER: 'transfer',
-} as const;
-
-export const BuildingMethods = {
-	ADD: 'add',
-	REMOVE: 'remove',
-} as const;
-
-export const DevelopmentMethods = {
-	ADD: 'add',
-	REMOVE: 'remove',
-} as const;
-
-export const PassiveMethods = {
-	ADD: 'add',
-	REMOVE: 'remove',
-} as const;
-
-export const CostModMethods = {
-	ADD: 'add',
-	REMOVE: 'remove',
-} as const;
-
-export const ResultModMethods = {
-	ADD: 'add',
-	REMOVE: 'remove',
-} as const;
-
-export const PopulationMethods = {
-	ADD: 'add',
-	REMOVE: 'remove',
-} as const;
-
-export const ActionMethods = {
-	ADD: 'add',
-	REMOVE: 'remove',
-	PERFORM: 'perform',
-} as const;
-
-export const AttackMethods = {
-	PERFORM: 'perform',
-} as const;
-
-export const StatMethods = {
-	ADD: 'add',
-	ADD_PCT: 'add_pct',
-	REMOVE: 'remove',
-} as const;
-
-export const RequirementTypes = {
-	Evaluator: 'evaluator',
-} as const;
-
-type Params = Record<string, unknown>;
-
-abstract class ParamsBuilder<P extends Params = Params> {
-	protected params: P;
-	private readonly assigned = new Set<keyof P>();
-
-	constructor(initial?: P) {
-		this.params = initial ?? ({} as P);
-	}
-
-	protected wasSet(key: keyof P) {
-		return this.assigned.has(key);
-	}
-
-	protected set<K extends keyof P>(key: K, value: P[K], message?: string) {
-		if (this.assigned.has(key)) {
-			throw new Error(
-				message ??
-					`You already set ${String(
-						key,
-					)} for this configuration. Remove the extra ${String(key)} call.`,
-			);
-		}
-		this.params[key] = value;
-		this.assigned.add(key);
-		return this;
-	}
-
-	build(): P {
-		return this.params;
-	}
-}
+import {
+	Types,
+	PassiveMethods,
+	RequirementTypes,
+	ParamsBuilder,
+} from './builderShared';
+import type { Params } from './builderShared';
 
 function resolveEffectConfig(effect: EffectConfig | EffectBuilder) {
 	return effect instanceof EffectBuilder ? effect.build() : effect;

--- a/packages/contents/src/developments.ts
+++ b/packages/contents/src/developments.ts
@@ -4,15 +4,17 @@ import { Resource } from './resources';
 import {
 	development,
 	effect,
-	Types,
-	StatMethods,
-	DevelopmentMethods,
-	ResourceMethods,
 	resourceParams,
 	statParams,
 	developmentParams,
 	developmentEvaluator,
 } from './config/builders';
+import {
+	Types,
+	StatMethods,
+	DevelopmentMethods,
+	ResourceMethods,
+} from './config/builderShared';
 import type { DevelopmentDef } from './defs';
 
 export type { DevelopmentDef } from './defs';

--- a/packages/contents/src/happinessHelpers.ts
+++ b/packages/contents/src/happinessHelpers.ts
@@ -1,16 +1,18 @@
 import type { EffectConfig } from '@kingdom-builder/protocol';
 import {
-	Types,
-	CostModMethods,
-	ResultModMethods,
-	StatMethods,
 	costModParams,
 	developmentTarget,
 	resultModParams,
 	statParams,
 	effect,
-	PassiveMethods,
 } from './config/builders';
+import {
+	Types,
+	CostModMethods,
+	ResultModMethods,
+	StatMethods,
+	PassiveMethods,
+} from './config/builderShared';
 import type { passiveParams } from './config/builders';
 import { Resource } from './resources';
 import { Stat } from './stats';

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -2,8 +2,6 @@ import { Stat } from './stats';
 import { PopulationRole } from './populationRoles';
 import {
 	effect,
-	Types,
-	StatMethods,
 	phase,
 	step,
 	populationEvaluator,
@@ -12,6 +10,7 @@ import {
 	statEvaluator,
 	type PhaseDef,
 } from './config/builders';
+import { Types, StatMethods } from './config/builderShared';
 import {
 	ON_GAIN_AP_STEP,
 	ON_GAIN_INCOME_STEP,

--- a/packages/contents/src/populations.ts
+++ b/packages/contents/src/populations.ts
@@ -5,14 +5,16 @@ import { Stat } from './stats';
 import {
 	population,
 	effect,
-	Types,
-	ResourceMethods,
-	PassiveMethods,
-	StatMethods,
 	resourceParams,
 	statParams,
 	populationEvaluator,
 } from './config/builders';
+import {
+	Types,
+	ResourceMethods,
+	PassiveMethods,
+	StatMethods,
+} from './config/builderShared';
 import type { PopulationDef } from './defs';
 
 export type { PopulationDef } from './defs';

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -10,10 +10,9 @@ import {
 	attackParams,
 	transferParams,
 	happinessTier,
-	Types,
-	PassiveMethods,
 	populationParams,
 } from '../src/config/builders';
+import { Types, PassiveMethods } from '../src/config/builderShared';
 import { RESOURCES, type ResourceKey } from '../src/resources';
 import { STATS, type StatKey } from '../src/stats';
 import { describe, expect, it } from 'vitest';

--- a/packages/engine/tests/actions/simulate-action.test.ts
+++ b/packages/engine/tests/actions/simulate-action.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { simulateAction, performAction } from '../../src/index.ts';
 import { createTestEngine } from '../helpers.ts';
 import { createContentFactory } from '../factories/content.ts';
-import { LandMethods } from '@kingdom-builder/contents/config/builders';
+import { LandMethods } from '@kingdom-builder/contents/config/builderShared';
 
 describe('simulateAction', () => {
 	it('does not mutate state when previewing an action', () => {

--- a/packages/engine/tests/advance-skip.test.ts
+++ b/packages/engine/tests/advance-skip.test.ts
@@ -4,9 +4,11 @@ import {
 	happinessTier,
 	effect,
 	passiveParams,
+} from '@kingdom-builder/contents/config/builders';
+import {
 	Types,
 	PassiveMethods,
-} from '@kingdom-builder/contents/config/builders';
+} from '@kingdom-builder/contents/config/builderShared';
 import { advance } from '../src';
 import { createTestEngine } from './helpers';
 import type { RuleSet } from '../src/services';

--- a/packages/engine/tests/effects/till_land.test.ts
+++ b/packages/engine/tests/effects/till_land.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { performAction } from '../../src/index.ts';
 import { createTestEngine } from '../helpers.ts';
 import { createContentFactory } from '../factories/content.ts';
-import { LandMethods } from '@kingdom-builder/contents/config/builders';
+import { LandMethods } from '@kingdom-builder/contents/config/builderShared';
 
 describe('land:till effect', () => {
 	it('tills the specified land and marks it as tilled', () => {

--- a/packages/engine/tests/happiness-tier-controller.test.ts
+++ b/packages/engine/tests/happiness-tier-controller.test.ts
@@ -8,9 +8,11 @@ import {
 	happinessTier,
 	effect,
 	passiveParams,
+} from '@kingdom-builder/contents/config/builders';
+import {
 	Types,
 	PassiveMethods,
-} from '@kingdom-builder/contents/config/builders';
+} from '@kingdom-builder/contents/config/builderShared';
 import { runEffects, getActionCosts } from '../src';
 import { createTestEngine } from './helpers';
 import { createContentFactory } from './factories/content';

--- a/packages/engine/tests/services/rules.test.ts
+++ b/packages/engine/tests/services/rules.test.ts
@@ -7,9 +7,11 @@ import {
 	happinessTier,
 	effect,
 	passiveParams,
+} from '@kingdom-builder/contents/config/builders';
+import {
 	Types,
 	PassiveMethods,
-} from '@kingdom-builder/contents/config/builders';
+} from '@kingdom-builder/contents/config/builderShared';
 import { getActionCosts } from '../../src';
 import { createContentFactory } from '../factories/content';
 

--- a/packages/web/tests/army-attack-translation.test.ts
+++ b/packages/web/tests/army-attack-translation.test.ts
@@ -27,15 +27,17 @@ import {
 } from '../src/translation/effects/formatters/attack/shared';
 import {
 	effect,
-	Types,
-	ResourceMethods,
-	ActionMethods,
-	StatMethods,
 	attackParams,
 	resourceParams,
 	transferParams,
 	statParams,
 } from '@kingdom-builder/contents/config/builders';
+import {
+	Types,
+	ResourceMethods,
+	ActionMethods,
+	StatMethods,
+} from '@kingdom-builder/contents/config/builderShared';
 import { createContentFactory } from '../../engine/tests/factories/content';
 import type { PhaseDef } from '@kingdom-builder/engine/phases';
 import type { StartConfig } from '@kingdom-builder/protocol';

--- a/packages/web/tests/land-till-formatter.test.ts
+++ b/packages/web/tests/land-till-formatter.test.ts
@@ -12,7 +12,7 @@ import {
 	RULES,
 	SLOT_INFO,
 } from '@kingdom-builder/contents';
-import { LandMethods } from '@kingdom-builder/contents/config/builders';
+import { LandMethods } from '@kingdom-builder/contents/config/builderShared';
 
 vi.mock('@kingdom-builder/engine', async () => {
 	return await import('../../engine/src');

--- a/tests/integration/synthetic.ts
+++ b/tests/integration/synthetic.ts
@@ -17,9 +17,11 @@ import {
 	happinessTier,
 	effect,
 	passiveParams,
+} from '@kingdom-builder/contents/config/builders';
+import {
 	Types,
 	PassiveMethods,
-} from '@kingdom-builder/contents/config/builders';
+} from '@kingdom-builder/contents/config/builderShared';
 
 export function createSyntheticContext() {
 	const costKey = 'r0';


### PR DESCRIPTION
## Summary
- extract the shared builder constants and parameter helper into `builderShared.ts`
- update contents builders and every consumer to import the shared primitives from the new module
- keep cross-package tests compiling by pointing them at `builderShared.ts`

## Text formatting audit (required)
1. **Translator/formatter reuse:** No player-facing translators or formatters were added or modified; existing flows remain unchanged.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** No player-facing strings were introduced or updated, so no voice changes were required.

## Standards compliance (required)
1. **File length limits respected:** `packages/contents/src/config/builderShared.ts` is 106 lines long (<250), and all other touched files remain within existing limits.
2. **Line length limits respected:** Prettier enforcement inside `npm run check` verified max line length compliance (see `/tmp/commit.log`).
3. **Domain separation upheld:** Only the content package and its engine/web consumers were updated to reference the extracted shared module; no engine or web runtime logic was changed.
4. **Code standards satisfied:** `npm run lint` completed successfully (logs in `/tmp/commit.log`).
5. **Tests updated:** Engine and web test imports (e.g., `packages/engine/tests/services/rules.test.ts`) were updated to target `builderShared.ts` so the refactor keeps coverage.
6. **Documentation updated:** Not required because no documentation or text guidelines changed.
7. **`npm run check` results:** Captured in `/tmp/commit.log` from the commit hook run.
8. **`npm run test:coverage` results:** Captured in `/tmp/test_coverage.log`.

## Testing
- `npm run check`
- `npm run lint`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e2553b5e0c8325a49f568e9124c429