### PR TITLE
Add building id constants

### DIFF
--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -1,244 +1,30 @@
-import {
-	Registry,
-	TRANSFER_PCT_EVALUATION_ID,
-	TRANSFER_PCT_EVALUATION_TYPE,
-	buildingSchema,
-} from '@kingdom-builder/protocol';
-import { ActionId } from './actions';
-import { Resource } from './resources';
-import { Stat } from './stats';
-import { DevelopmentId } from './developments';
-import {
-	building,
-	effect,
-	resourceParams,
-	actionParams,
-	resultModParams,
-	evaluationTarget,
-	developmentTarget,
-	populationTarget,
-	costModParams,
-	statParams,
-} from './config/builders';
-import {
-	Types,
-	CostModMethods,
-	ResultModMethods,
-	ResourceMethods,
-	ActionMethods,
-	PassiveMethods,
-	StatMethods,
-} from './config/builderShared';
-import { Focus } from './defs';
+import { Registry, buildingSchema } from '@kingdom-builder/protocol';
 import type { BuildingDef } from './defs';
+import { registerBuildings } from './buildings/registerBuildings';
 
 export type { BuildingDef } from './defs';
+
+export const BuildingId = {
+	TownCharter: 'town_charter',
+	Mill: 'mill',
+	RaidersGuild: 'raiders_guild',
+	PlowWorkshop: 'plow_workshop',
+	Market: 'market',
+	Barracks: 'barracks',
+	Citadel: 'citadel',
+	CastleWalls: 'castle_walls',
+	CastleGardens: 'castle_gardens',
+	Temple: 'temple',
+	Palace: 'palace',
+	GreatHall: 'great_hall',
+} as const;
+export type BuildingId = (typeof BuildingId)[keyof typeof BuildingId];
+export type BuildingIds = typeof BuildingId;
 
 export function createBuildingRegistry() {
 	const registry = new Registry<BuildingDef>(buildingSchema.passthrough());
 
-	registry.add(
-		'town_charter',
-		building()
-			.id('town_charter')
-			.name('Town Charter')
-			.icon('🏘️')
-			.cost(Resource.gold, 5)
-			.onBuild(
-				effect(Types.CostMod, CostModMethods.ADD)
-					.params(
-						costModParams()
-							.id('tc_expand_cost')
-							.actionId(ActionId.expand)
-							.key(Resource.gold)
-							.amount(2),
-					)
-					.build(),
-			)
-			.onBuild(
-				effect(Types.ResultMod, ResultModMethods.ADD)
-					.params(
-						resultModParams().id('tc_expand_result').actionId(ActionId.expand),
-					)
-					.effect(
-						effect(Types.Resource, ResourceMethods.ADD)
-							.params(resourceParams().key(Resource.happiness).amount(1))
-							.build(),
-					)
-					.build(),
-			)
-			.focus(Focus.Economy)
-			.build(),
-	);
-
-	// TODO: remaining buildings from original manual config
-	const millFarmTarget = developmentTarget().id(DevelopmentId.Farm);
-	const millFarmResultParams = resultModParams()
-		.id('mill_farm_bonus')
-		.evaluation(millFarmTarget)
-		.amount(1);
-
-	registry.add(
-		'mill',
-		building()
-			.id('mill')
-			.name('Mill')
-			.icon('⚙️')
-			.cost(Resource.gold, 7)
-			.onBuild(
-				effect(Types.ResultMod, ResultModMethods.ADD)
-					.params(millFarmResultParams)
-					.build(),
-			)
-			.focus(Focus.Economy)
-			.build(),
-	);
-	registry.add(
-		'raiders_guild',
-		building()
-			.id('raiders_guild')
-			.name("Raider's Guild")
-			.icon('🏴‍☠️')
-			.cost(Resource.gold, 8)
-			.cost(Resource.ap, 1)
-			.upkeep(Resource.gold, 1)
-			.onBuild(
-				effect(Types.ResultMod, ResultModMethods.ADD)
-					.params(
-						resultModParams()
-							.id('raiders_guild_plunder_bonus')
-							.evaluation(
-								evaluationTarget(TRANSFER_PCT_EVALUATION_TYPE).id(
-									TRANSFER_PCT_EVALUATION_ID,
-								),
-							)
-							.adjust(25),
-					)
-					.build(),
-			)
-			.focus(Focus.Aggressive)
-			.build(),
-	);
-	registry.add(
-		'plow_workshop',
-		building()
-			.id('plow_workshop')
-			.name('Plow Workshop')
-			.icon('🏭')
-			.cost(Resource.gold, 10)
-			.onBuild(
-				effect(Types.Action, ActionMethods.ADD)
-					.params(actionParams().id(ActionId.plow))
-					.build(),
-			)
-			.focus(Focus.Economy)
-			.build(),
-	);
-	registry.add(
-		'market',
-		building()
-			.id('market')
-			.name('Market')
-			.icon('🏪')
-			.cost(Resource.gold, 10)
-			.onBuild(
-				effect(Types.ResultMod, ResultModMethods.ADD)
-					.params(
-						resultModParams()
-							.id('market_tax_bonus')
-							.evaluation(populationTarget().id('tax'))
-							.amount(1),
-					)
-					.build(),
-			)
-			.focus(Focus.Economy)
-			.build(),
-	);
-	registry.add(
-		'barracks',
-		building()
-			.id('barracks')
-			.name('Barracks')
-			.icon('🪖')
-			.cost(Resource.gold, 12)
-			.focus(Focus.Aggressive)
-			.build(),
-	);
-	registry.add(
-		'citadel',
-		building()
-			.id('citadel')
-			.name('Citadel')
-			.icon('🏯')
-			.cost(Resource.gold, 12)
-			.focus(Focus.Defense)
-			.build(),
-	);
-	registry.add(
-		'castle_walls',
-		building()
-			.id('castle_walls')
-			.name('Castle Walls')
-			.icon('🧱')
-			.cost(Resource.gold, 12)
-			.onBuild(
-				effect(Types.Passive, PassiveMethods.ADD)
-					.param('id', 'castle_walls_bonus')
-					.effect(
-						effect(Types.Stat, StatMethods.ADD)
-							.params(statParams().key(Stat.fortificationStrength).amount(5))
-							.build(),
-					)
-					.effect(
-						effect(Types.Stat, StatMethods.ADD)
-							.params(statParams().key(Stat.absorption).amount(0.2))
-							.build(),
-					)
-					.build(),
-			)
-			.focus(Focus.Defense)
-			.build(),
-	);
-	registry.add(
-		'castle_gardens',
-		building()
-			.id('castle_gardens')
-			.name('Castle Gardens')
-			.icon('🌷')
-			.cost(Resource.gold, 15)
-			.focus(Focus.Economy)
-			.build(),
-	);
-	registry.add(
-		'temple',
-		building()
-			.id('temple')
-			.name('Temple')
-			.icon('⛪')
-			.cost(Resource.gold, 16)
-			.focus(Focus.Other)
-			.build(),
-	);
-	registry.add(
-		'palace',
-		building()
-			.id('palace')
-			.name('Palace')
-			.icon('👑')
-			.cost(Resource.gold, 20)
-			.focus(Focus.Other)
-			.build(),
-	);
-	registry.add(
-		'great_hall',
-		building()
-			.id('great_hall')
-			.name('Great Hall')
-			.icon('🏟️')
-			.cost(Resource.gold, 22)
-			.focus(Focus.Other)
-			.build(),
-	);
+	registerBuildings(registry, BuildingId);
 
 	return registry;
 }

