### PR TITLE
Format phased translation test imports

### DIFF
--- a/tests/integration/phased-translation.test.ts
+++ b/tests/integration/phased-translation.test.ts
@@ -5,7 +5,10 @@ import {
 	summarizeContent,
 	describeContent,
 } from '@kingdom-builder/web/translation/content';
-import type { PhasedDef } from '@kingdom-builder/web/translation/content/phased';
+// prettier-ignore
+import type {
+	PhasedDef,
+} from '@kingdom-builder/web/translation/content/phased';
 import {
 	TRIGGER_INFO,
 	RESOURCES,
@@ -15,7 +18,10 @@ import {
 	RULES,
 } from '@kingdom-builder/contents';
 import type { ResourceKey } from '@kingdom-builder/contents';
-import { createContentFactory } from '../../packages/engine/tests/factories/content';
+// prettier-ignore
+import {
+	createContentFactory,
+} from '../../packages/engine/tests/factories/content';
 
 type Entry = string | { title: string; items: Entry[] };
 


### PR DESCRIPTION
## Summary
- Reformatted the phased translation integration test imports to span multiple lines with Prettier guards so the shorter layout is preserved.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no translator or formatter logic was modified.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** Not applicable; no player-facing strings changed.

## Standards compliance (required)
1. **File length limits respected:** Updated files remain within the existing length constraints (e.g., `tests/integration/phased-translation.test.ts` is 197 lines).
2. **Line length limits respected:** Reformatted imports stay below the 80-character limit.
3. **Domain separation upheld:** Only a test file import was reformatted; no cross-domain coupling was introduced.
4. **Code standards satisfied:** `npm run lint tests/integration/phased-translation.test.ts` (pass).
5. **Tests updated:** No functional test changes were necessary for this formatting-only update.
6. **Documentation updated:** Not required; no documentation files were touched.
7. **`npm run check` results:** Executed automatically via the Husky pre-commit hook (see `/tmp/commit.log` in this environment).
8. **`npm run test:coverage` results:** Not run; unnecessary for the requested formatting change.

## Testing
- ✅ `npm run check` (executed by pre-commit hook; see `/tmp/commit.log`)
- ✅ `npm run lint tests/integration/phased-translation.test.ts`
- ⚠️ `npm run test:coverage` (not run; unnecessary for formatting-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e27994338083259d80d4f2e0a71925