### PR TITLE
Refactor resolveAttack test coverage

### DIFF
--- a/packages/engine/tests/resolveAttack-buildings.test.ts
+++ b/packages/engine/tests/resolveAttack-buildings.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAttack, runEffects } from '../src/index.ts';
+import { createTestEngine } from './helpers.ts';
+import { Resource, Stat } from '../src/state/index.ts';
+import { createContentFactory } from './factories/content.ts';
+
+describe('resolveAttack buildings', () => {
+	it('keeps buildings intact when damage is fully mitigated', () => {
+		const content = createContentFactory();
+		const bastion = content.building({});
+		const engineContext = createTestEngine({
+			buildings: content.buildings,
+		});
+		const defender = engineContext.game.opponent;
+		engineContext.game.currentPlayerIndex = 1;
+		runEffects(
+			[
+				{
+					type: 'building',
+					method: 'add',
+					params: { id: bastion.id },
+				},
+			],
+			engineContext,
+		);
+		engineContext.game.currentPlayerIndex = 0;
+		defender.absorption = 1;
+		defender.fortificationStrength = 0;
+
+		const castleBefore = defender.resources[Resource.castleHP];
+		const result = resolveAttack(defender, 3, engineContext, {
+			type: 'building',
+			id: bastion.id,
+		});
+
+		expect(result.damageDealt).toBe(0);
+		expect(defender.buildings.has(bastion.id)).toBe(true);
+		expect(defender.resources[Resource.castleHP]).toBe(castleBefore);
+		expect(result.evaluation.target.type).toBe('building');
+		if (result.evaluation.target.type === 'building') {
+			expect(result.evaluation.target.existed).toBe(true);
+			expect(result.evaluation.target.destroyed).toBe(false);
+			expect(result.evaluation.target.damage).toBe(0);
+		}
+	});
+
+	it('destroys buildings without spilling damage onto the castle', () => {
+		const content = createContentFactory();
+		const fortress = content.building({
+			onBuild: [
+				{
+					type: 'stat',
+					method: 'add',
+					params: { key: Stat.fortificationStrength, amount: 3 },
+				},
+			],
+		});
+		const engineContext = createTestEngine({
+			buildings: content.buildings,
+		});
+		const defender = engineContext.game.opponent;
+		engineContext.game.currentPlayerIndex = 1;
+		runEffects(
+			[
+				{
+					type: 'building',
+					method: 'add',
+					params: { id: fortress.id },
+				},
+			],
+			engineContext,
+		);
+		engineContext.game.currentPlayerIndex = 0;
+
+		const castleBefore = defender.resources[Resource.castleHP];
+		expect(defender.fortificationStrength).toBe(3);
+
+		const result = resolveAttack(defender, 5, engineContext, {
+			type: 'building',
+			id: fortress.id,
+		});
+
+		expect(result.damageDealt).toBe(2);
+		expect(defender.buildings.has(fortress.id)).toBe(false);
+		expect(defender.resources[Resource.castleHP]).toBe(castleBefore);
+		expect(defender.fortificationStrength).toBe(0);
+		expect(result.evaluation.target.type).toBe('building');
+		if (result.evaluation.target.type === 'building') {
+			expect(result.evaluation.target.destroyed).toBe(true);
+			expect(result.evaluation.target.damage).toBe(result.damageDealt);
+		}
+	});
+
+	it('respects ignore flags when targeting buildings', () => {
+		const content = createContentFactory();
+		const stronghold = content.building({});
+		const engineContext = createTestEngine({
+			buildings: content.buildings,
+		});
+		const defender = engineContext.game.opponent;
+		engineContext.game.currentPlayerIndex = 1;
+		runEffects(
+			[
+				{
+					type: 'building',
+					method: 'add',
+					params: { id: stronghold.id },
+				},
+			],
+			engineContext,
+		);
+		engineContext.game.currentPlayerIndex = 0;
+
+		defender.absorption = 0.9;
+		defender.fortificationStrength = 10;
+		const castleBefore = defender.resources[Resource.castleHP];
+
+		const result = resolveAttack(
+			defender,
+			4,
+			engineContext,
+			{
+				type: 'building',
+				id: stronghold.id,
+			},
+			{ ignoreAbsorption: true, ignoreFortification: true },
+		);
+
+		expect(result.damageDealt).toBe(4);
+		expect(result.evaluation.absorption.ignored).toBe(true);
+		expect(result.evaluation.fortification.ignored).toBe(true);
+		expect(defender.fortificationStrength).toBe(10);
+		expect(defender.resources[Resource.castleHP]).toBe(castleBefore);
+		expect(defender.buildings.has(stronghold.id)).toBe(false);
+		expect(result.evaluation.target.type).toBe('building');
+		if (result.evaluation.target.type === 'building') {
+			expect(result.evaluation.target.destroyed).toBe(true);
+		}
+	});
+});

