### PR TITLE
Fix manual phase tab highlighting and add test

### DIFF
--- a/packages/web/src/state/useMainPhaseTracker.ts
+++ b/packages/web/src/state/useMainPhaseTracker.ts
@@ -1,4 +1,10 @@
-import { useCallback, useState } from 'react';
+import {
+	useCallback,
+	useState,
+	type Dispatch,
+	type MutableRefObject,
+	type SetStateAction,
+} from 'react';
 import { RESOURCES, type ResourceKey } from '@kingdom-builder/contents';
 import type { EngineSession } from '@kingdom-builder/engine';
 import type { PhaseStep } from './phaseTypes';
@@ -7,11 +13,10 @@ interface MainPhaseTrackerOptions {
 	session: EngineSession;
 	actionCostResource: ResourceKey;
 	actionPhaseId: string | undefined;
-	setPhaseSteps: React.Dispatch<React.SetStateAction<PhaseStep[]>>;
-	setPhaseHistories: React.Dispatch<
-		React.SetStateAction<Record<string, PhaseStep[]>>
-	>;
+	setPhaseSteps: Dispatch<SetStateAction<PhaseStep[]>>;
+	setPhaseHistories: Dispatch<SetStateAction<Record<string, PhaseStep[]>>>;
 	setDisplayPhase: (phase: string) => void;
+	displayPhaseRef: MutableRefObject<string>;
 }
 
 export function useMainPhaseTracker({
@@ -21,6 +26,7 @@ export function useMainPhaseTracker({
 	setPhaseSteps,
 	setPhaseHistories,
 	setDisplayPhase,
+	displayPhaseRef,
 }: MainPhaseTrackerOptions) {
 	const [mainApStart, setMainApStart] = useState(0);
 
@@ -53,14 +59,17 @@ export function useMainPhaseTracker({
 				},
 			];
 			setPhaseSteps(steps);
+			const currentPhaseId = snapshot.game.currentPhase;
 			if (actionPhaseId) {
 				setPhaseHistories((prev) => ({
 					...prev,
 					[actionPhaseId]: steps,
 				}));
-				setDisplayPhase(actionPhaseId);
-			} else {
-				setDisplayPhase(snapshot.game.currentPhase);
+				if (displayPhaseRef.current === actionPhaseId) {
+					setDisplayPhase(actionPhaseId);
+				}
+			} else if (displayPhaseRef.current === currentPhaseId) {
+				setDisplayPhase(currentPhaseId);
 			}
 		},
 		[
@@ -69,6 +78,7 @@ export function useMainPhaseTracker({
 			session,
 			mainApStart,
 			setDisplayPhase,
+			displayPhaseRef,
 			setPhaseHistories,
 			setPhaseSteps,
 		],

--- a/packages/web/src/state/usePhaseProgress.ts
+++ b/packages/web/src/state/usePhaseProgress.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
 	type EngineSession,
 	type EngineSessionSnapshot,
@@ -44,6 +44,10 @@ export function usePhaseProgress({
 	const [displayPhase, setDisplayPhase] = useState(
 		sessionState.game.currentPhase,
 	);
+	const displayPhaseRef = useRef(displayPhase);
+	useEffect(() => {
+		displayPhaseRef.current = displayPhase;
+	}, [displayPhase]);
 	const [phaseHistories, setPhaseHistories] = useState<
 		Record<string, PhaseStep[]>
 	>({});
@@ -57,6 +61,7 @@ export function usePhaseProgress({
 			setPhaseSteps,
 			setPhaseHistories,
 			setDisplayPhase,
+			displayPhaseRef,
 		});
 
 	const { runDelay, runStepDelay } = usePhaseDelays({


### PR DESCRIPTION
## Summary
- Track the active phase tab via a ref so manual selections persist until an automatic phase change occurs.
- Prevent the main phase tracker from forcing the display back to the action phase unless the player is already viewing it.
- Expand the PhasePanel test harness to use stateful mocks and cover the manual highlight scenario.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no translators or formatters were touched.
2. **Canonical keywords/icons/helpers touched:** None; phase tab logic and tests only reuse existing icons.
3. **Voice review:** Not applicable; no player-facing copy changed.

## Standards compliance (required)
1. **File length limits respected:** Updated files remain under the established limits (usePhaseProgress.ts 176 lines, useMainPhaseTracker.ts 88 lines, PhasePanel.test.tsx 156 lines).
2. **Line length limits respected:** Prettier’s `npm run check` passed without reporting overlength lines (see `/tmp/check.log`).
3. **Domain separation upheld:** Changes are confined to the web package and related tests; engine/content layers were untouched.
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint) completed successfully (`CI=1 npm run check`, log: `/tmp/check.log`).
5. **Tests updated:** Added coverage in `packages/web/tests/PhasePanel.test.tsx` for manual phase selection highlighting.
6. **Documentation updated:** Not required; behavior change is confined to UI logic.
7. **`npm run check` results:** Full output stored in `/tmp/check.log` (ran with `CI=1 npm run check`).
8. **`npm run test:coverage` results:** Full output stored in `/tmp/test-coverage.log` (`npm run test:coverage`).

## Testing
- `npm test -- PhasePanel`
- `CI=1 npm run check`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e2af0c00e48325af5351845ae3b655