### PR TITLE
Refactor button variant class definitions

### DIFF
--- a/packages/web/src/components/common/Button.tsx
+++ b/packages/web/src/components/common/Button.tsx
@@ -6,17 +6,69 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 const VARIANT_CLASSES: Record<string, string> = {
-	primary:
-		'bg-gradient-to-r from-blue-600 to-indigo-500 text-white shadow-md shadow-blue-600/30 hover:from-blue-500 hover:to-indigo-400 focus-visible:ring-blue-200/80',
-	secondary:
-		'bg-slate-900/80 text-white shadow-md shadow-slate-900/30 hover:bg-slate-900/70 dark:bg-white/15 dark:text-slate-100 dark:hover:bg-white/20 focus-visible:ring-slate-200/60',
-	success:
-		'bg-gradient-to-r from-emerald-500 to-teal-500 text-white shadow-md shadow-emerald-500/30 hover:from-emerald-400 hover:to-teal-400 focus-visible:ring-emerald-200/70',
-	danger:
-		'bg-gradient-to-r from-rose-500 to-red-500 text-white shadow-md shadow-rose-500/40 hover:from-rose-400 hover:to-red-400 focus-visible:ring-rose-200/70',
-	ghost:
-		'bg-transparent text-slate-700 hover:bg-white/60 dark:text-slate-200 dark:hover:bg-white/10 focus-visible:ring-white/40',
-	dev: 'bg-gradient-to-r from-purple-600 to-fuchsia-500 text-white shadow-md shadow-purple-500/40 hover:from-purple-500 hover:to-fuchsia-400 focus-visible:ring-purple-200/70',
+	primary: [
+		'bg-gradient-to-r',
+		'from-blue-600',
+		'to-indigo-500',
+		'text-white',
+		'shadow-md',
+		'shadow-blue-600/30',
+		'hover:from-blue-500',
+		'hover:to-indigo-400',
+		'focus-visible:ring-blue-200/80',
+	].join(' '),
+	secondary: [
+		'bg-slate-900/80',
+		'text-white',
+		'shadow-md',
+		'shadow-slate-900/30',
+		'hover:bg-slate-900/70',
+		'dark:bg-white/15',
+		'dark:text-slate-100',
+		'dark:hover:bg-white/20',
+		'focus-visible:ring-slate-200/60',
+	].join(' '),
+	success: [
+		'bg-gradient-to-r',
+		'from-emerald-500',
+		'to-teal-500',
+		'text-white',
+		'shadow-md',
+		'shadow-emerald-500/30',
+		'hover:from-emerald-400',
+		'hover:to-teal-400',
+		'focus-visible:ring-emerald-200/70',
+	].join(' '),
+	danger: [
+		'bg-gradient-to-r',
+		'from-rose-500',
+		'to-red-500',
+		'text-white',
+		'shadow-md',
+		'shadow-rose-500/40',
+		'hover:from-rose-400',
+		'hover:to-red-400',
+		'focus-visible:ring-rose-200/70',
+	].join(' '),
+	ghost: [
+		'bg-transparent',
+		'text-slate-700',
+		'hover:bg-white/60',
+		'dark:text-slate-200',
+		'dark:hover:bg-white/10',
+		'focus-visible:ring-white/40',
+	].join(' '),
+	dev: [
+		'bg-gradient-to-r',
+		'from-purple-600',
+		'to-fuchsia-500',
+		'text-white',
+		'shadow-md',
+		'shadow-purple-500/40',
+		'hover:from-purple-500',
+		'hover:to-fuchsia-400',
+		'focus-visible:ring-purple-200/70',
+	].join(' '),
 };
 
 export default function Button({


### PR DESCRIPTION
## Summary
* Convert each button variant definition to an array of Tailwind classes that gets joined at runtime, keeping every line within the 80-character limit.

## Text formatting audit (required)
1. **Translator/formatter reuse:** N/A – no translators or formatters were modified.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** No player-facing copy changed; existing text remains in its original voices.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/src/components/common/Button.tsx` remains 106 lines long, well under the 250-line cap.
2. **Line length limits respected:** Splitting each variant’s class list across array entries keeps all new lines ≤80 characters.
3. **Domain separation upheld:** Changes are confined to the web UI component layer and do not cross domain boundaries.
4. **Code standards satisfied:** `CI=1 npm run check` (see log below) passed without issues.
5. **Tests updated:** No new tests were required; existing suites continue to cover the button rendering path.
6. **Documentation updated:** Not applicable—no documentation changes were needed.
7. **`npm run check` results:**
    <details>
    <summary>CI=1 npm run check</summary>

    ```
    > kingdom-builder-engine@0.1.0 check
    > npm run format:check && npm run typecheck && npm run lint

    > kingdom-builder-engine@0.1.0 format:check
    > prettier --check .

    Checking formatting...
    All matched files use Prettier code style!

    > kingdom-builder-engine@0.1.0 typecheck
    > tsc -b --pretty false

    > kingdom-builder-engine@0.1.0 posttypecheck
    > node scripts/clean-dists.cjs

    > kingdom-builder-engine@0.1.0 prelint
    > node scripts/ensure-dev-dependencies.cjs

    > kingdom-builder-engine@0.1.0 lint
    > eslint . --ext .ts,.tsx --rulesdir scripts
    ```
    </details>
8. **`npm run test:coverage` results:**
    <details>
    <summary>CI=1 npm run test:coverage</summary>

    ```
    > kingdom-builder-engine@0.1.0 pretest:coverage
    > node scripts/ensure-dev-dependencies.cjs

    > kingdom-builder-engine@0.1.0 test:coverage
    > vitest run --coverage

     RUN  v3.2.4 /workspace/kingdom-builder-game
          Coverage enabled with v8

     ✓ packages/engine/tests/phases/growth.test.ts (9 tests) 267ms
     ✓ packages/engine/tests/engine.property.test.ts (1 test) 1312ms
       ✓ engine property invariants > pays costs, executes triggers, keeps resources non-negative and preserves snapshots  1309ms
     ✓ packages/engine/tests/effects/add_building.test.ts (4 tests) 147ms
     ✓ packages/engine/tests/services/rules.test.ts (11 tests) 126ms
     ✓ packages/web/tests/army-attack-translation.test.ts (6 tests) 160ms
     ✓ packages/engine/tests/effects/till_land.test.ts (3 tests) 95ms
     ✓ packages/engine/tests/effects/development_remove.test.ts (4 tests) 97ms
     ✓ packages/web/tests/Game.render.test.tsx (1 test) 88ms
     ✓ packages/web/tests/raiders-guild-translation.test.ts (5 tests) 130ms
     ✓ packages/web/tests/log-source.test.ts (3 tests) 90ms
     ✓ packages/engine/tests/phases/upkeep.test.ts (4 tests) 156ms
     ✓ packages/web/tests/hold-festival-action-translation.test.ts (3 tests) 152ms
     ✓ packages/web/tests/plow-action-translation.test.ts (3 tests) 118ms
     ✓ packages/engine/tests/resolveAttack-buildings.test.ts (3 tests) 85ms
     ✓ packages/web/tests/subaction-log.test.ts (1 test) 70ms
     ✓ packages/engine/tests/actions/tax-happiness.test.ts (2 tests) 63ms
     ✓ packages/engine/tests/actions/synthetic.test.ts (3 tests) 95ms
     ✓ packages/engine/tests/effects/nonnegative.test.ts (3 tests) 81ms
     ✓ packages/engine/tests/effects/add_development.test.ts (3 tests) 106ms
     ✓ packages/web/tests/modifier-eval-handlers.test.ts (5 tests) 89ms
     ✓ packages/web/tests/tax-market-log.test.ts (1 test) 68ms
     ✓ packages/engine/tests/result-mod-stack.test.ts (1 test) 45ms
     ✓ packages/engine/tests/resolveAttack.test.ts (7 tests) 48ms
     ✓ packages/engine/tests/effects/cost_mod.test.ts (2 tests) 76ms
     ✓ packages/engine/tests/actions/simulate-action.test.ts (2 tests) 84ms
     ✓ packages/engine/tests/plunder-zero-gold.test.ts (1 test) 58ms
     ✓ packages/engine/tests/requirements/evaluator_compare.test.ts (1 test) 48ms
     ✓ packages/web/tests/plow-workshop-translation.test.ts (1 test) 56ms
     ✓ packages/engine/tests/ai/tax-collector.test.ts (1 test) 42ms
     ✓ tests/integration/action-effect-groups.test.ts (3 tests) 31ms
     ✓ packages/engine/tests/effects/action_add.test.ts (1 test) 29ms
     ✓ tests/integration/action-log-hooks.test.ts (1 test) 69ms
     ✓ packages/web/tests/royal-decree-translation.test.ts (4 tests) 24ms
     ✓ packages/engine/tests/effects/resource-remove.test.ts (2 tests) 70ms
     ✓ tests/integration/tax-translation.test.ts (1 test) 58ms
     ✓ packages/engine/tests/attack-zero-damage-no-effects.test.ts (3 tests) 35ms
     ✓ tests/integration/market-translation.test.ts (1 test) 52ms
     ✓ tests/integration/phased-translation.test.ts (1 test) 48ms
     ✓ packages/engine/tests/attack-evaluation-handlers.test.ts (2 tests) 56ms
     ✓ packages/engine/tests/runtime/session.test.ts (4 tests) 45ms
     ✓ packages/engine/tests/happiness-tier-controller.test.ts (2 tests) 55ms
     ✓ packages/web/tests/tier-content-summary.test.ts (1 test) 17ms
     ✓ packages/engine/tests/effects/resource-add.test.ts (2 tests) 55ms
     ✓ packages/engine/tests/actions/army-attack-happiness.test.ts (1 test) 36ms
     ✓ packages/web/tests/passive-duration-formatter.test.ts (1 test) 56ms
     ✓ packages/web/tests/translation/createTranslationContext.test.ts (1 test) 29ms
     ✓ packages/engine/tests/effects/action_remove.test.ts (1 test) 49ms
     ✓ packages/engine/tests/stat-sources.longevity.test.ts (1 test) 41ms
     ✓ packages/engine/tests/effects/population.test.ts (1 test) 50ms
     ✓ packages/engine/tests/effects/cost-mod-action-owner.test.ts (1 test) 53ms
     ✓ packages/web/tests/tier-summary-translation.test.ts (3 tests) 9ms
     ✓ tests/integration/random-game-flow.test.ts (1 test) 20ms
     ✓ tests/integration/turn-cycle.test.ts (1 test) 50ms
     ✓ packages/web/tests/population-summary.test.ts (2 tests) 33ms
     ✓ tests/integration/edge-cases.test.ts (3 tests) 13ms
     ✓ packages/web/tests/stat-breakdown.test.ts (2 tests) 26ms
     ✓ packages/engine/tests/effects/add_stat.test.ts (1 test) 39ms
     ✓ tests/integration/royal-decree-session.test.ts (1 test) 35ms
     ✓ packages/engine/tests/context/queue.test.ts (1 test) 23ms
     ✓ packages/engine/tests/advance-skip.test.ts (3 tests) 18ms
     ✓ packages/engine/tests/actions/royal-decree-effect-group.test.ts (1 test) 45ms
     ✓ packages/engine/tests/stat-sources.metadata.test.ts (3 tests) 37ms
     ✓ packages/web/tests/describe-skip-event.test.ts (6 tests) 17ms
     ✓ packages/web/tests/passive-log-labels.test.ts (2 tests) 22ms
     ✓ packages/contents/tests/builder-validations.test.ts (20 tests) 20ms
     ✓ packages/engine/tests/effects/action-perform.test.ts (1 test) 20ms
     ✓ tests/integration/building-placement.test.ts (1 test) 16ms
     ✓ packages/web/tests/log-source-icons.test.ts (4 tests) 18ms
     ✓ packages/engine/tests/actions/royal-decree-auto-land.test.ts (1 test) 24ms
     ✓ packages/web/tests/stat-descriptor-registry.test.ts (1 test) 15ms
     ✓ packages/web/tests/development-summary.test.ts (2 tests) 15ms
     ✓ packages/web/tests/App.test.tsx (1 test) 32ms
     ✓ packages/contents/tests/start-config-builder-validations.test.ts (6 tests) 12ms
     ✓ tests/integration/happiness-tier-content.test.ts (1 test) 19ms
     ✓ packages/engine/tests/effects/resource-transfer-percent-bounds.test.ts (2 tests) 14ms
     ✓ packages/web/tests/land-change-log.test.ts (2 tests) 15ms
     ✓ tests/integration/building-stat-bonus.test.ts (1 test) 15ms
     ✓ packages/engine/tests/effects/land_add.test.ts (1 test) 14ms
     ✓ packages/web/tests/overview-tokens.test.ts (2 tests) 8ms
     ✓ packages/engine/tests/resolveAttack-targets.test.ts (1 test) 18ms
     ✓ packages/web/tests/land-till-formatter.test.ts (2 tests) 12ms
     ✓ packages/web/tests/development-translation.test.ts (1 test) 10ms
     ✓ packages/contents/tests/action-effect-group-builders.test.ts (5 tests) 17ms
     ✓ packages/engine/tests/registry/registry.test.ts (2 tests) 14ms
     ✓ packages/engine/tests/effects/passive-add.test.ts (1 test) 10ms
     ✓ packages/web/tests/attack-on-damage-registry.test.ts (3 tests) 10ms
     ✓ packages/engine/tests/additive-stat-pct.test.ts (1 test) 12ms
     ✓ packages/engine/tests/absorption-cap.test.ts (1 test) 20ms
     ✓ packages/engine/tests/effects/stat-add-pct-step-reset.test.ts (1 test) 9ms
     ✓ packages/web/tests/attack-diff-formatters.test.ts (3 tests) 9ms
     ✓ packages/engine/tests/state/state.test.ts (5 tests) 7ms
     ✓ packages/engine/tests/config/requirement_builder.test.ts (1 test) 9ms
     ✓ packages/web/tests/getRequirementIcons.test.ts (2 tests) 18ms
     ✓ packages/engine/tests/utils/applyParamsToEffects.test.ts (2 tests) 7ms
     ✓ packages/web/tests/phase-history.test.ts (2 tests) 14ms
     ✓ packages/web/src/startup/resolvePrimaryIcon.test.ts (2 tests) 6ms
     ✓ packages/web/tests/overview-content-source.test.tsx (1 test) 408ms
       ✓ Overview content integration > consumes swapped overview metadata from the content package  405ms
     ✓ packages/web/tests/ActionsPanel.test.tsx (4 tests) 584ms
     ✓ packages/web/tests/generic-actions-effect-group.test.tsx (1 test) 253ms
     ✓ packages/web/tests/PhasePanel.test.tsx (1 test) 209ms
     ✓ packages/web/tests/resource-bar.test.tsx (1 test) 210ms
     ✓ packages/web/tests/Overview.test.tsx (1 test) 107ms
     ✓ packages/web/tests/passive-display.test.tsx (3 tests) 70ms
     ✓ packages/web/tests/PlayerPanel.test.tsx (1 test) 78ms
     ✓ packages/web/tests/HoverCard.test.tsx (1 test) 55ms

     Test Files  105 passed (105)
          Tests  254 passed (254)
       Start at  14:49:58
       Duration  87.62s (transform 7.92s, setup 0ms, collect 60.52s, tests 7.83s, environment 10.67s, prepare 21.24s)

     % Coverage report from v8
    -------------------|---------|----------|---------|---------|-------------------
    File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
    -------------------|---------|----------|---------|---------|-------------------
    All files          |    81.1 |    84.24 |      93 |    81.1 |
    ... (full table continues in log)
    -------------------|---------|----------|---------|---------|-------------------
    ```
    </details>

## Testing
- ✅ CI=1 npm run check
- ✅ CI=1 npm run test:coverage


------
https://chatgpt.com/codex/tasks/task_e_68e28318aad88325ba77a9781c31b6ae