### PR TITLE
Refine development translator naming

### DIFF
--- a/packages/web/src/translation/content/development.ts
+++ b/packages/web/src/translation/content/development.ts
@@ -49,29 +49,30 @@ function gatherEffects(
 	if (!effects) {
 		return;
 	}
-	for (const eff of effects) {
+	for (const effect of effects) {
 		if (
-			eff.evaluator?.type === 'development' &&
-			(eff.evaluator.params as Record<string, string> | undefined)?.['id'] ===
-				id
+			effect.evaluator?.type === 'development' &&
+			(effect.evaluator.params as Record<string, string> | undefined)?.[
+				'id'
+			] === id
 		) {
-			out.push(eff);
+			out.push(effect);
 		}
-		if (eff.effects) {
-			gatherEffects(eff.effects, id, out);
+		if (effect.effects) {
+			gatherEffects(effect.effects, id, out);
 		}
 	}
 }
 
 function applySelfParams(
-	def: PhasedDef,
+	definition: PhasedDef,
 	params: Record<string, unknown>,
 ): PhasedDef {
 	const mapped: PhasedDef = {};
 	const rawId = params['id'];
 	const selfId = typeof rawId === 'string' ? rawId : undefined;
-	for (const key of Object.keys(def) as (keyof PhasedDef)[]) {
-		const value = def[key];
+	for (const key of Object.keys(definition) as (keyof PhasedDef)[]) {
+		const value = definition[key];
 		if (!Array.isArray(value)) {
 			continue;
 		}
@@ -83,15 +84,17 @@ function applySelfParams(
 
 function collectPhaseEffects(
 	id: string,
-	ctx: EngineContext,
+	engineContext: EngineContext,
 	params: Record<string, unknown>,
 ): PhaseEffects {
 	const result: PhaseEffects = {};
 	const rawId = params['id'];
 	const selfId = typeof rawId === 'string' ? rawId : undefined;
-	for (const phase of ctx.phases) {
-		const key =
-			`on${phase.id.charAt(0).toUpperCase() + phase.id.slice(1)}Phase` as keyof PhaseEffects;
+	for (const phase of engineContext.phases) {
+		const phaseHandlerKey = `on${
+			phase.id.charAt(0).toUpperCase() + phase.id.slice(1)
+		}Phase`;
+		const key = phaseHandlerKey as keyof PhaseEffects;
 		for (const step of phase.steps) {
 			const bucket: EffectDef[] = [];
 			gatherEffects(step.effects, id, bucket);
@@ -109,15 +112,15 @@ function collectPhaseEffects(
 
 class DevelopmentCore implements LegacyContentTranslator<string> {
 	private phased = new PhasedTranslator();
-	summarize(id: string, ctx: EngineContext): Summary {
-		const def = ctx.developments.get(id);
-		if (!def) {
+	summarize(id: string, engineContext: EngineContext): Summary {
+		const definition = engineContext.developments.get(id);
+		if (!definition) {
 			return [];
 		}
 		const params = { id };
-		const base = applySelfParams(def as unknown as PhasedDef, params);
+		const base = applySelfParams(definition as unknown as PhasedDef, params);
 		const merged: PhasedDef = { ...base };
-		const phases = collectPhaseEffects(id, ctx, params);
+		const phases = collectPhaseEffects(id, engineContext, params);
 		for (const [key, effects] of Object.entries(phases)) {
 			if (!effects?.length) {
 				continue;
@@ -125,17 +128,17 @@ class DevelopmentCore implements LegacyContentTranslator<string> {
 			const current = merged[key as keyof PhasedDef] ?? [];
 			merged[key as keyof PhasedDef] = [...current, ...effects];
 		}
-		return this.phased.summarize(merged, ctx);
+		return this.phased.summarize(merged, engineContext);
 	}
-	describe(id: string, ctx: EngineContext): Summary {
-		const def = ctx.developments.get(id);
-		if (!def) {
+	describe(id: string, engineContext: EngineContext): Summary {
+		const definition = engineContext.developments.get(id);
+		if (!definition) {
 			return [];
 		}
 		const params = { id };
-		const base = applySelfParams(def as unknown as PhasedDef, params);
+		const base = applySelfParams(definition as unknown as PhasedDef, params);
 		const merged: PhasedDef = { ...base };
-		const phases = collectPhaseEffects(id, ctx, params);
+		const phases = collectPhaseEffects(id, engineContext, params);
 		for (const [key, effects] of Object.entries(phases)) {
 			if (!effects?.length) {
 				continue;
@@ -143,12 +146,12 @@ class DevelopmentCore implements LegacyContentTranslator<string> {
 			const current = merged[key as keyof PhasedDef] ?? [];
 			merged[key as keyof PhasedDef] = [...current, ...effects];
 		}
-		return this.phased.describe(merged, ctx);
+		return this.phased.describe(merged, engineContext);
 	}
-	log(id: string, ctx: EngineContext): string[] {
-		const def = ctx.developments.get(id);
-		const name = def?.name ?? id;
-		const icon = def?.icon ?? '';
+	log(id: string, engineContext: EngineContext): string[] {
+		const definition = engineContext.developments.get(id);
+		const name = definition?.name ?? id;
+		const icon = definition?.icon ?? '';
 		const display = [icon, name].filter(Boolean).join(' ').trim();
 		return [display || name];
 	}


### PR DESCRIPTION
## Summary
- rename abbreviated variables in the development content translator for clarity
- extract the computed phase handler key into a helper variable to keep assignments within 80 characters

## Text formatting audit (required)
1. **Translator/formatter reuse:** Continued using the existing `PhasedTranslator` and `withInstallation` pipeline; no new translators or formatters were introduced.
2. **Canonical keywords/icons/helpers touched:** None; the refactor only adjusted TypeScript logic.
3. **Voice review:** No player-facing Summary, Description, or Log strings were modified.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/src/translation/content/development.ts` now sits at 163 lines, well under the 250-line limit.
2. **Line length limits respected:** The new `phaseHandlerKey` helper keeps the phase assignment under the 80-character cap.
3. **Domain separation upheld:** All changes remain inside the web translation layer and interact with the engine solely through existing translator APIs.
4. **Code standards satisfied:** `npm run check` (see log below) completed without issues, confirming linting and formatting requirements.
5. **Tests updated:** No new tests were necessary; existing coverage continues to pass (see testing section).
6. **Documentation updated:** Not required for this internal naming refactor.
7. **`npm run check` results:**
   ```text
   > kingdom-builder-engine@0.1.0 check
   > npm run format:check && npm run typecheck && npm run lint
   
   npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
   
   > kingdom-builder-engine@0.1.0 format:check
   > prettier --check .
   
   Checking formatting...
   All matched files use Prettier code style!
   npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
   
   > kingdom-builder-engine@0.1.0 typecheck
   > tsc -b --pretty false
   
   > kingdom-builder-engine@0.1.0 posttypecheck
   > node scripts/clean-dists.cjs
   
   npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
   
   > kingdom-builder-engine@0.1.0 prelint
   > node scripts/ensure-dev-dependencies.cjs
   
   > kingdom-builder-engine@0.1.0 lint
   ```
8. **`npm run test:coverage` results:** Not run (coverage unaffected by the refactor).

## Testing
- ✅ `npm run typecheck`
- ✅ `npm run check`
- ✅ `npm run test:quick`


------
https://chatgpt.com/codex/tasks/task_e_68e283192ad083259753f8fcd0f08d27