### PR TITLE
Refine missing selection error formatting

### DIFF
--- a/packages/engine/src/actions/action_execution.ts
+++ b/packages/engine/src/actions/action_execution.ts
@@ -88,9 +88,10 @@ function executeAction<T extends string>(
 			.map((id) => `"${id}"`)
 			.join(', ');
 		const suffix = resolved.missingSelections.length > 1 ? 'groups' : 'group';
-		throw new Error(
-			`Action ${actionDefinition.id} requires a selection for effect ${suffix} ${formatted}`,
-		);
+		const missingSelectionMessage =
+			`Action ${actionDefinition.id} requires a selection for effect ` +
+			`${suffix} ${formatted}`;
+		throw new Error(missingSelectionMessage);
 	}
 	const pendingBuildingIds = collectPendingBuildingAdds(resolved.effects);
 	assertBuildingsNotYetConstructed(pendingBuildingIds, engineContext);


### PR DESCRIPTION
## Summary
* Reformat the missing selection error throw to satisfy the 80-character limit without changing its message.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no player-facing text was modified.
2. **Canonical keywords/icons/helpers touched:** None; the change only touches engine error handling.
3. **Voice review:** Not applicable; no surfaces with localized or player-facing text were affected.

## Standards compliance (required)
1. **File length limits respected:** `packages/engine/src/actions/action_execution.ts` remains at 147 lines (`wc -l` output).
2. **Line length limits respected:** The reflowed template literal keeps each source line ≤80 characters while preserving the runtime message.
3. **Domain separation upheld:** Only the engine action execution helper was updated; no other domain files were changed.
4. **Code standards satisfied:** Manual review confirmed adherence to the repository's tab indentation and formatting rules for the touched block.
5. **Tests updated:** No tests required updates for this formatting-only change.
6. **Documentation updated:** No documentation changes were necessary for this refactor.
7. **`npm run check` results:** Not run; the repository currently contains unrelated Prettier violations that block the command.
8. **`npm run test:coverage` results:** Not run; coverage was not requested for this localized formatting adjustment.

## Testing
* Not run (not requested for this formatting-only change).


------
https://chatgpt.com/codex/tasks/task_e_68e265b7adf08325a7e7e3ef07db2753