### PR TITLE
Refactor effect group helpers into dedicated module

### DIFF
--- a/packages/web/src/translation/effects/factory.ts
+++ b/packages/web/src/translation/effects/factory.ts
@@ -1,13 +1,12 @@
-import type {
-	ActionEffectGroupOption,
-	EffectDef,
-	EngineContext,
-	ResolvedActionEffectStep,
-	ResolvedActionEffectGroupOption,
-} from '@kingdom-builder/engine';
+import type { EffectDef, EngineContext } from '@kingdom-builder/engine';
 import type { SummaryEntry } from '../content';
-import { describeContent, logContent, summarizeContent } from '../content';
-import { buildActionOptionTranslation } from './optionLabel';
+export {
+	formatEffectGroups,
+	buildGroupEntry,
+	buildOptionEntry,
+	mergeOptionParams,
+	type EffectGroupMode,
+} from './groups';
 // Effect and evaluator formatter registries drive translation lookups.
 
 export interface EffectFormatter {
@@ -184,129 +183,4 @@ export function logEffects(
 		}
 		return part;
 	});
-}
-
-type EffectGroupMode = 'summarize' | 'describe' | 'log';
-
-function mergeOptionParams(
-	option: ActionEffectGroupOption,
-	baseParams: Record<string, unknown>,
-): Record<string, unknown> {
-	const merged: Record<string, unknown> = { ...baseParams };
-	for (const [key, value] of Object.entries(option.params || {})) {
-		if (typeof value === 'string' && value.startsWith('$')) {
-			const placeholder = value.slice(1);
-			if (placeholder in baseParams) {
-				merged[key] = baseParams[placeholder];
-			}
-			continue;
-		}
-		merged[key] = value;
-	}
-	return merged;
-}
-
-function buildOptionEntry(
-	option: ActionEffectGroupOption,
-	mode: EffectGroupMode,
-	context: EngineContext,
-	baseParams: Record<string, unknown>,
-	selection?: ResolvedActionEffectGroupOption,
-): SummaryEntry {
-	const mergedParams =
-		selection?.params || mergeOptionParams(option, baseParams);
-
-	if (mode === 'log') {
-		const fallbackTitle = [option.icon, option.label]
-			.filter(Boolean)
-			.join(' ')
-			.trim();
-		if (selection) {
-			const logs = logEffects(selection.effects, context);
-			if (!fallbackTitle) {
-				return logs.length ? { title: option.id, items: logs } : option.id;
-			}
-			return logs.length
-				? { title: fallbackTitle, items: logs }
-				: fallbackTitle;
-		}
-		const logged = logContent('action', option.actionId, context, mergedParams);
-		if (!fallbackTitle) {
-			return logged.length ? { title: option.id, items: logged } : option.id;
-		}
-		return logged.length
-			? { title: fallbackTitle, items: logged }
-			: fallbackTitle;
-	}
-
-	const translated =
-		mode === 'summarize'
-			? summarizeContent('action', option.actionId, context, mergedParams)
-			: describeContent('action', option.actionId, context, mergedParams);
-
-	const { entry } = buildActionOptionTranslation(
-		option,
-		context,
-		translated,
-		mode,
-	);
-	return entry;
-}
-
-function buildGroupEntry(
-	step: Extract<ResolvedActionEffectStep, { type: 'group' }>,
-	mode: EffectGroupMode,
-	context: EngineContext,
-): SummaryEntry {
-	const { group, selection, params } = step;
-	const title =
-		[group.icon, group.title || 'Choose one:']
-			.filter(Boolean)
-			.join(' ')
-			.trim() || group.id;
-	const items: SummaryEntry[] = [];
-	if (mode !== 'log' && group.summary) {
-		items.push(group.summary);
-	}
-	if (mode === 'describe' && group.description) {
-		if (!group.summary || group.summary !== group.description) {
-			items.push(group.description);
-		}
-	}
-	if (mode === 'log' && group.summary && !selection) {
-		items.push(group.summary);
-	}
-	if (mode === 'log' && group.description && !selection) {
-		if (!group.summary || group.summary !== group.description) {
-			items.push(group.description);
-		}
-	}
-	if (selection) {
-		items.push(
-			buildOptionEntry(selection.option, mode, context, params, selection),
-		);
-	} else {
-		for (const option of group.options) {
-			items.push(buildOptionEntry(option, mode, context, params));
-		}
-	}
-	return { title, items };
-}
-
-export function formatEffectGroups(
-	steps: readonly ResolvedActionEffectStep[] | undefined,
-	mode: EffectGroupMode,
-	context: EngineContext,
-): SummaryEntry[] {
-	if (!steps || steps.length === 0) {
-		return [];
-	}
-	const entries: SummaryEntry[] = [];
-	for (const step of steps) {
-		if (step.type !== 'group') {
-			continue;
-		}
-		entries.push(buildGroupEntry(step, mode, context));
-	}
-	return entries;
 }

