### PR TITLE
Fix phase tab selection resetting

### DIFF
--- a/packages/web/src/state/useMainPhaseTracker.ts
+++ b/packages/web/src/state/useMainPhaseTracker.ts
@@ -12,6 +12,7 @@ interface MainPhaseTrackerOptions {
 		React.SetStateAction<Record<string, PhaseStep[]>>
 	>;
 	setDisplayPhase: (phase: string) => void;
+	getDisplayPhase: () => string;
 }
 
 export function useMainPhaseTracker({
@@ -21,6 +22,7 @@ export function useMainPhaseTracker({
 	setPhaseSteps,
 	setPhaseHistories,
 	setDisplayPhase,
+	getDisplayPhase,
 }: MainPhaseTrackerOptions) {
 	const [mainApStart, setMainApStart] = useState(0);
 
@@ -52,15 +54,25 @@ export function useMainPhaseTracker({
 					active: remaining > 0,
 				},
 			];
-			setPhaseSteps(steps);
+			const currentDisplay = getDisplayPhase();
+			const currentPhaseId = snapshot.game.currentPhase;
+			const viewingActionPhase =
+				actionPhaseId !== undefined && currentDisplay === actionPhaseId;
+			const shouldUpdateSteps =
+				actionPhaseId === undefined || viewingActionPhase;
+			if (shouldUpdateSteps) {
+				setPhaseSteps(steps);
+			}
 			if (actionPhaseId) {
 				setPhaseHistories((prev) => ({
 					...prev,
 					[actionPhaseId]: steps,
 				}));
-				setDisplayPhase(actionPhaseId);
-			} else {
-				setDisplayPhase(snapshot.game.currentPhase);
+				if (viewingActionPhase) {
+					setDisplayPhase(actionPhaseId);
+				}
+			} else if (currentDisplay === currentPhaseId) {
+				setDisplayPhase(currentPhaseId);
 			}
 		},
 		[
@@ -71,6 +83,7 @@ export function useMainPhaseTracker({
 			setDisplayPhase,
 			setPhaseHistories,
 			setPhaseSteps,
+			getDisplayPhase,
 		],
 	);
 

--- a/packages/web/src/state/usePhaseProgress.ts
+++ b/packages/web/src/state/usePhaseProgress.ts
@@ -41,14 +41,14 @@ export function usePhaseProgress({
 }: PhaseProgressOptions) {
 	const [phaseSteps, setPhaseSteps] = useState<PhaseStep[]>([]);
 	const [phaseTimer, setPhaseTimer] = useState(0);
-	const [displayPhase, setDisplayPhase] = useState(
+	const [displayPhase, setDisplayPhaseState] = useState(
 		sessionState.game.currentPhase,
 	);
 	const displayPhaseRef = useRef(displayPhase);
-
-	useEffect(() => {
-		displayPhaseRef.current = displayPhase;
-	}, [displayPhase]);
+	const setDisplayPhase = useCallback((phase: string) => {
+		displayPhaseRef.current = phase;
+		setDisplayPhaseState(phase);
+	}, []);
 	const getDisplayPhase = useCallback(() => displayPhaseRef.current, []);
 	const [phaseHistories, setPhaseHistories] = useState<
 		Record<string, PhaseStep[]>

--- a/packages/web/src/state/usePhaseProgress.ts
+++ b/packages/web/src/state/usePhaseProgress.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
 	type EngineSession,
 	type EngineSessionSnapshot,
@@ -44,6 +44,12 @@ export function usePhaseProgress({
 	const [displayPhase, setDisplayPhase] = useState(
 		sessionState.game.currentPhase,
 	);
+	const displayPhaseRef = useRef(displayPhase);
+
+	useEffect(() => {
+		displayPhaseRef.current = displayPhase;
+	}, [displayPhase]);
+	const getDisplayPhase = useCallback(() => displayPhaseRef.current, []);
 	const [phaseHistories, setPhaseHistories] = useState<
 		Record<string, PhaseStep[]>
 	>({});
@@ -57,6 +63,7 @@ export function usePhaseProgress({
 			setPhaseSteps,
 			setPhaseHistories,
 			setDisplayPhase,
+			getDisplayPhase,
 		});
 
 	const { runDelay, runStepDelay } = usePhaseDelays({


### PR DESCRIPTION
## Summary
- ensure the phase progress hook keeps a ref-backed getter for the currently displayed phase so user tab changes are preserved when phase data updates【F:packages/web/src/state/usePhaseProgress.ts†L42-L112】
- guard main phase tracking updates so history mutations no longer overwrite the active tab selection while still syncing the action phase history【F:packages/web/src/state/useMainPhaseTracker.ts†L6-L87】

## Text formatting audit (required)

1. **Translator/formatter reuse:** Not applicable; no translator or formatter modules were modified.
2. **Canonical keywords/icons/helpers touched:** None; no keyword or icon helpers were changed.
3. **Voice review:** Not required because no player-facing copy was introduced or edited.

## Standards compliance (required)

1. **File length limits respected:** Updated hooks remain under the 250-line ceiling (usePhaseProgress.ts at 178 lines, useMainPhaseTracker.ts at 91 lines).【F:packages/web/src/state/usePhaseProgress.ts†L1-L178】【F:packages/web/src/state/useMainPhaseTracker.ts†L1-L90】
2. **Line length limits respected:** ESLint passed without formatting violations, confirming 80-character compliance.【6c22e8†L1-L18】
3. **Domain separation upheld:** Changes are limited to web state management hooks and do not cross into engine, content, or protocol domains.【F:packages/web/src/state/usePhaseProgress.ts†L42-L177】【F:packages/web/src/state/useMainPhaseTracker.ts†L6-L90】
4. **Code standards satisfied:** `npm run check` succeeded, covering formatting, type-checking, and linting requirements.【6c22e8†L1-L18】
5. **Tests updated:** No new tests were necessary; the existing `<PhasePanel />` test suite passes against the change set.【fd2863†L1-L28】
6. **Documentation updated:** Not needed; behavior adjustments are internal to state hooks with no documentation impact.
7. **`npm run check` results:** See the captured `npm run check` output for full details.【6c22e8†L1-L18】
8. **`npm run test:coverage` results:** Coverage run completed successfully (see summarized output).【854574†L1-L20】

## Testing

- `npm run test -- PhasePanel` (pass)【fd2863†L1-L28】
- `npm run check` (pass)【6c22e8†L1-L18】
- `npm run test:coverage` (pass with expected SSR warnings)【854574†L1-L20】【c3f3f2†L1-L13】

------
https://chatgpt.com/codex/tasks/task_e_68e25f490a708325981ac95313f84125