--- a/packages/contents/src/buildings/registerBuildings.ts
+++ b/packages/contents/src/buildings/registerBuildings.ts
@@ -1,0 +1,240 @@
+import type { Registry } from '@kingdom-builder/protocol';
+import {
+	TRANSFER_PCT_EVALUATION_ID,
+	TRANSFER_PCT_EVALUATION_TYPE,
+} from '@kingdom-builder/protocol';
+import { ActionId } from '../actions';
+import { Resource } from '../resources';
+import { Stat } from '../stats';
+import { DevelopmentId } from '../developments';
+import {
+	building,
+	effect,
+	resourceParams,
+	actionParams,
+	resultModParams,
+	evaluationTarget,
+	developmentTarget,
+	populationTarget,
+	costModParams,
+	statParams,
+} from '../config/builders';
+import {
+	Types,
+	CostModMethods,
+	ResultModMethods,
+	ResourceMethods,
+	ActionMethods,
+	PassiveMethods,
+	StatMethods,
+} from '../config/builderShared';
+import { Focus } from '../defs';
+import type { BuildingDef } from '../defs';
+import type { BuildingIds } from '../buildings';
+
+export function registerBuildings(
+	registry: Registry<BuildingDef>,
+	ids: BuildingIds,
+) {
+	registry.add(
+		ids.TownCharter,
+		building()
+			.id(ids.TownCharter)
+			.name('Town Charter')
+			.icon('🏘️')
+			.cost(Resource.gold, 5)
+			.onBuild(
+				effect(Types.CostMod, CostModMethods.ADD)
+					.params(
+						costModParams()
+							.id('tc_expand_cost')
+							.actionId(ActionId.expand)
+							.key(Resource.gold)
+							.amount(2),
+					)
+					.build(),
+			)
+			.onBuild(
+				effect(Types.ResultMod, ResultModMethods.ADD)
+					.params(
+						resultModParams().id('tc_expand_result').actionId(ActionId.expand),
+					)
+					.effect(
+						effect(Types.Resource, ResourceMethods.ADD)
+							.params(resourceParams().key(Resource.happiness).amount(1))
+							.build(),
+					)
+					.build(),
+			)
+			.focus(Focus.Economy)
+			.build(),
+	);
+
+	const millFarmTarget = developmentTarget().id(DevelopmentId.Farm);
+	const millFarmResultParams = resultModParams()
+		.id('mill_farm_bonus')
+		.evaluation(millFarmTarget)
+		.amount(1);
+
+	registry.add(
+		ids.Mill,
+		building()
+			.id(ids.Mill)
+			.name('Mill')
+			.icon('⚙️')
+			.cost(Resource.gold, 7)
+			.onBuild(
+				effect(Types.ResultMod, ResultModMethods.ADD)
+					.params(millFarmResultParams)
+					.build(),
+			)
+			.focus(Focus.Economy)
+			.build(),
+	);
+	registry.add(
+		ids.RaidersGuild,
+		building()
+			.id(ids.RaidersGuild)
+			.name("Raider's Guild")
+			.icon('🏴‍☠️')
+			.cost(Resource.gold, 8)
+			.cost(Resource.ap, 1)
+			.upkeep(Resource.gold, 1)
+			.onBuild(
+				effect(Types.ResultMod, ResultModMethods.ADD)
+					.params(
+						resultModParams()
+							.id('raiders_guild_plunder_bonus')
+							.evaluation(
+								evaluationTarget(TRANSFER_PCT_EVALUATION_TYPE).id(
+									TRANSFER_PCT_EVALUATION_ID,
+								),
+							)
+							.adjust(25),
+					)
+					.build(),
+			)
+			.focus(Focus.Aggressive)
+			.build(),
+	);
+	registry.add(
+		ids.PlowWorkshop,
+		building()
+			.id(ids.PlowWorkshop)
+			.name('Plow Workshop')
+			.icon('🏭')
+			.cost(Resource.gold, 10)
+			.onBuild(
+				effect(Types.Action, ActionMethods.ADD)
+					.params(actionParams().id(ActionId.plow))
+					.build(),
+			)
+			.focus(Focus.Economy)
+			.build(),
+	);
+	registry.add(
+		ids.Market,
+		building()
+			.id(ids.Market)
+			.name('Market')
+			.icon('🏪')
+			.cost(Resource.gold, 10)
+			.onBuild(
+				effect(Types.ResultMod, ResultModMethods.ADD)
+					.params(
+						resultModParams()
+							.id('market_tax_bonus')
+							.evaluation(populationTarget().id('tax'))
+							.amount(1),
+					)
+					.build(),
+			)
+			.focus(Focus.Economy)
+			.build(),
+	);
+	registry.add(
+		ids.Barracks,
+		building()
+			.id(ids.Barracks)
+			.name('Barracks')
+			.icon('🪖')
+			.cost(Resource.gold, 12)
+			.focus(Focus.Aggressive)
+			.build(),
+	);
+	registry.add(
+		ids.Citadel,
+		building()
+			.id(ids.Citadel)
+			.name('Citadel')
+			.icon('🏯')
+			.cost(Resource.gold, 12)
+			.focus(Focus.Defense)
+			.build(),
+	);
+	registry.add(
+		ids.CastleWalls,
+		building()
+			.id(ids.CastleWalls)
+			.name('Castle Walls')
+			.icon('🧱')
+			.cost(Resource.gold, 12)
+			.onBuild(
+				effect(Types.Passive, PassiveMethods.ADD)
+					.param('id', 'castle_walls_bonus')
+					.effect(
+						effect(Types.Stat, StatMethods.ADD)
+							.params(statParams().key(Stat.fortificationStrength).amount(5))
+							.build(),
+					)
+					.effect(
+						effect(Types.Stat, StatMethods.ADD)
+							.params(statParams().key(Stat.absorption).amount(0.2))
+							.build(),
+					)
+					.build(),
+			)
+			.focus(Focus.Defense)
+			.build(),
+	);
+	registry.add(
+		ids.CastleGardens,
+		building()
+			.id(ids.CastleGardens)
+			.name('Castle Gardens')
+			.icon('🌷')
+			.cost(Resource.gold, 15)
+			.focus(Focus.Economy)
+			.build(),
+	);
+	registry.add(
+		ids.Temple,
+		building()
+			.id(ids.Temple)
+			.name('Temple')
+			.icon('⛪')
+			.cost(Resource.gold, 16)
+			.focus(Focus.Other)
+			.build(),
+	);
+	registry.add(
+		ids.Palace,
+		building()
+			.id(ids.Palace)
+			.name('Palace')
+			.icon('👑')
+			.cost(Resource.gold, 20)
+			.focus(Focus.Other)
+			.build(),
+	);
+	registry.add(
+		ids.GreatHall,
+		building()
+			.id(ids.GreatHall)
+			.name('Great Hall')
+			.icon('🏟️')
+			.cost(Resource.gold, 22)
+			.focus(Focus.Other)
+			.build(),
+	);
+}

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -1,5 +1,5 @@
 export { ACTIONS, createActionRegistry, ActionId } from './actions';
