### PR TITLE
Use tabs for CallToActionSection knowledge header

### DIFF
--- a/packages/web/src/menu/CallToActionSection.tsx
+++ b/packages/web/src/menu/CallToActionSection.tsx
@@ -155,8 +155,8 @@ export function CallToActionSection({
 				<div className={KNOWLEDGE_HEADER_LAYOUT_CLASS}>
 					{/* prettier-ignore */}
 					<div className={KNOWLEDGE_TITLE_CLASS}>
-                                                Learn The Basics
-                                        </div>
+						Learn The Basics
+					</div>
 					{knowledgeActions}
 				</div>
 				<p>{KNOWLEDGE_PARAGRAPH_TEXT}</p>


### PR DESCRIPTION
## Summary

- Replace the remaining space-indented lines in `CallToActionSection`'s knowledge header with tab-indented equivalents to align with the repository's formatting rules.

## Text formatting audit (required)

1. **Translator/formatter reuse:** Not applicable; no translators or formatters were touched by this indentation-only change.
2. **Canonical keywords/icons/helpers touched:** None; the update only adjusts indentation.
3. **Voice review:** Not applicable; no player-facing text was added or modified.

## Standards compliance (required)

1. **File length limits respected:** `packages/web/src/menu/CallToActionSection.tsx` is 165 lines after the change, well under the 250-line limit.
2. **Line length limits respected:** No lines were added or modified beyond adjusting indentation, so existing ≤80-character limits remain satisfied.
3. **Domain separation upheld:** Only a web presentation component was touched; engine, content, protocol, and tests remain unchanged.
4. **Code standards satisfied:** Husky ran `npm run check` (format check, typecheck, lint) successfully during commit, confirming style compliance.
5. **Tests updated:** No new or existing tests required changes for this indentation update.
6. **Documentation updated:** Not needed for a formatting-only adjustment.
7. **`npm run check` results:** Executed automatically via Husky during commit (`CI=1 git commit ...`); all subtasks passed.
8. **`npm run test:coverage` results:** Not run; coverage is unnecessary for indentation-only changes.

## Testing

- `npm run format -- packages/web/src/menu/CallToActionSection.tsx`
- `CI=1 git commit -m "Use tabs for CallToActionSection knowledge header"` (runs Husky pre-commit: `npm run check` and `npm test`)

------
https://chatgpt.com/codex/tasks/task_e_68e2769944d08325b2c594d2884715d6