### PR TITLE
Add action resolution hover card rendering

### DIFF
--- a/packages/web/src/components/ActionResolutionCard.tsx
+++ b/packages/web/src/components/ActionResolutionCard.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import type { ActionResolution } from '../state/useActionResolution';
+import {
+	CARD_BASE_CLASS,
+	CARD_META_TEXT_CLASS,
+	CARD_TITLE_TEXT_CLASS,
+	CONTINUE_BUTTON_CLASS,
+	RESOLUTION_LINE_CLASS,
+	RESOLUTION_LINES_CLASS,
+} from './common/cardStyles';
+
+interface ActionResolutionCardProps {
+	title?: string;
+	resolution: ActionResolution;
+	onContinue: () => void;
+}
+
+function ActionResolutionCard({
+	title,
+	resolution,
+	onContinue,
+}: ActionResolutionCardProps) {
+	const playerLabel = resolution.player?.name ?? resolution.player?.id ?? null;
+	const playerName = playerLabel ?? 'Unknown player';
+	const containerClass = `${CARD_BASE_CLASS} pointer-events-auto`;
+	const headerTitle = title ?? 'Action resolution';
+
+	return (
+		<div className={containerClass} data-state="enter">
+			<div className="mb-4 space-y-1">
+				<div className={CARD_TITLE_TEXT_CLASS}>{headerTitle}</div>
+				{resolution.player ? (
+					<div className={CARD_META_TEXT_CLASS}>
+						{`Played by ${playerName}`}
+					</div>
+				) : null}
+			</div>
+			<div className={RESOLUTION_LINES_CLASS}>
+				{resolution.visibleLines.map((line, index) => (
+					<pre key={index} className={RESOLUTION_LINE_CLASS}>
+						{line}
+					</pre>
+				))}
+			</div>
+			<div className="mt-6 flex justify-end">
+				<button
+					type="button"
+					onClick={onContinue}
+					disabled={!resolution.isComplete}
+					className={CONTINUE_BUTTON_CLASS}
+				>
+					Continue
+				</button>
+			</div>
+		</div>
+	);
+}
+
+export type { ActionResolutionCardProps };
+export { ActionResolutionCard };

--- a/packages/web/src/components/HoverCard.tsx
+++ b/packages/web/src/components/HoverCard.tsx
@@ -1,6 +1,18 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { renderSummary, renderCosts } from '../translation/render';
 import { useGameEngine } from '../state/GameContext';
+import {
+	CARD_ALERT_TEXT_CLASS,
+	CARD_BASE_CLASS,
+	CARD_BODY_TEXT_CLASS,
+	CARD_LABEL_CLASS,
+	CARD_LIST_CLASS,
+	CARD_META_TEXT_CLASS,
+	CARD_REQUIREMENT_LIST_CLASS,
+	CARD_TITLE_TEXT_CLASS,
+	joinClasses,
+} from './common/cardStyles';
+import { ActionResolutionCard } from './ActionResolutionCard';
 
 const FADE_DURATION_MS = 200;
 