-export { BUILDINGS, createBuildingRegistry } from './buildings';
+export { BUILDINGS, createBuildingRegistry, BuildingId } from './buildings';
 export { DEVELOPMENTS, createDevelopmentRegistry } from './developments';
 export { POPULATIONS, createPopulationRegistry } from './populations';
 export { PHASES, PhaseId, PhaseStepId, PhaseTrigger } from './phases';
@@ -39,7 +39,11 @@ export {
 export { PRIMARY_ICON_ID } from './startup';
 export { type ActionDef } from './actions';
 export type { ActionId as ActionIdType } from './actions';
-export type { BuildingDef } from './buildings';
+export type {
+	BuildingDef,
+	BuildingId as BuildingIdType,
+	BuildingIds,
+} from './buildings';
 export type { DevelopmentDef } from './developments';
 export type { PopulationDef, TriggerKey, Focus } from './defs';
 export type {

--- a/packages/web/tests/passive-log-labels.test.ts
+++ b/packages/web/tests/passive-log-labels.test.ts
@@ -6,6 +6,7 @@ import { LOG_KEYWORDS } from '../src/translation/log/logMessages';
 import {
 	ACTIONS,
 	BUILDINGS,
+	BuildingId,
 	DEVELOPMENTS,
 	POPULATIONS,
 	PHASES,
@@ -97,7 +98,7 @@ describe('passive log labels', () => {
 				{
 					type: 'building',
 					method: 'add',
-					params: { id: 'castle_walls' },
+					params: { id: BuildingId.CastleWalls },
 				},
 			],
 			ctx,


### PR DESCRIPTION
## Summary
* Added `BuildingId` constants and types alongside a `registerBuildings` helper so the building registry consistently uses shared IDs when populating entries. 【F:packages/contents/src/buildings.ts†L7-L29】【F:packages/contents/src/buildings/registerBuildings.ts†L1-L240】
* Re-exported the new identifiers and updated the passive log test to import constants instead of literals. 【F:packages/contents/src/index.ts†L1-L46】【F:packages/web/tests/passive-log-labels.test.ts†L1-L115】

## Text formatting audit (required)

1. **Translator/formatter reuse:** Not applicable; no translator or formatter code was touched.
2. **Canonical keywords/icons/helpers touched:** Not applicable; no canonical keywords or icons were modified.
3. **Voice review:** Not applicable; no player-facing text was changed.

## Standards compliance (required)

1. **File length limits respected:** `buildings.ts` now has 32 lines and `registerBuildings.ts` has 240 lines, both within limits. 【F:packages/contents/src/buildings.ts†L1-L32】【F:packages/contents/src/buildings/registerBuildings.ts†L1-L240】
2. **Line length limits respected:** `CI=1 npm run check` succeeded, confirming lint and formatting constraints were met. 【7d6967†L1-L11】【b7fe0b†L1-L25】
3. **Domain separation upheld:** Changes were confined to the contents package and related web tests; engine and protocol layers remain untouched.
4. **Code standards satisfied:** `CI=1 npm run check` completed without errors, covering formatting, type checks, and linting. 【7d6967†L1-L11】【b7fe0b†L1-L25】
5. **Tests updated:** `packages/web/tests/passive-log-labels.test.ts` now imports `BuildingId` instead of hard-coded IDs. 【F:packages/web/tests/passive-log-labels.test.ts†L1-L115】
6. **Documentation updated:** Not required; no documentation changes were necessary.
7. **`npm run check` results:** `CI=1 npm run check` (see logs). 【7d6967†L1-L11】【b7fe0b†L1-L25】
8. **`npm run test:coverage` results:** `CI=1 npm run test:coverage` (see logs). 【13a65e†L1-L58】

## Testing

* `CI=1 npm run check` ✅ 【7d6967†L1-L11】【b7fe0b†L1-L25】
* `npm run test --workspace @kingdom-builder/contents` ✅ 【1dc8df†L1-L13】
* `npx vitest run packages/web/tests/passive-log-labels.test.ts packages/web/tests/translation/createTranslationContext.test.ts` ✅ 【d57b2f†L1-L24】
* `CI=1 npm run test:quick` ✅ 【4f6c27†L1-L7】
* `CI=1 npm run test:coverage` ✅ 【13a65e†L1-L58】

------
https://chatgpt.com/codex/tasks/task_e_68e28a211fbc8325952bd3496d392aa0