### PR TITLE
Adjust CallToActionSection indentation and class layout

### DIFF
--- a/packages/web/src/menu/CallToActionSection.tsx
+++ b/packages/web/src/menu/CallToActionSection.tsx
@@ -2,14 +2,16 @@ import Button from '../components/common/Button';
 import { ShowcaseCard } from '../components/layouts/ShowcasePage';
 
 const KNOWLEDGE_CARD_CLASS = [
-	'mt-8 flex flex-col gap-4 rounded-2xl border border-white/60 bg-white/60 p-4',
-	'text-sm text-slate-600 shadow-inner dark:border-white/10 dark:bg-white/5',
-	'dark:text-slate-300/80',
+	'mt-8 flex flex-col gap-4 rounded-2xl border border-white/60',
+	'bg-white/60 p-4',
+	'text-sm text-slate-600 shadow-inner dark:border-white/10',
+	'dark:bg-white/5 dark:text-slate-300/80',
 ].join(' ');
 
 const GHOST_BUTTON_CLASS = [
-	'w-full rounded-full border border-slate-200/60 bg-white/50 px-5 py-2',
-	'text-sm font-semibold text-slate-700 hover:border-slate-300 hover:bg-white/80',
+	'w-full rounded-full border border-slate-200/60 bg-white/50 px-5',
+	'py-2 text-sm font-semibold text-slate-700',
+	'hover:border-slate-300 hover:bg-white/80',
 	'dark:border-white/10 dark:bg-white/5 dark:text-slate-200',
 	'dark:hover:border-white/20 dark:hover:bg-white/10 sm:w-auto',
 ].join(' ');
@@ -25,10 +27,11 @@ const DEV_BUTTON_CLASS = [
 ].join(' ');
 
 const SETTINGS_BUTTON_CLASS = [
-	'w-full rounded-full border border-slate-200/60 bg-white/50 px-5 py-2.5 text-sm font-semibold',
-	'text-slate-700 shadow-inner shadow-white/40 transition dark:border-white/10 dark:bg-white/5',
-	'dark:text-slate-200 hover:border-slate-300 hover:bg-white/75 dark:hover:border-white/20 dark:hover:bg-white/10',
-	'sm:w-full',
+	'w-full rounded-full border border-slate-200/60 bg-white/50 px-5',
+	'py-2.5 text-sm font-semibold text-slate-700 shadow-inner shadow-white/40',
+	'transition dark:border-white/10 dark:bg-white/5 dark:text-slate-200',
+	'hover:border-slate-300 hover:bg-white/75',
+	'dark:hover:border-white/20 dark:hover:bg-white/10 sm:w-full',
 ].join(' ');
 
 const CTA_CONTENT_LAYOUT_CLASS = [
@@ -89,8 +92,8 @@ export function CallToActionSection({
 					</h2>
 					{/* prettier-ignore */}
 					<p className={CTA_DESCRIPTION_CLASS}>
-                                                {CTA_DESCRIPTION_TEXT}
-                                        </p>
+						{CTA_DESCRIPTION_TEXT}
+					</p>
 				</div>
 				<div className={CTA_BUTTON_COLUMN_CLASS}>
 					<Button
@@ -127,8 +130,8 @@ export function CallToActionSection({
 				<div className={KNOWLEDGE_HEADER_LAYOUT_CLASS}>
 					{/* prettier-ignore */}
 					<div className={KNOWLEDGE_TITLE_CLASS}>
-                                                Learn The Basics
-                                        </div>
+						Learn The Basics
+					</div>
 					<div className={KNOWLEDGE_ACTIONS_CLASS}>
 						<Button
 							variant="ghost"


### PR DESCRIPTION
## Summary
* Split long CallToActionSection class name entries into shorter segments to keep each line under 80 characters while preserving tab indentation.
* Replaced space indentation in the CallToActionSection JSX with tabs to align with the repository’s formatting rules.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable – no translators or formatters were added or modified.
2. **Canonical keywords/icons/helpers touched:** None – only class name strings and indentation changed.
3. **Voice review:** Not applicable – no player-facing strings were added or edited.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/src/menu/CallToActionSection.tsx` remains 156 lines, under the 250 line limit.
2. **Line length limits respected:** All modified class name strings were split so no physical line exceeds 80 characters.
3. **Domain separation upheld:** Changes are confined to the web UI layer and do not affect engine/content boundaries.
4. **Code standards satisfied:** `npm run check` completed successfully (see excerpt below).
5. **Tests updated:** Not required – no logic changes that affect runtime behaviour.
6. **Documentation updated:** Not required – documentation remains accurate for this formatting-only change.
7. **`npm run check` results:**
```
> kingdom-builder-engine@0.1.0 check
> npm run format:check && npm run typecheck && npm run lint
...
Checking formatting...
All matched files use Prettier code style!
...
> kingdom-builder-engine@0.1.0 lint
> eslint . --ext .ts,.tsx --rulesdir scripts
```
8. **`npm run test:coverage` results:** Not run – formatting-only change with no impact on coverage.

## Testing
* `npm run check`
* `npm test` (executed automatically by the pre-commit hook)


------
https://chatgpt.com/codex/tasks/task_e_68e259b919fc8325acfcf5acfcd7e890