### PR TITLE
Add shared helper for passive visibility filtering

### DIFF
--- a/packages/web/src/passives/visibility.ts
+++ b/packages/web/src/passives/visibility.ts
@@ -1,0 +1,188 @@
+import { POPULATIONS } from '@kingdom-builder/contents';
+import type { PassiveSummary } from '@kingdom-builder/engine';
+import type { PlayerSnapshot } from '../translation/log/snapshots';
+
+type PopulationPrefix = string;
+
+const POPULATION_PASSIVE_PREFIXES: PopulationPrefix[] = Array.from(
+	POPULATIONS.keys(),
+	(id) => `${id}_`,
+);
+
+export type PassiveOrigin =
+	| 'building'
+	| 'building-bonus'
+	| 'development'
+	| 'population-assignment'
+	| 'standalone';
+
+export type PassiveSurface = 'player-panel' | 'log';
+
+export type PassiveLike = Pick<PassiveSummary, 'id' | 'meta'>;
+
+interface PassiveOwnerState {
+	buildings: Iterable<string>;
+	lands: ReadonlyArray<{ id: string; developments: Iterable<string> }>;
+}
+
+export type PassiveOwner = PlayerSnapshot | PassiveOwnerState;
+
+interface PassiveVisibilityContext {
+	buildingIds: string[];
+	buildingIdSet: Set<string>;
+	buildingPrefixes: string[];
+	developmentPassiveIds: Set<string>;
+}
+
+type PassiveVisibilitySource = PassiveOwner | PassiveVisibilityContext;
+
+function isVisibilityContext(
+	source: PassiveVisibilitySource,
+): source is PassiveVisibilityContext {
+	return (
+		(source as PassiveVisibilityContext).buildingIdSet !== undefined &&
+		(source as PassiveVisibilityContext).buildingPrefixes !== undefined
+	);
+}
+
+function toArray(iterable: Iterable<string>): string[] {
+	return Array.from(iterable);
+}
+
+function createContextFromOwner(owner: PassiveOwner): PassiveVisibilityContext {
+	const buildingIds = toArray(owner.buildings);
+	const buildingIdSet = new Set(buildingIds);
+	const buildingPrefixes = buildingIds.map((id) => `${id}_`);
+	const developmentPassiveIds = new Set<string>();
+	for (const land of owner.lands) {
+		const landId = land.id;
+		for (const development of land.developments) {
+			developmentPassiveIds.add(`${development}_${landId}`);
+		}
+	}
+	return {
+		buildingIds,
+		buildingIdSet,
+		buildingPrefixes,
+		developmentPassiveIds,
+	};
+}
+
+function resolveContext(
+	source: PassiveVisibilitySource,
+): PassiveVisibilityContext {
+	if (isVisibilityContext(source)) {
+		return source;
+	}
+	return createContextFromOwner(source);
+}
+
+function hasPopulationPrefix(id: string): boolean {
+	for (const prefix of POPULATION_PASSIVE_PREFIXES) {
+		if (id.startsWith(prefix)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function deriveOriginFromContext(
+	passive: PassiveLike,
+	context: PassiveVisibilityContext,
+): PassiveOrigin {
+	const metaType = passive.meta?.source?.type;
+	if (metaType) {
+		const normalized = metaType.toLowerCase();
+		if (normalized === 'building') {
+			if (
+				context.buildingPrefixes.some((prefix) => passive.id.startsWith(prefix))
+			) {
+				return 'building-bonus';
+			}
+			return 'building';
+		}
+		if (normalized === 'development') {
+			return 'development';
+		}
+		if (normalized.startsWith('population')) {
+			return 'population-assignment';
+		}
+	}
+	if (context.buildingIdSet.has(passive.id)) {
+		return 'building';
+	}
+	if (
+		context.buildingPrefixes.some((prefix) => passive.id.startsWith(prefix))
+	) {
+		return 'building-bonus';
+	}
+	if (context.developmentPassiveIds.has(passive.id)) {
+		return 'development';
+	}
+	if (hasPopulationPrefix(passive.id)) {
+		return 'population-assignment';
+	}
+	return 'standalone';
+}
+
+export function derivePassiveOrigin(
+	passive: PassiveLike,
+	source: PassiveVisibilitySource,
+): PassiveOrigin {
+	const context = resolveContext(source);
+	return deriveOriginFromContext(passive, context);
+}
+
+const HIDDEN_ORIGINS: Record<PassiveSurface, ReadonlySet<PassiveOrigin>> = {
+	'player-panel': new Set([
+		'building',
+		'building-bonus',
+		'development',
+		'population-assignment',
+	]),
+	log: new Set([
+		'building',
+		'building-bonus',
+		'development',
+		'population-assignment',
+	]),
+};
+
+function shouldSurfacePassiveWithContext(
+	passive: PassiveLike,
+	context: PassiveVisibilityContext,
+	surface: PassiveSurface,
+): boolean {
+	const origin = deriveOriginFromContext(passive, context);
+	const hidden = HIDDEN_ORIGINS[surface];
+	if (!hidden) {
+		return true;
+	}
+	return !hidden.has(origin);
+}
+
+export function shouldSurfacePassive(
+	passive: PassiveLike,
+	source: PassiveVisibilitySource,
+	surface: PassiveSurface,
+): boolean {
+	const context = resolveContext(source);
+	return shouldSurfacePassiveWithContext(passive, context, surface);
+}
+
+export function filterPassivesForSurface<T extends PassiveLike>(
+	passives: readonly T[],
+	source: PassiveVisibilitySource,
+	surface: PassiveSurface,
+): T[] {
+	const context = resolveContext(source);
+	return passives.filter((passive) =>
+		shouldSurfacePassiveWithContext(passive, context, surface),
+	);
+}
+
+export function createPassiveVisibilityContext(
+	source: PassiveOwner,
+): PassiveVisibilityContext {
+	return createContextFromOwner(source);
+}

--- a/packages/web/tests/passive-visibility.test.ts
+++ b/packages/web/tests/passive-visibility.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { POPULATIONS } from '@kingdom-builder/contents';
+import {
+	createPassiveVisibilityContext,
+	derivePassiveOrigin,
+	filterPassivesForSurface,
+	shouldSurfacePassive,
+	type PassiveLike,
+	type PassiveOwner,
+} from '../src/passives/visibility';
+
+function createOwner(overrides: Partial<PassiveOwner> = {}): PassiveOwner {
+	return {
+		buildings: new Set<string>(),
+		lands: [],
+		...overrides,
+	};
+}
+
+describe('passive visibility helpers', () => {
+	it('derives origins from metadata when available', () => {
+		const owner = createOwner();
+		const passive: PassiveLike = {
+			id: 'mystery-source',
+			meta: { source: { type: 'building' } },
+		};
+		expect(derivePassiveOrigin(passive, owner)).toBe('building');
+	});
+
+	it('falls back to heuristics for building, development, and population passives', () => {
+		const owner = createOwner({
+			buildings: new Set<string>(['castle']),
+			lands: [
+				{
+					id: 'land-1',
+					developments: ['watchtower'],
+				},
+			],
+		});
+		const context = createPassiveVisibilityContext(owner);
+		expect(derivePassiveOrigin({ id: 'castle' }, context)).toBe('building');
+		expect(derivePassiveOrigin({ id: 'castle_bonus' }, context)).toBe(
+			'building-bonus',
+		);
+		expect(derivePassiveOrigin({ id: 'watchtower_land-1' }, context)).toBe(
+			'development',
+		);
+		let populationEntry: string | undefined;
+		for (const candidate of POPULATIONS.keys()) {
+			populationEntry = candidate;
+			break;
+		}
+		expect(populationEntry).toBeTruthy();
+		if (!populationEntry) {
+			throw new Error('Expected at least one population definition.');
+		}
+		expect(
+			derivePassiveOrigin({ id: `${populationEntry}_assignment` }, context),
+		).toBe('population-assignment');
+		expect(derivePassiveOrigin({ id: 'independent' }, context)).toBe(
+			'standalone',
+		);
+	});
+
+	it('hides building-derived passives for common surfaces', () => {
+		const owner = createOwner({
+			buildings: new Set<string>(['castle']),
+			lands: [],
+		});
+		const context = createPassiveVisibilityContext(owner);
+		const buildingPassive: PassiveLike = { id: 'castle' };
+		expect(shouldSurfacePassive(buildingPassive, context, 'player-panel')).toBe(
+			false,
+		);
+		expect(shouldSurfacePassive(buildingPassive, context, 'log')).toBe(false);
+		const standalone: PassiveLike = { id: 'standalone' };
+		expect(shouldSurfacePassive(standalone, context, 'player-panel')).toBe(
+			true,
+		);
+	});
+
+	it('filters out hidden passives when preparing surface collections', () => {
+		const owner = createOwner({
+			buildings: new Set<string>(['castle']),
+			lands: [
+				{
+					id: 'land-1',
+					developments: ['watchtower'],
+				},
+			],
+		});
+		const context = createPassiveVisibilityContext(owner);
+		let populationEntry: string | undefined;
+		for (const candidate of POPULATIONS.keys()) {
+			populationEntry = candidate;
+			break;
+		}
+		expect(populationEntry).toBeTruthy();
+		if (!populationEntry) {
+			throw new Error('Expected at least one population definition.');
+		}
+		const passives: PassiveLike[] = [
+			{ id: 'castle' },
+			{ id: 'castle_bonus' },
+			{ id: 'watchtower_land-1' },
+			{ id: `${populationEntry}_assignment` },
+			{ id: 'independent' },
+		];
+		const visible = filterPassivesForSurface(passives, context, 'player-panel');
+		expect(visible).toEqual([{ id: 'independent' }]);
+	});
+});


### PR DESCRIPTION
## Summary
* add `passives/visibility` helper to derive passive origins and provide surface filtering APIs. 【F:packages/web/src/passives/visibility.ts†L1-L188】
* update the player panel and log change translator to rely on the helper instead of duplicating heuristics. 【F:packages/web/src/components/player/PassiveDisplay.tsx†L35-L61】【F:packages/web/src/translation/log/passiveChanges.ts†L35-L60】
* add dedicated passive visibility tests and extend existing panel/log suites to confirm omissions are unchanged. 【F:packages/web/tests/passive-visibility.test.ts†L1-L112】【F:packages/web/tests/passive-display.test.tsx†L210-L255】

## Text formatting audit (required)
1. **Translator/formatter reuse:** Continued using `resolvePassivePresentation` and existing log translators for passive labels; relied on the shared `buildTierEntries` presenter for tier previews.
2. **Canonical keywords/icons/helpers touched:** `PASSIVE_INFO` icon/label usage in panel hover cards.
3. **Voice review:** Verified player panel cards and log change entries continue to use established Summary/Description/Log voices without new copy.

## Standards compliance (required)
1. **File length limits respected:** New `packages/web/src/passives/visibility.ts` is 188 lines; other edited files remain below 250-line guidance. 【F:packages/web/src/passives/visibility.ts†L1-L188】
2. **Line length limits respected:** Applied Prettier to all touched files; no lines exceed 80 characters. 【F:packages/web/src/components/player/PassiveDisplay.tsx†L45-L61】
3. **Domain separation upheld:** All changes stay in the Web package and tests; no Engine/Content/Protocol cross-contamination. 【F:packages/web/src/passives/visibility.ts†L1-L188】
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint) passes. 【a76f3d†L1-L19】
5. **Tests updated:** Added `packages/web/tests/passive-visibility.test.ts` and expanded panel/log tests; see coverage run. 【44e41c†L1-L13】
6. **Documentation updated:** Not required; behaviour and APIs are internal to the web client.
7. **`npm run check` results:** Full log captured at `/tmp/check.log`. 【a76f3d†L1-L19】
8. **`npm run test:coverage` results:** Coverage report stored in `/tmp/test-coverage.log`. 【aa679b†L1-L21】

## Testing
* ✅ `npx vitest run packages/web/tests/passive-visibility.test.ts packages/web/tests/passive-display.test.tsx packages/web/tests/passive-log-labels.test.ts` 【44e41c†L1-L13】
* ✅ `npm run check` 【a76f3d†L1-L19】
* ✅ `npm run test:coverage` 【aa679b†L1-L21】

------
https://chatgpt.com/codex/tasks/task_e_68e28e1d3668832594c17b757148f37a