### PR TITLE
Refactor phase identifiers and update usages

### DIFF
--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -25,8 +25,8 @@ import type {
 import type { ResourceKey } from '../resources';
 import type { StatKey } from '../stats';
 import type { PopulationRoleId } from '../populationRoles';
-import type { TriggerKey } from '../defs';
 import type { ActionId } from '../actions';
+import type { PhaseId, PhaseStepId, PhaseTrigger } from '../phases';
 import {
 	Types,
 	PassiveMethods,
@@ -556,17 +556,17 @@ class PassiveEffectParamsBuilder extends ParamsBuilder<{
 		this.params.skip = this.params.skip || ({} as PhaseSkipConfig);
 		return this.params.skip;
 	}
-	skipPhase(phaseId: string) {
+	skipPhase(phaseId: PhaseId) {
 		const skip = this.ensureSkip();
 		skip.phases = skip.phases || [];
 		skip.phases.push(phaseId);
 		return this;
 	}
-	skipPhases(...phaseIds: string[]) {
+	skipPhases(...phaseIds: PhaseId[]) {
 		phaseIds.forEach((id) => this.skipPhase(id));
 		return this;
 	}
-	skipStep(phaseId: string, stepId: string) {
+	skipStep(phaseId: PhaseId, stepId: PhaseStepId) {
 		if (!phaseId || !stepId) {
 			throw new Error(
 				'Passive params skipStep(...) requires both phaseId and stepId. Provide both values when calling skipStep().',
@@ -1986,16 +1986,16 @@ class StatBuilder extends InfoBuilder<StatInfo> {
 }
 
 export interface StepDef {
-	id: string;
+	id: PhaseStepId;
 	title?: string;
-	triggers?: TriggerKey[];
+	triggers?: PhaseTrigger[];
 	effects?: EffectDef[];
 	icon?: string;
 }
 
 class StepBuilder {
 	private config: StepDef;
-	constructor(id: string) {
+	constructor(id: PhaseStepId) {
 		this.config = { id };
 	}
 	title(title: string) {
@@ -2006,12 +2006,12 @@ class StepBuilder {
 		this.config.icon = icon;
 		return this;
 	}
-	trigger(trigger: TriggerKey) {
+	trigger(trigger: PhaseTrigger) {
 		this.config.triggers = this.config.triggers || [];
 		this.config.triggers.push(trigger);
 		return this;
 	}
-	triggers(...triggers: TriggerKey[]) {
+	triggers(...triggers: PhaseTrigger[]) {
 		this.config.triggers = this.config.triggers || [];
 		this.config.triggers.push(...triggers);
 		return this;
@@ -2027,7 +2027,7 @@ class StepBuilder {
 }
 
 export interface PhaseDef {
-	id: string;
+	id: PhaseId;
 	steps: StepDef[];
 	action?: boolean;
 	label: string;
@@ -2036,7 +2036,7 @@ export interface PhaseDef {
 
 class PhaseBuilder {
 	private config: PhaseDef;
-	constructor(id: string) {
+	constructor(id: PhaseId) {
 		this.config = { id, steps: [], label: '' };
 	}
 	label(label: string) {
@@ -2410,9 +2410,9 @@ export function stat(key: StatKey) {
 export function populationRole(key: PopulationRoleId) {
 	return new PopulationRoleBuilder(key);
 }
-export function phase(id: string) {
+export function phase(id: PhaseId) {
 	return new PhaseBuilder(id);
 }
-export function step(id: string) {
+export function step(id: PhaseStepId) {
 	return new StepBuilder(id);
 }

--- a/packages/contents/src/happinessHelpers.ts
+++ b/packages/contents/src/happinessHelpers.ts
@@ -19,10 +19,6 @@ import { Resource } from './resources';
 import { Stat } from './stats';
 import { formatPassiveRemoval } from './text';
 
-export const GROWTH_PHASE_ID = 'growth';
-export const UPKEEP_PHASE_ID = 'upkeep';
-export const WAR_RECOVERY_STEP_ID = 'war-recovery';
-
 const DEVELOPMENT_EVALUATION = developmentTarget();
 
 export const incomeModifier = (id: string, percent: number) =>

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -2,7 +2,7 @@ export { ACTIONS, createActionRegistry, ActionId } from './actions';
 export { BUILDINGS, createBuildingRegistry } from './buildings';
 export { DEVELOPMENTS, createDevelopmentRegistry } from './developments';
 export { POPULATIONS, createPopulationRegistry } from './populations';
-export { PHASES } from './phases';
+export { PHASES, PhaseId, PhaseStepId, PhaseTrigger } from './phases';
 export type { PhaseDef, StepDef } from './config/builders';
 export {
 	POPULATION_ROLES,

--- a/packages/contents/src/overview.ts
+++ b/packages/contents/src/overview.ts
@@ -1,4 +1,5 @@
 import { ActionId } from './actions';
+import { PhaseId } from './phases';
 
 export type OverviewTokenCategoryName =
 	| 'actions'
@@ -74,9 +75,9 @@ const DEFAULT_TOKENS: OverviewTokenCandidates = {
 		[ActionId.army_attack]: [ActionId.army_attack],
 	},
 	phases: {
-		growth: ['growth'],
-		upkeep: ['upkeep'],
-		main: ['main'],
+		[PhaseId.Growth]: [PhaseId.Growth],
+		[PhaseId.Upkeep]: [PhaseId.Upkeep],
+		[PhaseId.Main]: [PhaseId.Main],
 	},
 	resources: {
 		gold: ['gold'],
@@ -117,12 +118,12 @@ const DEFAULT_SECTIONS: OverviewSectionTemplate[] = [
 	{
 		kind: 'list',
 		id: 'turn-flow',
-		icon: 'growth',
+		icon: PhaseId.Growth,
 		title: 'Turn Flow',
 		span: true,
 		items: [
 			{
-				icon: 'growth',
+				icon: PhaseId.Growth,
 				label: 'Growth',
 				body: [
 					'Kickstarts your engine with income and {armyStrength} Army strength.',
@@ -130,14 +131,14 @@ const DEFAULT_SECTIONS: OverviewSectionTemplate[] = [
 				],
 			},
 			{
-				icon: 'upkeep',
+				icon: PhaseId.Upkeep,
 				label: 'Upkeep',
 				body: [
 					'Settles wages, ongoing effects, and any debts your realm has racked up.',
 				],
 			},
 			{
-				icon: 'main',
+				icon: PhaseId.Main,
 				label: 'Main Phase',
 				body: [
 					'Both players secretly queue actions.',

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -17,24 +17,58 @@ import {
 	ON_PAY_UPKEEP_STEP,
 } from './defs';
 
+export const PhaseId = {
+	Growth: 'growth',
+	Upkeep: 'upkeep',
+	Main: 'main',
+} as const;
+
+export type PhaseId = (typeof PhaseId)[keyof typeof PhaseId];
+
+export const PhaseStepId = {
+	ResolveDynamicTriggers: 'resolve-dynamic-triggers',
+	GainIncome: 'gain-income',
+	GainActionPoints: 'gain-ap',
+	RaiseStrength: 'raise-strength',
+	PayUpkeep: 'pay-upkeep',
+	WarRecovery: 'war-recovery',
+	MainPhase: 'main',
+} as const;
+
+export type PhaseStepId = (typeof PhaseStepId)[keyof typeof PhaseStepId];
+
+export const PhaseTrigger = {
+	OnGrowthPhase: 'onGrowthPhase',
+	OnUpkeepPhase: 'onUpkeepPhase',
+	OnGainIncomeStep: ON_GAIN_INCOME_STEP,
+	OnGainActionPointsStep: ON_GAIN_AP_STEP,
+	OnPayUpkeepStep: ON_PAY_UPKEEP_STEP,
+} as const;
+
+export type PhaseTrigger = (typeof PhaseTrigger)[keyof typeof PhaseTrigger];
+
 export const PHASES: PhaseDef[] = [
-	phase('growth')
+	phase(PhaseId.Growth)
 		.label('Growth')
 		.icon('🏗️')
 		.step(
-			step('resolve-dynamic-triggers')
+			step(PhaseStepId.ResolveDynamicTriggers)
 				.title('Resolve dynamic triggers')
-				.triggers('onGrowthPhase'),
+				.triggers(PhaseTrigger.OnGrowthPhase),
 		)
 		.step(
-			step('gain-income')
+			step(PhaseStepId.GainIncome)
 				.title('Gain Income')
 				.icon('💰')
 				.triggers(ON_GAIN_INCOME_STEP),
 		)
-		.step(step('gain-ap').title('Gain Action Points').triggers(ON_GAIN_AP_STEP))
 		.step(
-			step('raise-strength')
+			step(PhaseStepId.GainActionPoints)
+				.title('Gain Action Points')
+				.triggers(ON_GAIN_AP_STEP),
+		)
+		.step(
+			step(PhaseStepId.RaiseStrength)
 				.title('Raise Strength')
 				.effect(
 					effect()
@@ -68,17 +102,21 @@ export const PHASES: PhaseDef[] = [
 				),
 		)
 		.build(),
-	phase('upkeep')
+	phase(PhaseId.Upkeep)
 		.label('Upkeep')
 		.icon('🧹')
 		.step(
-			step('resolve-dynamic-triggers')
+			step(PhaseStepId.ResolveDynamicTriggers)
 				.title('Resolve dynamic triggers')
-				.triggers('onUpkeepPhase'),
+				.triggers(PhaseTrigger.OnUpkeepPhase),
 		)
-		.step(step('pay-upkeep').title('Pay Upkeep').triggers(ON_PAY_UPKEEP_STEP))
 		.step(
-			step('war-recovery')
+			step(PhaseStepId.PayUpkeep)
+				.title('Pay Upkeep')
+				.triggers(ON_PAY_UPKEEP_STEP),
+		)
+		.step(
+			step(PhaseStepId.WarRecovery)
 				.title('War recovery')
 				.effect(
 					effect()
@@ -97,10 +135,10 @@ export const PHASES: PhaseDef[] = [
 				),
 		)
 		.build(),
-	phase('main')
+	phase(PhaseId.Main)
 		.label('Main')
 		.icon('🎯')
 		.action()
-		.step(step('main').title('Main Phase'))
+		.step(step(PhaseStepId.MainPhase).title('Main Phase'))
 		.build(),
 ];

--- a/packages/contents/src/rules.types.ts
+++ b/packages/contents/src/rules.types.ts
@@ -1,0 +1,20 @@
+import type { EffectConfig } from '@kingdom-builder/protocol';
+import type { PhaseId, PhaseStepId } from './phases';
+
+export type TierSkipStep = { phase: PhaseId; step: PhaseStepId };
+
+export type TierConfig = {
+	id: string;
+	passiveId?: string;
+	slug: string;
+	range: { min: number; max?: number };
+	incomeMultiplier: number;
+	disableGrowth?: boolean;
+	skipPhases?: PhaseId[];
+	skipSteps?: TierSkipStep[];
+	summary: string;
+	removal: string;
+	effects?: EffectConfig[];
+	buildingDiscountPct?: number;
+	growthBonusPct?: number;
+};

--- a/packages/engine/tests/advance-skip.test.ts
+++ b/packages/engine/tests/advance-skip.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { RULES, PHASES } from '@kingdom-builder/contents';
+import { RULES, PHASES, PhaseId, PhaseStepId } from '@kingdom-builder/contents';
 import {
 	happinessTier,
 	effect,
@@ -13,17 +13,14 @@ import { advance } from '../src';
 import { createTestEngine } from './helpers';
 import type { RuleSet } from '../src/services';
 
-const growthPhaseId = PHASES[0]?.id ?? '';
+const growthPhaseId = PhaseId.Growth;
 const upkeepPhase =
-	PHASES.find((phase) => phase.id !== growthPhaseId) ?? PHASES[0];
-const upkeepPhaseId = upkeepPhase?.id ?? '';
+	PHASES.find((phase) => phase.id === PhaseId.Upkeep) ?? PHASES[0];
+const upkeepPhaseId = upkeepPhase?.id ?? PhaseId.Upkeep;
 const warRecoveryStepId =
-	upkeepPhase?.steps.find((step) => step.id.includes('war-recovery'))?.id ?? '';
-const mainPhase =
-	PHASES[
-		(PHASES.findIndex((phase) => phase.id === upkeepPhaseId) + 1) %
-			PHASES.length
-	];
+	upkeepPhase?.steps.find((step) => step.id === PhaseStepId.WarRecovery)?.id ??
+	PhaseStepId.WarRecovery;
+const mainPhase = PHASES.find((phase) => phase.id === PhaseId.Main);
 
 const phaseSummary = 'test.summary.phase';
 const stepSummary = 'test.summary.step';
@@ -72,7 +69,8 @@ describe('advance skip handling', () => {
 
 		expect(ctx.game.currentPhase).toBe(upkeepPhaseId);
 		const firstUpkeepStep =
-			PHASES.find((phase) => phase.id === upkeepPhaseId)?.steps[0]?.id ?? '';
+			PHASES.find((phase) => phase.id === upkeepPhaseId)?.steps[0]?.id ??
+			PhaseStepId.ResolveDynamicTriggers;
 		expect(ctx.game.currentStep).toBe(firstUpkeepStep);
 	});
 
@@ -127,7 +125,7 @@ describe('advance skip handling', () => {
 		expect(result.skipped?.sources[0]?.detail).toBe(stepSummary);
 
 		expect(ctx.game.currentPhase).toBe(mainPhase?.id ?? '');
-		const expectedStep = mainPhase?.steps[0]?.id ?? '';
+		const expectedStep = mainPhase?.steps[0]?.id ?? PhaseStepId.MainPhase;
 		expect(ctx.game.currentStep).toBe(expectedStep);
 	});
 

--- a/packages/engine/tests/happiness-tier-controller.test.ts
+++ b/packages/engine/tests/happiness-tier-controller.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
 	RULES,
-	PHASES,
 	Resource as CResource,
+	PhaseId,
+	PhaseStepId,
 } from '@kingdom-builder/contents';
 import {
 	happinessTier,
@@ -20,11 +21,9 @@ import type { RuleSet } from '../src/services';
 
 describe('happiness tier controller', () => {
 	it('swaps tier passives and updates skip markers when thresholds change', () => {
-		const [firstPhase, secondPhase] = PHASES;
-		const growthPhaseId = firstPhase?.id ?? '';
-		const upkeepPhaseId = secondPhase?.id ?? growthPhaseId;
-		const payUpkeepStepId =
-			secondPhase?.steps?.[0]?.id ?? firstPhase?.steps?.[0]?.id ?? '';
+		const growthPhaseId = PhaseId.Growth;
+		const upkeepPhaseId = PhaseId.Upkeep;
+		const payUpkeepStepId = PhaseStepId.PayUpkeep;
 
 		const lowRemovalToken = 'test.removal.low';
 		const highRemovalToken = 'test.removal.high';

--- a/packages/engine/tests/phases/fixtures.ts
+++ b/packages/engine/tests/phases/fixtures.ts
@@ -3,6 +3,7 @@ import type { PhaseDef } from '../../src/phases.ts';
 import type { StartConfig } from '@kingdom-builder/protocol';
 import type { RuleSet } from '../../src/services/index.ts';
 import { createContentFactory } from '../factories/content.ts';
+import { PhaseTrigger } from '@kingdom-builder/contents';
 
 const resourceKeys = {
 	ap: 'synthetic:resource:ap',
@@ -116,16 +117,31 @@ export function createPhaseTestEnvironment() {
 		{
 			id: phaseIds.growth,
 			steps: [
-				{ id: stepIds.growthTriggers, triggers: ['onGrowthPhase'] },
-				{ id: stepIds.gainIncome, triggers: ['onGainIncomeStep'] },
-				{ id: stepIds.gainAp, triggers: ['onGainAPStep'] },
+				{
+					id: stepIds.growthTriggers,
+					triggers: [PhaseTrigger.OnGrowthPhase],
+				},
+				{
+					id: stepIds.gainIncome,
+					triggers: [PhaseTrigger.OnGainIncomeStep],
+				},
+				{
+					id: stepIds.gainAp,
+					triggers: [PhaseTrigger.OnGainActionPointsStep],
+				},
 			],
 		},
 		{
 			id: phaseIds.upkeep,
 			steps: [
-				{ id: stepIds.upkeepTriggers, triggers: ['onUpkeepPhase'] },
-				{ id: stepIds.payUpkeep, triggers: ['onPayUpkeepStep'] },
+				{
+					id: stepIds.upkeepTriggers,
+					triggers: [PhaseTrigger.OnUpkeepPhase],
+				},
+				{
+					id: stepIds.payUpkeep,
+					triggers: [PhaseTrigger.OnPayUpkeepStep],
+				},
 				{
 					id: stepIds.warRecovery,
 					effects: [

--- a/packages/web/src/components/overview/overviewTokens.ts
+++ b/packages/web/src/components/overview/overviewTokens.ts
@@ -56,7 +56,9 @@ const CATEGORY_CONFIG = [
 		name: 'phases',
 		keys: () => PHASES.map((phase) => phase.id),
 		resolve: (candidates: string[]) =>
-			resolveByCandidates(candidates, (id) => PHASE_ICON_LOOKUP.get(id)),
+			resolveByCandidates(candidates, (id) =>
+				PHASE_ICON_LOOKUP.get(id as (typeof PHASES)[number]['id']),
+			),
 	},
 	{
 		name: 'resources',
@@ -189,9 +191,9 @@ function mergeTokenConfig(
 	};
 }
 
-function resolveByCandidates<T>(
-	candidates: string[],
-	resolver: (candidate: string) => T | undefined,
+function resolveByCandidates<T, Candidate extends string>(
+	candidates: Candidate[],
+	resolver: (candidate: Candidate) => T | undefined,
 ): T | undefined {
 	for (const candidate of candidates) {
 		const resolved = resolver(candidate);

--- a/packages/web/tests/Overview.test.tsx
+++ b/packages/web/tests/Overview.test.tsx
@@ -11,6 +11,7 @@ import {
 	RESOURCES,
 	POPULATION_ROLES,
 	STATS,
+	PhaseId,
 } from '@kingdom-builder/contents';
 
 describe('<Overview />', () => {
@@ -44,12 +45,14 @@ describe('<Overview />', () => {
 		const [fallbackPopulationKey, fallbackPopulationDef] =
 			populationEntries[0]!;
 
+		const growthToken = `{${PhaseId.Growth}}`;
+
 		const tokenConfig: OverviewTokenConfig = {
 			actions: {
 				expand: ['missing-action', fallbackActionId],
 			},
 			phases: {
-				growth: ['missing-phase', fallbackPhase.id],
+				[PhaseId.Growth]: ['missing-phase', fallbackPhase.id],
 			},
 			resources: {
 				gold: ['missing-gold', fallbackGoldKey],
@@ -78,14 +81,14 @@ describe('<Overview />', () => {
 			{
 				kind: 'list',
 				id: 'custom-flow',
-				icon: 'growth',
+				icon: PhaseId.Growth,
 				title: 'Custom Flow',
 				items: [
 					{
 						icon: 'expand',
 						label: 'Advance',
 						body: [
-							'Execute {expand} during the {growth} sequence.',
+							`Execute {expand} during the ${growthToken} sequence.`,
 							'Strengthen {army} before moving out.',
 						],
 					},
@@ -128,7 +131,7 @@ describe('<Overview />', () => {
 			return;
 		}
 		expect(flowSection.textContent).not.toContain('{expand}');
-		expect(flowSection.textContent).not.toContain('{growth}');
+		expect(flowSection.textContent).not.toContain(growthToken);
 		expect(flowSection.textContent).not.toContain('{army}');
 
 		if (typeof fallbackActionDef.icon === 'string') {

--- a/packages/web/tests/describe-skip-event.test.ts
+++ b/packages/web/tests/describe-skip-event.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import type { AdvanceSkip } from '@kingdom-builder/engine';
+import { PhaseId, PhaseStepId } from '@kingdom-builder/contents';
 import { describeSkipEvent } from '../src/utils/describeSkipEvent';
 
 describe('describeSkipEvent', () => {
 	it('formats phase skip entries with source summaries', () => {
 		const skip: AdvanceSkip = {
 			type: 'phase',
-			phaseId: 'growth',
+			phaseId: PhaseId.Growth,
 			sources: [
 				{
 					id: 'passive:golden-age',
@@ -15,7 +16,7 @@ describe('describeSkipEvent', () => {
 				},
 			],
 		};
-		const phase = { id: 'growth', label: 'Growth', icon: '🌱' };
+		const phase = { id: PhaseId.Growth, label: 'Growth', icon: '🌱' };
 
 		const result = describeSkipEvent(skip, phase);
 
@@ -29,8 +30,8 @@ describe('describeSkipEvent', () => {
 	it('formats step skip entries with fallback labels', () => {
 		const skip: AdvanceSkip = {
 			type: 'step',
-			phaseId: 'upkeep',
-			stepId: 'war-recovery',
+			phaseId: PhaseId.Upkeep,
+			stepId: PhaseStepId.WarRecovery,
 			sources: [
 				{
 					id: 'passive:morale-crash',
@@ -38,8 +39,12 @@ describe('describeSkipEvent', () => {
 				},
 			],
 		};
-		const phase = { id: 'upkeep', label: 'Upkeep', icon: '🧹' };
-		const step = { id: 'war-recovery', title: 'War recovery', icon: '🛡️' };
+		const phase = { id: PhaseId.Upkeep, label: 'Upkeep', icon: '🧹' };
+		const step = {
+			id: PhaseStepId.WarRecovery,
+			title: 'War recovery',
+			icon: '🛡️',
+		};
 
 		const result = describeSkipEvent(skip, phase, step);
 

--- a/packages/web/tests/fixtures/syntheticTaxData.ts
+++ b/packages/web/tests/fixtures/syntheticTaxData.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import { PhaseId, PhaseStepId } from '@kingdom-builder/contents';
 import type { RuleSet } from '@kingdom-builder/engine/services';
 import type { PhaseDef } from '@kingdom-builder/engine/phases';
 import type { StartConfig } from '@kingdom-builder/protocol';
@@ -23,7 +24,7 @@ type SyntheticContent = {
 		| 'homeLand',
 		string
 	>;
-	phaseIds: Record<'growth' | 'main' | 'upkeep', string>;
+	phaseIds: Record<PhaseId, string>;
 	stepIds: Record<'gainIncome' | 'payUpkeep', string>;
 };
 
@@ -72,8 +73,19 @@ export const SYNTHETIC_POPULATION_ROLES = syntheticData.populationRoles;
 export const SYNTHETIC_LAND_INFO = syntheticData.landInfo;
 export const SYNTHETIC_SLOT_INFO = syntheticData.slotInfo;
 export const SYNTHETIC_IDS = syntheticData.ids;
-export const SYNTHETIC_PHASE_IDS = syntheticData.phaseIds;
-export const SYNTHETIC_STEP_IDS = syntheticData.stepIds;
+export const SYNTHETIC_PHASE_IDS: Record<PhaseId, string> = {
+	[PhaseId.Growth]: syntheticData.phaseIds.growth,
+	[PhaseId.Main]: syntheticData.phaseIds.main,
+	[PhaseId.Upkeep]: syntheticData.phaseIds.upkeep,
+};
+type SyntheticStepKey =
+	| typeof PhaseStepId.GainIncome
+	| typeof PhaseStepId.PayUpkeep;
+
+export const SYNTHETIC_STEP_IDS: Record<SyntheticStepKey, string> = {
+	[PhaseStepId.GainIncome]: syntheticData.stepIds.gainIncome,
+	[PhaseStepId.PayUpkeep]: syntheticData.stepIds.payUpkeep,
+};
 
 export const SYNTHETIC_RULES: RuleSet = {
 	defaultActionAPCost: 1,

--- a/packages/web/tests/fixtures/syntheticTaxLog.ts
+++ b/packages/web/tests/fixtures/syntheticTaxLog.ts
@@ -1,3 +1,4 @@
+import { PhaseId, PhaseStepId, PhaseTrigger } from '@kingdom-builder/contents';
 import {
 	createContentFactory,
 	type ContentFactory,
@@ -115,30 +116,30 @@ export function createSyntheticTaxScenario(): SyntheticTaxScenario {
 	});
 	const phases: PhaseDef[] = [
 		{
-			id: SYNTHETIC_PHASE_IDS.growth,
+			id: SYNTHETIC_PHASE_IDS[PhaseId.Growth],
 			label: 'Synthetic Growth',
 			steps: [
 				{
-					id: SYNTHETIC_STEP_IDS.gainIncome,
+					id: SYNTHETIC_STEP_IDS[PhaseStepId.GainIncome],
 					title: 'Gain Synthetic Income',
-					triggers: ['onGainIncomeStep'],
+					triggers: [PhaseTrigger.OnGainIncomeStep],
 				},
 			],
 		},
 		{
-			id: SYNTHETIC_PHASE_IDS.main,
+			id: SYNTHETIC_PHASE_IDS[PhaseId.Main],
 			label: 'Synthetic Main',
 			action: true,
 			steps: [],
 		},
 		{
-			id: SYNTHETIC_PHASE_IDS.upkeep,
+			id: SYNTHETIC_PHASE_IDS[PhaseId.Upkeep],
 			label: 'Synthetic Upkeep',
 			steps: [
 				{
-					id: SYNTHETIC_STEP_IDS.payUpkeep,
+					id: SYNTHETIC_STEP_IDS[PhaseStepId.PayUpkeep],
 					title: 'Synthetic Upkeep',
-					triggers: ['onPayUpkeepStep'],
+					triggers: [PhaseTrigger.OnPayUpkeepStep],
 				},
 			],
 		},

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -6,6 +6,7 @@ import {
 	advance,
 	collectTriggerEffects,
 } from '@kingdom-builder/engine';
+import { PhaseId, PhaseStepId, PhaseTrigger } from '@kingdom-builder/contents';
 import {
 	createSyntheticTaxScenario,
 	SYNTHETIC_IDS,
@@ -56,13 +57,13 @@ describe('log resource sources', () => {
 		ctx.game.currentPlayerIndex = 0;
 
 		const growthPhase = ctx.phases.find(
-			(phase) => phase.id === SYNTHETIC_PHASE_IDS.growth,
+			(phase) => phase.id === SYNTHETIC_PHASE_IDS[PhaseId.Growth],
 		);
 		const step = growthPhase?.steps.find(
-			(s) => s.id === SYNTHETIC_STEP_IDS.gainIncome,
+			(s) => s.id === SYNTHETIC_STEP_IDS[PhaseStepId.GainIncome],
 		);
 		const before = snapshotPlayer(ctx.activePlayer, ctx);
-		const bundles = collectTriggerEffects('onGainIncomeStep', ctx);
+		const bundles = collectTriggerEffects(PhaseTrigger.OnGainIncomeStep, ctx);
 		for (const bundle of bundles) {
 			runEffects(bundle.effects, ctx);
 		}
@@ -107,7 +108,7 @@ describe('log resource sources', () => {
 			],
 			ctx,
 		);
-		while (ctx.game.currentPhase !== SYNTHETIC_PHASE_IDS.main) {
+		while (ctx.game.currentPhase !== SYNTHETIC_PHASE_IDS[PhaseId.Main]) {
 			advance(ctx);
 		}
 		const step = {
@@ -154,13 +155,13 @@ describe('log resource sources', () => {
 			ctx,
 		);
 		const upkeepPhase = ctx.phases.find(
-			(phase) => phase.id === SYNTHETIC_PHASE_IDS.upkeep,
+			(phase) => phase.id === SYNTHETIC_PHASE_IDS[PhaseId.Upkeep],
 		);
 		const step = upkeepPhase?.steps.find(
-			(s) => s.id === SYNTHETIC_STEP_IDS.payUpkeep,
+			(s) => s.id === SYNTHETIC_STEP_IDS[PhaseStepId.PayUpkeep],
 		);
 		const before = snapshotPlayer(ctx.activePlayer, ctx);
-		const bundles = collectTriggerEffects('onPayUpkeepStep', ctx);
+		const bundles = collectTriggerEffects(PhaseTrigger.OnPayUpkeepStep, ctx);
 		for (const bundle of bundles) {
 			runEffects(bundle.effects, ctx);
 		}

--- a/packages/web/tests/overview-content-source.test.tsx
+++ b/packages/web/tests/overview-content-source.test.tsx
@@ -32,7 +32,7 @@ describe('Overview content integration', () => {
 					{
 						kind: 'paragraph',
 						id: 'scouting',
-						icon: 'growth',
+						icon: actual.PhaseId.Growth,
 						title: 'Scouting Notes',
 						paragraphs: [
 							'Secure {land} footholds and guard your {castleHP} borders.',

--- a/packages/web/tests/tax-market-log.test.ts
+++ b/packages/web/tests/tax-market-log.test.ts
@@ -7,6 +7,7 @@ import {
 	runEffects,
 	type ActionTrace,
 } from '@kingdom-builder/engine';
+import { PhaseId } from '@kingdom-builder/contents';
 import {
 	createSyntheticTaxScenario,
 	SYNTHETIC_IDS,
@@ -55,7 +56,7 @@ describe('tax action logging with market', () => {
 			ctx,
 		);
 		ctx.activePlayer.resources[SYNTHETIC_RESOURCE_KEYS.coin] = 0;
-		while (ctx.game.currentPhase !== SYNTHETIC_PHASE_IDS.main) {
+		while (ctx.game.currentPhase !== SYNTHETIC_PHASE_IDS[PhaseId.Main]) {
 			advance(ctx);
 		}
 		const action = ctx.actions.get(SYNTHETIC_IDS.taxAction);


### PR DESCRIPTION
## Summary
- Introduced shared `PhaseId`, `PhaseStepId`, and `PhaseTrigger` exports in the content phase definitions and applied them across the phase builder helpers.
- Updated rule configuration, overview defaults, and supporting tests to consume the shared identifiers and tightened skip helper typings.

## Text formatting audit (required)
1. **Translator/formatter reuse:** N/A – no translator or formatter code paths were touched in this change.
2. **Canonical keywords/icons/helpers touched:** Phase icons now referenced via `PhaseId` within overview content and related tests.
3. **Voice review:** No player-facing copy was modified; existing strings retain their original voice.

## Standards compliance (required)
1. **File length limits respected:** `packages/contents/src/rules.ts` is 239 lines after refactor, within the 250-line limit.
2. **Line length limits respected:** `npm run check` (which runs linting) verified that max line length rules are satisfied.
3. **Domain separation upheld:** Adjustments are confined to the contents package and its consumers; engine/web layers continue to consume exported identifiers only.
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint, and tests) completed successfully.
5. **Tests updated:** Updated phase-aware tests in `packages/web/tests/Overview.test.tsx`, `packages/web/tests/describe-skip-event.test.ts`, and `packages/engine/tests/advance-skip.test.ts` to rely on the shared constants.
6. **Documentation updated:** Not required for this change.
7. **`npm run check` results:** See the successful run captured during the commit (includes format, typecheck, lint, and test execution).
8. **`npm run test:coverage` results:** Not run; existing test coverage was exercised via `npm run check`.

## Testing
- `npm run check` (pass)


------
https://chatgpt.com/codex/tasks/task_e_68e26038cfbc8325a2df03555f23b5c9