### PR TITLE
Add building params builder for building effects

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -11,6 +11,7 @@ import {
 	resourceParams,
 	statParams,
 	developmentParams,
+	buildingParams,
 	actionParams,
 	resultModParams,
 	passiveParams,
@@ -490,7 +491,9 @@ export function createActionRegistry() {
 			.name('Build')
 			.icon('🏛️')
 			.effect(
-				effect(Types.Building, BuildingMethods.ADD).param('id', '$id').build(),
+				effect(Types.Building, BuildingMethods.ADD)
+					.params(buildingParams().id('$id'))
+					.build(),
 			)
 			.category(ActionCategory.Building)
 			.order(1)

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -461,6 +461,40 @@ export function developmentParams() {
 	return new DevelopmentEffectParamsBuilder();
 }
 
+class BuildingEffectParamsBuilder extends ParamsBuilder<{
+	id?: string;
+	landId?: string;
+}> {
+	id(id: string) {
+		return this.set(
+			'id',
+			id,
+			'Building effect params already set id(). Remove the extra id() call.',
+		);
+	}
+
+	landId(landId: string) {
+		return this.set(
+			'landId',
+			landId,
+			'Building effect params already set landId(). Remove the extra landId() call.',
+		);
+	}
+
+	override build() {
+		if (!this.wasSet('id')) {
+			throw new Error(
+				'Building effect params is missing id(). Call id("your-building-id") before build().',
+			);
+		}
+		return super.build();
+	}
+}
+
+export function buildingParams() {
+	return new BuildingEffectParamsBuilder();
+}
+
 class ActionEffectParamsBuilder extends ParamsBuilder<{
 	id?: string;
 	landId?: string;


### PR DESCRIPTION
## Summary
- Added a `BuildingEffectParamsBuilder` helper and exported `buildingParams()` so building effect definitions can share a typed parameter API. 
- Updated the Build action to use the shared builder for its building effect parameters.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable – no translators or formatters were touched.
2. **Canonical keywords/icons/helpers touched:** None – the change only affects builder helpers and action wiring.
3. **Voice review:** Not applicable – no player-facing text was added or modified.

## Standards compliance (required)
1. **File length limits respected:** `packages/contents/src/actions.ts` (507 lines) and `packages/contents/src/config/builders.ts` (2492 lines) remain at their existing lengths. 【f69faa†L1-L4】
2. **Line length limits respected:** `npm run check` confirmed Prettier formatting without adjustments. 【ec30b4†L1-L24】
3. **Domain separation upheld:** All modifications are confined to the content package (`packages/contents/src/config/builders.ts`, `packages/contents/src/actions.ts`). 【F:packages/contents/src/config/builders.ts†L464-L495】【F:packages/contents/src/actions.ts†L488-L501】
4. **Code standards satisfied:** `npm run check` ran formatting, type-checking, and linting successfully. 【ec30b4†L1-L24】
5. **Tests updated:** No new tests were required; existing content/action tests already cover building effect wiring.
6. **Documentation updated:** Not required; the change only introduces a helper and updates an action definition.
7. **`npm run check` results:**
```
【ec30b4†L1-L24】
```
8. **`npm run test:coverage` results:**
```
【c76587†L1-L104】
【de95a8†L1-L112】
【259dd9†L1-L20】
```

## Testing
- ✅ `npm run check`【c954fd†L1-L19】
- ✅ `npm run test:coverage`【832e90†L1-L20】

------
https://chatgpt.com/codex/tasks/task_e_68e280e55c3083258b02f6a9cbcc6f37