### PR TITLE
Introduce building id constants

### DIFF
--- a/packages/contents/src/buildings.ts
+++ b/packages/contents/src/buildings.ts
@@ -31,16 +31,28 @@ import {
 } from './config/builderShared';
 import { Focus } from './defs';
 import type { BuildingDef } from './defs';
-
-export type { BuildingDef } from './defs';
-
+export const BuildingId = {
+	TownCharter: 'town_charter',
+	Mill: 'mill',
+	RaidersGuild: 'raiders_guild',
+	PlowWorkshop: 'plow_workshop',
+	Market: 'market',
+	Barracks: 'barracks',
+	Citadel: 'citadel',
+	CastleWalls: 'castle_walls',
+	CastleGardens: 'castle_gardens',
+	Temple: 'temple',
+	Palace: 'palace',
+	GreatHall: 'great_hall',
+} as const;
+export type BuildingId = (typeof BuildingId)[keyof typeof BuildingId];
 export function createBuildingRegistry() {
-	const registry = new Registry<BuildingDef>(buildingSchema.passthrough());
-
+	const schema = buildingSchema.passthrough();
+	const registry = new Registry<BuildingDef>(schema);
 	registry.add(
-		'town_charter',
+		BuildingId.TownCharter,
 		building()
-			.id('town_charter')
+			.id(BuildingId.TownCharter)
 			.name('Town Charter')
 			.icon('🏘️')
 			.cost(Resource.gold, 5)
@@ -70,18 +82,15 @@ export function createBuildingRegistry() {
 			.focus(Focus.Economy)
 			.build(),
 	);
-
-	// TODO: remaining buildings from original manual config
-	const millFarmTarget = developmentTarget().id(DevelopmentId.Farm);
 	const millFarmResultParams = resultModParams()
 		.id('mill_farm_bonus')
-		.evaluation(millFarmTarget)
+		.evaluation(developmentTarget().id(DevelopmentId.Farm))
 		.amount(1);
 
 	registry.add(
-		'mill',
+		BuildingId.Mill,
 		building()
-			.id('mill')
+			.id(BuildingId.Mill)
 			.name('Mill')
 			.icon('⚙️')
 			.cost(Resource.gold, 7)
@@ -94,9 +103,9 @@ export function createBuildingRegistry() {
 			.build(),
 	);
 	registry.add(
-		'raiders_guild',
+		BuildingId.RaidersGuild,
 		building()
-			.id('raiders_guild')
+			.id(BuildingId.RaidersGuild)
 			.name("Raider's Guild")
 			.icon('🏴‍☠️')
 			.cost(Resource.gold, 8)
@@ -120,9 +129,9 @@ export function createBuildingRegistry() {
 			.build(),
 	);
 	registry.add(
-		'plow_workshop',
+		BuildingId.PlowWorkshop,
 		building()
-			.id('plow_workshop')
+			.id(BuildingId.PlowWorkshop)
 			.name('Plow Workshop')
 			.icon('🏭')
 			.cost(Resource.gold, 10)
@@ -135,9 +144,9 @@ export function createBuildingRegistry() {
 			.build(),
 	);
 	registry.add(
-		'market',
+		BuildingId.Market,
 		building()
-			.id('market')
+			.id(BuildingId.Market)
 			.name('Market')
 			.icon('🏪')
 			.cost(Resource.gold, 10)
@@ -155,29 +164,9 @@ export function createBuildingRegistry() {
 			.build(),
 	);
 	registry.add(
-		'barracks',
+		BuildingId.CastleWalls,
 		building()
-			.id('barracks')
-			.name('Barracks')
-			.icon('🪖')
-			.cost(Resource.gold, 12)
-			.focus(Focus.Aggressive)
-			.build(),
-	);
-	registry.add(
-		'citadel',
-		building()
-			.id('citadel')
-			.name('Citadel')
-			.icon('🏯')
-			.cost(Resource.gold, 12)
-			.focus(Focus.Defense)
-			.build(),
-	);
-	registry.add(
-		'castle_walls',
-		building()
-			.id('castle_walls')
+			.id(BuildingId.CastleWalls)
 			.name('Castle Walls')
 			.icon('🧱')
 			.cost(Resource.gold, 12)
@@ -199,48 +188,26 @@ export function createBuildingRegistry() {
 			.focus(Focus.Defense)
 			.build(),
 	);
-	registry.add(
-		'castle_gardens',
-		building()
-			.id('castle_gardens')
-			.name('Castle Gardens')
-			.icon('🌷')
-			.cost(Resource.gold, 15)
-			.focus(Focus.Economy)
-			.build(),
-	);
-	registry.add(
-		'temple',
-		building()
-			.id('temple')
-			.name('Temple')
-			.icon('⛪')
-			.cost(Resource.gold, 16)
-			.focus(Focus.Other)
-			.build(),
-	);
-	registry.add(
-		'palace',
-		building()
-			.id('palace')
-			.name('Palace')
-			.icon('👑')
-			.cost(Resource.gold, 20)
-			.focus(Focus.Other)
-			.build(),
-	);
-	registry.add(
-		'great_hall',
-		building()
-			.id('great_hall')
-			.name('Great Hall')
-			.icon('🏟️')
-			.cost(Resource.gold, 22)
-			.focus(Focus.Other)
-			.build(),
-	);
-
+	const simpleBuildings: Array<[BuildingId, string, string, number, Focus]> = [
+		[BuildingId.Barracks, 'Barracks', '🪖', 12, Focus.Aggressive],
+		[BuildingId.Citadel, 'Citadel', '🏯', 12, Focus.Defense],
+		[BuildingId.CastleGardens, 'Castle Gardens', '🌷', 15, Focus.Economy],
+		[BuildingId.Temple, 'Temple', '⛪', 16, Focus.Other],
+		[BuildingId.Palace, 'Palace', '👑', 20, Focus.Other],
+		[BuildingId.GreatHall, 'Great Hall', '🏟️', 22, Focus.Other],
+	];
+	simpleBuildings.forEach(([id, name, icon, cost, focus]) => {
+		registry.add(
+			id,
+			building()
+				.id(id)
+				.name(name)
+				.icon(icon)
+				.cost(Resource.gold, cost)
+				.focus(focus)
+				.build(),
+		);
+	});
 	return registry;
 }
-
 export const BUILDINGS = createBuildingRegistry();

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -1,5 +1,5 @@
 export { ACTIONS, createActionRegistry, ActionId } from './actions';
-export { BUILDINGS, createBuildingRegistry } from './buildings';
+export { BUILDINGS, createBuildingRegistry, BuildingId } from './buildings';
 export { DEVELOPMENTS, createDevelopmentRegistry } from './developments';
 export { POPULATIONS, createPopulationRegistry } from './populations';
 export { PHASES, PhaseId, PhaseStepId, PhaseTrigger } from './phases';
@@ -39,7 +39,7 @@ export {
 export { PRIMARY_ICON_ID } from './startup';
 export { type ActionDef } from './actions';
 export type { ActionId as ActionIdType } from './actions';
-export type { BuildingDef } from './buildings';
+export type { BuildingDef } from './defs';
 export type { DevelopmentDef } from './developments';
 export type { PopulationDef, TriggerKey, Focus } from './defs';
 export type {

--- a/packages/web/tests/passive-log-labels.test.ts
+++ b/packages/web/tests/passive-log-labels.test.ts
@@ -6,6 +6,7 @@ import { LOG_KEYWORDS } from '../src/translation/log/logMessages';
 import {
 	ACTIONS,
 	BUILDINGS,
+	BuildingId,
 	DEVELOPMENTS,
 	POPULATIONS,
 	PHASES,
@@ -97,7 +98,7 @@ describe('passive log labels', () => {
 				{
 					type: 'building',
 					method: 'add',
-					params: { id: 'castle_walls' },
+					params: { id: BuildingId.CastleWalls },
 				},
 			],
 			ctx,


### PR DESCRIPTION
## Summary
- add a shared `BuildingId` map/type in the content registry and switch registrations to reuse it
- consolidate simple building registrations through a shared helper loop while keeping advanced entries intact
- update passive log tests to import the new ids instead of hard-coded strings

## Text formatting audit (required)

1. **Translator/formatter reuse:** N/A – no translators or formatters were touched.
2. **Canonical keywords/icons/helpers touched:** Building icons for Barracks, Citadel, Castle Gardens, Temple, Palace, and Great Hall were referenced while refactoring their registrations.
3. **Voice review:** N/A – no player-facing strings or logs were modified.

## Standards compliance (required)

1. **File length limits respected:** `packages/contents/src/buildings.ts` now sits at 213 lines (well under the 250-line ceiling) after the refactor. `packages/web/tests/passive-log-labels.test.ts` remains below prior limits.
2. **Line length limits respected:** Prettier `--check` (see `npm run check` logs below) confirmed all files meet the 80-character requirement.
3. **Domain separation upheld:** All changes remain inside the content registry and web test layers; no engine, protocol, or cross-domain dependencies were introduced.
4. **Code standards satisfied:** `npm run check` (Prettier, TypeScript, ESLint) completed without errors; see excerpt below.
5. **Tests updated:** `packages/web/tests/passive-log-labels.test.ts` now uses the exported `BuildingId` constants. Content and targeted web tests were rerun (see Testing section) to cover the changes.
6. **Documentation updated:** Not required—no docs or player-facing copy changed.
7. **`npm run check` results:**
```
> kingdom-builder-engine@0.1.0 check
> npm run format:check && npm run typecheck && npm run lint

> kingdom-builder-engine@0.1.0 format:check
> prettier --check .

Checking formatting...
All matched files use Prettier code style!

> kingdom-builder-engine@0.1.0 typecheck
> tsc -b --pretty false

> kingdom-builder-engine@0.1.0 posttypecheck
> node scripts/clean-dists.cjs

> kingdom-builder-engine@0.1.0 prelint
> node scripts/ensure-dev-dependencies.cjs

> kingdom-builder-engine@0.1.0 lint
> eslint . --ext .ts,.tsx --rulesdir scripts
```
8. **`npm run test:coverage` results:**
```
 Test Files  110 passed (110)
      Tests  262 passed (262)
   Start at  15:48:03
   Duration  49.54s (transform 5.14s, setup 0ms, collect 38.39s, tests 4.64s, environment 7.38s, prepare 13.16s)
```

## Testing

- `npm run test --workspace @kingdom-builder/contents`
- `npx vitest run packages/web/tests/passive-log-labels.test.ts packages/web/tests/translation/createTranslationContext.test.ts`
- `npm run check`
- `npm run test:quick`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e28fd4fc148325a83db6dfa566b9d2