### PR TITLE
Wrap action log hook test name to 80 characters

### DIFF
--- a/tests/integration/action-log-hooks.test.ts
+++ b/tests/integration/action-log-hooks.test.ts
@@ -14,98 +14,102 @@ import { logContent } from '@kingdom-builder/web/translation/content';
 import { createContentFactory } from '../../packages/engine/tests/factories/content';
 
 describe('content-driven action log hooks', () => {
-	it('render linked targets for actions without relying on build/develop ids', () => {
-		const content = createContentFactory();
-		const hall = content.building({ name: 'Custom Hall', icon: '🏯' });
-		const plainHall = content.building({ name: 'Plain Hall' });
-		const improvement = content.development({
-			name: 'Custom Improvement',
-			icon: '🌿',
-		});
-		const idToken = ['$', 'id'].join('');
-		const landIdToken = ['$', 'landId'].join('');
+	it(
+		'render linked targets for actions without relying on build/' +
+			'develop ids',
+		() => {
+			const content = createContentFactory();
+			const hall = content.building({ name: 'Custom Hall', icon: '🏯' });
+			const plainHall = content.building({ name: 'Plain Hall' });
+			const improvement = content.development({
+				name: 'Custom Improvement',
+				icon: '🌿',
+			});
+			const idToken = ['$', 'id'].join('');
+			const landIdToken = ['$', 'landId'].join('');
 
-		const construct = content.action({
-			name: 'Construct Hall',
-			icon: '🚧',
-			effects: [
-				{
-					type: 'building',
-					method: 'add',
-					params: { id: idToken },
-				},
-			],
-		});
+			const construct = content.action({
+				name: 'Construct Hall',
+				icon: '🚧',
+				effects: [
+					{
+						type: 'building',
+						method: 'add',
+						params: { id: idToken },
+					},
+				],
+			});
 
-		const establish = content.action({
-			name: 'Establish Improvement',
-			icon: '✨',
-			effects: [
-				{
-					type: 'development',
-					method: 'add',
-					params: { id: idToken, landId: landIdToken },
-				},
-			],
-		});
+			const establish = content.action({
+				name: 'Establish Improvement',
+				icon: '✨',
+				effects: [
+					{
+						type: 'development',
+						method: 'add',
+						params: { id: idToken, landId: landIdToken },
+					},
+				],
+			});
 
-		const constructStatic = content.action({
-			name: 'Construct Static Hall',
-			icon: '🏗️',
-			effects: [
-				{
-					type: 'building',
-					method: 'add',
-					params: { id: plainHall.id },
-				},
-			],
-		});
+			const constructStatic = content.action({
+				name: 'Construct Static Hall',
+				icon: '🏗️',
+				effects: [
+					{
+						type: 'building',
+						method: 'add',
+						params: { id: plainHall.id },
+					},
+				],
+			});
 
-		const buildings = createBuildingRegistry();
-		for (const [id, def] of BUILDINGS.entries()) {
-			buildings.add(id, def);
-		}
-		buildings.add(hall.id, hall);
-		buildings.add(plainHall.id, plainHall);
+			const buildings = createBuildingRegistry();
+			for (const [id, def] of BUILDINGS.entries()) {
+				buildings.add(id, def);
+			}
+			buildings.add(hall.id, hall);
+			buildings.add(plainHall.id, plainHall);
 
-		const developments = createDevelopmentRegistry();
-		for (const [id, def] of DEVELOPMENTS.entries()) {
-			developments.add(id, def);
-		}
-		developments.add(improvement.id, improvement);
+			const developments = createDevelopmentRegistry();
+			for (const [id, def] of DEVELOPMENTS.entries()) {
+				developments.add(id, def);
+			}
+			developments.add(improvement.id, improvement);
 
-		const ctx = createEngine({
-			actions: content.actions,
-			buildings,
-			developments,
-			populations: POPULATIONS,
-			phases: PHASES,
-			start: GAME_START,
-			rules: RULES,
-		});
+			const ctx = createEngine({
+				actions: content.actions,
+				buildings,
+				developments,
+				populations: POPULATIONS,
+				phases: PHASES,
+				start: GAME_START,
+				rules: RULES,
+			});
 
-		const buildingLog = logContent('action', construct.id, ctx, {
-			id: hall.id,
-		});
-		if (hall.icon) {
-			expect(buildingLog[0]).toContain(hall.icon);
-		}
-		expect(buildingLog[0]).toContain(hall.name);
+			const buildingLog = logContent('action', construct.id, ctx, {
+				id: hall.id,
+			});
+			if (hall.icon) {
+				expect(buildingLog[0]).toContain(hall.icon);
+			}
+			expect(buildingLog[0]).toContain(hall.name);
 
-		const landId = ctx.activePlayer.lands[0]?.id;
-		const developmentLog = logContent('action', establish.id, ctx, {
-			id: improvement.id,
-			landId,
-		});
-		if (improvement.icon) {
-			expect(developmentLog[0]).toContain(improvement.icon);
-		}
-		expect(developmentLog[0]).toContain(improvement.name);
+			const landId = ctx.activePlayer.lands[0]?.id;
+			const developmentLog = logContent('action', establish.id, ctx, {
+				id: improvement.id,
+				landId,
+			});
+			if (improvement.icon) {
+				expect(developmentLog[0]).toContain(improvement.icon);
+			}
+			expect(developmentLog[0]).toContain(improvement.name);
 
-		const staticLog = logContent('action', constructStatic.id, ctx);
-		expect(staticLog[0]).toContain(plainHall.name);
+			const staticLog = logContent('action', constructStatic.id, ctx);
+			expect(staticLog[0]).toContain(plainHall.name);
 
-		const buildingLabel = logContent('building', plainHall.id, ctx)[0];
-		expect(buildingLabel).toBe(plainHall.name);
-	});
+			const buildingLabel = logContent('building', plainHall.id, ctx)[0];
+			expect(buildingLabel).toBe(plainHall.name);
+		},
+	);
 });


### PR DESCRIPTION
## Summary
- Wrap the action log hook integration test description over two strings to respect the 80-character line limit.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no translator or formatter logic touched.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** Not applicable; only a test description string changed.

## Standards compliance (required)
1. **File length limits respected:** `tests/integration/action-log-hooks.test.ts` remains 119 lines after the change.
2. **Line length limits respected:** Updated the `it()` description to wrap under 80 characters.
3. **Domain separation upheld:** Change affects only a test description; no engine, web, or content code modified.
4. **Code standards satisfied:** `npm run lint tests/integration/action-log-hooks.test.ts`
5. **Tests updated:** No test logic changed; only the test description string was reformatted.
6. **Documentation updated:** Not required for a test description formatting adjustment.
7. **`npm run check` results:** Executed automatically by the commit hook (`CI=1 git commit ...`). Key excerpt:
   ```
   Test Files  105 passed (105)
        Tests  252 passed (252)
   ```
8. **`npm run test:coverage` results:** Not run; this change only reformats a test name and does not impact coverage metrics.

## Testing
- `npm run lint tests/integration/action-log-hooks.test.ts`
- `npm run check` (via commit hook)


------
https://chatgpt.com/codex/tasks/task_e_68e27997bd3083259de16acc486602e7