### PR TITLE
Refactor population assignment passives

### DIFF
--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -35,6 +35,10 @@ import {
 } from './builderShared';
 import type { Params } from './builderShared';
 
+export function populationAssignmentPassiveId(role: PopulationRoleId) {
+	return `${role}_$player_$index`;
+}
+
 function resolveEffectConfig(effect: EffectConfig | EffectBuilder) {
 	return effect instanceof EffectBuilder ? effect.build() : effect;
 }

--- a/packages/contents/src/populations.ts
+++ b/packages/contents/src/populations.ts
@@ -8,6 +8,8 @@ import {
 	resourceParams,
 	statParams,
 	populationEvaluator,
+	passiveParams,
+	populationAssignmentPassiveId,
 } from './config/builders';
 import {
 	Types,
@@ -32,6 +34,14 @@ const LEGION_STRENGTH_GAIN_PARAMS = statParams()
 const FORTIFIER_STRENGTH_GAIN_PARAMS = statParams()
 	.key(Stat.fortificationStrength)
 	.amount(1)
+	.build();
+
+const LEGION_ASSIGNMENT_PASSIVE_PARAMS = passiveParams()
+	.id(populationAssignmentPassiveId(PopulationRole.Legion))
+	.build();
+
+const FORTIFIER_ASSIGNMENT_PASSIVE_PARAMS = passiveParams()
+	.id(populationAssignmentPassiveId(PopulationRole.Fortifier))
 	.build();
 
 export function createPopulationRegistry() {
@@ -70,7 +80,7 @@ export function createPopulationRegistry() {
 			.upkeep(Resource.gold, 1)
 			.onAssigned(
 				effect(Types.Passive, PassiveMethods.ADD)
-					.param('id', 'legion_$player_$index')
+					.params(LEGION_ASSIGNMENT_PASSIVE_PARAMS)
 					.effect(
 						effect(Types.Stat, StatMethods.ADD)
 							.params(LEGION_STRENGTH_GAIN_PARAMS)
@@ -80,7 +90,7 @@ export function createPopulationRegistry() {
 			)
 			.onUnassigned(
 				effect(Types.Passive, PassiveMethods.REMOVE)
-					.param('id', 'legion_$player_$index')
+					.params(LEGION_ASSIGNMENT_PASSIVE_PARAMS)
 					.build(),
 			)
 			.build(),
@@ -95,7 +105,7 @@ export function createPopulationRegistry() {
 			.upkeep(Resource.gold, 1)
 			.onAssigned(
 				effect(Types.Passive, PassiveMethods.ADD)
-					.param('id', 'fortifier_$player_$index')
+					.params(FORTIFIER_ASSIGNMENT_PASSIVE_PARAMS)
 					.effect(
 						effect(Types.Stat, StatMethods.ADD)
 							.params(FORTIFIER_STRENGTH_GAIN_PARAMS)
@@ -105,7 +115,7 @@ export function createPopulationRegistry() {
 			)
 			.onUnassigned(
 				effect(Types.Passive, PassiveMethods.REMOVE)
-					.param('id', 'fortifier_$player_$index')
+					.params(FORTIFIER_ASSIGNMENT_PASSIVE_PARAMS)
 					.build(),
 			)
 			.build(),


### PR DESCRIPTION
## Summary
- add `populationAssignmentPassiveId` to centralize the canonical population passive id template
- reuse shared passive params for Legion and Fortifier assignments to remove duplicate string literals

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable—no translators or formatters were touched.
2. **Canonical keywords/icons/helpers touched:** Added the `populationAssignmentPassiveId` helper and reused the existing `passiveParams()` builder while wiring Legion and Fortifier passives.
3. **Voice review:** Not applicable—no player-facing copy changed.

## Standards compliance (required)
1. **File length limits respected:** `packages/contents/src/populations.ts` remains 132 lines and `packages/contents/src/config/builders.ts` stays at its pre-existing 2422 lines. (See `wc -l` output below.)
2. **Line length limits respected:** Newly added lines stay within 80 characters; longer lines in `builders.ts` pre-date this change.
3. **Domain separation upheld:** Changes are confined to the content package and only adjust content builders/definitions.
4. **Code standards satisfied:** `npm run lint` and `npm run check` both completed without errors (see logs below).
5. **Tests updated:** No new tests were required; existing suites under `npm run check` cover the affected content configuration.
6. **Documentation updated:** No documentation changes were necessary for this internal refactor.
7. **`npm run check` results:**
   ```
   > kingdom-builder-engine@0.1.0 check
   > npm run format:check && npm run typecheck && npm run lint
   ...
   Test Files  98 passed (98)
        Tests  247 passed (247)
     Start at  12:19:51
     Duration  75.87s (transform 9.06s, setup 0ms, collect 57.73s, tests 7.87s, environment 11.71s, prepare 19.42s)
   ```
8. **`npm run test:coverage` results:**
   ```
   -------------------|---------|----------|---------|---------|-------------------
   File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
   ...
   -------------------|---------|----------|---------|---------|-------------------
   ```

## Testing
- ✅ `npm run lint`
- ✅ `CI=1 npm run check`
- ✅ `CI=1 npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e2603c1eb48325afac28b2789ef99c