### PR TITLE
feat(engine): simulate upcoming phases

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -25,6 +25,13 @@ export {
 	type PlayerStateSnapshot,
 	type LandSnapshot,
 } from './runtime/session';
+export {
+	simulateUpcomingPhases,
+	type SimulateUpcomingPhasesOptions,
+	type SimulateUpcomingPhasesIds,
+	type SimulateUpcomingPhasesResult,
+	type PlayerSnapshotDeltaBucket,
+} from './runtime/simulate_upcoming_phases';
 export { getActionCosts, getActionRequirements } from './actions/costs';
 export { performAction, simulateAction } from './actions/action_execution';
 export {

--- a/packages/engine/src/runtime/simulate_upcoming_phases.ts
+++ b/packages/engine/src/runtime/simulate_upcoming_phases.ts
@@ -1,0 +1,138 @@
+import { cloneEngineContext } from '../actions/context_clone';
+import type { EngineContext } from '../context';
+import { advance } from '../phases/advance';
+import type { PlayerId } from '../state';
+import { snapshotPlayer } from './player_snapshot';
+import { snapshotAdvance } from './engine_snapshot';
+import type { EngineAdvanceResult, PlayerStateSnapshot } from './types';
+
+export interface SimulateUpcomingPhasesIds {
+	growth: string;
+	upkeep: string;
+}
+
+export interface SimulateUpcomingPhasesOptions {
+	phaseIds?: SimulateUpcomingPhasesIds;
+	maxIterations?: number;
+}
+
+export interface PlayerSnapshotDeltaBucket {
+	resources: Record<string, number>;
+	stats: Record<string, number>;
+	population: Record<string, number>;
+}
+
+export interface SimulateUpcomingPhasesResult {
+	playerId: PlayerId;
+	before: PlayerStateSnapshot;
+	after: PlayerStateSnapshot;
+	delta: PlayerSnapshotDeltaBucket;
+	steps: EngineAdvanceResult[];
+}
+
+function resolvePhaseIds(
+	context: EngineContext,
+	ids: SimulateUpcomingPhasesIds | undefined,
+): SimulateUpcomingPhasesIds {
+	if (ids) {
+		return ids;
+	}
+	const [firstPhase, secondPhase] = context.phases;
+	if (!firstPhase || !secondPhase) {
+		throw new Error('Engine context is missing growth or upkeep phases.');
+	}
+	return { growth: firstPhase.id, upkeep: secondPhase.id };
+}
+
+function buildDelta(
+	before: PlayerStateSnapshot,
+	after: PlayerStateSnapshot,
+): PlayerSnapshotDeltaBucket {
+	const toDelta = (
+		sourceBefore: Record<string, number>,
+		sourceAfter: Record<string, number>,
+	) => {
+		const result: Record<string, number> = {};
+		const keys = new Set([
+			...Object.keys(sourceBefore),
+			...Object.keys(sourceAfter),
+		]);
+		for (const key of keys) {
+			const diff = (sourceAfter[key] ?? 0) - (sourceBefore[key] ?? 0);
+			if (diff !== 0) {
+				result[key] = diff;
+			}
+		}
+		return result;
+	};
+	return {
+		resources: toDelta(before.resources, after.resources),
+		stats: toDelta(before.stats, after.stats),
+		population: toDelta(before.population, after.population),
+	};
+}
+
+function hasReachedIterationLimit(iterations: number, limit: number): boolean {
+	return iterations >= limit;
+}
+
+export function simulateUpcomingPhases(
+	context: EngineContext,
+	playerId: PlayerId,
+	options: SimulateUpcomingPhasesOptions = {},
+): SimulateUpcomingPhasesResult {
+	const phaseIds = resolvePhaseIds(context, options.phaseIds);
+	const clone = cloneEngineContext(context);
+	const playerIndex = clone.game.players.findIndex(
+		(player) => player.id === playerId,
+	);
+	if (playerIndex === -1) {
+		throw new Error(`Player ${playerId} does not exist in this context.`);
+	}
+	const before = snapshotPlayer(clone, clone.game.players[playerIndex]!);
+	const steps: EngineAdvanceResult[] = [];
+	let growthComplete = false;
+	let upkeepComplete = false;
+	let iterations = 0;
+	const limit =
+		options.maxIterations ??
+		clone.phases.length * clone.game.players.length * 10;
+	while (!upkeepComplete) {
+		if (hasReachedIterationLimit(iterations, limit)) {
+			throw new Error('simulateUpcomingPhases exceeded iteration limit.');
+		}
+		iterations += 1;
+		const result = advance(clone);
+		steps.push(snapshotAdvance(clone, result));
+		if (result.player.id !== playerId) {
+			continue;
+		}
+		const currentPhase = clone.game.currentPhase;
+		if (!growthComplete) {
+			if (
+				result.phase === phaseIds.growth &&
+				currentPhase !== phaseIds.growth
+			) {
+				growthComplete = true;
+			} else if (result.phase === phaseIds.upkeep) {
+				growthComplete = true;
+			}
+		}
+		if (growthComplete && !upkeepComplete) {
+			if (
+				result.phase === phaseIds.upkeep &&
+				currentPhase !== phaseIds.upkeep
+			) {
+				upkeepComplete = true;
+			}
+		}
+	}
+	const after = snapshotPlayer(clone, clone.game.players[playerIndex]!);
+	return {
+		playerId,
+		before,
+		after,
+		delta: buildDelta(before, after),
+		steps,
+	};
+}

--- a/packages/engine/tests/phases/simulate-upcoming-phases.test.ts
+++ b/packages/engine/tests/phases/simulate-upcoming-phases.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { PhaseId, Resource, PopulationRole } from '@kingdom-builder/contents';
+import { createTestEngine } from '../helpers';
+import { simulateUpcomingPhases } from '../../src';
+
+function sanitizePlayerState(context: ReturnType<typeof createTestEngine>) {
+	const player = context.game.players[0]!;
+	for (const key of Object.keys(player.resources)) {
+		player.resources[key] = 0;
+	}
+	for (const key of Object.keys(player.stats)) {
+		player.stats[key] = 0;
+		player.statsHistory[key] = false;
+		player.statSources[key] = {};
+	}
+	for (const key of Object.keys(player.population)) {
+		player.population[key] = 0;
+	}
+	player.buildings.clear();
+	player.actions.clear();
+	for (const land of player.lands) {
+		land.developments = [];
+		land.slotsUsed = 0;
+		delete land.upkeep;
+		delete land.onPayUpkeepStep;
+		delete land.onGainIncomeStep;
+		delete land.onGainAPStep;
+	}
+	return player;
+}
+
+describe('simulateUpcomingPhases', () => {
+	it('resolves growth/upkeep effects without mutating the source context', () => {
+		const context = createTestEngine();
+		const player = sanitizePlayerState(context);
+		const land = player.lands[0]!;
+		const goldGain = 7;
+		const apGain = 2;
+		land.onGainIncomeStep = [
+			{
+				type: 'resource',
+				method: 'add',
+				params: { key: Resource.gold, amount: goldGain },
+			},
+		];
+		land.onGainAPStep = [
+			{
+				type: 'resource',
+				method: 'add',
+				params: { key: Resource.ap, amount: apGain },
+			},
+		];
+		const beforePhase = context.game.currentPhase;
+		const beforePlayerIndex = context.game.currentPlayerIndex;
+		const result = simulateUpcomingPhases(context, player.id, {
+			phaseIds: {
+				growth: PhaseId.Growth,
+				upkeep: PhaseId.Upkeep,
+			},
+		});
+		expect(context.game.currentPhase).toBe(beforePhase);
+		expect(context.game.currentPlayerIndex).toBe(beforePlayerIndex);
+		expect(result.delta.resources[Resource.gold]).toBe(goldGain);
+		expect(result.delta.resources[Resource.ap]).toBe(apGain);
+		expect(result.delta.stats).toEqual({});
+		expect(result.delta.population).toEqual({});
+	});
+
+	it('treats skip flags as completing the affected phases', () => {
+		const context = createTestEngine();
+		const player = sanitizePlayerState(context);
+		const skipId = 'test-skip';
+		player.skipPhases[PhaseId.Growth] = { [skipId]: true };
+		player.skipPhases[PhaseId.Upkeep] = { [skipId]: true };
+		const result = simulateUpcomingPhases(context, player.id, {
+			phaseIds: {
+				growth: PhaseId.Growth,
+				upkeep: PhaseId.Upkeep,
+			},
+		});
+		expect(result.delta.resources).toEqual({});
+		expect(
+			result.steps.some((step) => step.skipped?.phaseId === PhaseId.Growth),
+		).toBe(true);
+		expect(
+			result.steps.some((step) => step.skipped?.phaseId === PhaseId.Upkeep),
+		).toBe(true);
+	});
+
+	it('applies upkeep costs from lands and population', () => {
+		const context = createTestEngine();
+		const player = sanitizePlayerState(context);
+		const land = player.lands[0]!;
+		const upkeepCost = 3;
+		player.resources[Resource.gold] = 10;
+		land.upkeep = { [Resource.gold]: upkeepCost };
+		player.population[PopulationRole.Council] = 1;
+		const result = simulateUpcomingPhases(context, player.id, {
+			phaseIds: {
+				growth: PhaseId.Growth,
+				upkeep: PhaseId.Upkeep,
+			},
+		});
+		const councilUpkeep =
+			context.populations.get(PopulationRole.Council)?.upkeep?.[
+				Resource.gold
+			] ?? 0;
+		expect(result.delta.resources[Resource.gold]).toBe(
+			-(upkeepCost + councilUpkeep),
+		);
+		expect(result.after.resources[Resource.gold]).toBe(
+			10 - upkeepCost - councilUpkeep,
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- add a runtime `simulateUpcomingPhases` helper that clones the engine context, advances a target player through Growth and Upkeep, and returns their snapshots plus deltas【F:packages/engine/src/runtime/simulate_upcoming_phases.ts†L9-L137】
- re-export the helper and related types from `@kingdom-builder/engine` for consumer access【F:packages/engine/src/index.ts†L28-L34】
- cover the helper with targeted phase tests for normal income, skip flags, and upkeep costs【F:packages/engine/tests/phases/simulate-upcoming-phases.test.ts†L1-L115】

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable—no translation or formatting helpers were touched.
2. **Canonical keywords/icons/helpers touched:** None; no canonical keywords, icons, or helpers were modified.
3. **Voice review:** Not applicable—no player-facing text was introduced or changed.

## Standards compliance (required)
1. **File length limits respected:** `simulate_upcoming_phases.ts` (138 lines) and the new test file (115 lines) stay within the 250-line guidance.【F:packages/engine/src/runtime/simulate_upcoming_phases.ts†L1-L138】【F:packages/engine/tests/phases/simulate-upcoming-phases.test.ts†L1-L115】
2. **Line length limits respected:** Verified with `awk` that no lines exceed 80 characters.【6039f7†L1-L1】【90e0c8†L1-L1】
3. **Domain separation upheld:** Changes are confined to engine runtime logic and engine tests, avoiding cross-domain coupling.【F:packages/engine/src/runtime/simulate_upcoming_phases.ts†L9-L137】【F:packages/engine/tests/phases/simulate-upcoming-phases.test.ts†L1-L115】
4. **Code standards satisfied:** `CI=1 npm run check` (format, typecheck, lint) completed without errors.【3b9c28†L1-L4】【8a4620†L1-L4】【98995a†L1-L8】【b9a395†L1-L5】【8bd6fb†L1-L9】【4d5f32†L1-L13】【9d98b7†L1-L1】
5. **Tests updated:** Added `simulate-upcoming-phases.test.ts` to cover the new helper.【F:packages/engine/tests/phases/simulate-upcoming-phases.test.ts†L1-L115】
6. **Documentation updated:** Not required because behaviour is covered by automated tests without user-facing documentation changes.
7. **`npm run check` results:** See `CI=1 npm run check` log above for the full output.【3b9c28†L1-L4】【8a4620†L1-L4】【98995a†L1-L8】【b9a395†L1-L5】【8bd6fb†L1-L9】【4d5f32†L1-L13】【9d98b7†L1-L1】
8. **`npm run test:coverage` results:** Command fails due to repository-wide coverage thresholds (expected for targeted unit runs).【7a8823†L1-L86】

## Testing
- `npm test -- packages/engine/tests/phases/simulate-upcoming-phases.test.ts` (pass)【83b8fa†L1-L15】
- `CI=1 npm run check` (pass)【3b9c28†L1-L4】【8a4620†L1-L4】【98995a†L1-L8】【b9a395†L1-L5】【8bd6fb†L1-L9】【4d5f32†L1-L13】【9d98b7†L1-L1】
- `npm run test:coverage -- packages/engine/tests/phases/simulate-upcoming-phases.test.ts` (fails: global coverage thresholds exceed baseline)【7a8823†L1-L86】

------
https://chatgpt.com/codex/tasks/task_e_68e285fdaeec8325af98b0188a75adb3