### PR TITLE
Add helpers for action effect group option params

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -237,29 +237,29 @@ export function createActionRegistry() {
 			actionEffectGroupOption('royal_decree_house')
 				.icon('🏠')
 				.action(ActionId.develop)
-				.param('developmentId', 'house')
-				.param('landId', '$landId'),
+				.paramDevelopmentId(DevelopmentId.House)
+				.paramLandId('$landId'),
 		)
 		.option(
 			actionEffectGroupOption('royal_decree_farm')
 				.icon('🌾')
 				.action(ActionId.develop)
-				.param('developmentId', 'farm')
-				.param('landId', '$landId'),
+				.paramDevelopmentId(DevelopmentId.Farm)
+				.paramLandId('$landId'),
 		)
 		.option(
 			actionEffectGroupOption('royal_decree_outpost')
 				.icon('🏹')
 				.action(ActionId.develop)
-				.param('developmentId', 'outpost')
-				.param('landId', '$landId'),
+				.paramDevelopmentId(DevelopmentId.Outpost)
+				.paramLandId('$landId'),
 		)
 		.option(
 			actionEffectGroupOption('royal_decree_watchtower')
 				.icon('🗼')
 				.action(ActionId.develop)
-				.param('developmentId', 'watchtower')
-				.param('landId', '$landId'),
+				.paramDevelopmentId(DevelopmentId.Watchtower)
+				.paramLandId('$landId'),
 		);
 
 	registry.add(

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -146,6 +146,20 @@ class ActionEffectGroupOptionBuilder {
 		return this;
 	}
 
+	paramActionId(actionId: ActionId): this;
+	paramActionId(actionId: string): this;
+	paramActionId(actionId: string) {
+		return this.param('actionId', actionId);
+	}
+
+	paramDevelopmentId(developmentId: DevelopmentIdParam) {
+		return this.param('developmentId', developmentId);
+	}
+
+	paramLandId(landId: string) {
+		return this.param('landId', landId);
+	}
+
 	params(params: Params | ParamsBuilder) {
 		if (this.paramsSet) {
 			throw new Error(
@@ -203,6 +217,42 @@ class ActionEffectGroupOptionBuilder {
 
 export function actionEffectGroupOption(id?: string) {
 	return new ActionEffectGroupOptionBuilder(id);
+}
+
+class ActionEffectGroupOptionParamsBuilder extends ParamsBuilder<{
+	actionId?: string;
+	developmentId?: DevelopmentIdParam;
+	landId?: string;
+}> {
+	actionId(actionId: ActionId): this;
+	actionId(actionId: string): this;
+	actionId(actionId: string) {
+		return this.set(
+			'actionId',
+			actionId,
+			'Action effect group option params already set actionId(). Remove the extra actionId() call.',
+		);
+	}
+
+	developmentId(developmentId: DevelopmentIdParam) {
+		return this.set(
+			'developmentId',
+			developmentId,
+			'Action effect group option params already set developmentId(). Remove the extra developmentId() call.',
+		);
+	}
+
+	landId(landId: string) {
+		return this.set(
+			'landId',
+			landId,
+			'Action effect group option params already set landId(). Remove the extra landId() call.',
+		);
+	}
+}
+
+export function actionEffectGroupOptionParams() {
+	return new ActionEffectGroupOptionParamsBuilder();
 }
 
 export type ActionEffectGroupDef = ActionEffectGroup;


### PR DESCRIPTION
## Summary
- Added typed helper methods and a params builder for action effect group options so callers no longer rely on magic param keys. 【F:packages/contents/src/config/builders.ts†L132-L256】
- Updated Royal Decree option definitions to consume the new helpers and use the shared `DevelopmentId` constants. 【F:packages/contents/src/actions.ts†L234-L263】

## Text formatting audit (required)

1. **Translator/formatter reuse:** Not applicable – no player-facing strings were added or modified.
2. **Canonical keywords/icons/helpers touched:** Not applicable – changes only affect builder utilities and option wiring.
3. **Voice review:** Not applicable – no Summary/Description/Log text changed.

## Standards compliance (required)

1. **File length limits respected:** `actions.ts` remains at 504 lines and `builders.ts` (an existing grandfathered file) at 2508 lines. 【1e6cd6†L1-L4】
2. **Line length limits respected:** `npm run check` (which runs Prettier) passes after the updates. 【58bd4a†L1-L31】
3. **Domain separation upheld:** All edits stay within the `@kingdom-builder/contents` package, updating only configuration builders and content definitions. 【F:packages/contents/src/config/builders.ts†L132-L256】【F:packages/contents/src/actions.ts†L234-L263】
4. **Code standards satisfied:** `npm run check` (formatting, type-checking, linting) completes successfully. 【58bd4a†L1-L31】
5. **Tests updated:** No new tests were required; the existing suite passes under the automated `vitest run` invoked during the commit hook. 【8ff2ff†L1-L19】
6. **Documentation updated:** Not needed – the change only touches builder helpers and existing content wiring.
7. **`npm run check` results:** See the recorded run in `/tmp/npm-check.log`. 【58bd4a†L1-L31】
8. **`npm run test:coverage` results:** Not run – coverage was not requested for this helper refactor.

## Testing

- ✅ `npm run check`
- ⚠️ `npm run test:coverage` (not run; helper refactor only)


------
https://chatgpt.com/codex/tasks/task_e_68e282ef5e188325bc58383bfe70df44