### PR TITLE
Add helper for tiered resource passive metadata

### DIFF
--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -25,6 +25,7 @@ import type { PopulationRoleId } from '../populationRoles';
 import type { DevelopmentId } from '../developments';
 import type { BuildingDef, DevelopmentDef, Focus, TriggerKey } from '../defs';
 import type { ActionCategory, ActionDef, ActionId } from '../actions';
+import { formatPassiveRemoval } from '../text';
 import type {
 	PhaseId as PhaseIdentifier,
 	PhaseStepId as PhaseStepIdentifier,
@@ -643,6 +644,41 @@ class PassiveEffectParamsBuilder extends ParamsBuilder<{
 			meta,
 			'You already set meta() for this passive. Remove the duplicate meta() call.',
 		);
+	}
+
+	tieredResourceSource({
+		tierId,
+		removalDetail,
+		summaryToken,
+		name,
+		icon,
+	}: {
+		tierId: string;
+		removalDetail: string;
+		summaryToken?: string;
+		name?: string;
+		icon?: string;
+	}) {
+		const source: PassiveMetadata['source'] & { name?: string } = {
+			type: 'tiered-resource',
+			id: tierId,
+		};
+		if (summaryToken) {
+			source.labelToken = summaryToken;
+		}
+		if (icon) {
+			source.icon = icon;
+		}
+		if (name) {
+			source.name = name;
+		}
+		return this.meta({
+			source,
+			removal: {
+				token: removalDetail,
+				text: formatPassiveRemoval(removalDetail),
+			},
+		});
 	}
 	private ensureSkip() {
 		this.params.skip = this.params.skip || ({} as PhaseSkipConfig);

--- a/packages/contents/src/happinessHelpers.ts
+++ b/packages/contents/src/happinessHelpers.ts
@@ -104,13 +104,26 @@ export function createTierPassiveEffect({
 	if (icon) {
 		params.icon(icon);
 	}
-	params.tieredResourceSource({
+	const tieredSource: {
+		tierId: string;
+		removalDetail: string;
+		summaryToken?: string;
+		name?: string;
+		icon?: string;
+	} = {
 		tierId,
 		removalDetail,
-		summaryToken,
-		name,
-		icon,
-	});
+	};
+	if (summaryToken) {
+		tieredSource.summaryToken = summaryToken;
+	}
+	if (name) {
+		tieredSource.name = name;
+	}
+	if (icon) {
+		tieredSource.icon = icon;
+	}
+	params.tieredResourceSource(tieredSource);
 	const builder = effect()
 		.type(Types.Passive)
 		.method(PassiveMethods.ADD)

--- a/packages/contents/src/happinessHelpers.ts
+++ b/packages/contents/src/happinessHelpers.ts
@@ -17,7 +17,6 @@ import { ActionId } from './actions';
 import type { passiveParams } from './config/builders';
 import { Resource } from './resources';
 import { Stat } from './stats';
-import { formatPassiveRemoval } from './text';
 
 export type HappinessTierSlug =
 	| 'despair'
@@ -105,18 +104,12 @@ export function createTierPassiveEffect({
 	if (icon) {
 		params.icon(icon);
 	}
-	params.meta({
-		source: {
-			type: 'tiered-resource',
-			id: tierId,
-			...(summaryToken ? { labelToken: summaryToken } : {}),
-			...(name ? { name } : {}),
-			...(icon ? { icon } : {}),
-		},
-		removal: {
-			token: removalDetail,
-			text: formatPassiveRemoval(removalDetail),
-		},
+	params.tieredResourceSource({
+		tierId,
+		removalDetail,
+		summaryToken,
+		name,
+		icon,
 	});
 	const builder = effect()
 		.type(Types.Passive)

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -132,6 +132,32 @@ describe('content builder safeguards', () => {
 		);
 	});
 
+	it('builds tiered resource metadata with helper', () => {
+		const params = passiveParams()
+			.id('passive:test')
+			.tieredResourceSource({
+				tierId: 'tier:test',
+				removalDetail: 'the sun shines',
+				summaryToken: 'tier.summary',
+				name: 'Tier Test',
+				icon: '✨',
+			})
+			.build();
+		expect(params.meta).toEqual({
+			source: {
+				type: 'tiered-resource',
+				id: 'tier:test',
+				labelToken: 'tier.summary',
+				name: 'Tier Test',
+				icon: '✨',
+			},
+			removal: {
+				token: 'the sun shines',
+				text: 'Active as long as the sun shines',
+			},
+		});
+	});
+
 	it('ensures attacks have a single target', () => {
 		expect(() => attackParams().build()).toThrowError(
 			'Attack effect is missing a target. Call targetResource(...), targetStat(...), or targetBuilding(...) once.',


### PR DESCRIPTION
## Summary
- add a `tieredResourceSource` helper to `passiveParams` so tier metadata is built consistently
- update `createTierPassiveEffect` to rely on the new helper when populating passive metadata
- extend builder validation tests to cover tiered resource source metadata (label token, icon, removal text)

## Text formatting audit (required)
1. **Translator/formatter reuse:** Reused the existing `formatPassiveRemoval` helper (`packages/contents/src/text.ts`).
2. **Canonical keywords/icons/helpers touched:** No new canonical keywords, icons, or helpers were introduced.
3. **Voice review:** Not applicable—no player-facing copy changed.

## Standards compliance (required)
1. **File length limits respected:** Verified current file lengths; the touched modules remain within their existing (grandfathered) sizes. (`wc -l packages/contents/src/config/builders.ts packages/contents/src/happinessHelpers.ts packages/contents/tests/builder-validations.test.ts`)
2. **Line length limits respected:** Checked modified files for 80-character compliance; only pre-existing builder guard strings exceed the limit. (`awk 'length>80 { print FNR ":" $0 }' ...` on touched files)
3. **Domain separation upheld:** All modifications stay inside `@kingdom-builder/contents`; engine and web packages remain untouched.
4. **Code standards satisfied:** `npm run format:check` reports all files adhere to the repository’s formatting rules.
5. **Tests updated:** Added coverage in `packages/contents/tests/builder-validations.test.ts` for the new helper.
6. **Documentation updated:** No documentation changes were necessary.
7. **`npm run check` results:** Not run for this iteration (timeboxed); focused on targeted validation instead.
8. **`npm run test:coverage` results:** Not run for this iteration (timeboxed); targeted unit test execution covered the change.

## Testing
- Not run: `npm run check` (see Standards compliance #7)
- Not run: `npm run test:coverage` (see Standards compliance #8)
- Pass: `npm test -- packages/contents/tests/builder-validations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e29c4721408325a45ecd312e87840a