### PR TITLE
Rename engine effect context parameters and update loop counters

### DIFF
--- a/packages/engine/src/effects/action_add.ts
+++ b/packages/engine/src/effects/action_add.ts
@@ -1,11 +1,14 @@
 import type { EffectHandler } from '.';
 
-export const actionAdd: EffectHandler = (effect, ctx, mult = 1) => {
+export const actionAdd: EffectHandler = (effect, context, mult = 1) => {
 	const id = effect.params?.['id'] as string;
 	if (!id) {
 		throw new Error('action:add requires id');
 	}
-	for (let i = 0; i < Math.floor(mult); i++) {
-		ctx.activePlayer.actions.add(id);
+	const iterations = Math.floor(mult);
+	let iterationIndex = 0;
+	while (iterationIndex < iterations) {
+		context.activePlayer.actions.add(id);
+		iterationIndex++;
 	}
 };

--- a/packages/engine/src/effects/action_remove.ts
+++ b/packages/engine/src/effects/action_remove.ts
@@ -1,11 +1,14 @@
 import type { EffectHandler } from '.';
 
-export const actionRemove: EffectHandler = (effect, ctx, mult = 1) => {
+export const actionRemove: EffectHandler = (effect, context, mult = 1) => {
 	const id = effect.params?.['id'] as string;
 	if (!id) {
 		throw new Error('action:remove requires id');
 	}
-	for (let i = 0; i < Math.floor(mult); i++) {
-		ctx.activePlayer.actions.delete(id);
+	const iterations = Math.floor(mult);
+	let iterationIndex = 0;
+	while (iterationIndex < iterations) {
+		context.activePlayer.actions.delete(id);
+		iterationIndex++;
 	}
 };

--- a/packages/engine/src/effects/population_add.ts
+++ b/packages/engine/src/effects/population_add.ts
@@ -4,14 +4,16 @@ import { applyParamsToEffects } from '../utils';
 import { withStatSourceFrames } from '../stat_sources';
 import type { PopulationRoleId } from '../state';
 
-export const populationAdd: EffectHandler = (effect, ctx, mult = 1) => {
+export const populationAdd: EffectHandler = (effect, context, mult = 1) => {
 	const role = effect.params?.['role'] as PopulationRoleId;
 	if (!role) {
 		throw new Error('population:add requires role');
 	}
-	for (let i = 0; i < Math.floor(mult); i++) {
-		const player = ctx.activePlayer;
-		const def = ctx.populations.get(role);
+	const iterations = Math.floor(mult);
+	let iterationIndex = 0;
+	while (iterationIndex < iterations) {
+		const player = context.activePlayer;
+		const def = context.populations.get(role);
 		player.population[role] = (player.population[role] || 0) + 1;
 		const index = player.population[role];
 		if (def.onAssigned) {
@@ -39,7 +41,8 @@ export const populationAdd: EffectHandler = (effect, ctx, mult = 1) => {
 					},
 				}),
 			];
-			withStatSourceFrames(ctx, frames, () => runEffects(effects, ctx));
+			withStatSourceFrames(context, frames, () => runEffects(effects, context));
 		}
+		iterationIndex++;
 	}
 };

--- a/packages/engine/src/effects/population_remove.ts
+++ b/packages/engine/src/effects/population_remove.ts
@@ -4,22 +4,20 @@ import { applyParamsToEffects } from '../utils';
 import { withStatSourceFrames } from '../stat_sources';
 import type { PopulationRoleId } from '../state';
 
-export const populationRemove: EffectHandler = (
-	effect,
-	engineContext,
-	mult = 1,
-) => {
+export const populationRemove: EffectHandler = (effect, context, mult = 1) => {
 	const role = effect.params?.['role'] as PopulationRoleId;
 	if (!role) {
 		throw new Error('population:remove requires role');
 	}
-	for (let i = 0; i < Math.floor(mult); i++) {
-		const player = engineContext.activePlayer;
+	const iterations = Math.floor(mult);
+	let iterationIndex = 0;
+	while (iterationIndex < iterations) {
+		const player = context.activePlayer;
 		const current = player.population[role] || 0;
 		if (current <= 0) {
 			return;
 		}
-		const roleDefinition = engineContext.populations.get(role);
+		const roleDefinition = context.populations.get(role);
 		const index = current;
 		if (roleDefinition.onUnassigned) {
 			const effects = applyParamsToEffects(roleDefinition.onUnassigned, {
@@ -46,10 +44,9 @@ export const populationRemove: EffectHandler = (
 					},
 				}),
 			];
-			withStatSourceFrames(engineContext, frames, () =>
-				runEffects(effects, engineContext),
-			);
+			withStatSourceFrames(context, frames, () => runEffects(effects, context));
 		}
 		player.population[role] = current - 1;
+		iterationIndex++;
 	}
 };


### PR DESCRIPTION
## Summary
* rename engine effect handler parameters from `ctx` to `context` and update call sites for consistency
* replace raw index-based `for` loops with named iteration counters and while loops across engine effect handlers
* align `actionPerform` helper usage with the new context naming while keeping stat frame and trace updates intact

## Text formatting audit (required)

1. **Translator/formatter reuse:** N/A – no player-facing translators or formatters were touched.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** N/A – no player-facing surfaces were changed.

## Standards compliance (required)

1. **File length limits respected:** Touched engine effect files remain between 14 and 97 lines (`wc -l` confirms they are under the 250-line limit).
2. **Line length limits respected:** `npm run lint packages/engine/src/effects` passed after the updates (warning only about unsupported TypeScript version).
3. **Domain separation upheld:** Changes are limited to engine effect handlers under `packages/engine/src/effects`, leaving other domains untouched.
4. **Code standards satisfied:** ESLint run for the engine effects directory completed successfully.
5. **Tests updated:** No new tests were required; existing suites cover the behaviour, and the full check/test run passes.
6. **Documentation updated:** Not required for parameter renaming and loop refactors.
7. **`npm run check` results:** Passed – `Test Files 105 passed (105)` and `Tests 252 passed (252)`.
8. **`npm run test:coverage` results:** Passed – coverage run reported `Test Files 105 passed (105)` with overall statements coverage at 81.03%.

## Testing

* `npm run lint packages/engine/src/effects`
* `npm run check`
* `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e276985ee0832594a2889806d493d2