### PR TITLE
refactor: unify button styling with icons

### DIFF
--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -40,6 +40,12 @@ function GameLayout() {
 		setQuitDialogOpen(false);
 		onExit();
 	}, [onExit]);
+	const openSettings = useCallback(() => {
+		setSettingsOpen(true);
+	}, []);
+	const closeSettings = useCallback(() => {
+		setSettingsOpen(false);
+	}, []);
 	const playerAreaRef = useRef<HTMLElement | null>(null);
 	const [phasePanelHeight, setPhasePanelHeight] = useState(320);
 	useEffect(() => {
@@ -122,7 +128,7 @@ function GameLayout() {
 		<div className="relative min-h-screen w-full overflow-hidden bg-gradient-to-br from-amber-100 via-rose-100 to-sky-100 text-slate-900 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 dark:text-slate-100">
 			<SettingsDialog
 				open={isSettingsOpen}
-				onClose={() => setSettingsOpen(false)}
+				onClose={closeSettings}
 				darkMode={darkMode}
 				onToggleDark={onToggleDark}
 				musicEnabled={musicEnabled}
@@ -156,19 +162,15 @@ function GameLayout() {
 						<div className="ml-4 flex items-center gap-3">
 							<TimeControl />
 							<Button
-								onClick={() => setSettingsOpen(true)}
+								onClick={openSettings}
 								variant="secondary"
 								aria-label="Open settings"
 								title="Settings"
-								className="h-10 w-10 rounded-full p-0 text-lg shadow-lg shadow-slate-900/10 dark:shadow-black/30"
+								icon="⚙️"
 							>
-								<span aria-hidden>⚙️</span>
+								Settings
 							</Button>
-							<Button
-								onClick={requestQuit}
-								variant="danger"
-								className="rounded-full px-4 py-2 text-sm font-semibold shadow-lg shadow-rose-500/30"
-							>
+							<Button onClick={requestQuit} variant="danger" icon="🏳️">
 								Quit
 							</Button>
 						</div>

--- a/packages/web/src/Overview.tsx
+++ b/packages/web/src/Overview.tsx
@@ -114,6 +114,7 @@ export default function Overview({
 					variant="ghost"
 					className={OVERVIEW_BACK_BUTTON_CLASS}
 					onClick={onBack}
+					icon="⬅️"
 				>
 					Back to Start
 				</Button>

--- a/packages/web/src/Tutorial.tsx
+++ b/packages/web/src/Tutorial.tsx
@@ -127,6 +127,7 @@ export default function Tutorial({ onBack }: TutorialProps) {
 					variant="ghost"
 					className={TUTORIAL_BACK_BUTTON_CLASS}
 					onClick={onBack}
+					icon="⬅️"
 				>
 					Back to Start
 				</Button>

--- a/packages/web/src/components/common/Button.tsx
+++ b/packages/web/src/components/common/Button.tsx
@@ -2,20 +2,21 @@ import React from 'react';
 
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 	variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'ghost' | 'dev';
+	icon: React.ReactNode;
 };
 
 const VARIANT_CLASSES: Record<string, string> = {
 	primary:
-		'bg-gradient-to-r from-blue-600 to-indigo-500 text-white shadow-lg shadow-blue-500/30 hover:from-blue-500 hover:to-indigo-400 focus-visible:ring-blue-200/80',
+		'border-blue-500 bg-blue-600 text-white hover:bg-blue-500 focus-visible:ring-blue-200/70',
 	secondary:
-		'bg-slate-900/80 text-white shadow-lg shadow-slate-900/30 hover:bg-slate-900/70 dark:bg-white/15 dark:text-slate-100 dark:hover:bg-white/20 focus-visible:ring-slate-200/60',
+		'border-slate-500/70 bg-slate-800 text-slate-100 hover:bg-slate-700 focus-visible:ring-slate-200/60 dark:border-slate-600 dark:bg-slate-800/80 dark:text-slate-100 dark:hover:bg-slate-700/90',
 	success:
-		'bg-gradient-to-r from-emerald-500 to-teal-500 text-white shadow-lg shadow-emerald-500/30 hover:from-emerald-400 hover:to-teal-400 focus-visible:ring-emerald-200/70',
+		'border-emerald-500 bg-emerald-600 text-white hover:bg-emerald-500 focus-visible:ring-emerald-200/70',
 	danger:
-		'bg-gradient-to-r from-rose-500 to-red-500 text-white shadow-lg shadow-rose-500/40 hover:from-rose-400 hover:to-red-400 focus-visible:ring-rose-200/70',
+		'border-rose-500 bg-rose-600 text-white hover:bg-rose-500 focus-visible:ring-rose-200/70',
 	ghost:
-		'bg-transparent text-slate-700 hover:bg-white/60 dark:text-slate-200 dark:hover:bg-white/10 focus-visible:ring-white/40',
-	dev: 'bg-gradient-to-r from-purple-600 to-fuchsia-500 text-white shadow-lg shadow-purple-500/40 hover:from-purple-500 hover:to-fuchsia-400 focus-visible:ring-purple-200/70',
+		'border-transparent bg-transparent text-slate-700 hover:bg-slate-200/60 focus-visible:ring-slate-200/50 dark:text-slate-200 dark:hover:bg-white/10 dark:focus-visible:ring-white/30',
+	dev: 'border-fuchsia-500 bg-fuchsia-600 text-white hover:bg-fuchsia-500 focus-visible:ring-fuchsia-200/70',
 };
 
 export default function Button({
@@ -23,6 +24,8 @@ export default function Button({
 	disabled,
 	className = '',
 	type = 'button',
+	icon,
+	children,
 	...rest
 }: ButtonProps) {
 	const variantClass = VARIANT_CLASSES[variant] ?? VARIANT_CLASSES.secondary;
@@ -30,10 +33,18 @@ export default function Button({
 		<button
 			type={type}
 			disabled={disabled}
-			className={`inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${
+			className={`inline-flex items-center justify-start gap-3 rounded-xl border px-4 py-2 text-left text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${
 				disabled ? '' : 'hoverable'
 			} ${variantClass} focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-0 ${className}`}
 			{...rest}
-		/>
+		>
+			<span
+				aria-hidden
+				className="flex h-6 w-6 items-center justify-center text-base"
+			>
+				{icon}
+			</span>
+			<span className="flex-1 text-left leading-tight">{children}</span>
+		</button>
 	);
 }

--- a/packages/web/src/components/common/ConfirmDialog.tsx
+++ b/packages/web/src/components/common/ConfirmDialog.tsx
@@ -69,10 +69,15 @@ export default function ConfirmDialog({
 					{description}
 				</p>
 				<div className="mt-8 flex flex-wrap justify-end gap-3">
-					<Button variant="ghost" onClick={onCancel} className="px-5">
+					<Button variant="ghost" onClick={onCancel} className="px-5" icon="↩️">
 						{cancelLabel}
 					</Button>
-					<Button variant="danger" onClick={onConfirm} className="px-5">
+					<Button
+						variant="danger"
+						onClick={onConfirm}
+						className="px-5"
+						icon="⚠️"
+					>
 						{confirmLabel}
 					</Button>
 				</div>

--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -50,22 +50,12 @@ const PhasePanel = React.forwardRef<HTMLDivElement, PhasePanelProps>(
 
 		const phaseTabs = ctx.phases.map((phase) => {
 			const isSelected = displayPhase === phase.id;
-			const baseTabClassSegments = [
-				'relative flex items-center gap-2 rounded-full',
-				'px-4 py-2 text-sm transition-all',
-			];
-			const selectedTabSegments = [
-				'bg-gradient-to-r from-blue-500/90 to-indigo-500/90',
-				'text-white shadow-lg shadow-blue-500/30',
-			];
-			const idleTabSegments = [
-				'text-slate-600 hover:bg-white/60 hover:text-slate-800',
-				'dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-slate-100',
-			];
-			const tabSegments = isSelected ? selectedTabSegments : idleTabSegments;
-			const tabClasses = [
-				...baseTabClassSegments,
-				...tabSegments,
+			const tabClassSegments = [
+				'rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em]',
+				'transition-all',
+				isSelected
+					? 'shadow-sm'
+					: 'border-slate-300/60 text-slate-600 hover:text-slate-900 dark:border-slate-600/60 dark:text-slate-300 dark:hover:text-slate-100',
 				tabsEnabled ? null : 'opacity-60',
 			]
 				.filter(Boolean)
@@ -84,13 +74,11 @@ const PhasePanel = React.forwardRef<HTMLDivElement, PhasePanelProps>(
 					type="button"
 					disabled={!tabsEnabled}
 					onClick={handleSelectPhase}
-					variant="ghost"
-					className={tabClasses}
+					variant={isSelected ? 'primary' : 'ghost'}
+					className={tabClassSegments}
+					icon={phase.icon}
 				>
-					<span className="text-lg leading-none">{phase.icon}</span>
-					<span className="text-xs font-semibold uppercase tracking-[0.2em]">
-						{phase.label}
-					</span>
+					{phase.label}
 				</Button>
 			);
 		});
@@ -182,6 +170,7 @@ const PhasePanel = React.forwardRef<HTMLDivElement, PhasePanelProps>(
 				variant="primary"
 				disabled={shouldDisableEndTurn}
 				onClick={handleEndTurnClick}
+				icon="⏭️"
 			>
 				Next Turn
 			</Button>

--- a/packages/web/src/components/settings/SettingsDialog.tsx
+++ b/packages/web/src/components/settings/SettingsDialog.tsx
@@ -149,7 +149,7 @@ export default function SettingsDialog({
 					/>
 				</div>
 				<div className="mt-8 flex justify-end">
-					<Button variant="ghost" onClick={onClose} className="px-6">
+					<Button variant="ghost" onClick={onClose} className="px-6" icon="✅">
 						Close
 					</Button>
 				</div>

--- a/packages/web/src/menu/CallToActionSection.tsx
+++ b/packages/web/src/menu/CallToActionSection.tsx
@@ -100,6 +100,7 @@ export function CallToActionSection({
 						variant="primary"
 						className={PRIMARY_BUTTON_CLASS}
 						onClick={onStart}
+						icon="🎮"
 					>
 						Start New Game
 					</Button>
@@ -107,21 +108,17 @@ export function CallToActionSection({
 						variant="dev"
 						className={DEV_BUTTON_CLASS}
 						onClick={onStartDev}
+						icon="🧪"
 					>
 						Start Dev/Debug Game
 					</Button>
 					<Button
 						variant="ghost"
-						className={[
-							SETTINGS_BUTTON_CLASS,
-							'flex items-center justify-center gap-2',
-						].join(' ')}
+						className={SETTINGS_BUTTON_CLASS}
 						onClick={onOpenSettings}
+						icon="⚙️"
 					>
-						<span aria-hidden className="text-base">
-							⚙️
-						</span>
-						<span>Settings</span>
+						Settings
 					</Button>
 				</div>
 			</div>
@@ -137,6 +134,7 @@ export function CallToActionSection({
 							variant="ghost"
 							className={GHOST_BUTTON_CLASS}
 							onClick={onTutorial}
+							icon="📘"
 						>
 							Tutorial
 						</Button>
@@ -144,6 +142,7 @@ export function CallToActionSection({
 							variant="ghost"
 							className={GHOST_BUTTON_CLASS}
 							onClick={onOverview}
+							icon="📜"
 						>
 							Game Overview
 						</Button>

--- a/packages/web/tests/PhasePanel.test.tsx
+++ b/packages/web/tests/PhasePanel.test.tsx
@@ -76,9 +76,10 @@ describe('<PhasePanel />', () => {
 			).toBeInTheDocument();
 		}
 		const firstPhase = ctx.phases[0];
-		const phaseLabel = `${firstPhase.icon} ${firstPhase.label}`;
-		expect(
-			screen.getByRole('button', { name: phaseLabel }),
-		).toBeInTheDocument();
+		const phaseButton = screen.getByRole('button', {
+			name: firstPhase.label,
+		});
+		expect(phaseButton).toBeInTheDocument();
+		expect(within(phaseButton).getByText(firstPhase.label)).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary
- Standardized the shared `Button` component so every button supplies an icon, left-aligned content, and flat variant styling. 
- Updated game header controls, menu call-to-actions, dialogs, and overview/tutorial navigation to use the new button contract with consistent iconography. 
- Refined phase tab styling in the phase panel and aligned the associated test with the updated accessible labels. 

## Text formatting audit (required)
1. **Translator/formatter reuse:** Reused existing button copy throughout the UI; no new translators or formatters were needed.
2. **Canonical keywords/icons/helpers touched:** Added emoji icons (⚙️, 🏳️, 🎮, 🧪, 📘, 📜, ⏭️, ⬅️, ✅, ↩️, ⚠️) via the shared button API so all buttons display consistent glyphs.
3. **Voice review:** Confirmed all surfaced button labels retain the established UI voice and tone.

## Standards compliance (required)
1. **File length limits respected:** Touched files remain under the 250-line cap (e.g., `Button.tsx` is 50 lines and `Game.tsx` tops out at line 220).
2. **Line length limits respected:** `npm run lint` passed without max-length violations.
3. **Domain separation upheld:** Changes are limited to web presentation components and accompanying web tests; engine/content layers were untouched.
4. **Code standards satisfied:** `npm run lint` completed successfully.
5. **Tests updated:** Adjusted `PhasePanel.test.tsx` expectations to match the new button semantics.
6. **Documentation updated:** Not required; no docs reference these UI controls.
7. **`npm run check` results:** Executed via the pre-commit hook (see captured log in /tmp/commit.log).
8. **`npm run test:coverage` results:** Completed successfully (see command output below).

## Testing
- ✅ `npm run lint`
- ✅ `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e25e1545008325920cb88f593ea05a