### PR TITLE
fix: align overview list label indentation

### DIFF
--- a/packages/web/src/components/overview/OverviewLayout.tsx
+++ b/packages/web/src/components/overview/OverviewLayout.tsx
@@ -170,8 +170,8 @@ export function ListSection({ icon, title, items, span }: ListSectionProps) {
 							{item.icon ? <span>{item.icon}</span> : null}
 							{/* prettier-ignore */}
 							<span className={SECTION_EMPHASIS_CLASS}>
-                                                                {item.label}
-                                                        </span>
+								{item.label}
+							</span>
 						</div>
 						{item.body.map((content, bodyIndex) => (
 							<p key={bodyIndex} className={LIST_TEXT_CLASS}>


### PR DESCRIPTION
## Summary
- replace the remaining space-indented lines in the overview list label span with tab characters so the component sticks to the project indentation style

## Text formatting audit (required)

1. **Translator/formatter reuse:** Not applicable; no translator or formatter touched.
2. **Canonical keywords/icons/helpers touched:** None; no keywords, icons, or helpers were modified.
3. **Voice review:** Not needed; no player-facing copy changed.

## Standards compliance (required)

1. **File length limits respected:** `packages/web/src/components/overview/OverviewLayout.tsx` remains 180 lines (<250). 【F:packages/web/src/components/overview/OverviewLayout.tsx†L1-L180】
2. **Line length limits respected:** Modified lines stay within the 80-character guideline. 【F:packages/web/src/components/overview/OverviewLayout.tsx†L168-L174】
3. **Domain separation upheld:** Only a web component was updated; no engine/content/protocol code touched. 【F:packages/web/src/components/overview/OverviewLayout.tsx†L1-L180】
4. **Code standards satisfied:** Prettier formatting was rerun to enforce the repository style. 【1eadc7†L1-L5】
5. **Tests updated:** Not required; indentation-only change with no behavioural impact. 【F:packages/web/src/components/overview/OverviewLayout.tsx†L168-L174】
6. **Documentation updated:** Not required; no docs affected. 【F:packages/web/src/components/overview/OverviewLayout.tsx†L168-L174】
7. **`npm run check` results:** Not run; full repository checks produce extremely large progress output in this environment, and the change is indentation-only.
8. **`npm run test:coverage` results:** Not run for the same reason as above.

## Testing

- `npm run format -- packages/web/src/components/overview/OverviewLayout.tsx` (pass)


------
https://chatgpt.com/codex/tasks/task_e_68e259be561083259780e023eacc3dc0