--- a/packages/web/src/translation/effects/groups.ts
+++ b/packages/web/src/translation/effects/groups.ts
@@ -1,0 +1,135 @@
+import type {
+	ActionEffectGroupOption,
+	EngineContext,
+	ResolvedActionEffectGroupOption,
+	ResolvedActionEffectStep,
+} from '@kingdom-builder/engine';
+import type { SummaryEntry } from '../content';
+import { describeContent, logContent, summarizeContent } from '../content';
+import { buildActionOptionTranslation } from './optionLabel';
+import { logEffects } from './factory';
+
+export type EffectGroupMode = 'summarize' | 'describe' | 'log';
+
+export function mergeOptionParams(
+	option: ActionEffectGroupOption,
+	baseParams: Record<string, unknown>,
+): Record<string, unknown> {
+	const merged: Record<string, unknown> = { ...baseParams };
+	for (const [key, value] of Object.entries(option.params || {})) {
+		if (typeof value === 'string' && value.startsWith('$')) {
+			const placeholder = value.slice(1);
+			if (placeholder in baseParams) {
+				merged[key] = baseParams[placeholder];
+			}
+			continue;
+		}
+		merged[key] = value;
+	}
+	return merged;
+}
+
+export function buildOptionEntry(
+	option: ActionEffectGroupOption,
+	mode: EffectGroupMode,
+	context: EngineContext,
+	baseParams: Record<string, unknown>,
+	selection?: ResolvedActionEffectGroupOption,
+): SummaryEntry {
+	const mergedParams =
+		selection?.params || mergeOptionParams(option, baseParams);
+
+	if (mode === 'log') {
+		const fallbackTitle = [option.icon, option.label]
+			.filter(Boolean)
+			.join(' ')
+			.trim();
+		if (selection) {
+			const logs = logEffects(selection.effects, context);
+			if (!fallbackTitle) {
+				return logs.length ? { title: option.id, items: logs } : option.id;
+			}
+			return logs.length
+				? { title: fallbackTitle, items: logs }
+				: fallbackTitle;
+		}
+		const logged = logContent('action', option.actionId, context, mergedParams);
+		if (!fallbackTitle) {
+			return logged.length ? { title: option.id, items: logged } : option.id;
+		}
+		return logged.length
+			? { title: fallbackTitle, items: logged }
+			: fallbackTitle;
+	}
+
+	const translated =
+		mode === 'summarize'
+			? summarizeContent('action', option.actionId, context, mergedParams)
+			: describeContent('action', option.actionId, context, mergedParams);
+
+	const { entry } = buildActionOptionTranslation(
+		option,
+		context,
+		translated,
+		mode,
+	);
+	return entry;
+}
+
+export function buildGroupEntry(
+	step: Extract<ResolvedActionEffectStep, { type: 'group' }>,
+	mode: EffectGroupMode,
+	context: EngineContext,
+): SummaryEntry {
+	const { group, selection, params } = step;
+	const title =
+		[group.icon, group.title || 'Choose one:']
+			.filter(Boolean)
+			.join(' ')
+			.trim() || group.id;
+	const items: SummaryEntry[] = [];
+	if (mode !== 'log' && group.summary) {
+		items.push(group.summary);
+	}
+	if (mode === 'describe' && group.description) {
+		if (!group.summary || group.summary !== group.description) {
+			items.push(group.description);
+		}
+	}
+	if (mode === 'log' && group.summary && !selection) {
+		items.push(group.summary);
+	}
+	if (mode === 'log' && group.description && !selection) {
+		if (!group.summary || group.summary !== group.description) {
+			items.push(group.description);
+		}
+	}
+	if (selection) {
+		items.push(
+			buildOptionEntry(selection.option, mode, context, params, selection),
+		);
+	} else {
+		for (const option of group.options) {
+			items.push(buildOptionEntry(option, mode, context, params));
+		}
+	}
+	return { title, items };
+}
+
+export function formatEffectGroups(
+	steps: readonly ResolvedActionEffectStep[] | undefined,
+	mode: EffectGroupMode,
+	context: EngineContext,
+): SummaryEntry[] {
+	if (!steps || steps.length === 0) {
+		return [];
+	}
+	const entries: SummaryEntry[] = [];
+	for (const step of steps) {
+		if (step.type !== 'group') {
+			continue;
+		}
+		entries.push(buildGroupEntry(step, mode, context));
+	}
+	return entries;
+}


### PR DESCRIPTION
## Summary
- Extract the effect-group helper utilities into `packages/web/src/translation/effects/groups.ts` for reuse.
- Re-export the helpers from `factory.ts` to keep the public API stable while trimming the file below the 250-line limit.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Reused `buildActionOptionTranslation` (`packages/web/src/translation/effects/optionLabel.ts`) and existing content translators in `packages/web/src/translation/content`.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** No player-facing copy changed; existing translations remain intact.

## Standards compliance (required)
1. **File length limits respected:** `factory.ts` is 186 lines and `groups.ts` is 135 lines (`wc -l`).
2. **Line length limits respected:** `npm run format` (Prettier) keeps lines within the configured 80-character limit.
3. **Domain separation upheld:** All changes are limited to the web translation layer; no engine/content/protocol code touched.
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint) passes.
5. **Tests updated:** Not required—logic moved without behavioural changes.
6. **Documentation updated:** Not required for this refactor.
7. **`npm run check` results:**
   <details>
   <summary>CI=1 npm run check</summary>

   ```
   > kingdom-builder-engine@0.1.0 check
   > npm run format:check && npm run typecheck && npm run lint


   > kingdom-builder-engine@0.1.0 format:check
   > prettier --check .

   Checking formatting...
   All matched files use Prettier code style!

   > kingdom-builder-engine@0.1.0 typecheck
   > tsc -b --pretty false


   > kingdom-builder-engine@0.1.0 posttypecheck
   > node scripts/clean-dists.cjs


   > kingdom-builder-engine@0.1.0 prelint
   > node scripts/ensure-dev-dependencies.cjs


   > kingdom-builder-engine@0.1.0 lint
   > eslint . --ext .ts,.tsx --rulesdir scripts
   ```
   </details>
8. **`npm run test:coverage` results:** Not run (not required for this refactor).

## Testing
- ✅ `npm run check`
- ✅ `npm run test`
- ⚠️ `npm run test:coverage` *(not run; not requested for this refactor)*

------
https://chatgpt.com/codex/tasks/task_e_68e259c7026c83259108800813c8831a