### PR TITLE
Fix Royal Decree develop option action parameters

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -211,28 +211,36 @@ export function createActionRegistry() {
 							.label('Raise a House')
 							.icon('🏠')
 							.action('develop')
-							.params(actionParams().id('house').landId('$landId')),
+							.param('actionId', 'develop')
+							.param('id', 'house')
+							.param('landId', '$landId'),
 					)
 					.option(
 						actionEffectGroupOption('royal_decree_farm')
 							.label('Establish a Farm')
 							.icon('🌾')
 							.action('develop')
-							.params(actionParams().id('farm').landId('$landId')),
+							.param('actionId', 'develop')
+							.param('id', 'farm')
+							.param('landId', '$landId'),
 					)
 					.option(
 						actionEffectGroupOption('royal_decree_outpost')
 							.label('Fortify with an Outpost')
 							.icon('🏹')
 							.action('develop')
-							.params(actionParams().id('outpost').landId('$landId')),
+							.param('actionId', 'develop')
+							.param('id', 'outpost')
+							.param('landId', '$landId'),
 					)
 					.option(
 						actionEffectGroupOption('royal_decree_watchtower')
 							.label('Raise a Watchtower')
 							.icon('🗼')
 							.action('develop')
-							.params(actionParams().id('watchtower').landId('$landId')),
+							.param('actionId', 'develop')
+							.param('id', 'watchtower')
+							.param('landId', '$landId'),
 					),
 			)
 			.effect(


### PR DESCRIPTION
## Summary
- ensure Royal Decree's effect group options forward the nested develop action id via their parameters so the action registry resolves correctly

## Text formatting audit (required)
1. **Translator/formatter reuse:** N/A – no text or formatter logic touched.
2. **Canonical keywords/icons/helpers touched:** None – no keyword/icon helpers were modified.
3. **Voice review:** N/A – no player-facing copy was changed.

## Standards compliance (required)
1. **File length limits respected:** Verified `packages/contents/src/actions.ts` remains under repository limits.
2. **Line length limits respected:** All added lines stay within the 80 character guideline.
3. **Domain separation upheld:** Changes are limited to content definitions and do not cross engine/web boundaries.
4. **Code standards satisfied:** Prettier check (`npx prettier --check packages/contents/src/actions.ts`) succeeded locally.
5. **Tests updated:** Existing engine Royal Decree effect group test continues to pass (`npm test -- packages/engine/tests/actions/royal-decree-effect-group.test.ts`).
6. **Documentation updated:** Not required – behaviour change is confined to content configuration.
7. **`npm run check` results:** Not run; relied on targeted formatting check due to scope.
8. **`npm run test:coverage` results:** Not run; focused on the relevant targeted unit test for this fix.

## Testing
- ✅ `npm test -- packages/engine/tests/actions/royal-decree-effect-group.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e25638554c83259f753531bf015355