### PR TITLE
Refactor action card layout helpers

### DIFF
--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -2,21 +2,13 @@ import React from 'react';
 import type { Focus } from '@kingdom-builder/contents';
 import { type Summary } from '../../translation';
 import { renderSummary, renderCosts } from '../../translation/render';
+import OptionList from './OptionList';
+import StepBadge from './StepBadge';
+import { type ActionCardOption } from './OptionCard';
 import { FOCUS_GRADIENTS } from './focusGradients';
 import { stripSummary } from './stripSummary';
 
-export type ActionCardOption = {
-	id: string;
-	label: string;
-	icon?: string;
-	summary?: string;
-	description?: string;
-	disabled?: boolean;
-	onSelect: () => void;
-	onMouseEnter?: (() => void) | undefined;
-	onMouseLeave?: (() => void) | undefined;
-	compact?: boolean;
-};
+export type { ActionCardOption } from './OptionCard';
 
 export type ActionCardVariant = 'front' | 'back';
 
@@ -48,124 +40,6 @@ export interface ActionCardProps {
 	multiStep?: boolean | undefined;
 }
 
-function StepBadge({
-	stepIndex: _stepIndex,
-	stepCount: _stepCount,
-	stepLabel,
-	variant,
-	multiStep,
-}: {
-	stepIndex: number | undefined;
-	stepCount: number | undefined;
-	stepLabel: string | undefined;
-	variant: ActionCardVariant;
-	multiStep: boolean | undefined;
-}) {
-	if (variant === 'back') {
-		const label = stepLabel?.trim();
-		if (!label) {
-			return null;
-		}
-		return (
-			<div className="action-card__badge">
-				<span className="action-card__badge-pill">{label}</span>
-			</div>
-		);
-	}
-	if (!multiStep || variant !== 'front') {
-		return null;
-	}
-	return (
-		<div className="action-card__badge">
-			<span
-				className="action-card__multi-step"
-				role="img"
-				aria-label="Multi-step action"
-				title="Multi-step action"
-			>
-				<svg
-					className="action-card__multi-step-icon"
-					viewBox="0 0 16 16"
-					fill="none"
-					xmlns="http://www.w3.org/2000/svg"
-				>
-					<path
-						d="M3.25 12.75h3.5v-3.5h3.5V5.75H13.5"
-						stroke="currentColor"
-						strokeWidth="1.25"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-					/>
-					<path
-						d="M11.25 3.75L13.75 6l-2.5 2.25"
-						stroke="currentColor"
-						strokeWidth="1.25"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-					/>
-				</svg>
-			</span>
-		</div>
-	);
-}
-
-function OptionCard({ option }: { option: ActionCardOption }) {
-	const icon = option.icon?.trim();
-	const label = option.label.trim();
-	const ariaLabel = label.length > 0 ? label : option.id;
-	const optionClass = [
-		'action-card__option',
-		option.compact ? 'action-card__option--compact' : '',
-		option.disabled ? 'opacity-50 cursor-not-allowed' : 'hoverable',
-	]
-		.filter(Boolean)
-		.join(' ');
-	const compactVisual = icon || (label.length > 0 ? label[0] : '–');
-	return (
-		<button
-			type="button"
-			className={optionClass}
-			onClick={option.disabled ? undefined : option.onSelect}
-			disabled={option.disabled}
-			style={{ cursor: option.disabled ? 'not-allowed' : 'pointer' }}
-			onMouseEnter={option.onMouseEnter}
-			onMouseLeave={option.onMouseLeave}
-			aria-label={ariaLabel}
-			title={option.compact ? ariaLabel : undefined}
-		>
-			{option.compact ? (
-				<>
-					<span
-						aria-hidden="true"
-						className="action-card__option-compact-visual"
-					>
-						{compactVisual}
-					</span>
-					<span className="sr-only">{ariaLabel}</span>
-				</>
-			) : (
-				<>
-					<span className="action-card__option-header">
-						{icon ? (
-							<span aria-hidden="true" className="action-card__option-icon">
-								{icon}
-							</span>
-						) : null}
-						<span className="action-card__option-title">{label}</span>
-					</span>
-					{option.summary ? (
-						<p className="action-card__option-summary">{option.summary}</p>
-					) : null}
-					{option.description ? (
-						<p className="action-card__option-description">
-							{option.description}
-						</p>
-					) : null}
-				</>
-			)}
-		</button>
-	);
-}
 export default function ActionCard({
 	title,
 	costs,
@@ -192,22 +66,64 @@ export default function ActionCard({
 	options = [],
 	onCancel,
 	multiStep = false,
-}: ActionCardProps) {
+}: ActionCardProps): JSX.Element {
 	const focusClass =
 		(focus && FOCUS_GRADIENTS[focus]) ?? FOCUS_GRADIENTS.default;
 	const isBack = variant === 'back';
 	const interactive = !isBack && enabled;
-	const containerClass = `action-card panel-card relative h-full bg-gradient-to-br ${focusClass} ${
+	const containerClass = [
+		'action-card',
+		'panel-card',
+		'relative',
+		'h-full',
+		'bg-gradient-to-br',
+		focusClass,
 		interactive
 			? 'hoverable cursor-pointer'
 			: isBack
 				? 'cursor-default'
-				: 'cursor-not-allowed opacity-50'
-	}`;
+				: 'cursor-not-allowed opacity-50',
+	]
+		.filter(Boolean)
+		.join(' ');
+	const requirementBadgeClass = [
+		'flex',
+		'flex-col',
+		'items-end',
+		'gap-0.5',
+		'text-xs',
+		'text-rose-500',
+		'dark:text-rose-300',
+	].join(' ');
+	const costBlockClass = [
+		'absolute',
+		'top-2',
+		'right-2',
+		'flex',
+		'flex-col',
+		'items-end',
+		'gap-1',
+		'text-right',
+	].join(' ');
+	const frontContentClass = [
+		'flex',
+		'h-full',
+		'flex-col',
+		'items-start',
+		'gap-2',
+		'p-4',
+		'text-left',
+	].join(' ');
+	const promptHeaderClass = [
+		'flex',
+		'items-start',
+		'justify-between',
+		'gap-2',
+	].join(' ');
 
 	const requirementBadge =
 		requirements.length > 0 ? (
-			<div className="flex flex-col items-end gap-0.5 text-xs text-rose-500 dark:text-rose-300">
+			<div className={requirementBadgeClass}>
 				<div className="whitespace-nowrap">
 					Req
 					{requirementIcons.length > 0 && ` ${requirementIcons.join('')}`}
@@ -245,9 +161,9 @@ export default function ActionCard({
 					onClick={interactive ? onClick : undefined}
 					disabled={!interactive}
 				>
-					<div className="flex h-full flex-col items-start gap-2 p-4 text-left">
+					<div className={frontContentClass}>
 						<span className="text-base font-medium">{title}</span>
-						<div className="absolute top-2 right-2 flex flex-col items-end gap-1 text-right">
+						<div className={costBlockClass}>
 							{renderCosts(costs, playerResources, actionCostResource, upkeep)}
 							{requirementBadge}
 						</div>
@@ -256,7 +172,7 @@ export default function ActionCard({
 				</button>
 				<div className="action-card__face action-card__face--back">
 					<div className="flex h-full flex-col gap-3 p-4">
-						<div className="flex items-start justify-between gap-2">
+						<div className={promptHeaderClass}>
 							<div className="flex flex-col gap-1">
 								{promptTitle && (
 									<span className="text-base font-semibold">{promptTitle}</span>
@@ -285,17 +201,7 @@ export default function ActionCard({
 								</button>
 							)}
 						</div>
-						<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-							{options.length > 0 ? (
-								options.map((option) => (
-									<OptionCard key={option.id} option={option} />
-								))
-							) : (
-								<div className="text-sm text-slate-600 dark:text-slate-300">
-									No options available.
-								</div>
-							)}
-						</div>
+						<OptionList options={options} />
 					</div>
 				</div>
 			</div>

--- a/packages/web/src/components/actions/OptionCard.tsx
+++ b/packages/web/src/components/actions/OptionCard.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+export type ActionCardOption = {
+	id: string;
+	label: string;
+	icon?: string;
+	summary?: string;
+	description?: string;
+	disabled?: boolean;
+	onSelect: () => void;
+	onMouseEnter?: (() => void) | undefined;
+	onMouseLeave?: (() => void) | undefined;
+	compact?: boolean;
+};
+
+function buildOptionClass(option: ActionCardOption): string {
+	return [
+		'action-card__option',
+		option.compact ? 'action-card__option--compact' : '',
+		option.disabled ? 'opacity-50 cursor-not-allowed' : 'hoverable',
+	]
+		.filter(Boolean)
+		.join(' ');
+}
+
+export default function OptionCard({
+	option,
+}: {
+	option: ActionCardOption;
+}): JSX.Element {
+	const icon = option.icon?.trim();
+	const label = option.label.trim();
+	const ariaLabel = label.length > 0 ? label : option.id;
+	const optionClass = buildOptionClass(option);
+	const compactVisual = icon || (label.length > 0 ? label[0] : '–');
+
+	return (
+		<button
+			type="button"
+			className={optionClass}
+			onClick={option.disabled ? undefined : option.onSelect}
+			disabled={option.disabled}
+			style={{ cursor: option.disabled ? 'not-allowed' : 'pointer' }}
+			onMouseEnter={option.onMouseEnter}
+			onMouseLeave={option.onMouseLeave}
+			aria-label={ariaLabel}
+			title={option.compact ? ariaLabel : undefined}
+		>
+			{option.compact ? (
+				<>
+					<span
+						aria-hidden="true"
+						className="action-card__option-compact-visual"
+					>
+						{compactVisual}
+					</span>
+					<span className="sr-only">{ariaLabel}</span>
+				</>
+			) : (
+				<>
+					<span className="action-card__option-header">
+						{icon ? (
+							<span aria-hidden="true" className="action-card__option-icon">
+								{icon}
+							</span>
+						) : null}
+						<span className="action-card__option-title">{label}</span>
+					</span>
+					{option.summary ? (
+						<p className="action-card__option-summary">{option.summary}</p>
+					) : null}
+					{option.description ? (
+						<p className="action-card__option-description">
+							{option.description}
+						</p>
+					) : null}
+				</>
+			)}
+		</button>
+	);
+}

--- a/packages/web/src/components/actions/OptionList.tsx
+++ b/packages/web/src/components/actions/OptionList.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import OptionCard, { type ActionCardOption } from './OptionCard';
+
+export interface OptionListProps {
+	options: ActionCardOption[];
+}
+
+export default function OptionList({ options }: OptionListProps): JSX.Element {
+	if (options.length === 0) {
+		return (
+			<div className="text-sm text-slate-600 dark:text-slate-300">
+				No options available.
+			</div>
+		);
+	}
+	return (
+		<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+			{options.map((option) => (
+				<OptionCard key={option.id} option={option} />
+			))}
+		</div>
+	);
+}

--- a/packages/web/src/components/actions/StepBadge.tsx
+++ b/packages/web/src/components/actions/StepBadge.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { type ActionCardVariant } from './ActionCard';
+
+export interface StepBadgeProps {
+	stepIndex: number | undefined;
+	stepCount: number | undefined;
+	stepLabel: string | undefined;
+	variant: ActionCardVariant;
+	multiStep: boolean | undefined;
+}
+
+export default function StepBadge({
+	stepIndex: _stepIndex,
+	stepCount: _stepCount,
+	stepLabel,
+	variant,
+	multiStep,
+}: StepBadgeProps): JSX.Element | null {
+	if (variant === 'back') {
+		const label = stepLabel?.trim();
+		if (!label) {
+			return null;
+		}
+		return (
+			<div className="action-card__badge">
+				<span className="action-card__badge-pill">{label}</span>
+			</div>
+		);
+	}
+	if (!multiStep || variant !== 'front') {
+		return null;
+	}
+	return (
+		<div className="action-card__badge">
+			<span
+				className="action-card__multi-step"
+				role="img"
+				aria-label="Multi-step action"
+				title="Multi-step action"
+			>
+				<svg
+					className="action-card__multi-step-icon"
+					viewBox="0 0 16 16"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path
+						d="M3.25 12.75h3.5v-3.5h3.5V5.75H13.5"
+						stroke="currentColor"
+						strokeWidth="1.25"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					/>
+					<path
+						d="M11.25 3.75L13.75 6l-2.5 2.25"
+						stroke="currentColor"
+						strokeWidth="1.25"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					/>
+				</svg>
+			</span>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- refactored the action card component to split class name assembly and delegate option rendering while re-exporting the option type for consumers. 【F:packages/web/src/components/actions/ActionCard.tsx†L1-L205】
- added dedicated `OptionCard`, `OptionList`, and `StepBadge` components to reuse markup and keep the main view within the file-length budget. 【F:packages/web/src/components/actions/OptionCard.tsx†L1-L81】【F:packages/web/src/components/actions/OptionList.tsx†L1-L24】【F:packages/web/src/components/actions/StepBadge.tsx†L1-L66】

## Text formatting audit (required)
1. **Translator/formatter reuse:** No new translators or formatters were introduced; existing `renderSummary` and `renderCosts` usage remains unchanged. 【F:packages/web/src/components/actions/ActionCard.tsx†L1-L205】
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** No user-facing strings changed; existing copy (e.g., “No options available.”) retains its approved voice. 【F:packages/web/src/components/actions/OptionList.tsx†L9-L22】

## Standards compliance (required)
1. **File length limits respected:** `ActionCard.tsx` now totals 221 lines (<250). 【6cd3ae†L1-L2】
2. **Line length limits respected:** Class name construction now uses arrays to keep each line ≤80 characters. 【F:packages/web/src/components/actions/ActionCard.tsx†L74-L122】
3. **Domain separation upheld:** Changes are limited to web UI components; engine/content code remains untouched. 【F:packages/web/src/components/actions/ActionCard.tsx†L1-L205】
4. **Code standards satisfied:** `npm run lint` passes on the workspace. 【0599ef†L1-L14】
5. **Tests updated:** Not required; no behavioral changes to logic under test.
6. **Documentation updated:** Not required; no docs were affected.
7. **`npm run check` results:** Ran via commit hook; see `/tmp/commit.log` for full output (excerpt). 【481431†L1-L33】
8. **`npm run test:coverage` results:** `vitest` coverage run succeeds (summary attached). 【9f4646†L1-L77】

## Testing
- ✅ `npm run lint` 【0599ef†L1-L14】
- ✅ `npm run check` 【481431†L1-L33】
- ✅ `npm run test:coverage` 【9f4646†L1-L77】

------
https://chatgpt.com/codex/tasks/task_e_68e259c44ed48325bc9fc9820cb17983