### PR TITLE
Refactor attack zero-damage tests and split handler coverage

### DIFF
--- a/packages/engine/src/effects/attack_handlers.ts
+++ b/packages/engine/src/effects/attack_handlers.ts
@@ -1,0 +1,1 @@
+export { attackTargetHandlers } from './attack_target_handlers';

--- a/packages/engine/tests/attack-evaluation-handlers.test.ts
+++ b/packages/engine/tests/attack-evaluation-handlers.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runEffects } from '../src/index.ts';
+import { attackTargetHandlers } from '../src/effects/attack_handlers.ts';
+import { Resource } from '../src/state/index.ts';
+import { createTestEngine } from './helpers.ts';
+import { createContentFactory } from './factories/content.ts';
+
+describe('attack:perform evaluation handlers', () => {
+	it('delegates modifier keys for resource targets to handler', () => {
+		const engineContext = createTestEngine();
+		const attacker = engineContext.activePlayer;
+		attacker.armyStrength = 2;
+
+		const target = { type: 'resource', key: Resource.castleHP } as const;
+		const resourceHandler = attackTargetHandlers.resource;
+		const originalGetKey = resourceHandler.getEvaluationModifierKey.bind(
+			resourceHandler,
+		) as typeof resourceHandler.getEvaluationModifierKey;
+		const derivedKey = 'resource-eval-key';
+		const getKeySpy = vi.fn(() => derivedKey) as typeof originalGetKey;
+		resourceHandler.getEvaluationModifierKey = getKeySpy;
+		const evaluationSpy = vi.spyOn(engineContext.passives, 'runEvaluationMods');
+
+		try {
+			runEffects(
+				[
+					{
+						type: 'attack',
+						method: 'perform',
+						params: { target },
+					},
+				],
+				engineContext,
+			);
+
+			expect(getKeySpy).toHaveBeenCalledWith(target);
+			expect(evaluationSpy).toHaveBeenCalled();
+			const modifiers = evaluationSpy.mock.calls[0]![2];
+			expect(modifiers[0]!.key).toBe(derivedKey);
+		} finally {
+			resourceHandler.getEvaluationModifierKey = originalGetKey;
+			evaluationSpy.mockRestore();
+		}
+	});
+
+	it('delegates modifier keys for building targets to handler', () => {
+		const content = createContentFactory();
+		const workshop = content.building({});
+		const engineContext = createTestEngine({ buildings: content.buildings });
+		const attacker = engineContext.activePlayer;
+		attacker.armyStrength = 3;
+
+		const target = { type: 'building', id: workshop.id } as const;
+		const buildingHandler = attackTargetHandlers.building;
+		const originalGetKey = buildingHandler.getEvaluationModifierKey.bind(
+			buildingHandler,
+		) as typeof buildingHandler.getEvaluationModifierKey;
+		const derivedKey = 'building-eval-key';
+		const getKeySpy = vi.fn(() => derivedKey) as typeof originalGetKey;
+		buildingHandler.getEvaluationModifierKey = getKeySpy;
+		const evaluationSpy = vi.spyOn(engineContext.passives, 'runEvaluationMods');
+
+		try {
+			runEffects(
+				[
+					{
+						type: 'attack',
+						method: 'perform',
+						params: { target },
+					},
+				],
+				engineContext,
+			);
+
+			expect(getKeySpy).toHaveBeenCalledWith(target);
+			expect(evaluationSpy).toHaveBeenCalled();
+			const modifiers = evaluationSpy.mock.calls[0]![2];
+			expect(modifiers[0]!.key).toBe(derivedKey);
+		} finally {
+			buildingHandler.getEvaluationModifierKey = originalGetKey;
+			evaluationSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- rename the attack evaluation tests to use descriptive engine context and log variables while keeping each description under the 80-character style limit
- move the handler-specific assertions into a dedicated `attack-evaluation-handlers` suite so the zero-damage spec stays compact
- re-export the engine attack target handlers for shorter test imports

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no player-facing text was touched.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** Not applicable; no in-game text or logs were modified.

## Standards compliance (required)
1. **File length limits respected:** `attack-zero-damage-no-effects.test.ts` is 186 lines and the new `attack-evaluation-handlers.test.ts` is 92 lines, both under the 250-line limit. 【724239†L1-L4】
2. **Line length limits respected:** Updated expectations and log assertions now span multiple lines so no modified line exceeds 80 characters. 【F:packages/engine/tests/attack-zero-damage-no-effects.test.ts†L68-L130】【F:packages/engine/tests/attack-evaluation-handlers.test.ts†L14-L83】
3. **Domain separation upheld:** Changes only touch engine tests and a small engine re-export, with no cross-domain coupling. 【F:packages/engine/tests/attack-zero-damage-no-effects.test.ts†L1-L184】【F:packages/engine/tests/attack-evaluation-handlers.test.ts†L1-L83】【F:packages/engine/src/effects/attack_handlers.ts†L1-L1】
4. **Code standards satisfied:** Pre-commit `npm run check` (formatting, type checks, linting, and tests) completed successfully. 【bb7536†L1-L38】
5. **Tests updated:** Added `attack-evaluation-handlers.test.ts` and adjusted `attack-zero-damage-no-effects.test.ts` expectations. 【F:packages/engine/tests/attack-zero-damage-no-effects.test.ts†L9-L183】【F:packages/engine/tests/attack-evaluation-handlers.test.ts†L8-L83】
6. **Documentation updated:** Not required; no docs were impacted.
7. **`npm run check` results:** See `/tmp/git-commit.log` for the full output from the pre-commit run. 【bb7536†L1-L38】
8. **`npm run test:coverage` results:** Output is stored in `/tmp/npm-test-coverage.log`. 【2242e5†L1-L20】

## Testing
- `npm run check` (pre-commit) — pass 【bb7536†L1-L38】
- `npx vitest run packages/engine/tests/attack-zero-damage-no-effects.test.ts packages/engine/tests/attack-evaluation-handlers.test.ts` — pass 【82728a†L1-L20】
- `npm run test:coverage` — pass 【2242e5†L1-L20】

------
https://chatgpt.com/codex/tasks/task_e_68e2608557088325a4c4829eee7123d0