### PR TITLE
feat(web): add next turn forecast hook

### DIFF
--- a/packages/web/src/state/useNextTurnForecast.ts
+++ b/packages/web/src/state/useNextTurnForecast.ts
@@ -1,0 +1,70 @@
+import { useMemo, useRef } from 'react';
+import {
+	simulateUpcomingPhases,
+	type PlayerSnapshotDeltaBucket,
+	type PlayerStateSnapshot,
+} from '@kingdom-builder/engine';
+import { useGameEngine } from './GameContext';
+
+export type NextTurnForecast = Record<string, PlayerSnapshotDeltaBucket>;
+
+function cloneEmptyDelta(): PlayerSnapshotDeltaBucket {
+	return {
+		resources: {},
+		stats: {},
+		population: {},
+	};
+}
+
+function serializeRecord(source: Record<string, unknown>): string {
+	const entries = Object.entries(source).sort(([a], [b]) => {
+		if (a < b) {
+			return -1;
+		}
+		if (a > b) {
+			return 1;
+		}
+		return 0;
+	});
+	return JSON.stringify(entries);
+}
+
+function hashPlayer(player: PlayerStateSnapshot): string {
+	return [
+		player.id,
+		serializeRecord(player.resources),
+		serializeRecord(player.stats),
+		serializeRecord(player.population),
+		player.lands.length,
+		serializeRecord(player.skipPhases),
+		serializeRecord(player.skipSteps),
+	].join('|');
+}
+
+export function useNextTurnForecast(): NextTurnForecast {
+	const { session, sessionState } = useGameEngine();
+	const players = sessionState.game.players;
+	const hashKey = useMemo(() => {
+		const hashes = players.map((player) => hashPlayer(player));
+		hashes.sort();
+		return hashes.join(',');
+	}, [players]);
+	const cacheRef = useRef<{ key: string; value: NextTurnForecast }>();
+	return useMemo(() => {
+		if (cacheRef.current?.key === hashKey) {
+			return cacheRef.current.value;
+		}
+		const context = session.getLegacyContext();
+		const forecast: NextTurnForecast = {};
+		for (const player of players) {
+			try {
+				const { delta } = simulateUpcomingPhases(context, player.id);
+				forecast[player.id] = delta;
+			} catch (error) {
+				forecast[player.id] = cloneEmptyDelta();
+			}
+		}
+		cacheRef.current = { key: hashKey, value: forecast };
+		return forecast;
+	}, [session, hashKey]);
+}

