### PR TITLE
feat: define translation context types

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -219,7 +219,7 @@ export function createActionRegistry() {
 				.params(actionParams().id('house').landId('$landId')),
 		)
 		.option(
-		   actionEffectGroupOption('royal_decree_farm')
+			actionEffectGroupOption('royal_decree_farm')
 				.label('Establish a Farm')
 				.icon('🌾')
 				.action(ActionId.develop)

--- a/packages/web/src/translation/context/index.ts
+++ b/packages/web/src/translation/context/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/web/src/translation/context/types.ts
+++ b/packages/web/src/translation/context/types.ts
@@ -1,0 +1,102 @@
+import type {
+	PassiveSummary,
+	PlayerId,
+	EngineContext as LegacyEngineContext,
+} from '@kingdom-builder/engine';
+import type {
+	ActionConfig,
+	BuildingConfig,
+	DevelopmentConfig,
+} from '@kingdom-builder/protocol';
+
+/**
+ * Lightweight registry surface exposed to translators. Only lookup helpers that
+ * are used within translation paths are represented to discourage direct
+ * coupling with the protocol registry implementation.
+ */
+export interface TranslationRegistry<TDefinition> {
+	get(id: string): TDefinition;
+	has(id: string): boolean;
+}
+
+/**
+ * Minimal passive descriptor pulled through the translation layer. This mirrors
+ * the subset of {@link PassiveRecord} properties that log formatters and
+ * resource source helpers inspect today.
+ */
+export type TranslationPassiveDescriptor = {
+	icon?: string;
+	meta?: { source?: { icon?: string } };
+};
+
+/**
+ * Map of evaluator modifier identifiers to the owning modifier instances. The
+ * values remain intentionally untyped because translation formatters only
+ * inspect presence and icon metadata.
+ */
+export type TranslationPassiveModifierMap = ReadonlyMap<
+	string,
+	ReadonlyMap<string, unknown>
+>;
+
+/**
+ * Read-only view over the passive manager for translators. The surface area is
+ * intentionally tiny; imperative mutators are omitted while the existing log
+ * helpers continue to rely on evaluation metadata.
+ */
+export interface TranslationPassives {
+	list(owner?: PlayerId): PassiveSummary[];
+	get(id: string, owner: PlayerId): TranslationPassiveDescriptor | undefined;
+	readonly evaluationMods: TranslationPassiveModifierMap;
+	/**
+	 * @deprecated Temporary escape hatch for utilities that still need access to
+	 * the underlying engine passive manager. Prefer modelling the missing data on
+	 * {@link TranslationPassives} before using this.
+	 */
+	readonly legacy?: unknown;
+}
+
+/**
+ * Minimal phase metadata consumed by translation renderers.
+ */
+export interface TranslationPhase {
+	id: string;
+	icon?: string;
+	label?: string;
+}
+
+/**
+ * Snapshot of active/opposing players required by translation helpers. The
+ * fields mirror the read access patterns used when formatting stat breakdowns
+ * and passive ownership.
+ */
+export interface TranslationPlayer {
+	id: PlayerId;
+	name?: string;
+	resources: Record<string, number>;
+	stats: Record<string, number>;
+	population: Record<string, number>;
+}
+
+/**
+ * Translation-focused view over the engine context. Implementations are free to
+ * wrap the full {@link LegacyEngineContext} as long as the read-only surface
+ * documented here remains stable.
+ */
+export interface TranslationContext {
+	readonly actions: TranslationRegistry<ActionConfig>;
+	readonly buildings: TranslationRegistry<BuildingConfig>;
+	readonly developments: TranslationRegistry<DevelopmentConfig>;
+	readonly passives: TranslationPassives;
+	readonly phases: readonly TranslationPhase[];
+	readonly activePlayer: TranslationPlayer;
+	readonly opponent: TranslationPlayer;
+	pullEffectLog<T>(key: string): T | undefined;
+	readonly actionCostResource?: string;
+	/**
+	 * @deprecated Legacy escape hatch for callers that still require the
+	 * full {@link LegacyEngineContext}. Usage should be phased out in favour of
+	 * the typed accessors declared above.
+	 */
+	readonly legacy?: LegacyEngineContext;
+}

--- a/packages/web/src/translation/index.ts
+++ b/packages/web/src/translation/index.ts
@@ -2,3 +2,4 @@ export * from './effects';
 export * from './content';
 export * from './log';
 export * from './render';
+export * from './context';


### PR DESCRIPTION
## Summary
* add translation-focused registry, passive, and context interfaces for translators to consume minimal engine surfaces【F:packages/web/src/translation/context/types.ts†L1-L102】
* expose the new context types via the translation barrel exports for downstream callers【F:packages/web/src/translation/context/index.ts†L1-L1】【F:packages/web/src/translation/index.ts†L1-L5】
* normalize the royal decree farm option indentation to satisfy lint spacing rules【F:packages/contents/src/actions.ts†L216-L227】

## Text formatting audit (required)

1. **Translator/formatter reuse:** N/A – type-only change; no translator or formatter behaviour modified.
2. **Canonical keywords/icons/helpers touched:** None – existing helpers referenced without changes.
3. **Voice review:** N/A – no player-facing copy was added or edited.

## Standards compliance (required)

1. **File length limits respected:** New `translation/context/types.ts` is 102 lines, well under the 250-line limit.【F:packages/web/src/translation/context/types.ts†L1-L102】
2. **Line length limits respected:** All added lines stay within the 80-character guideline (verified during lint run).【72cee4†L1-L9】
3. **Domain separation upheld:** All additions live inside the web translation layer; engine and content logic remain untouched except for lint-driven indentation adjustment.【F:packages/web/src/translation/context/types.ts†L1-L102】【F:packages/contents/src/actions.ts†L216-L227】
4. **Code standards satisfied:** `npm run lint` passes after the updates.【72cee4†L1-L9】
5. **Tests updated:** No tests required updates; changes are type definitions and formatting only.
6. **Documentation updated:** Not required—no behavioural or user-facing adjustments occurred.
7. **`npm run check` results:** Executed via the pre-commit hook; all stages (format, typecheck, lint, tests) completed successfully.【fd2b3b†L1-L6】【7144f5†L3-L9】
8. **`npm run test:coverage` results:** Not run—coverage was not requested for these type-only updates.

## Testing

* ✅ `npm run lint`【72cee4†L1-L9】
* ✅ `npm run check` (pre-commit hook)【fd2b3b†L1-L6】【7144f5†L3-L9】
* ⚠️ `npm run test:coverage` (not run; coverage not required for type/interface additions)

------
https://chatgpt.com/codex/tasks/task_e_68e266df116c8325b2d5db651b555f60