### PR TITLE
Refactor tax evaluator identifier usage

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -58,9 +58,20 @@ const ACTION_ID_MAP = {
 	till: 'till',
 } as const;
 
+const POPULATION_EVALUATION_ID_MAP = {
+	tax: 'tax',
+} as const;
+
 export const ActionId = ACTION_ID_MAP;
 
 export type ActionId = (typeof ACTION_ID_MAP)[keyof typeof ACTION_ID_MAP];
+
+export const PopulationEvaluationId = POPULATION_EVALUATION_ID_MAP;
+
+type PopulationEvaluationIdMap = typeof POPULATION_EVALUATION_ID_MAP;
+
+export type PopulationEvaluationId =
+	PopulationEvaluationIdMap[keyof PopulationEvaluationIdMap];
 
 export const ActionCategory = {
 	Basic: 'basic',
@@ -160,7 +171,7 @@ export function createActionRegistry() {
 			.cost(Resource.ap, 1)
 			.effect(
 				effect()
-					.evaluator(populationEvaluator().id('tax'))
+					.evaluator(populationEvaluator().id(PopulationEvaluationId.tax))
 					.effect(
 						effect(Types.Resource, ResourceMethods.ADD)
 							.params(resourceParams().key(Resource.gold).amount(4))

--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -4,7 +4,7 @@ import {
 	TRANSFER_PCT_EVALUATION_TYPE,
 	buildingSchema,
 } from '@kingdom-builder/protocol';
-import { ActionId } from './actions';
+import { ActionId, PopulationEvaluationId } from './actions';
 import { Resource } from './resources';
 import { Stat } from './stats';
 import { DevelopmentId } from './developments';
@@ -146,7 +146,7 @@ export function createBuildingRegistry() {
 					.params(
 						resultModParams()
 							.id('market_tax_bonus')
-							.evaluation(populationTarget().id('tax'))
+							.evaluation(populationTarget().id(PopulationEvaluationId.tax))
 							.amount(1),
 					)
 					.build(),


### PR DESCRIPTION
## Summary

- Introduced a shared `PopulationEvaluationId` map in the contents actions module and exported the associated type for reuse.
- Updated the tax action and Market building to rely on the shared identifier rather than hard-coded evaluator strings.

## Text formatting audit (required)

1. **Translator/formatter reuse:** Not applicable; no translators or formatters were touched.
2. **Canonical keywords/icons/helpers touched:** None; no player-facing keywords, icons, or helpers changed.
3. **Voice review:** Not applicable; no player-facing copy was modified.

## Standards compliance (required)

1. **File length limits respected:** `packages/contents/src/actions.ts` (518 lines) and `packages/contents/src/buildings.ts` (246 lines) remain within the existing grandfathered limits (`wc -l`).
2. **Line length limits respected:** Added lines stay within the 80-character limit; verified via the passing lint step in `npm run check`.
3. **Domain separation upheld:** All modifications are confined to the contents package; no engine, web, or protocol code paths were altered.
4. **Code standards satisfied:** `npm run check` completed successfully (see `/tmp/npm-check.log`).
5. **Tests updated:** No new tests were required; existing suites continue to cover tax evaluator usage.
6. **Documentation updated:** Not needed because no documentation-facing behavior changed.
7. **`npm run check` results:** Output stored in `/tmp/npm-check.log` (all checks passed).
8. **`npm run test:coverage` results:** Not run; targeted engine and contents test suites were executed instead per task instructions.

## Testing

- ✅ `npm test --workspace @kingdom-builder/contents`
- ✅ `npm test --workspace @kingdom-builder/engine`


------
https://chatgpt.com/codex/tasks/task_e_68e28a21f7a8832587680b7e59f19230