--- a/packages/engine/tests/resolveAttack-targets.test.ts
+++ b/packages/engine/tests/resolveAttack-targets.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveAttack } from '../src/index.ts';
+import { createTestEngine } from './helpers.ts';
+import { Resource } from '../src/state/index.ts';
+import {
+	attackTargetHandlers,
+	type AttackTargetHandler,
+} from '../src/effects/attack_target_handlers/index.ts';
+import type { ResourceAttackTarget } from '../src/effects/attack.types.ts';
+
+describe('resolveAttack target handlers', () => {
+	it('delegates target application to registered handlers', () => {
+		const engineContext = createTestEngine();
+		const defender = engineContext.game.opponent;
+		const target: ResourceAttackTarget = {
+			type: 'resource',
+			key: Resource.castleHP,
+		};
+
+		const originalHandler = attackTargetHandlers.resource;
+		const mutation = {
+			before: defender.resources[target.key] ?? 0,
+			after: 3,
+		};
+		const applySpy = vi.fn<typeof originalHandler.applyDamage>(
+			(_target, damage) => {
+				return {
+					...mutation,
+					after: Math.max(0, mutation.before - damage),
+				};
+			},
+		);
+		const buildSpy = vi.fn<typeof originalHandler.buildLog>(
+			(resourceTarget, damage, _ctx, _defender, _meta, mut) => ({
+				type: 'resource',
+				key: resourceTarget.key,
+				before: mut.before,
+				damage,
+				after: mut.after,
+			}),
+		);
+
+		const stubHandler: AttackTargetHandler<
+			ResourceAttackTarget,
+			typeof mutation
+		> = {
+			getEvaluationModifierKey: vi.fn(
+				() => target.key,
+			) as typeof originalHandler.getEvaluationModifierKey,
+			applyDamage: applySpy,
+			buildLog: buildSpy,
+		};
+
+		attackTargetHandlers.resource = stubHandler;
+
+		try {
+			const result = resolveAttack(defender, 2, engineContext, target);
+			expect(applySpy).toHaveBeenCalledTimes(1);
+			expect(buildSpy).toHaveBeenCalledTimes(1);
+			const [applyTarget, appliedDamage] = applySpy.mock.calls[0]!;
+			expect(applyTarget).toEqual(target);
+			expect(appliedDamage).toBe(result.damageDealt);
+			const buildResult = buildSpy.mock.results[0]!.value;
+			expect(result.evaluation.target).toEqual(buildResult);
+			expect(applySpy.mock.invocationCallOrder[0]).toBeLessThan(
+				buildSpy.mock.invocationCallOrder[0]!,
+			);
+		} finally {
+			attackTargetHandlers.resource = originalHandler;
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Partitioned resolveAttack scenarios into dedicated core, building, and target suites for clarity.
- Renamed engine test contexts to the descriptive `engineContext` identifier across the suites.
- Shortened scenario titles to satisfy the 80-character guidance while preserving assertions.

## Text formatting audit (required)

1. **Translator/formatter reuse:** N/A – no player-facing text or translators involved.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** N/A – no player-facing copy was added or modified.

## Standards compliance (required)

1. **File length limits respected:** Core, building, and target suites sit at 232, 140, and 72 lines respectively. 【F:packages/engine/tests/resolveAttack.test.ts†L1-L232】【F:packages/engine/tests/resolveAttack-buildings.test.ts†L1-L140】【F:packages/engine/tests/resolveAttack-targets.test.ts†L1-L72】
2. **Line length limits respected:** Repository-wide Prettier check passed without modifications. 【bea503†L1-L24】
3. **Domain separation upheld:** Changes are limited to engine test files and keep domain boundaries intact. 【F:packages/engine/tests/resolveAttack.test.ts†L1-L232】【F:packages/engine/tests/resolveAttack-buildings.test.ts†L1-L140】【F:packages/engine/tests/resolveAttack-targets.test.ts†L1-L72】
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint) completed successfully. 【bea503†L1-L24】
5. **Tests updated:** Added focused suites for building and target handling and exercised them with Vitest. 【F:packages/engine/tests/resolveAttack-buildings.test.ts†L1-L140】【F:packages/engine/tests/resolveAttack-targets.test.ts†L1-L72】【9ad51f†L1-L23】
6. **Documentation updated:** Not required; no documentation files changed.
7. **`npm run check` results:** `npm run check` succeeded. 【bea503†L1-L24】
8. **`npm run test:coverage` results:** Coverage run completed (with existing SSR warnings) and reported results. 【e9bd40†L1-L22】

## Testing
- ✅ `npx vitest run packages/engine/tests/resolveAttack*.test.ts`
- ✅ `npm run check`
- ✅ `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e2608a51608325a12eb9d739f7ee78