### PR TITLE
Align quit dialog styling with main buttons

### DIFF
--- a/packages/web/src/components/common/ConfirmDialog.tsx
+++ b/packages/web/src/components/common/ConfirmDialog.tsx
@@ -69,14 +69,19 @@ export default function ConfirmDialog({
 					{description}
 				</p>
 				<div className="mt-8 flex flex-wrap justify-end gap-3">
-					<Button variant="ghost" onClick={onCancel} className="px-5" icon="↩️">
+					<Button
+						variant="secondary"
+						onClick={onCancel}
+						className="px-5"
+						icon="↩️"
+					>
 						{cancelLabel}
 					</Button>
 					<Button
 						variant="danger"
 						onClick={onConfirm}
 						className="px-5"
-						icon="✅"
+						icon="🏳️"
 					>
 						{confirmLabel}
 					</Button>


### PR DESCRIPTION
## Summary
- Match the quit confirmation dialog's primary action icon to the surrender icon used by the in-game Quit Game button.
- Restyle the Continue Playing button with the shared secondary button variant so it mirrors the Settings button background.

## Text formatting audit (required)
1. **Translator/formatter reuse:** No new player-facing text or formatters introduced; existing labels reused.
2. **Canonical keywords/icons/helpers touched:** Reused the existing surrender icon (🏳️) already used by the Quit Game button.
3. **Voice review:** No new strings added; existing dialog copy remains unchanged.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/src/components/common/ConfirmDialog.tsx` is 93 lines (limit 250). 【a1d267†L1-L3】
2. **Line length limits respected:** Verified all newly added lines remain under the 80-character limit. 【4b682f†L1-L8】
3. **Domain separation upheld:** Changes are confined to the web UI component layer and do not touch engine/content logic.
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint, tests) passes on the updated tree. 【9583f3†L1-L38】【f495df†L1-L56】
5. **Tests updated:** No new tests required; existing dialog coverage remains valid for styling-only adjustments.
6. **Documentation updated:** Not applicable; no documentation changes were necessary.
7. **`npm run check` results:** Full output captured in `/tmp/commit.log`. 【9583f3†L1-L38】【f495df†L1-L56】
8. **`npm run test:coverage` results:** Full output captured in `/tmp/test-coverage.log`. 【fa73cc†L1-L20】【f945b5†L1-L27】【e96746†L1-L20】

## Testing
- `npm run check`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e28814d79c8325a171d08774fd4275