### PR TITLE
Refactor happiness tier controller test helpers

### DIFF
--- a/packages/engine/tests/factories/happinessRules.ts
+++ b/packages/engine/tests/factories/happinessRules.ts
@@ -1,0 +1,152 @@
+import {
+	RULES,
+	PHASES,
+	Resource as CResource,
+} from '@kingdom-builder/contents';
+import {
+	happinessTier,
+	effect,
+	passiveParams,
+} from '@kingdom-builder/contents/config/builders';
+import {
+	Types,
+	PassiveMethods,
+} from '@kingdom-builder/contents/config/builderShared';
+import type { RuleSet } from '../../src/services';
+
+interface TierSwapConfiguration {
+	rules: RuleSet;
+	growthPhaseId: string;
+	upkeepPhaseId: string;
+	payUpkeepStepId: string;
+}
+
+export const createTierSwapConfiguration = (): TierSwapConfiguration => {
+	const [firstPhase, secondPhase] = PHASES;
+	const growthPhaseId = firstPhase?.id ?? '';
+	const upkeepPhaseId = secondPhase?.id ?? growthPhaseId;
+	const payUpkeepStepId =
+		secondPhase?.steps?.[0]?.id ?? firstPhase?.steps?.[0]?.id ?? '';
+
+	const lowRemovalToken = 'test.removal.low';
+	const highRemovalToken = 'test.removal.high';
+
+	const rules: RuleSet = {
+		...RULES,
+		tierDefinitions: [
+			happinessTier('test:tier:low')
+				.range(0, 2)
+				.passive(
+					effect()
+						.type(Types.Passive)
+						.method(PassiveMethods.ADD)
+						.params(
+							passiveParams()
+								.id('test:passive:low')
+								.meta({
+									source: {
+										type: 'tiered-resource',
+										id: 'test:tier:low',
+									},
+									removal: { token: lowRemovalToken },
+								})
+								.skipPhase(growthPhaseId)
+								.build(),
+						),
+				)
+				.text((text) => text.removal(lowRemovalToken))
+				.display((display) => display.removalCondition(lowRemovalToken))
+				.build(),
+			happinessTier('test:tier:high')
+				.range(3)
+				.passive(
+					effect()
+						.type(Types.Passive)
+						.method(PassiveMethods.ADD)
+						.params(
+							passiveParams()
+								.id('test:passive:high')
+								.meta({
+									source: {
+										type: 'tiered-resource',
+										id: 'test:tier:high',
+									},
+									removal: {
+										token: highRemovalToken,
+										text: 'test.removal.high',
+									},
+								})
+								.skipStep(upkeepPhaseId, payUpkeepStepId)
+								.build(),
+						),
+				)
+				.text((text) => text.removal(highRemovalToken))
+				.display((display) => display.removalCondition(highRemovalToken))
+				.build(),
+		],
+	};
+
+	return {
+		rules,
+		growthPhaseId,
+		upkeepPhaseId,
+		payUpkeepStepId,
+	};
+};
+
+export const createTierCostRules = (): RuleSet => ({
+	...RULES,
+	tierDefinitions: [
+		happinessTier('test:tier:base')
+			.range(0, 2)
+			.passive(
+				effect()
+					.type(Types.Passive)
+					.method(PassiveMethods.ADD)
+					.params(
+						passiveParams()
+							.id('test:passive:base')
+							.detail('test.base')
+							.meta({
+								source: {
+									type: 'tiered-resource',
+									id: 'test:tier:base',
+								},
+							})
+							.build(),
+					),
+			)
+			.text((text) => text.summary('test.base'))
+			.build(),
+		happinessTier('test:tier:boosted')
+			.range(3)
+			.passive(
+				effect()
+					.type(Types.Passive)
+					.method(PassiveMethods.ADD)
+					.params(
+						passiveParams()
+							.id('test:passive:boosted')
+							.detail('test.boosted')
+							.meta({
+								source: {
+									type: 'tiered-resource',
+									id: 'test:tier:boosted',
+								},
+							})
+							.build(),
+					)
+					.effect({
+						type: 'cost_mod',
+						method: 'add',
+						params: {
+							id: 'tier:discount',
+							key: CResource.gold,
+							percent: 0.1,
+						},
+					}),
+			)
+			.text((text) => text.summary('test.boosted'))
+			.build(),
+	],
+});


### PR DESCRIPTION
## Summary
* Extracted reusable happiness tier rule builders into `packages/engine/tests/factories/happinessRules.ts` and updated the controller tests to import them.
* Renamed the test engine context variable and tightened test descriptions to satisfy style constraints.

## Text formatting audit (required)
1. **Translator/formatter reuse:** N/A – no player-facing text added.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** N/A – no player-facing copy changed.

## Standards compliance (required)
1. **File length limits respected:** `packages/engine/tests/happiness-tier-controller.test.ts` (148 lines) and `packages/engine/tests/factories/happinessRules.ts` (152 lines) remain under the 250-line ceiling.
2. **Line length limits respected:** Verified via Prettier formatting check; no lines exceed 80 characters.
3. **Domain separation upheld:** Changes only touch engine test helpers; runtime domains remain isolated.
4. **Code standards satisfied:** `npm run lint` (pass). 【551c1a†L1-L8】
5. **Tests updated:** Updated `packages/engine/tests/happiness-tier-controller.test.ts` to use the new helper module.
6. **Documentation updated:** Not required; no documentation files were touched.
7. **`npm run check` results:** Not run; executed `npm run format:check`, `npm run typecheck`, and `npm run lint` individually to cover formatting, types, and linting. 【1a7977†L1-L4】【ef4cf7†L1-L9】【551c1a†L1-L8】
8. **`npm run test:coverage` results:** Not run; validated behaviour with the focused Vitest suite. 【c2ada7†L1-L24】

## Testing
* `npm run format:check` (pass). 【1a7977†L1-L4】
* `npm run typecheck` (pass). 【ef4cf7†L1-L9】
* `npm run lint` (pass). 【551c1a†L1-L8】
* `npx vitest run packages/engine/tests/happiness-tier-controller.test.ts` (pass). 【c2ada7†L1-L24】

------
https://chatgpt.com/codex/tasks/task_e_68e26085e5e0832594095641d77ae272