### PR TITLE
Refactor ShowcasePage layout class strings

### DIFF
--- a/packages/web/src/components/layouts/ShowcasePage.tsx
+++ b/packages/web/src/components/layouts/ShowcasePage.tsx
@@ -8,13 +8,34 @@ export const SHOWCASE_BACKGROUND_CLASS = [
 
 const BACKDROP_LAYER = [
 	'pointer-events-none absolute inset-0',
-	'bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.6),_rgba(255,255,255,0)_55%)]',
-	'dark:bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.55),_rgba(15,23,42,0)_60%)]',
+	[
+		'bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.6),',
+		'_rgba(255,255,255,0)_55%)]',
+	].join(''),
+	[
+		'dark:bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.55),',
+		'_rgba(15,23,42,0)_60%)]',
+	].join(''),
+].join(' ');
+
+const TOP_GLOW_CLASS = [
+	'absolute -top-24 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full',
+	'bg-amber-300/30 blur-3xl dark:bg-amber-500/20',
+].join(' ');
+
+const BOTTOM_LEFT_GLOW_CLASS = [
+	'absolute -bottom-20 -left-10 h-72 w-72 rounded-full',
+	'bg-sky-300/30 blur-3xl dark:bg-sky-500/20',
+].join(' ');
+
+const RIGHT_GLOW_CLASS = [
+	'absolute top-1/3 right-10 h-64 w-64 rounded-full',
+	'bg-rose-300/30 blur-3xl dark:bg-rose-500/20',
 ].join(' ');
 
 export const SHOWCASE_LAYOUT_CLASS = [
-	'relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col items-center',
-	'gap-16 px-6 py-16',
+	'relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col',
+	'items-center gap-16 px-6 py-16',
 ].join(' ');
 
 export const SHOWCASE_BADGE_CLASS = [
@@ -49,9 +70,9 @@ export function ShowcaseBackground({
 	return (
 		<div className={`${SHOWCASE_BACKGROUND_CLASS} ${className}`}>
 			<div className="pointer-events-none absolute inset-0">
-				<div className="absolute -top-24 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-amber-300/30 blur-3xl dark:bg-amber-500/20" />
-				<div className="absolute -bottom-20 -left-10 h-72 w-72 rounded-full bg-sky-300/30 blur-3xl dark:bg-sky-500/20" />
-				<div className="absolute top-1/3 right-10 h-64 w-64 rounded-full bg-rose-300/30 blur-3xl dark:bg-rose-500/20" />
+				<div className={TOP_GLOW_CLASS} />
+				<div className={BOTTOM_LEFT_GLOW_CLASS} />
+				<div className={RIGHT_GLOW_CLASS} />
 				<div className={BACKDROP_LAYER} />
 			</div>
 			{children}


### PR DESCRIPTION
## Summary
- split the Showcase backdrop gradient utilities into concatenated pieces so each line stays within the 80-character limit while preserving the resolved classes
- extract constants for the decorative glow layers to shorten ShowcasePage markup without altering the rendered Tailwind classes

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no translator or formatter utilities were involved in this UI-only change.
2. **Canonical keywords/icons/helpers touched:** None of the canonical keywords, icons, or helpers listed in docs/text-formatting.md §4 were modified.
3. **Voice review:** Not applicable; no player-facing strings were added or edited, so existing voice remains unchanged.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/src/components/layouts/ShowcasePage.tsx` now contains 113 lines, well under the 250-line ceiling. 【a747b7†L1-L3】
2. **Line length limits respected:** Verified that no lines exceed 80 characters after the refactor. 【3f181b†L1-L9】【dee85e†L1-L2】
3. **Domain separation upheld:** Only the web layout component was updated; no engine, content, or protocol files were touched. 【F:packages/web/src/components/layouts/ShowcasePage.tsx†L1-L105】
4. **Code standards satisfied:** `npm run lint packages/web/src/components/layouts/ShowcasePage.tsx` passes (with the existing TypeScript version warning). 【3989ef†L1-L17】【b295a8†L1-L13】
5. **Tests updated:** No tests required updates because functionality did not change; classes resolve to the same values. 【F:packages/web/src/components/layouts/ShowcasePage.tsx†L1-L105】
6. **Documentation updated:** Not needed—this refactor only adjusts internal class definitions without affecting documented behavior. 【F:packages/web/src/components/layouts/ShowcasePage.tsx†L1-L105】
7. **`npm run check` results:** Not run; the scoped lint command above covers the touched file, and the broader suite was out of scope for this formatting-only change. 【3989ef†L1-L17】
8. **`npm run test:coverage` results:** Not run; no logic or tests changed, so rerunning full coverage was unnecessary. 【F:packages/web/src/components/layouts/ShowcasePage.tsx†L1-L105】

## Testing
- `npm run lint packages/web/src/components/layouts/ShowcasePage.tsx` ✅ 【3989ef†L1-L17】【b295a8†L1-L13】

------
https://chatgpt.com/codex/tasks/task_e_68e2799c70b48325a3970db9da4cd485