### PR TITLE
refactor: rename land translator parameters

### DIFF
--- a/packages/web/src/translation/content/land.ts
+++ b/packages/web/src/translation/content/land.ts
@@ -14,11 +14,11 @@ import type {
 
 function translate(
 	land: Land,
-	ctx: EngineContext,
-	fn: (
+	engineContext: EngineContext,
+	translateSummary: (
 		type: string,
 		target: unknown,
-		ctx: EngineContext,
+		engineContext: EngineContext,
 		opts?: Record<string, unknown>,
 	) => Summary,
 ): Summary {
@@ -26,11 +26,12 @@ function translate(
 	for (let i = 0; i < land.slotsMax; i++) {
 		const devId = land.developments[i];
 		if (devId) {
+			const development = engineContext.developments.get(devId);
 			items.push({
-				title: `${ctx.developments.get(devId)?.icon || ''} ${
-					ctx.developments.get(devId)?.name || devId
-				}`,
-				items: fn('development', devId, ctx, { installed: true }),
+				title: `${development?.icon || ''} ${development?.name || devId}`,
+				items: translateSummary('development', devId, engineContext, {
+					installed: true,
+				}),
 			});
 		} else {
 			items.push(`${SLOT_INFO.icon} Empty ${SLOT_INFO.label}`);
@@ -40,11 +41,11 @@ function translate(
 }
 
 class LandTranslator implements LegacyContentTranslator<Land> {
-	summarize(land: Land, ctx: EngineContext): Summary {
-		return translate(land, ctx, summarizeContent);
+	summarize(land: Land, engineContext: EngineContext): Summary {
+		return translate(land, engineContext, summarizeContent);
 	}
-	describe(land: Land, ctx: EngineContext): Summary {
-		return translate(land, ctx, describeContent);
+	describe(land: Land, engineContext: EngineContext): Summary {
+		return translate(land, engineContext, describeContent);
 	}
 }
 


### PR DESCRIPTION
## Summary
* Rename the land translation helper parameters to `engineContext` and `translateSummary` for clarity.
* Update the `LandTranslator` implementation to use the renamed arguments and reuse the computed development metadata.

## Text formatting audit (required)
1. **Translator/formatter reuse:** `summarizeContent` and `describeContent` in `packages/web/src/translation/content/land.ts` continue to be reused for land summaries.
2. **Canonical keywords/icons/helpers touched:** None; existing `SLOT_INFO` usage was left unchanged.
3. **Voice review:** No player-facing text was added or modified, so no voice changes were required.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/src/translation/content/land.ts` is 52 lines after the change, well under the 250-line limit.
2. **Line length limits respected:** `npm run lint -- packages/web/src/translation/content/land.ts` confirms max-length and other lint rules are satisfied.
3. **Domain separation upheld:** Only the web translation layer was updated; engine/content boundaries remain untouched.
4. **Code standards satisfied:** `npm run lint -- packages/web/src/translation/content/land.ts` validates the updated code against repository lint rules.
5. **Tests updated:** No tests required updates because the change was limited to parameter renaming without behavioral impact.
6. **Documentation updated:** No documentation updates were needed for this refactor.
7. **`npm run check` results:** Not run for this focused refactor; targeted linting covered the affected file.
8. **`npm run test:coverage` results:** Not run; no logic changes warranted a full coverage pass.

## Testing
* `npm run lint -- packages/web/src/translation/content/land.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e2986476ec8325975aa34f09bd8f4d