### PR TITLE
Add landAdd helper for land effects

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -7,6 +7,7 @@ import { actionSchema, type ActionConfig } from '@kingdom-builder/protocol';
 import {
 	action,
 	effect,
+	landAdd,
 	compareRequirement,
 	resourceParams,
 	statParams,
@@ -100,7 +101,7 @@ export function createActionRegistry() {
 			.icon('🌱')
 			.cost(Resource.ap, 1)
 			.cost(Resource.gold, 2)
-			.effect(effect(Types.Land, LandMethods.ADD).param('count', 1).build())
+			.effect(landAdd(1))
 			.effect(
 				effect(Types.Resource, ResourceMethods.ADD)
 					.params(resourceParams().key(Resource.happiness).amount(1))

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -31,6 +31,7 @@ import type {
 } from '../phases';
 import {
 	Types,
+	LandMethods,
 	PassiveMethods,
 	RequirementTypes,
 	ParamsBuilder,
@@ -595,6 +596,12 @@ class LandEffectParamsBuilder extends ParamsBuilder<{
 
 export function landParams() {
 	return new LandEffectParamsBuilder();
+}
+
+export function landAdd(count: number) {
+	return effect(Types.Land, LandMethods.ADD)
+		.params(landParams().count(count))
+		.build();
 }
 
 class PassiveEffectParamsBuilder extends ParamsBuilder<{

--- a/packages/contents/tests/builder-validations.test.ts
+++ b/packages/contents/tests/builder-validations.test.ts
@@ -4,6 +4,7 @@ import {
 	statParams,
 	actionParams,
 	effect,
+	landAdd,
 	requirement,
 	compareRequirement,
 	passiveParams,
@@ -13,7 +14,11 @@ import {
 	populationParams,
 } from '../src/config/builders';
 import { ActionId } from '../src/actions';
-import { Types, PassiveMethods } from '../src/config/builderShared';
+import {
+	Types,
+	LandMethods,
+	PassiveMethods,
+} from '../src/config/builderShared';
 import { RESOURCES, type ResourceKey } from '../src/resources';
 import { STATS, type StatKey } from '../src/stats';
 import { describe, expect, it } from 'vitest';
@@ -87,6 +92,15 @@ describe('content builder safeguards', () => {
 		expect(() => effect().build()).toThrowError(
 			'Effect is missing type() and method(). Call effect(Types.X, Methods.Y) or add nested effect(...) calls before build().',
 		);
+	});
+
+	it('builds land:add helper payloads consistently', () => {
+		const count = 3;
+		const manual = effect(Types.Land, LandMethods.ADD)
+			.param('count', count)
+			.build();
+
+		expect(landAdd(count)).toEqual(manual);
 	});
 
 	it('guides requirement configuration mistakes', () => {


### PR DESCRIPTION
## Summary

* Introduced a `landAdd` builder helper to preconfigure `Types.Land` add effects for reuse in content definitions.【F:packages/contents/src/config/builders.ts†L32-L38】【F:packages/contents/src/config/builders.ts†L597-L604】
* Updated the Expand action to use the new helper so its land gain payload stays declarative.【F:packages/contents/src/actions.ts†L7-L104】
* Added a builder validation test that asserts the helper builds the same payload as the previous manual configuration.【F:packages/contents/tests/builder-validations.test.ts†L1-L104】

## Text formatting audit (required)

1. **Translator/formatter reuse:** Not applicable—no text or formatting utilities were touched.
2. **Canonical keywords/icons/helpers touched:** Introduced the `landAdd` helper for `Types.Land` add effects.【F:packages/contents/src/config/builders.ts†L597-L604】
3. **Voice review:** Not applicable—no player-facing text changed.

## Standards compliance (required)

1. **File length limits respected:** Updated files remain within established limits (e.g., existing long-form `actions.ts` continues under its legacy allowance).【F:packages/contents/src/actions.ts†L1-L114】
2. **Line length limits respected:** New lines stay within the 80-character guideline.【F:packages/contents/src/config/builders.ts†L597-L604】【F:packages/contents/tests/builder-validations.test.ts†L97-L104】
3. **Domain separation upheld:** All changes live inside the content package without crossing into engine or web layers.【F:packages/contents/src/config/builders.ts†L32-L604】
4. **Code standards satisfied:** `npm run check` completed successfully via the commit hook.【bb4bf0†L23-L34】
5. **Tests updated:** Added a regression test covering the new helper output.【F:packages/contents/tests/builder-validations.test.ts†L97-L104】
6. **Documentation updated:** Not required for this helper addition.
7. **`npm run check` results:** Passed (`npm run check`).【bb4bf0†L23-L34】
8. **`npm run test:coverage` results:** Not run—full coverage testing was not requested.

## Testing

* `npm test`【0f214c†L1-L38】

------
https://chatgpt.com/codex/tasks/task_e_68e29c5115488325b7eeb88c5eef435f