### PR TITLE
Improve modifier labels for players

### DIFF
--- a/packages/contents/src/modifiers.ts
+++ b/packages/contents/src/modifiers.ts
@@ -1,4 +1,4 @@
 export const MODIFIER_INFO = {
-	cost: { icon: '💲', label: 'Cost Modifier' },
-	result: { icon: '✨', label: 'Result Modifier' },
+	cost: { icon: '💲', label: 'Cost Adjustment' },
+	result: { icon: '✨', label: 'Outcome Adjustment' },
 } as const;

--- a/packages/web/tests/plow-action-translation.test.ts
+++ b/packages/web/tests/plow-action-translation.test.ts
@@ -127,7 +127,7 @@ describe('plow action translation', () => {
 					upkeepDescriptionLabel
 				}`,
 				items: [
-					`💲 Cost Modifier on all actions: Increase cost by ${modIcon}${modAmt}`,
+					`💲 Cost Adjustment on all actions: Increase cost by ${modIcon}${modAmt}`,
 				],
 			},
 		]);


### PR DESCRIPTION
## Summary
- replace the cost/result modifier labels with player-friendly "Cost Adjustment" and "Outcome Adjustment" language
- update the plow action translation test to match the new modifier phrasing

## Text formatting audit (required)

1. **Translator/formatter reuse:** Existing modifier formatter at `packages/web/src/translation/effects/formatters/modifier.ts` continues to drive all modifier text.
2. **Canonical keywords/icons/helpers touched:** Updated `MODIFIER_INFO.cost` and `MODIFIER_INFO.result` labels (icons unchanged).
3. **Voice review:** Reviewed summary, description, and log modifier strings to ensure the softer wording reads naturally in all contexts.

## Standards compliance (required)

1. **File length limits respected:** `packages/contents/src/modifiers.ts` (4 lines) and `packages/web/tests/plow-action-translation.test.ts` (135 lines) remain far below the 250-line ceiling.
2. **Line length limits respected:** All new or modified strings stay well under the 80-character guideline.
3. **Domain separation upheld:** Adjustments are confined to the content package and a web test; engine and other domains remain untouched.
4. **Code standards satisfied:** `npm run check` succeeded after exercising Prettier, TypeScript, and ESLint. 【3f4960†L1-L24】
5. **Tests updated:** `packages/web/tests/plow-action-translation.test.ts` now reflects the new modifier wording. 【F:packages/web/tests/plow-action-translation.test.ts†L126-L131】
6. **Documentation updated:** Not required; the wording change is localized to existing UI strings with no docs impact.
7. **`npm run check` results:** See log output. 【3f4960†L1-L24】
8. **`npm run test:coverage` results:** Full Vitest coverage run completed successfully. 【e90efa†L1-L99】

## Testing

- `npm run check`
- `npm run test:coverage`
- `npm test -- plow`


------
https://chatgpt.com/codex/tasks/task_e_68e258482f30832592b0bd07a4936963