### PR TITLE
Add shared action ID constants for content builders

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -37,6 +37,24 @@ import {
 } from './config/builders';
 import type { Focus } from './defs';
 
+export const ACTION_ID = {
+	build: 'build',
+	armyAttack: 'army_attack',
+	develop: 'develop',
+	expand: 'expand',
+	holdFestival: 'hold_festival',
+	overwork: 'overwork',
+	plow: 'plow',
+	plunder: 'plunder',
+	raisePop: 'raise_pop',
+	reallocate: 'reallocate',
+	royalDecree: 'royal_decree',
+	tax: 'tax',
+	till: 'till',
+} as const;
+
+export type ActionId = (typeof ACTION_ID)[keyof typeof ACTION_ID];
+
 export interface ActionDef extends ActionConfig {
 	category?: string;
 	order?: number;
@@ -46,9 +64,9 @@ export interface ActionDef extends ActionConfig {
 export function createActionRegistry() {
 	const registry = new Registry<ActionDef>(actionSchema.passthrough());
 
-	registry.add('expand', {
+	registry.add(ACTION_ID.expand, {
 		...action()
-			.id('expand')
+			.id(ACTION_ID.expand)
 			.name('Expand')
 			.icon('🌱')
 			.cost(Resource.ap, 1)
@@ -65,9 +83,9 @@ export function createActionRegistry() {
 		focus: 'economy',
 	});
 
-	registry.add('overwork', {
+	registry.add(ACTION_ID.overwork, {
 		...action()
-			.id('overwork')
+			.id(ACTION_ID.overwork)
 			.name('Overwork')
 			.icon('🛠️')
 			.cost(Resource.ap, 1)
@@ -95,9 +113,9 @@ export function createActionRegistry() {
 		focus: 'economy',
 	});
 
-	registry.add('develop', {
+	registry.add(ACTION_ID.develop, {
 		...action()
-			.id('develop')
+			.id(ACTION_ID.develop)
 			.name('Develop')
 			.icon('🏗️')
 			.cost(Resource.ap, 1)
@@ -113,9 +131,9 @@ export function createActionRegistry() {
 		focus: 'economy',
 	});
 
-	registry.add('tax', {
+	registry.add(ACTION_ID.tax, {
 		...action()
-			.id('tax')
+			.id(ACTION_ID.tax)
 			.name('Tax')
 			.icon('💰')
 			.cost(Resource.ap, 1)
@@ -142,9 +160,9 @@ export function createActionRegistry() {
 		focus: 'economy',
 	});
 
-	registry.add('reallocate', {
+	registry.add(ACTION_ID.reallocate, {
 		...action()
-			.id('reallocate')
+			.id(ACTION_ID.reallocate)
 			.name('Reallocate')
 			.icon('🔄')
 			.cost(Resource.ap, 1)
@@ -155,9 +173,9 @@ export function createActionRegistry() {
 		focus: 'economy',
 	});
 
-	registry.add('raise_pop', {
+	registry.add(ACTION_ID.raisePop, {
 		...action()
-			.id('raise_pop')
+			.id(ACTION_ID.raisePop)
 			.name('Hire')
 			.icon('👶')
 			.cost(Resource.ap, 1)
@@ -186,21 +204,21 @@ export function createActionRegistry() {
 		focus: 'economy',
 	});
 
-	registry.add('royal_decree', {
+	registry.add(ACTION_ID.royalDecree, {
 		...action()
-			.id('royal_decree')
+			.id(ACTION_ID.royalDecree)
 			.name('Royal Decree')
 			.icon('📜')
 			.cost(Resource.ap, 1)
 			.cost(Resource.gold, 12)
 			.effect(
 				effect(Types.Action, ActionMethods.PERFORM)
-					.params(actionParams().id('expand'))
+					.params(actionParams().id(ACTION_ID.expand))
 					.build(),
 			)
 			.effect(
 				effect(Types.Action, ActionMethods.PERFORM)
-					.params(actionParams().id('till').landId('$landId'))
+					.params(actionParams().id(ACTION_ID.till).landId('$landId'))
 					.build(),
 			)
 			.effectGroup(
@@ -210,28 +228,28 @@ export function createActionRegistry() {
 						actionEffectGroupOption('royal_decree_house')
 							.label('Raise a House')
 							.icon('🏠')
-							.action('develop')
+							.action(ACTION_ID.develop)
 							.params(actionParams().id('house').landId('$landId')),
 					)
 					.option(
 						actionEffectGroupOption('royal_decree_farm')
 							.label('Establish a Farm')
 							.icon('🌾')
-							.action('develop')
+							.action(ACTION_ID.develop)
 							.params(actionParams().id('farm').landId('$landId')),
 					)
 					.option(
 						actionEffectGroupOption('royal_decree_outpost')
 							.label('Fortify with an Outpost')
 							.icon('🏹')
-							.action('develop')
+							.action(ACTION_ID.develop)
 							.params(actionParams().id('outpost').landId('$landId')),
 					)
 					.option(
 						actionEffectGroupOption('royal_decree_watchtower')
 							.label('Raise a Watchtower')
 							.icon('🗼')
-							.action('develop')
+							.action(ACTION_ID.develop)
 							.params(actionParams().id('watchtower').landId('$landId')),
 					),
 			)
@@ -247,9 +265,9 @@ export function createActionRegistry() {
 		focus: 'economy',
 	});
 
-	registry.add('army_attack', {
+	registry.add(ACTION_ID.armyAttack, {
 		...action()
-			.id('army_attack')
+			.id(ACTION_ID.armyAttack)
 			.name('Army Attack')
 			.icon('🗡️')
 			.cost(Resource.ap, 1)
@@ -276,7 +294,7 @@ export function createActionRegistry() {
 									.params(resourceParams().key(Resource.happiness).amount(1))
 									.build(),
 								effect(Types.Action, ActionMethods.PERFORM)
-									.params(actionParams().id('plunder'))
+									.params(actionParams().id(ACTION_ID.plunder))
 									.build(),
 							)
 							.onDamageDefender(
@@ -299,9 +317,9 @@ export function createActionRegistry() {
 		focus: 'aggressive',
 	});
 
-	registry.add('hold_festival', {
+	registry.add(ACTION_ID.holdFestival, {
 		...action()
-			.id('hold_festival')
+			.id(ACTION_ID.holdFestival)
 			.name('Hold Festival')
 			.icon('🎉')
 			.cost(Resource.ap, 1)
@@ -344,7 +362,7 @@ export function createActionRegistry() {
 							.params(
 								resultModParams()
 									.id('hold_festival_attack_happiness_penalty')
-									.actionId('army_attack'),
+									.actionId(ACTION_ID.armyAttack),
 							)
 							.effect(
 								effect(Types.Resource, ResourceMethods.REMOVE)
@@ -363,9 +381,9 @@ export function createActionRegistry() {
 	});
 
 	registry.add(
-		'plunder',
+		ACTION_ID.plunder,
 		action()
-			.id('plunder')
+			.id(ACTION_ID.plunder)
 			.name('Plunder')
 			.icon('🏴\u200d☠️')
 			.system()
@@ -380,9 +398,9 @@ export function createActionRegistry() {
 	);
 
 	registry.add(
-		'plow',
+		ACTION_ID.plow,
 		action()
-			.id('plow')
+			.id(ACTION_ID.plow)
 			.name('Plow')
 			.icon('🚜')
 			.system()
@@ -390,12 +408,12 @@ export function createActionRegistry() {
 			.cost(Resource.gold, 6)
 			.effect(
 				effect(Types.Action, ActionMethods.PERFORM)
-					.params(actionParams().id('expand'))
+					.params(actionParams().id(ACTION_ID.expand))
 					.build(),
 			)
 			.effect(
 				effect(Types.Action, ActionMethods.PERFORM)
-					.params(actionParams().id('till'))
+					.params(actionParams().id(ACTION_ID.till))
 					.build(),
 			)
 			.effect(
@@ -425,9 +443,9 @@ export function createActionRegistry() {
 	);
 
 	registry.add(
-		'till',
+		ACTION_ID.till,
 		action()
-			.id('till')
+			.id(ACTION_ID.till)
 			.name('Till')
 			.icon('🧑‍🌾')
 			.system()
@@ -435,9 +453,9 @@ export function createActionRegistry() {
 			.build(),
 	);
 
-	registry.add('build', {
+	registry.add(ACTION_ID.build, {
 		...action()
-			.id('build')
+			.id(ACTION_ID.build)
 			.name('Build')
 			.icon('🏛️')
 			.effect(

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -5,6 +5,7 @@ import {
 	buildingSchema,
 } from '@kingdom-builder/protocol';
 import { Resource } from './resources';
+import { ACTION_ID } from './actions';
 import { Stat } from './stats';
 import {
 	building,
@@ -43,7 +44,7 @@ export function createBuildingRegistry() {
 					.params(
 						costModParams()
 							.id('tc_expand_cost')
-							.actionId('expand')
+							.actionId(ACTION_ID.expand)
 							.key(Resource.gold)
 							.amount(2),
 					)
@@ -51,7 +52,9 @@ export function createBuildingRegistry() {
 			)
 			.onBuild(
 				effect(Types.ResultMod, ResultModMethods.ADD)
-					.params(resultModParams().id('tc_expand_result').actionId('expand'))
+					.params(
+						resultModParams().id('tc_expand_result').actionId(ACTION_ID.expand),
+					)
 					.effect(
 						effect(Types.Resource, ResourceMethods.ADD)
 							.params(resourceParams().key(Resource.happiness).amount(1))
@@ -116,7 +119,7 @@ export function createBuildingRegistry() {
 			.cost(Resource.gold, 10)
 			.onBuild(
 				effect(Types.Action, ActionMethods.ADD)
-					.params(actionParams().id('plow'))
+					.params(actionParams().id(ACTION_ID.plow))
 					.build(),
 			)
 			.build(),

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -26,6 +26,7 @@ import type { ResourceKey } from '../resources';
 import type { StatKey } from '../stats';
 import type { PopulationRoleId } from '../populationRoles';
 import type { TriggerKey } from '../defs';
+import type { ActionId } from '../actions';
 
 export const Types = {
 	Land: 'land',
@@ -211,7 +212,7 @@ class ActionEffectGroupOptionBuilder {
 		);
 	}
 
-	action(actionId: string) {
+	action(actionId: ActionId) {
 		return this.set(
 			'actionId',
 			actionId,
@@ -557,6 +558,8 @@ class ActionEffectParamsBuilder extends ParamsBuilder<{
 	id?: string;
 	landId?: string;
 }> {
+	id(id: ActionId): this;
+	id(id: string): this;
 	id(id: string) {
 		return this.set(
 			'id',
@@ -1027,7 +1030,7 @@ class CostModParamsBuilder extends ParamsBuilder<{
 	id(id: string) {
 		return this.set('id', id);
 	}
-	actionId(actionId: string) {
+	actionId(actionId: ActionId) {
 		return this.set('actionId', actionId);
 	}
 	key(key: ResourceKey) {
@@ -1092,7 +1095,7 @@ class ResultModParamsBuilder extends ParamsBuilder<{
 	id(id: string) {
 		return this.set('id', id);
 	}
-	actionId(actionId: string) {
+	actionId(actionId: ActionId) {
 		return this.set('actionId', actionId);
 	}
 	evaluation(
@@ -1803,6 +1806,10 @@ export class ActionBuilder extends BaseBuilder<ActionBuilderConfig> {
 
 	constructor() {
 		super({ effects: [] }, 'Action');
+	}
+	override id(id: ActionId) {
+		super.id(id);
+		return this;
 	}
 	cost(key: ResourceKey, amount: number) {
 		this.config.baseCosts = this.config.baseCosts || {};

--- a/packages/contents/src/happinessHelpers.ts
+++ b/packages/contents/src/happinessHelpers.ts
@@ -14,12 +14,13 @@ import {
 import type { passiveParams } from './config/builders';
 import { Resource } from './resources';
 import { Stat } from './stats';
+import { ACTION_ID, type ActionId } from './actions';
 import { formatPassiveRemoval } from './text';
 
 export const GROWTH_PHASE_ID = 'growth';
 export const UPKEEP_PHASE_ID = 'upkeep';
 export const WAR_RECOVERY_STEP_ID = 'war-recovery';
-const BUILD_ACTION_ID = 'build';
+const BUILD_ACTION_ID: ActionId = ACTION_ID.build;
 
 const DEVELOPMENT_EVALUATION = developmentTarget();
 

--- a/packages/contents/src/overview.ts
+++ b/packages/contents/src/overview.ts
@@ -1,3 +1,5 @@
+import { ACTION_ID } from './actions';
+
 export type OverviewTokenCategoryName =
 	| 'actions'
 	| 'phases'
@@ -65,11 +67,11 @@ const HERO_PARAGRAPH_TEXT = [
 
 const DEFAULT_TOKENS: OverviewTokenCandidates = {
 	actions: {
-		expand: ['expand'],
-		build: ['build'],
-		develop: ['develop'],
-		raise_pop: ['raise_pop'],
-		army_attack: ['army_attack'],
+		expand: [ACTION_ID.expand],
+		build: [ACTION_ID.build],
+		develop: [ACTION_ID.develop],
+		raise_pop: [ACTION_ID.raisePop],
+		army_attack: [ACTION_ID.armyAttack],
 	},
 	phases: {
 		growth: ['growth'],


### PR DESCRIPTION
## Summary
* Introduced a centralized `ACTION_ID` map and exported `ActionId` type so the action registry consistently references shared identifiers. 【F:packages/contents/src/actions.ts†L40-L458】
* Updated building passives, happiness helpers, and overview tokens to import and reuse the shared action identifiers instead of hard-coded strings. 【F:packages/contents/src/buildings.ts†L1-L127】【F:packages/contents/src/happinessHelpers.ts†L1-L45】【F:packages/contents/src/overview.ts†L1-L75】
* Extended builder utilities to accept the new `ActionId` type, improving typing for action effect groups, cost modifiers, result modifiers, and the action builder. 【F:packages/contents/src/config/builders.ts†L25-L218】【F:packages/contents/src/config/builders.ts†L557-L566】【F:packages/contents/src/config/builders.ts†L1023-L1104】【F:packages/contents/src/config/builders.ts†L1804-L1813】

## Text formatting audit (required)
1. **Translator/formatter reuse:** N/A – no translators or formatters were added or modified.
2. **Canonical keywords/icons/helpers touched:** N/A – only action identifiers were centralized; no canonical text assets changed.
3. **Voice review:** N/A – no user-facing copy was introduced or altered.

## Standards compliance (required)
1. **File length limits respected:** All modified files remain within existing limits (actions.ts is a pre-existing >250 line file; others remain ≤250 lines). 【c491df†L1-L8】
2. **Line length limits respected:** `npm run check` (Prettier + ESLint) completed without violations. 【f2ad3b†L1-L19】
3. **Domain separation upheld:** Changes are limited to the content package and its builder utilities. 【F:packages/contents/src/actions.ts†L40-L458】【F:packages/contents/src/buildings.ts†L1-L127】【F:packages/contents/src/config/builders.ts†L25-L218】
4. **Code standards satisfied:** Linting passed after the updates. 【f55d40†L1-L9】
5. **Tests updated:** No new tests were required; existing coverage exercises the adjusted registries and builders. 【753048†L1-L21】
6. **Documentation updated:** N/A – the change only centralizes existing identifiers.
7. **`npm run check` results:** ✅ `npm run check` (see log excerpt). 【f2ad3b†L1-L19】
8. **`npm run test:coverage` results:** ✅ `npm run test:coverage` (see coverage summary). 【753048†L1-L21】

## Testing
* ✅ `npm run lint` 【f55d40†L1-L9】
* ✅ `npm run check` 【f2ad3b†L1-L19】
* ✅ `npm run test:coverage` 【753048†L1-L21】

------
https://chatgpt.com/codex/tasks/task_e_68e254861bcc832593e9a389477fbb79