### PR TITLE
Add semantic helpers for compare requirements

### DIFF
--- a/packages/contents/src/actions.ts
+++ b/packages/contents/src/actions.ts
@@ -217,7 +217,7 @@ export function createActionRegistry() {
 			.requirement(
 				compareRequirement()
 					.left(populationEvaluator())
-					.operator('lt')
+					.lessThan()
 					.right(statEvaluator().key(Stat.maxPopulation))
 					.message('Free space for 👥')
 					.build(),
@@ -315,7 +315,7 @@ export function createActionRegistry() {
 			.requirement(
 				compareRequirement()
 					.left(statEvaluator().key(Stat.warWeariness))
-					.operator('lt')
+					.lessThan()
 					.right(populationEvaluator().role(PopulationRole.Legion))
 					.message(
 						`${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be lower than ${POPULATION_ROLES[PopulationRole.Legion].icon} ${POPULATION_ROLES[PopulationRole.Legion].label}`,
@@ -369,7 +369,7 @@ export function createActionRegistry() {
 			.requirement(
 				compareRequirement()
 					.left(statEvaluator().key(Stat.warWeariness))
-					.operator('eq')
+					.equalTo()
 					.right(0)
 					.message(
 						`${STATS[Stat.warWeariness].icon} ${STATS[Stat.warWeariness].label} must be 0`,

--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -1419,6 +1419,30 @@ class CompareEvaluatorBuilder extends EvaluatorBuilder<{
 	operator(op: 'lt' | 'lte' | 'gt' | 'gte' | 'eq' | 'ne') {
 		return this.param('operator', op);
 	}
+
+	lessThan() {
+		return this.operator('lt');
+	}
+
+	lessThanOrEqual() {
+		return this.operator('lte');
+	}
+
+	greaterThan() {
+		return this.operator('gt');
+	}
+
+	greaterThanOrEqual() {
+		return this.operator('gte');
+	}
+
+	equalTo() {
+		return this.operator('eq');
+	}
+
+	notEqualTo() {
+		return this.operator('ne');
+	}
 }
 
 export function compareEvaluator() {
@@ -1701,6 +1725,30 @@ class CompareRequirementBuilder extends RequirementBuilder<{
 		super.param('operator', op);
 		this.operatorSet = true;
 		return this;
+	}
+
+	lessThan() {
+		return this.operator('lt');
+	}
+
+	lessThanOrEqual() {
+		return this.operator('lte');
+	}
+
+	greaterThan() {
+		return this.operator('gt');
+	}
+
+	greaterThanOrEqual() {
+		return this.operator('gte');
+	}
+
+	equalTo() {
+		return this.operator('eq');
+	}
+
+	notEqualTo() {
+		return this.operator('ne');
 	}
 
 	override build(): RequirementConfig {

--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -121,7 +121,7 @@ export const PHASES: PhaseDef[] = [
 						.evaluator(
 							compareEvaluator()
 								.left(statEvaluator().key(Stat.warWeariness))
-								.operator('gt')
+								.greaterThan()
 								.right(0),
 						)
 						.effect(

--- a/packages/contents/tests/compare-requirement-builder.test.ts
+++ b/packages/contents/tests/compare-requirement-builder.test.ts
@@ -1,0 +1,57 @@
+import { compareRequirement } from '../src/config/builders';
+import { describe, expect, it } from 'vitest';
+
+type CompareBuilder = ReturnType<typeof compareRequirement>;
+
+type ConfigureBuilder = (builder: CompareBuilder) => CompareBuilder;
+
+const readOperator = (configure: ConfigureBuilder) => {
+	const built = configure(compareRequirement().left(1).right(2)).build();
+	const params = built.params as { operator: string };
+	return params.operator;
+};
+
+describe('compare requirement helpers', () => {
+	const cases: ReadonlyArray<{
+		name: string;
+		configure: ConfigureBuilder;
+		expected: 'lt' | 'lte' | 'gt' | 'gte' | 'eq' | 'ne';
+	}> = [
+		{
+			name: 'lessThan',
+			configure: (builder) => builder.lessThan(),
+			expected: 'lt',
+		},
+		{
+			name: 'lessThanOrEqual',
+			configure: (builder) => builder.lessThanOrEqual(),
+			expected: 'lte',
+		},
+		{
+			name: 'greaterThan',
+			configure: (builder) => builder.greaterThan(),
+			expected: 'gt',
+		},
+		{
+			name: 'greaterThanOrEqual',
+			configure: (builder) => builder.greaterThanOrEqual(),
+			expected: 'gte',
+		},
+		{
+			name: 'equalTo',
+			configure: (builder) => builder.equalTo(),
+			expected: 'eq',
+		},
+		{
+			name: 'notEqualTo',
+			configure: (builder) => builder.notEqualTo(),
+			expected: 'ne',
+		},
+	];
+
+	cases.forEach(({ name, configure, expected }) => {
+		it(`${name} sets operator token`, () => {
+			expect(readOperator(configure)).toBe(expected);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Add semantic helpers to the compare evaluator and requirement builders so content can express operator intent with named methods.【F:packages/contents/src/config/builders.ts†L1411-L1444】【F:packages/contents/src/config/builders.ts†L1697-L1752】
- Switch Hire, Army Attack, Hold Festival, and War Recovery definitions to the new helpers for clearer operator usage.【F:packages/contents/src/actions.ts†L210-L373】【F:packages/contents/src/phases.ts†L110-L134】
- Add regression tests that ensure each helper applies the correct operator token.【F:packages/contents/tests/compare-requirement-builder.test.ts†L1-L57】

## Text formatting audit (required)

1. **Translator/formatter reuse:** Not applicable; the change only touches content builders and test helpers, with no formatter usage.
2. **Canonical keywords/icons/helpers touched:** None; all updates are to comparison logic and test scaffolding.
3. **Voice review:** Not needed because no player-facing text changed.

## Standards compliance (required)

1. **File length limits respected:** The newly added regression test file is 57 lines, well below the 250-line limit.【F:packages/contents/tests/compare-requirement-builder.test.ts†L1-L57】
2. **Line length limits respected:** All newly added helper methods and call sites stay within the 80-character limit.【F:packages/contents/src/config/builders.ts†L1411-L1444】【F:packages/contents/src/actions.ts†L210-L373】
3. **Domain separation upheld:** All modifications remain inside the content package, leaving engine and web domains untouched.【F:packages/contents/src/config/builders.ts†L1411-L1752】【F:packages/contents/src/actions.ts†L210-L373】【F:packages/contents/src/phases.ts†L110-L134】
4. **Code standards satisfied:** `CI=1 npm run check` completed successfully, covering formatting, type checking, and linting.【5f15fc†L1-L6】【d6b6fc†L1-L4】【867a81†L1-L5】【e0d839†L1-L12】【5d22db†L1-L13】【534ec5†L1】
5. **Tests updated:** Added `compare-requirement-builder.test.ts` and verified it passes via `npx vitest run` and the coverage suite.【F:packages/contents/tests/compare-requirement-builder.test.ts†L1-L57】【7f7631†L1-L26】【2dbec6†L1-L78】
6. **Documentation updated:** No documentation required because the change only adds internal helper methods.
7. **`npm run check` results:** See command output confirming success.【5f15fc†L1-L6】【d6b6fc†L1-L4】【867a81†L1-L5】【e0d839†L1-L12】【5d22db†L1-L13】【534ec5†L1】
8. **`npm run test:coverage` results:** Full coverage run succeeded without failures.【2dbec6†L1-L78】

## Testing
- ✅ `CI=1 npm run check`【5f15fc†L1-L6】【d6b6fc†L1-L4】【867a81†L1-L5】【e0d839†L1-L12】【5d22db†L1-L13】【534ec5†L1】
- ✅ `CI=1 npm run test:coverage`【2dbec6†L1-L78】
- ✅ `npx vitest run packages/contents/tests/compare-requirement-builder.test.ts`【7f7631†L1-L26】

------
https://chatgpt.com/codex/tasks/task_e_68e29c4b125483259061a9716c0ba0b3