### PR TITLE
refactor: use translation context for content translators

### DIFF
--- a/packages/web/src/translation/content/action.ts
+++ b/packages/web/src/translation/content/action.ts
@@ -10,11 +10,11 @@ import {
 	formatEffectGroups,
 } from '../effects';
 import { registerContentTranslator } from './factory';
-import type { ContentTranslator, Summary } from './types';
+import type { LegacyContentTranslator, Summary } from './types';
 import { getActionLogHook } from './actionLogHooks';
 
 class ActionTranslator
-	implements ContentTranslator<string, Record<string, unknown>>
+	implements LegacyContentTranslator<string, Record<string, unknown>>
 {
 	summarize(
 		id: string,

--- a/packages/web/src/translation/content/building.ts
+++ b/packages/web/src/translation/content/building.ts
@@ -1,12 +1,12 @@
 import type { EngineContext } from '@kingdom-builder/engine';
 import { registerContentTranslator } from './factory';
-import type { ContentTranslator, Summary } from './types';
+import type { LegacyContentTranslator, Summary } from './types';
 import { PhasedTranslator } from './phased';
 import type { PhasedDef } from './phased';
 import { withInstallation } from './decorators';
 import { resolveBuildingDisplay } from './buildingIcons';
 
-class BuildingCore implements ContentTranslator<string> {
+class BuildingCore implements LegacyContentTranslator<string> {
 	private phased = new PhasedTranslator();
 	summarize(id: string, ctx: EngineContext): Summary {
 		const def = ctx.buildings.get(id);

--- a/packages/web/src/translation/content/decorators.ts
+++ b/packages/web/src/translation/content/decorators.ts
@@ -1,10 +1,10 @@
-import type { ContentTranslator, Summary } from './types';
+import type { LegacyContentTranslator, Summary } from './types';
 import { TRIGGER_INFO as triggerInfo } from '@kingdom-builder/contents';
 import type { EngineContext } from '@kingdom-builder/engine';
 
 export function withInstallation<T>(
-	translator: ContentTranslator<T, unknown>,
-): ContentTranslator<T, { installed?: boolean }> {
+	translator: LegacyContentTranslator<T, unknown>,
+): LegacyContentTranslator<T, { installed?: boolean }> {
 	return {
 		summarize(
 			target: T,

--- a/packages/web/src/translation/content/development.ts
+++ b/packages/web/src/translation/content/development.ts
@@ -1,7 +1,7 @@
 import type { EffectDef, EngineContext } from '@kingdom-builder/engine';
 import { applyParamsToEffects } from '@kingdom-builder/engine';
 import { registerContentTranslator } from './factory';
-import type { ContentTranslator, Summary } from './types';
+import type { LegacyContentTranslator, Summary } from './types';
 import { PhasedTranslator } from './phased';
 import type { PhasedDef } from './phased';
 import { withInstallation } from './decorators';
@@ -107,7 +107,7 @@ function collectPhaseEffects(
 	return result;
 }
 
-class DevelopmentCore implements ContentTranslator<string> {
+class DevelopmentCore implements LegacyContentTranslator<string> {
 	private phased = new PhasedTranslator();
 	summarize(id: string, ctx: EngineContext): Summary {
 		const def = ctx.developments.get(id);

--- a/packages/web/src/translation/content/factory.ts
+++ b/packages/web/src/translation/content/factory.ts
@@ -1,11 +1,16 @@
-import type { EngineContext } from '@kingdom-builder/engine';
-import type { ContentTranslator, Summary } from './types';
+import type { TranslationContext } from '../context';
+import type {
+	ContentTranslator,
+	LegacyContentTranslator,
+	LegacyContentTranslatorContext,
+	Summary,
+} from './types';
 
 const TRANSLATORS = new Map<string, ContentTranslator<unknown, unknown>>();
 
 export function registerContentTranslator<T, O>(
 	type: string,
-	translator: ContentTranslator<T, O>,
+	translator: ContentTranslator<T, O> | LegacyContentTranslator<T, O>,
 ): void {
 	TRANSLATORS.set(type, translator as ContentTranslator<unknown, unknown>);
 }
@@ -13,35 +18,77 @@ export function registerContentTranslator<T, O>(
 export function summarizeContent<T, O>(
 	type: string,
 	target: T,
-	ctx: EngineContext,
+	ctx: TranslationContext,
+	opts?: O,
+): Summary;
+export function summarizeContent<T, O>(
+	type: string,
+	target: T,
+	ctx: LegacyContentTranslatorContext,
+	opts?: O,
+): Summary;
+export function summarizeContent<T, O>(
+	type: string,
+	target: T,
+	ctx: TranslationContext | LegacyContentTranslatorContext,
 	opts?: O,
 ): Summary {
 	const translator = TRANSLATORS.get(type) as
 		| ContentTranslator<T, O>
 		| undefined;
-	return translator ? translator.summarize(target, ctx, opts) : [];
+	return translator
+		? translator.summarize(target, ctx as TranslationContext, opts)
+		: [];
 }
 
 export function describeContent<T, O>(
 	type: string,
 	target: T,
-	ctx: EngineContext,
+	ctx: TranslationContext,
+	opts?: O,
+): Summary;
+export function describeContent<T, O>(
+	type: string,
+	target: T,
+	ctx: LegacyContentTranslatorContext,
+	opts?: O,
+): Summary;
+export function describeContent<T, O>(
+	type: string,
+	target: T,
+	ctx: TranslationContext | LegacyContentTranslatorContext,
 	opts?: O,
 ): Summary {
 	const translator = TRANSLATORS.get(type) as
 		| ContentTranslator<T, O>
 		| undefined;
-	return translator ? translator.describe(target, ctx, opts) : [];
+	return translator
+		? translator.describe(target, ctx as TranslationContext, opts)
+		: [];
 }
 
 export function logContent<T, O>(
 	type: string,
 	target: T,
-	ctx: EngineContext,
+	ctx: TranslationContext,
+	opts?: O,
+): string[];
+export function logContent<T, O>(
+	type: string,
+	target: T,
+	ctx: LegacyContentTranslatorContext,
+	opts?: O,
+): string[];
+export function logContent<T, O>(
+	type: string,
+	target: T,
+	ctx: TranslationContext | LegacyContentTranslatorContext,
 	opts?: O,
 ): string[] {
 	const translator = TRANSLATORS.get(type) as
 		| ContentTranslator<T, O>
 		| undefined;
-	return translator?.log ? translator.log(target, ctx, opts) : [];
+	return translator?.log
+		? translator.log(target, ctx as TranslationContext, opts)
+		: [];
 }

--- a/packages/web/src/translation/content/index.ts
+++ b/packages/web/src/translation/content/index.ts
@@ -4,6 +4,9 @@ export type {
 	SummaryEntry,
 	SummaryGroup,
 	ContentTranslator,
+	ContentTranslatorContext,
+	LegacyContentTranslator,
+	LegacyContentTranslatorContext,
 } from './types';
 export {
 	registerContentTranslator,

--- a/packages/web/src/translation/content/land.ts
+++ b/packages/web/src/translation/content/land.ts
@@ -5,7 +5,12 @@ import {
 	summarizeContent,
 	registerContentTranslator,
 } from './factory';
-import type { ContentTranslator, Land, Summary, SummaryEntry } from './types';
+import type {
+	Land,
+	LegacyContentTranslator,
+	Summary,
+	SummaryEntry,
+} from './types';
 
 function translate(
 	land: Land,
@@ -34,7 +39,7 @@ function translate(
 	return items;
 }
 
-class LandTranslator implements ContentTranslator<Land> {
+class LandTranslator implements LegacyContentTranslator<Land> {
 	summarize(land: Land, ctx: EngineContext): Summary {
 		return translate(land, ctx, summarizeContent);
 	}

--- a/packages/web/src/translation/content/tier.ts
+++ b/packages/web/src/translation/content/tier.ts
@@ -4,7 +4,7 @@ import type { EngineContext } from '@kingdom-builder/engine';
 import { summarizeEffects } from '../effects';
 import { translateTierSummary } from './tierSummaries';
 import { registerContentTranslator } from './factory';
-import type { ContentTranslator, Summary, SummaryEntry } from './types';
+import type { LegacyContentTranslator, Summary, SummaryEntry } from './types';
 
 function splitLines(text: string | undefined): string[] {
 	if (!text) {
@@ -55,7 +55,8 @@ function flattenSummary(entries: Summary): string[] {
 }
 
 class TierTranslator
-	implements ContentTranslator<HappinessTierDefinition, Record<string, never>>
+	implements
+		LegacyContentTranslator<HappinessTierDefinition, Record<string, never>>
 {
 	summarize(tier: HappinessTierDefinition, ctx: EngineContext): Summary {
 		const summaryLines: string[] = [];

--- a/packages/web/src/translation/content/types.ts
+++ b/packages/web/src/translation/content/types.ts
@@ -1,4 +1,5 @@
-import type { EngineContext } from '@kingdom-builder/engine';
+import type { EngineContext as LegacyEngineContext } from '@kingdom-builder/engine';
+import type { TranslationContext } from '../context';
 
 export interface Land {
 	id: string;
@@ -20,8 +21,36 @@ export interface SummaryGroup {
 export type SummaryEntry = string | SummaryGroup;
 export type Summary = SummaryEntry[];
 
+type BivariantCallback<Args extends unknown[], TResult> = {
+	bivarianceHack(...args: Args): TResult;
+}['bivarianceHack'];
+
+export type ContentTranslatorContext = TranslationContext;
+
+/**
+ * @deprecated Prefer {@link ContentTranslatorContext}. This alias is retained
+ * so translators that still reference the full engine context continue to
+ * type-check during the transition.
+ */
+export type LegacyContentTranslatorContext = LegacyEngineContext;
+
 export interface ContentTranslator<T = unknown, O = Record<string, unknown>> {
-	summarize(target: T, ctx: EngineContext, opts?: O): Summary;
-	describe(target: T, ctx: EngineContext, opts?: O): Summary;
-	log?(target: T, ctx: EngineContext, opts?: O): string[];
+	summarize: BivariantCallback<[T, TranslationContext, O?], Summary>;
+	describe: BivariantCallback<[T, TranslationContext, O?], Summary>;
+	log?: BivariantCallback<[T, TranslationContext, O?], string[]>;
+}
+
+/**
+ * @deprecated Temporary compatibility surface for translators that still type
+ * their implementations against {@link LegacyContentTranslatorContext}. The
+ * runtime translation context conforms to {@link ContentTranslatorContext}; new
+ * code should migrate to that interface.
+ */
+export interface LegacyContentTranslator<
+	T = unknown,
+	O = Record<string, unknown>,
+> {
+	summarize: BivariantCallback<[T, LegacyEngineContext, O?], Summary>;
+	describe: BivariantCallback<[T, LegacyEngineContext, O?], Summary>;
+	log?: BivariantCallback<[T, LegacyEngineContext, O?], string[]>;
 }


### PR DESCRIPTION
## Summary
- update translation content types to expose `TranslationContext` while keeping bivariant compatibility wrappers for legacy engine access.
- extend the content translation factory to accept either translation or engine contexts, and re-export the new aliases for downstream imports.
- adjust existing content translators and decorators to opt into the legacy translator surface so current implementations continue compiling without runtime changes.

## Text formatting audit (required)

1. **Translator/formatter reuse:** Reused existing action/building/development/land/tier translators via `registerContentTranslator`. No new formatter logic added. <!-- packages/web/src/translation/content/action.ts, building.ts, development.ts, land.ts, tier.ts -->
2. **Canonical keywords/icons/helpers touched:** None; all references (e.g., `SLOT_INFO`, `formatPassiveRemoval`) were already in place without changes.
3. **Voice review:** No summary/description/log strings were altered, so existing voice remains valid.

## Standards compliance (required)

1. **File length limits respected:** All modified files remain under the 250-line limit (see snippets in packages/web/src/translation/content/*.ts).
2. **Line length limits respected:** `npm run lint` confirms 80-character adherence. <!-- chunk eda63c†L1-L9 -->
3. **Domain separation upheld:** Changes are confined to web translation helpers and do not introduce cross-domain dependencies. <!-- packages/web/src/translation/content/**/*.ts -->
4. **Code standards satisfied:** `npm run lint` succeeded. <!-- chunk eda63c†L1-L9 -->
5. **Tests updated:** No new tests were required; existing suites still pass via `npm run test:quick`. <!-- chunk a1b446†L1-L18 -->
6. **Documentation updated:** Not applicable; code-only change with no documentation impact.
7. **`npm run check` results:** Not run; pre-commit tooling already executed prettier, eslint, and `tsc --noEmit` for the staged files.
8. **`npm run test:coverage` results:** Not run; quick test suite (`npm run test:quick`) provided regression validation.

## Testing

- `npm run lint`
- `npm run test:quick`


------
https://chatgpt.com/codex/tasks/task_e_68e27678f99c832589daea940ce9065d