### PR TITLE
Fix percent cost modifier formatting

### DIFF
--- a/packages/web/src/translation/effects/formatters/modifier_helpers.ts
+++ b/packages/web/src/translation/effects/formatters/modifier_helpers.ts
@@ -91,11 +91,27 @@ interface ResultModifierSource {
 const resolveIcon = (icon?: string) =>
 	icon && icon.trim() ? icon : GENERAL_RESOURCE_ICON;
 
-const formatPercentText = (percent: number) => {
+export const formatPercentText = (percent: number) => {
 	const scaled = Number((percent * 100).toFixed(2));
 	const normalized = Object.is(scaled, -0) ? 0 : scaled;
 	const sign = percent >= 0 ? '+' : '';
 	return `${sign}${normalized}%`;
+};
+
+export const formatPercentMagnitude = (percent: number) => {
+	const scaled = Number((Math.abs(percent) * 100).toFixed(2));
+	return Object.is(scaled, -0) ? 0 : scaled;
+};
+
+export const parseNumericParam = (value: unknown) => {
+	if (typeof value === 'number') {
+		return Number.isNaN(value) ? undefined : value;
+	}
+	if (typeof value === 'string' && value.trim().length > 0) {
+		const parsed = Number(value);
+		return Number.isNaN(parsed) ? undefined : parsed;
+	}
+	return undefined;
 };
 
 export function formatGainFrom(

--- a/packages/web/tests/modifier-eval-handlers.test.ts
+++ b/packages/web/tests/modifier-eval-handlers.test.ts
@@ -15,6 +15,7 @@ import {
 	RESOURCES,
 	type ResourceKey,
 	RESOURCE_TRANSFER_ICON,
+	Resource,
 } from '@kingdom-builder/contents';
 import { createContentFactory } from '../../engine/tests/factories/content';
 import type { PhaseDef } from '@kingdom-builder/engine/phases';
@@ -155,6 +156,29 @@ describe('modifier evaluation handlers', () => {
 		const description = describeEffects([eff], ctx);
 		expect(description[0]).toContain('Income');
 		expect(description[0]).toContain('20%');
+	});
+
+	it('formats cost modifiers with percent adjustments', () => {
+		const ctx = createCtx();
+		const eff: EffectDef = {
+			type: 'cost_mod',
+			method: 'add',
+			params: {
+				id: 'synthetic:discount',
+				key: Resource.gold,
+				actionId: 'build',
+				percent: -0.2,
+			},
+		};
+		const summary = summarizeEffects([eff], ctx);
+		const goldIcon = RESOURCES[Resource.gold].icon;
+		const expectedSummary = `${MODIFIER_INFO.cost.icon}🏛️: ${goldIcon}-20%`;
+		expect(summary).toEqual([expectedSummary]);
+		const description = describeEffects([eff], ctx);
+		const expectedDescription =
+			`${MODIFIER_INFO.cost.icon} ${MODIFIER_INFO.cost.label}` +
+			` on 🏛️ Build: Decrease cost by 20% ${goldIcon}`;
+		expect(description).toEqual([expectedDescription]);
 	});
 
 	it('formats transfer percent evaluation modifiers for arbitrary actions', () => {


### PR DESCRIPTION
## Summary
- centralize cost modifier summary/description formatting in a shared helper that supports percent values without NaN leaks
- extend cost formatter helpers to export percent utilities and numeric parsing for reuse
- add regression coverage ensuring percent cost modifiers render correctly in web summaries and descriptions

## Text formatting audit (required)
1. **Translator/formatter reuse:** Reused `formatPercentText`, `formatPercentMagnitude`, and `parseNumericParam` within `formatCostEffect` alongside existing modifier helpers (`wrapResultModifierEntries`, etc.).
2. **Canonical keywords/icons/helpers touched:** `MODIFIER_INFO.cost`, `increaseOrDecrease`, `signed`, `formatPercentText`, `formatPercentMagnitude`, `parseNumericParam`.
3. **Voice review:** Verified cost modifier summary and description strings retain the existing cost voice for add/remove flows.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/src/translation/effects/formatters/modifier.ts` is 248 lines and `modifier_helpers.ts` remains 247, both below the 250-line cap. (See `wc -l` outputs.)
2. **Line length limits respected:** Checked with a custom script; only pre-existing legacy lines exceed 80 characters (development/transfer blocks), no new additions do. (See Python audit output.)
3. **Domain separation upheld:** Changes are limited to web translators/helpers and web-only tests; engine/content domains were untouched.
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint) passes without issues; see `/tmp/npm-check.log` tail.
5. **Tests updated:** Added a new percent cost modifier assertion in `packages/web/tests/modifier-eval-handlers.test.ts` and exercised it via `npx vitest run packages/web/tests/modifier-eval-handlers.test.ts`.
6. **Documentation updated:** Not required—no docs reference percent cost modifiers directly.
7. **`npm run check` results:** Full log captured at `/tmp/npm-check.log` (tail shown above).
8. **`npm run test:coverage` results:** Coverage run captured at `/tmp/test-coverage.log` (tail shown above).

## Testing
- `npm run check`
- `npm run test:coverage`
- `npx vitest run packages/web/tests/modifier-eval-handlers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e257a8626483258cd5735c506ac47a