### PR TITLE
Refactor translation render className formatting

### DIFF
--- a/packages/web/src/translation/render.tsx
+++ b/packages/web/src/translation/render.tsx
@@ -46,13 +46,22 @@ export function renderCosts(
 		);
 	}
 	return (
-		<div className="flex flex-col items-end text-right text-sm leading-tight text-gray-600 dark:text-gray-300">
+		<div
+			className={[
+				'flex flex-col items-end text-right text-sm leading-tight text-gray-600',
+				'dark:text-gray-300',
+			].join(' ')}
+		>
 			{entries.length > 0 && (
 				<div className="flex flex-wrap justify-end gap-x-1 gap-y-0.5">
 					{entries.map(([resourceKey, costAmount]) => (
 						<span
 							key={resourceKey}
-							className={`whitespace-nowrap ${(resources[resourceKey] ?? 0) < (costAmount ?? 0) ? 'text-red-500' : ''}`}
+							className={`whitespace-nowrap ${
+								(resources[resourceKey] ?? 0) < (costAmount ?? 0)
+									? 'text-red-500'
+									: ''
+							}`}
 						>
 							{RESOURCES[resourceKey as ResourceKey]?.icon}
 							{costAmount ?? 0}


### PR DESCRIPTION
## Summary
- Refactored the cost summary wrapper to build its `className` via an array join while preserving the rendered markup.
- Expanded the conditional cost span `className` into a multi-line template literal so every line stays under 80 characters.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no translators or formatters were touched.
2. **Canonical keywords/icons/helpers touched:** None; this change only restructures existing class name strings.
3. **Voice review:** Not applicable; there were no changes to player-facing text.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/src/translation/render.tsx` is 85 lines after the edit (`wc -l`).
2. **Line length limits respected:** The refactored `className` definitions now wrap at or below 80 characters (see updated file).
3. **Domain separation upheld:** Only web-layer presentation logic was modified; engine and content layers remain untouched.
4. **Code standards satisfied:** `npm run check` succeeded (captured in `/tmp/npm-check.log`).
5. **Tests updated:** Not required because the change only affects JSX formatting.
6. **Documentation updated:** Not required; no documentation references class name formatting.
7. **`npm run check` results:** `npm run check > /tmp/npm-check.log` (exit code 0).
8. **`npm run test:coverage` results:** Not run; unnecessary for a non-functional class name refactor.

## Testing
- ✅ `npm run check > /tmp/npm-check.log`
- ⚠️ `npm run test:coverage` *(not run; unnecessary for class name formatting change)*

------
https://chatgpt.com/codex/tasks/task_e_68e28318436083258a6fca27916d9ba1