### PR TITLE
Introduce development ID constants and tighten builder typing

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -2,6 +2,7 @@ import { Registry } from '@kingdom-builder/protocol';
 import { Resource } from './resources';
 import { Stat, STATS } from './stats';
 import { PopulationRole, POPULATION_ROLES } from './populationRoles';
+import { DevelopmentId } from './developments';
 import { actionSchema, type ActionConfig } from '@kingdom-builder/protocol';
 import {
 	action,
@@ -75,7 +76,7 @@ export function createActionRegistry() {
 			.cost(Resource.ap, 1)
 			.effect(
 				effect()
-					.evaluator(developmentEvaluator().id('farm'))
+					.evaluator(developmentEvaluator().id(DevelopmentId.Farm))
 					.effect(
 						effect(Types.Resource, ResourceMethods.ADD)
 							.round('down')
@@ -188,6 +189,37 @@ export function createActionRegistry() {
 		focus: 'economy',
 	});
 
+	const royalDecreeDevelopGroup = actionEffectGroup('royal_decree_develop')
+		.layout('compact')
+		.option(
+			actionEffectGroupOption('royal_decree_house')
+				.label('Raise a House')
+				.icon('🏠')
+				.action('develop')
+				.params(actionParams().id(DevelopmentId.House).landId('$landId')),
+		)
+		.option(
+			actionEffectGroupOption('royal_decree_farm')
+				.label('Establish a Farm')
+				.icon('🌾')
+				.action('develop')
+				.params(actionParams().id(DevelopmentId.Farm).landId('$landId')),
+		)
+		.option(
+			actionEffectGroupOption('royal_decree_outpost')
+				.label('Fortify with an Outpost')
+				.icon('🏹')
+				.action('develop')
+				.params(actionParams().id(DevelopmentId.Outpost).landId('$landId')),
+		)
+		.option(
+			actionEffectGroupOption('royal_decree_watchtower')
+				.label('Raise a Watchtower')
+				.icon('🗼')
+				.action('develop')
+				.params(actionParams().id(DevelopmentId.Watchtower).landId('$landId')),
+		);
+
 	registry.add('royal_decree', {
 		...action()
 			.id('royal_decree')
@@ -205,38 +237,7 @@ export function createActionRegistry() {
 					.params(actionParams().id('till').landId('$landId'))
 					.build(),
 			)
-			.effectGroup(
-				actionEffectGroup('royal_decree_develop')
-					.layout('compact')
-					.option(
-						actionEffectGroupOption('royal_decree_house')
-							.label('Raise a House')
-							.icon('🏠')
-							.action('develop')
-							.params(actionParams().id('house').landId('$landId')),
-					)
-					.option(
-						actionEffectGroupOption('royal_decree_farm')
-							.label('Establish a Farm')
-							.icon('🌾')
-							.action('develop')
-							.params(actionParams().id('farm').landId('$landId')),
-					)
-					.option(
-						actionEffectGroupOption('royal_decree_outpost')
-							.label('Fortify with an Outpost')
-							.icon('🏹')
-							.action('develop')
-							.params(actionParams().id('outpost').landId('$landId')),
-					)
-					.option(
-						actionEffectGroupOption('royal_decree_watchtower')
-							.label('Raise a Watchtower')
-							.icon('🗼')
-							.action('develop')
-							.params(actionParams().id('watchtower').landId('$landId')),
-					),
-			)
+			.effectGroup(royalDecreeDevelopGroup)
 			.effect(
 				effect(Types.Resource, ResourceMethods.REMOVE)
 					.params(resourceParams().key(Resource.happiness).amount(3))

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -6,6 +6,7 @@ import {
 } from '@kingdom-builder/protocol';
 import { Resource } from './resources';
 import { Stat } from './stats';
+import { DevelopmentId } from './developments';
 import {
 	building,
 	effect,
@@ -66,6 +67,12 @@ export function createBuildingRegistry() {
 	});
 
 	// TODO: remaining buildings from original manual config
+	const millFarmTarget = developmentTarget().id(DevelopmentId.Farm);
+	const millFarmResultParams = resultModParams()
+		.id('mill_farm_bonus')
+		.evaluation(millFarmTarget)
+		.amount(1);
+
 	registry.add('mill', {
 		...building()
 			.id('mill')
@@ -74,12 +81,7 @@ export function createBuildingRegistry() {
 			.cost(Resource.gold, 7)
 			.onBuild(
 				effect(Types.ResultMod, ResultModMethods.ADD)
-					.params(
-						resultModParams()
-							.id('mill_farm_bonus')
-							.evaluation(developmentTarget().id('farm'))
-							.amount(1),
-					)
+					.params(millFarmResultParams)
 					.build(),
 			)
 			.build(),

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -25,6 +25,7 @@ import type {
 import type { ResourceKey } from '../resources';
 import type { StatKey } from '../stats';
 import type { PopulationRoleId } from '../populationRoles';
+import type { DevelopmentId } from '../developments';
 import type { TriggerKey } from '../defs';
 import {
 	Types,
@@ -33,6 +34,10 @@ import {
 	ParamsBuilder,
 } from './builderShared';
 import type { Params } from './builderShared';
+
+type DevelopmentIdParam =
+	| DevelopmentId
+	| (string & { __developmentIdParam?: never });
 
 function resolveEffectConfig(effect: EffectConfig | EffectBuilder) {
 	return effect instanceof EffectBuilder ? effect.build() : effect;
@@ -420,10 +425,10 @@ export function statParams() {
 }
 
 class DevelopmentEffectParamsBuilder extends ParamsBuilder<{
-	id?: string;
+	id?: DevelopmentIdParam;
 	landId?: string;
 }> {
-	id(id: string) {
+	id(id: DevelopmentIdParam) {
 		return this.set(
 			'id',
 			id,
@@ -1280,11 +1285,13 @@ export function statEvaluator() {
 	return new StatEvaluatorBuilder();
 }
 
-class DevelopmentEvaluatorBuilder extends EvaluatorBuilder<{ id?: string }> {
+class DevelopmentEvaluatorBuilder extends EvaluatorBuilder<{
+	id?: DevelopmentIdParam;
+}> {
 	constructor() {
 		super('development');
 	}
-	id(id: string) {
+	id(id: DevelopmentIdParam) {
 		return this.param('id', id);
 	}
 }

--- a/packages/contents/src/developments.ts
+++ b/packages/contents/src/developments.ts
@@ -19,6 +19,15 @@ import type { DevelopmentDef } from './defs';
 
 export type { DevelopmentDef } from './defs';
 
+export const DevelopmentId = {
+	Farm: 'farm',
+	House: 'house',
+	Outpost: 'outpost',
+	Watchtower: 'watchtower',
+	Garden: 'garden',
+} as const;
+export type DevelopmentId = (typeof DevelopmentId)[keyof typeof DevelopmentId];
+
 export function createDevelopmentRegistry() {
 	const registry = new Registry<DevelopmentDef>(
 		developmentSchema.passthrough(),
@@ -26,7 +35,7 @@ export function createDevelopmentRegistry() {
 
 	registry.add('farm', {
 		...development()
-			.id('farm')
+			.id(DevelopmentId.Farm)
 			.name('Farm')
 			.icon('🌾')
 			.onGainIncomeStep(
@@ -46,7 +55,7 @@ export function createDevelopmentRegistry() {
 
 	registry.add('house', {
 		...development()
-			.id('house')
+			.id(DevelopmentId.House)
 			.name('House')
 			.icon('🏠')
 			.populationCap(1)
@@ -62,7 +71,7 @@ export function createDevelopmentRegistry() {
 
 	registry.add('outpost', {
 		...development()
-			.id('outpost')
+			.id(DevelopmentId.Outpost)
 			.name('Outpost')
 			.icon('🏹')
 			.onBuild(
@@ -80,9 +89,13 @@ export function createDevelopmentRegistry() {
 		focus: 'defense',
 	});
 
+	const watchtowerRemovalParams = developmentParams()
+		.id(DevelopmentId.Watchtower)
+		.landId('$landId');
+
 	registry.add('watchtower', {
 		...development()
-			.id('watchtower')
+			.id(DevelopmentId.Watchtower)
 			.name('Watchtower')
 			.icon('🗼')
 			.onBuild(
@@ -97,7 +110,7 @@ export function createDevelopmentRegistry() {
 			)
 			.onAttackResolved(
 				effect(Types.Development, DevelopmentMethods.REMOVE)
-					.params(developmentParams().id('watchtower').landId('$landId'))
+					.params(watchtowerRemovalParams)
 					.build(),
 			)
 			.build(),
@@ -107,7 +120,12 @@ export function createDevelopmentRegistry() {
 
 	registry.add(
 		'garden',
-		development().id('garden').name('Garden').icon('🌿').system().build(),
+		development()
+			.id(DevelopmentId.Garden)
+			.name('Garden')
+			.icon('🌿')
+			.system()
+			.build(),
 	);
 
 	return registry;

--- a/packages/contents/src/game.ts
+++ b/packages/contents/src/game.ts
@@ -2,6 +2,7 @@ import { startConfig, playerStart } from './config/builders';
 import { Resource } from './resources';
 import { Stat } from './stats';
 import { PopulationRole } from './populationRoles';
+import { DevelopmentId } from './developments';
 import type { StartConfig } from '@kingdom-builder/protocol';
 
 export const GAME_START: StartConfig = startConfig()
@@ -28,7 +29,10 @@ export const GAME_START: StartConfig = startConfig()
 				[PopulationRole.Citizen]: 0,
 			})
 			.lands((lands) => {
-				return lands.land((land) => land.development('farm')).land();
+				const developedLand = lands.land((land) => {
+					return land.development(DevelopmentId.Farm);
+				});
+				return developedLand.land();
 			}),
 	)
 	.lastPlayerCompensation((player) =>


### PR DESCRIPTION
## Summary
* Introduced the `DevelopmentId` constant and type so development definitions reuse a single source of truth for their IDs. 【F:packages/contents/src/developments.ts†L22-L135】
* Swapped actions, buildings, and game setup to reference the shared development IDs and inlined the royal decree option builder for readability. 【F:packages/contents/src/actions.ts†L1-L259】【F:packages/contents/src/buildings.ts†L1-L89】【F:packages/contents/src/game.ts†L1-L38】
* Added a `DevelopmentIdParam` helper and typed the development builder utilities to accept the constant-backed IDs while still permitting dynamic placeholders. 【F:packages/contents/src/config/builders.ts†L35-L458】【F:packages/contents/src/config/builders.ts†L1288-L1296】

## Text formatting audit (required)
1. **Translator/formatter reuse:** N/A – no translators or formatters were touched.
2. **Canonical keywords/icons/helpers touched:** None – existing development IDs were reused without changing canonical keywords or icons.
3. **Voice review:** Not required – no player-facing strings changed.

## Standards compliance (required)
1. **File length limits respected:** `wc -l` shows all edited files remain within existing allowances (legacy long files are unchanged). 【69dcd4†L1-L8】
2. **Line length limits respected:** `eslint` passed with max-length enforcement during `npm run check`. 【80b923†L1-L24】
3. **Domain separation upheld:** Changes are confined to the content package and its builder helpers. 【F:packages/contents/src/developments.ts†L22-L135】【F:packages/contents/src/config/builders.ts†L35-L458】
4. **Code standards satisfied:** `npm run check` executed `format:check`, `typecheck`, and `lint` successfully. 【aad4dd†L1-L12】【4e9223†L1-L8】【80b923†L1-L24】
5. **Tests updated:** No new tests were required; existing suites already cover development IDs and builder validation.
6. **Documentation updated:** Not needed – the change only refactors internal ID usage.
7. **`npm run check` results:** Passed during the gated commit run. 【aad4dd†L1-L12】【80b923†L1-L24】
8. **`npm run test:coverage` results:** `vitest` coverage run completed successfully. 【bdf921†L1-L9】【d1112b†L1-L73】

## Testing
* ✅ `npm run check` 【aad4dd†L1-L12】【80b923†L1-L24】
* ✅ `npm run test:coverage` 【bdf921†L1-L9】【d1112b†L1-L73】

------
https://chatgpt.com/codex/tasks/task_e_68e25e3ab7148325986aa1c6b6b7f831