### PR TITLE
Fix PhasePanel test to ignore icon in accessible name

### DIFF
--- a/packages/web/tests/PhasePanel.test.tsx
+++ b/packages/web/tests/PhasePanel.test.tsx
@@ -76,9 +76,12 @@ describe('<PhasePanel />', () => {
 			).toBeInTheDocument();
 		}
 		const firstPhase = ctx.phases[0];
-		const phaseLabel = `${firstPhase.icon} ${firstPhase.label}`;
+		const firstPhaseButton = screen.getByRole('button', {
+			name: firstPhase.label,
+		});
+		expect(firstPhaseButton).toBeInTheDocument();
 		expect(
-			screen.getByRole('button', { name: phaseLabel }),
+			within(firstPhaseButton).getByText(firstPhase.icon),
 		).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary
- Update the PhasePanel integration test to look up the current phase tab by its accessible label and verify the icon separately, preventing failures when icons are hidden from assistive labels.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no translator or formatter code was modified.
2. **Canonical keywords/icons/helpers touched:** None; assertions only reference existing phase icon strings in test data.
3. **Voice review:** Not applicable; no player-facing text was added or modified.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/tests/PhasePanel.test.tsx` remains 87 lines (<250). 【F:packages/web/tests/PhasePanel.test.tsx†L1-L87】
2. **Line length limits respected:** All added lines stay within the 80-character limit in `packages/web/tests/PhasePanel.test.tsx`. 【F:packages/web/tests/PhasePanel.test.tsx†L78-L85】
3. **Domain separation upheld:** Only a web test file was updated; engine/web separation remains unchanged. 【F:packages/web/tests/PhasePanel.test.tsx†L1-L87】
4. **Code standards satisfied:** Prettier check passes for the touched file. 【040730†L1-L4】
5. **Tests updated:** The modified test validates both the accessible label and icon rendering. 【F:packages/web/tests/PhasePanel.test.tsx†L78-L85】
6. **Documentation updated:** Not needed; no docs reference this internal test behaviour.
7. **`npm run check` results:** Not run; repository-wide check currently fails due to pre-existing formatting warnings (observed when Husky pre-commit invoked `npm run check`). Verified formatting locally via targeted Prettier check instead. 【040730†L1-L4】
8. **`npm run test:coverage` results:** `npm run test:coverage` now completes successfully. 【fb2cdf†L1-L170】

## Testing
- `npx prettier --check packages/web/tests/PhasePanel.test.tsx`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e2695dc388832590f1dc7faf5acb0e