@@ -10,6 +22,8 @@ export default function HoverCard() {
 		clearHoverCard,
 		ctx,
 		actionCostResource,
+		resolution: actionResolution,
+		acknowledgeResolution,
 	} = useGameEngine();
 	const [renderedData, setRenderedData] = useState(data);
 	const [transitionState, setTransitionState] = useState<'enter' | 'exit'>(
@@ -81,23 +95,54 @@ export default function HoverCard() {
 		[],
 	);
 
+	if (actionResolution) {
+		const resolutionTitle = renderedData?.title ?? 'Action resolution';
+		return (
+			<ActionResolutionCard
+				title={resolutionTitle}
+				resolution={actionResolution}
+				onContinue={acknowledgeResolution}
+			/>
+		);
+	}
+
 	if (!renderedData) {
 		return null;
 	}
 
+	const cardContainerClass = joinClasses(
+		CARD_BASE_CLASS,
+		'pointer-events-none',
+		renderedData.bgClass,
+	);
+	const headerRowClass = 'mb-3 flex items-start justify-between gap-4';
+	const costTextClass = joinClasses('text-right', CARD_META_TEXT_CLASS);
+	const effectsTitle = renderedData.effectsTitle ?? 'Effects';
+	const effectSummary = renderSummary(renderedData.effects);
+	const descriptionTitle = renderedData.descriptionTitle ?? 'Description';
+	const descriptionLabelClass = joinClasses(
+		CARD_LABEL_CLASS,
+		renderedData.descriptionClass,
+	);
+	const descriptionTextClass = joinClasses(
+		'mt-1',
+		CARD_BODY_TEXT_CLASS,
+		renderedData.descriptionClass,
+	);
+	const descriptionListClass = joinClasses(
+		CARD_LIST_CLASS,
+		renderedData.descriptionClass,
+	);
+
 	return (
 		<div
 			data-state={transitionState}
-			className={`hover-card-transition pointer-events-none w-full rounded-3xl border border-white/60 bg-white/80 p-6 shadow-2xl shadow-amber-500/10 dark:border-white/10 dark:bg-slate-900/80 dark:shadow-slate-900/60 frosted-surface ${
-				renderedData.bgClass ?? ''
-			}`}
+			className={cardContainerClass}
 			onMouseLeave={clearHoverCard}
 		>
-			<div className="mb-3 flex items-start justify-between gap-4">
-				<div className="text-lg font-semibold tracking-tight text-slate-900 dark:text-slate-100">
-					{renderedData.title}
-				</div>
-				<div className="text-right text-sm text-slate-600 dark:text-slate-300">
+			<div className={headerRowClass}>
+				<div className={CARD_TITLE_TEXT_CLASS}>{renderedData.title}</div>
+				<div className={costTextClass}>
 					{renderCosts(
 						renderedData.costs,
 						ctx.activePlayer.resources,
@@ -108,12 +153,8 @@ export default function HoverCard() {
 			</div>
 			{renderedData.effects.length > 0 && (
 				<div className="mb-2">
-					<div className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-300">
-						{renderedData.effectsTitle ?? 'Effects'}
-					</div>
-					<ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-slate-700 dark:text-slate-200">
-						{renderSummary(renderedData.effects)}
-					</ul>
+					<div className={CARD_LABEL_CLASS}>{effectsTitle}</div>
+					<ul className={CARD_LIST_CLASS}>{effectSummary}</ul>
 				</div>
 			)}
 			{(() => {
@@ -127,37 +168,21 @@ export default function HoverCard() {
 				}
 				return (
 					<div className="mt-2">
-						<div
-							className={`text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-300 ${
-								renderedData.descriptionClass ?? ''
-							}`}
-						>
-							{renderedData.descriptionTitle ?? 'Description'}
-						</div>
+						<div className={descriptionLabelClass}>{descriptionTitle}</div>
 						{typeof desc === 'string' ? (
-							<div
-								className={`mt-1 text-sm text-slate-700 dark:text-slate-200 ${
-									renderedData.descriptionClass ?? ''
-								}`}
-							>
-								{desc}
-							</div>
+							<div className={descriptionTextClass}>{desc}</div>
 						) : (
-							<ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-slate-700 dark:text-slate-200">
-								{renderSummary(desc)}
-							</ul>
+							<ul className={descriptionListClass}>{renderSummary(desc)}</ul>
 						)}
 					</div>
 				);
 			})()}
 			{renderedData.requirements.length > 0 && (
-				<div className="mt-2 text-sm text-rose-600 dark:text-rose-300">
-					<div className="text-xs font-semibold uppercase tracking-[0.3em]">
-						Requirements
-					</div>
-					<ul className="mt-1 list-disc space-y-1 pl-5">
-						{renderedData.requirements.map((r, i) => (
-							<li key={i}>{r}</li>
+				<div className={CARD_ALERT_TEXT_CLASS}>
+					<div className={CARD_LABEL_CLASS}>Requirements</div>
+					<ul className={CARD_REQUIREMENT_LIST_CLASS}>
+						{renderedData.requirements.map((requirement, index) => (
+							<li key={index}>{requirement}</li>
 						))}
 					</ul>
 				</div>

--- a/packages/web/src/components/common/cardStyles.ts
+++ b/packages/web/src/components/common/cardStyles.ts
@@ -1,0 +1,132 @@
+function joinClasses(...classes: (string | null | undefined | false)[]) {
+	return classes.filter(Boolean).join(' ');
+}
+
+const CARD_BASE_CLASS = [
+	'hover-card-transition',
+	'w-full',
+	'rounded-3xl',
+	'border',
+	'border-white/60',
+	'bg-white/80',
+	'p-6',
+	'shadow-2xl',
+	'shadow-amber-500/10',
+	'dark:border-white/10',
+	'dark:bg-slate-900/80',
+	'dark:shadow-slate-900/60',
+	'frosted-surface',
+].join(' ');
+
+const RESOLUTION_LINES_CLASS = [
+	'space-y-2',
+	'text-sm',
+	'text-slate-700',
+	'dark:text-slate-200',
+].join(' ');
+
+const RESOLUTION_LINE_CLASS = [
+	'rounded-2xl',
+	'bg-white/70',
+	'px-4',
+	'py-2',
+	'font-sans',
+	'text-sm',
+	'text-slate-800',
+	'shadow-inner',
+	'shadow-amber-500/10',
+	'whitespace-pre-wrap',
+	'dark:bg-slate-900/60',
+	'dark:text-slate-100',
+].join(' ');
+
+const CONTINUE_BUTTON_CLASS = [
+	'inline-flex',
+	'items-center',
+	'justify-center',
+	'rounded-2xl',
+	'bg-amber-500',
+	'px-4',
+	'py-2',
+	'text-sm',
+	'font-semibold',
+	'text-white',
+	'shadow-lg',
+	'shadow-amber-500/40',
+	'transition',
+	'hover:bg-amber-400',
+	'focus:outline-none',
+	'focus-visible:ring',
+	'focus-visible:ring-amber-500/60',
+	'disabled:cursor-not-allowed',
+	'disabled:bg-amber-500/60',
+	'disabled:shadow-none',
+].join(' ');
+
+const CARD_TITLE_TEXT_CLASS = [
+	'text-lg',
+	'font-semibold',
+	'tracking-tight',
+	'text-slate-900',
+	'dark:text-slate-100',
+].join(' ');
+
+const CARD_META_TEXT_CLASS = [
+	'text-sm',
+	'text-slate-600',
+	'dark:text-slate-300',
+].join(' ');
+
+const CARD_BODY_TEXT_CLASS = [
+	'text-sm',
+	'text-slate-700',
+	'dark:text-slate-200',
+].join(' ');
+
+const CARD_LABEL_CLASS = [
+	'text-xs',
+	'font-semibold',
+	'uppercase',
+	'tracking-[0.3em]',
+	'text-slate-500',
+	'dark:text-slate-300',
+].join(' ');
+
+const CARD_LIST_CLASS = [
+	'mt-1',
+	'list-disc',
+	'space-y-1',
+	'pl-5',
+	'text-sm',
+	'text-slate-700',
+	'dark:text-slate-200',
+].join(' ');
+
+const CARD_ALERT_TEXT_CLASS = [
+	'mt-2',
+	'text-sm',
+	'text-rose-600',
+	'dark:text-rose-300',
+].join(' ');
+
+const CARD_REQUIREMENT_LIST_CLASS = [
+	'mt-1',
+	'list-disc',
+	'space-y-1',
+	'pl-5',
+].join(' ');
+
+export {
+	CARD_ALERT_TEXT_CLASS,
+	CARD_BASE_CLASS,
+	CARD_BODY_TEXT_CLASS,
+	CARD_LABEL_CLASS,
+	CARD_LIST_CLASS,
+	CARD_META_TEXT_CLASS,
+	CARD_REQUIREMENT_LIST_CLASS,
+	CARD_TITLE_TEXT_CLASS,
+	CONTINUE_BUTTON_CLASS,
+	joinClasses,
+	RESOLUTION_LINE_CLASS,
+	RESOLUTION_LINES_CLASS,
+};


### PR DESCRIPTION
## Summary
* Added shared card style helpers for hover and resolution panels to keep tailwind class usage consistent. 【F:packages/web/src/components/common/cardStyles.ts†L1-L132】
* Introduced an `ActionResolutionCard` component that renders the active action resolution, attribution, revealed log lines, and continue affordance. 【F:packages/web/src/components/ActionResolutionCard.tsx†L1-L60】
* Updated the hover card to delegate to the resolution card (with a defaulted title) whenever a resolution is active while preserving the legacy hover details otherwise. 【F:packages/web/src/components/HoverCard.tsx†L1-L189】

## Text formatting audit (required)

1. **Translator/formatter reuse:** Continued using the existing `renderSummary` and `renderCosts` helpers for hover content; no new translators were introduced. 【F:packages/web/src/components/HoverCard.tsx†L1-L73】
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** Verified the new resolution strings (`Action resolution`, `Played by …`, `Continue`) match existing hover/action voice and tone. 【F:packages/web/src/components/ActionResolutionCard.tsx†L24-L53】

## Standards compliance (required)

1. **File length limits respected:** `HoverCard.tsx`, `ActionResolutionCard.tsx`, and `cardStyles.ts` remain under 250 lines. 【d60ec5†L1-L2】【29ea00†L1-L4】
2. **Line length limits respected:** No modified files contain lines longer than 80 characters. 【6e79db†L1-L1】【debc67†L1-L1】
3. **Domain separation upheld:** All changes are isolated to web UI components.
4. **Code standards satisfied:** `npm run check` passes after formatting, type checking, and linting. (Excerpt below; full output captured in `/tmp/check.log` because Prettier lists every file when run in CI.) 【b69da8†L1-L20】
5. **Tests updated:** No new tests were required; existing coverage validated via `npm run test:coverage`. 【8546af†L1-L10】
6. **Documentation updated:** Not applicable; no docs changes were needed.
7. **`npm run check` results:**
   ```
   > kingdom-builder-engine@0.1.0 check
   > npm run format:check && npm run typecheck && npm run lint
   
   > kingdom-builder-engine@0.1.0 format:check
   > prettier --check .
   
   Checking formatting...
   All matched files use Prettier code style!
   
   > kingdom-builder-engine@0.1.0 typecheck
   > tsc -b --pretty false
   
   > kingdom-builder-engine@0.1.0 posttypecheck
   > node scripts/clean-dists.cjs
   
   > kingdom-builder-engine@0.1.0 prelint
   > node scripts/ensure-dev-dependencies.cjs
   
   > kingdom-builder-engine@0.1.0 lint
   > eslint . --ext .ts,.tsx --rulesdir scripts
   ```
8. **`npm run test:coverage` results:**
   ```
   ✓ packages/web/tests/overview-content-source.test.tsx (1 test) 312ms
   
   Test Files 115 passed (115)
        Tests 272 passed (272)
     Start at 17:00:48
     Duration 88.85s
   ```

## Testing

* `npm run check`
* `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e29dedcc088325b436d823f32928a8