--- a/packages/web/tests/useNextTurnForecast.test.ts
+++ b/packages/web/tests/useNextTurnForecast.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, beforeEach, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { JSDOM } from 'jsdom';
+import {
+	RESOURCES,
+	STATS,
+	POPULATIONS,
+	type ResourceKey,
+	type StatKey,
+	type PopulationRoleId,
+} from '@kingdom-builder/contents';
+import type {
+	PlayerSnapshotDeltaBucket,
+	PlayerStateSnapshot,
+} from '@kingdom-builder/engine';
+import { useNextTurnForecast } from '../src/state/useNextTurnForecast';
+
+const simulateUpcomingPhasesMock = vi.hoisted(() => vi.fn());
+
+const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
+vi.stubGlobal('window', jsdom.window as unknown as typeof globalThis);
+vi.stubGlobal('document', jsdom.window.document);
+vi.stubGlobal('navigator', jsdom.window.navigator);
+
+vi.mock('@kingdom-builder/engine', async () => {
+	const actual = await vi.importActual('@kingdom-builder/engine');
+	return {
+		...(actual as Record<string, unknown>),
+		simulateUpcomingPhases: simulateUpcomingPhasesMock,
+	};
+});
+
+interface MockGameEngine {
+	session: { getLegacyContext: ReturnType<typeof vi.fn> };
+	sessionState: { game: { players: PlayerStateSnapshot[] } };
+}
+
+const contextStub = { context: true } as const;
+const engineValue: MockGameEngine = {
+	session: { getLegacyContext: vi.fn(() => contextStub) },
+	sessionState: { game: { players: [] } },
+};
+
+vi.mock('../src/state/GameContext', () => ({
+	useGameEngine: (): MockGameEngine => engineValue,
+}));
+
+const resourceKeys = Object.keys(RESOURCES) as ResourceKey[];
+const statKeys = Object.keys(STATS) as StatKey[];
+const populationKeys = Object.keys(POPULATIONS) as PopulationRoleId[];
+const primaryResource = resourceKeys[0]!;
+const primaryStat = statKeys[0]!;
+const primaryPopulation = populationKeys[0]!;
+
+function createPlayer(
+	index: number,
+	overrides: Partial<PlayerStateSnapshot> = {},
+): PlayerStateSnapshot {
+	const baseResources: Record<string, number> = {
+		[primaryResource]: index,
+	};
+	const baseStats: Record<string, number> = {
+		[primaryStat]: index * 2,
+	};
+	const basePopulation: Record<string, number> = {
+		[primaryPopulation]: index,
+	};
+	const {
+		resources: overrideResources,
+		stats: overrideStats,
+		population: overridePopulation,
+		...restOverrides
+	} = overrides;
+	return {
+		id: `player-${index}`,
+		name: `Player ${index}`,
+		resources: { ...baseResources, ...(overrideResources ?? {}) },
+		stats: { ...baseStats, ...(overrideStats ?? {}) },
+		population: {
+			...basePopulation,
+			...(overridePopulation ?? {}),
+		},
+		statsHistory: {},
+		lands: [],
+		buildings: [],
+		actions: [],
+		statSources: {},
+		skipPhases: {},
+		skipSteps: {},
+		passives: [],
+		...restOverrides,
+	};
+}
+
+function setPlayers(players: PlayerStateSnapshot[]) {
+	engineValue.sessionState = { game: { players } };
+}
+
+function createDelta(amount: number): PlayerSnapshotDeltaBucket {
+	return {
+		resources: { [primaryResource]: amount },
+		stats: { [primaryStat]: amount * 2 },
+		population: { [primaryPopulation]: amount },
+	};
+}
+
+describe('useNextTurnForecast', () => {
+	const firstPlayerId = createPlayer(1).id;
+	const secondPlayerId = createPlayer(2).id;
+
+	beforeEach(() => {
+		simulateUpcomingPhasesMock.mockReset();
+		engineValue.session.getLegacyContext.mockClear();
+		setPlayers([createPlayer(1), createPlayer(2)]);
+	});
+
+	it('returns per-player forecast data and memoizes stable hashes', () => {
+		simulateUpcomingPhasesMock.mockImplementation((_, playerId: string) => ({
+			playerId,
+			before: {} as PlayerStateSnapshot,
+			after: {} as PlayerStateSnapshot,
+			delta: createDelta(playerId === firstPlayerId ? 3 : 5),
+			steps: [],
+		}));
+		const { result, rerender } = renderHook(() => useNextTurnForecast());
+		expect(simulateUpcomingPhasesMock).toHaveBeenCalledTimes(2);
+		expect(result.current[firstPlayerId]).toEqual(createDelta(3));
+		expect(result.current[secondPlayerId]).toEqual(createDelta(5));
+
+		simulateUpcomingPhasesMock.mockClear();
+		rerender();
+		expect(simulateUpcomingPhasesMock).not.toHaveBeenCalled();
+		expect(result.current[firstPlayerId]).toEqual(createDelta(3));
+		expect(result.current[secondPlayerId]).toEqual(createDelta(5));
+
+		simulateUpcomingPhasesMock.mockClear();
+		setPlayers([createPlayer(1), createPlayer(2)]);
+		rerender();
+		expect(simulateUpcomingPhasesMock).not.toHaveBeenCalled();
+		expect(result.current[firstPlayerId]).toEqual(createDelta(3));
+		expect(result.current[secondPlayerId]).toEqual(createDelta(5));
+	});
+
+	it('returns empty buckets on simulation failure and recomputes on hash change', () => {
+		simulateUpcomingPhasesMock.mockImplementation((_, playerId: string) => {
+			if (playerId === firstPlayerId) {
+				throw new Error('fail');
+			}
+			return {
+				playerId,
+				before: {} as PlayerStateSnapshot,
+				after: {} as PlayerStateSnapshot,
+				delta: createDelta(7),
+				steps: [],
+			};
+		});
+		const { result, rerender } = renderHook(() => useNextTurnForecast());
+		expect(simulateUpcomingPhasesMock).toHaveBeenCalledTimes(2);
+		expect(result.current[firstPlayerId]).toEqual({
+			resources: {},
+			stats: {},
+			population: {},
+		});
+		expect(result.current[secondPlayerId]).toEqual(createDelta(7));
+
+		simulateUpcomingPhasesMock.mockClear();
+		setPlayers([
+			createPlayer(1, {
+				resources: { [primaryResource]: 11 },
+			}),
+			createPlayer(2),
+		]);
+		rerender();
+		expect(simulateUpcomingPhasesMock).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
## Summary
- add a `useNextTurnForecast` hook that simulates upcoming phases for each player and caches results off player hashes
- cover the hook with unit tests that mock the engine simulation, exercise memoization, and verify graceful fallbacks

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; the change only adds state logic and tests.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** Not applicable; no user-facing text was added or changed.

## Standards compliance (required)
1. **File length limits respected:** `useNextTurnForecast.ts` (70 lines) and `useNextTurnForecast.test.ts` (176 lines) are under the 250-line limit.
2. **Line length limits respected:** `npm run lint` (part of `npm run check`) passed without reporting max-length violations (see `/tmp/check.log`).
3. **Domain separation upheld:** The hook consumes engine APIs through the established session facade; tests rely on mocked engine helpers, so no domain boundaries were crossed.
4. **Code standards satisfied:** `npm run check` completed successfully (see `/tmp/check.log`).
5. **Tests updated:** Added `packages/web/tests/useNextTurnForecast.test.ts` to cover the new hook; results are in `npm run check` and the focused `vitest` run.
6. **Documentation updated:** Not required for this internal hook addition.
7. **`npm run check` results:** Captured in `/tmp/check.log` (tail excerpt included in terminal output chunk `1d976c`).
8. **`npm run test:coverage` results:** Captured in `/tmp/coverage.log` (see terminal output chunk `c76743`).

## Testing
- ✅ `npm run check`
- ✅ `npm run test:coverage`
- ✅ `npx vitest run packages/web/tests/useNextTurnForecast.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e28a3a4e588325ad238cbc852a4ac0