### PR TITLE
Refactor attack evaluation strings for line length

### DIFF
--- a/packages/web/src/translation/effects/formatters/attack/evaluation.ts
+++ b/packages/web/src/translation/effects/formatters/attack/evaluation.ts
@@ -34,15 +34,26 @@ export function buildDescribeEntry(
 	const { stats, ignoreAbsorption } = context;
 	const power = stats.power;
 	const absorption = stats.absorption;
+	const powerLabel = statLabel(power, 'attack power');
+	const absorptionLabel = statLabel(absorption, 'damage reduction');
 	const title = power
-		? `Attack opponent with your ${statLabel(power, 'attack power')}`
+		? ['Attack opponent with your ', powerLabel].join('')
 		: 'Attack opponent with your forces';
+	const ignoringAbsorption = [
+		'Ignoring ',
+		absorptionLabel,
+		' damage reduction',
+	].join('');
+	const appliedAbsorption = [
+		absorptionLabel,
+		' damage reduction applied',
+	].join('');
 	const absorptionItem = ignoreAbsorption
 		? absorption
-			? `Ignoring ${statLabel(absorption, 'damage reduction')} damage reduction`
+			? ignoringAbsorption
 			: 'Ignoring damage reduction'
 		: absorption
-			? `${statLabel(absorption, 'damage reduction')} damage reduction applied`
+			? appliedAbsorption
 			: 'Damage reduction applied';
 	return {
 		title,
@@ -57,14 +68,25 @@ export function defaultFortificationItems(
 	const fort = stats.fortification;
 	if (!fort) {
 		return [
-			`Damage applied to opponent's defenses`,
-			`If opponent defenses fall, overflow remaining damage on opponent ${targetLabel}`,
+			"Damage applied to opponent's defenses",
+			[
+				'If opponent defenses fall, ',
+				'overflow remaining damage ',
+				'on opponent ',
+				targetLabel,
+			].join(''),
 		];
 	}
 	const fortDisplay = statLabel(fort, 'fortification');
 	return [
 		`Damage applied to opponent's ${fortDisplay}`,
-		`If opponent ${fortDisplay} reduced to 0, overflow remaining damage on opponent ${targetLabel}`,
+		[
+			'If opponent ',
+			fortDisplay,
+			' reduced to 0, overflow remaining damage ',
+			'on opponent ',
+			targetLabel,
+		].join(''),
 	];
 }
 
@@ -76,13 +98,24 @@ export function buildingFortificationItems(
 	if (!fort) {
 		return [
 			`Damage applied to opponent's defenses`,
-			`If opponent defenses fall, overflow remaining damage attempts to destroy opponent ${targetLabel}`,
+			[
+				'If opponent defenses fall, ',
+				'overflow remaining damage ',
+				'attempts to destroy opponent ',
+				targetLabel,
+			].join(''),
 		];
 	}
 	const fortDisplay = statLabel(fort, 'fortification');
 	return [
 		`Damage applied to opponent's ${fortDisplay}`,
-		`If opponent ${fortDisplay} reduced to 0, overflow remaining damage attempts to destroy opponent ${targetLabel}`,
+		[
+			'If opponent ',
+			fortDisplay,
+			' reduced to 0, overflow remaining damage ',
+			'attempts to destroy opponent ',
+			targetLabel,
+		].join(''),
 	];
 }
 
@@ -130,24 +163,40 @@ export function buildStandardEvaluationEntry(
 		}
 		return `${info.label} ${formatted}`;
 	};
-	const title = `Damage evaluation: ${powerValue(log.power.modified)} vs. ${absorptionPart} ${fortPart} ${targetDisplay(
-		target.before,
-	)}`;
+	const title = [
+		'Damage evaluation:',
+		`${powerValue(log.power.modified)} vs.`,
+		absorptionPart,
+		fortPart,
+		targetDisplay(target.before),
+	].join(' ');
 	const items: SummaryEntry[] = [];
 
 	if (log.absorption.ignored) {
-		items.push(`${powerValue(log.power.modified)} ignores ${absorptionLabel}`);
+		items.push(
+			[
+				powerValue(log.power.modified),
+				'ignores',
+				absorptionLabel,
+			].join(' '),
+		);
 	} else {
 		items.push(
-			`${powerValue(log.power.modified)} vs. ${absorptionValue(
-				log.absorption.before,
-			)} --> ${powerValue(log.absorption.damageAfter)}`,
+			[
+				`${powerValue(log.power.modified)} vs.`,
+				absorptionValue(log.absorption.before),
+				`--> ${powerValue(log.absorption.damageAfter)}`,
+			].join(' '),
 		);
 	}
 
 	if (log.fortification.ignored) {
 		items.push(
-			`${powerValue(log.absorption.damageAfter)} bypasses ${fortLabel}`,
+			[
+				powerValue(log.absorption.damageAfter),
+				'bypasses',
+				fortLabel,
+			].join(' '),
 		);
 	} else {
 		const remaining = Math.max(
@@ -155,14 +204,21 @@ export function buildStandardEvaluationEntry(
 			log.absorption.damageAfter - log.fortification.damage,
 		);
 		items.push(
-			`${powerValue(log.absorption.damageAfter)} vs. ${fortValue(
-				log.fortification.before,
-			)} --> ${fortValue(log.fortification.after)} ${powerValue(remaining)}`,
+			[
+				`${powerValue(log.absorption.damageAfter)} vs.`,
+				fortValue(log.fortification.before),
+				`--> ${fortValue(log.fortification.after)}`,
+				powerValue(remaining),
+			].join(' '),
 		);
 	}
 
 	items.push(
-		`${powerValue(log.target.damage)} vs. ${targetDisplay(target.before)} --> ${targetDisplay(target.after)}`,
+		[
+			`${powerValue(log.target.damage)} vs.`,
+			targetDisplay(target.before),
+			`--> ${targetDisplay(target.after)}`,
+		].join(' '),
 	);
 
 	return { title, items };


### PR DESCRIPTION
## Summary
- restructure `packages/web/src/translation/effects/formatters/attack/evaluation.ts` to split long template literals used for overflow descriptions and evaluation summaries while preserving the rendered text

## Text formatting audit (required)
1. **Translator/formatter reuse:** Adjusted existing helpers in `packages/web/src/translation/effects/formatters/attack/evaluation.ts`; no new translators were introduced.
2. **Canonical keywords/icons/helpers touched:** Continued using existing helpers `statLabel`, `statValue`, `formatNumber`, `formatPercent`, `formatStatValue`, and `iconLabel` in their prior contexts.
3. **Voice review:** Text output is unchanged—strings were only reassembled—so summary, description, and log voices remain consistent with previous usage.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/src/translation/effects/formatters/attack/evaluation.ts` is 220 lines (<250). (See `wc -l packages/web/src/translation/effects/formatters/attack/evaluation.ts`.)
2. **Line length limits respected:** Verified with a Python check (`len(line.expandtabs(8))`) that the maximum line length in the modified file is now 80 characters. (See `python - <<'PY' ...` check.)
3. **Domain separation upheld:** Changes are confined to the web translation layer; engine/content domains were untouched.
4. **Code standards satisfied:** Formatting and helper usage follow existing patterns; pre-commit linting could not complete due to an unrelated Prettier warning (see below).
5. **Tests updated:** Not applicable—no logic changes requiring new or updated tests.
6. **Documentation updated:** Not required because no behavior or user-facing copy changed.
7. **`npm run check` results:** Attempted during commit; it failed because `prettier --check` reported an unrelated formatting issue in `packages/contents/src/actions.ts`. (See `/tmp/commit.log` excerpt.)
8. **`npm run test:coverage` results:** Not run for this change.

## Testing
- Not run (`npm run check` fails in this workspace because `packages/contents/src/actions.ts` violates Prettier; no tests executed after the formatting-only edits.)

------
https://chatgpt.com/codex/tasks/task_e_68e265bb832c8325bcd40c975a92ab54