### PR TITLE
feat: add passive removal helpers

### DIFF
--- a/packages/contents/src/actions/specialActions.ts
+++ b/packages/contents/src/actions/specialActions.ts
@@ -123,11 +123,7 @@ export function registerSpecialActions(registry: Registry<ActionDef>) {
 							.id('hold_festival_penalty')
 							.name('Festival Hangover')
 							.icon('🥴')
-							.onUpkeepPhase(
-								effect(Types.Passive, PassiveMethods.REMOVE)
-									.param('id', 'hold_festival_penalty')
-									.build(),
-							),
+							.removeOnUpkeepStep(),
 					)
 					.effect(
 						effect(Types.ResultMod, ResultModMethods.ADD)
@@ -167,6 +163,10 @@ export function registerSpecialActions(registry: Registry<ActionDef>) {
 			.build(),
 	);
 
+	const plowCostPenalty = passiveParams()
+		.id('plow_cost_mod')
+		.removeOnUpkeepStep();
+
 	registry.add(
 		ActionId.plow,
 		action()
@@ -188,15 +188,7 @@ export function registerSpecialActions(registry: Registry<ActionDef>) {
 			)
 			.effect(
 				effect(Types.Passive, PassiveMethods.ADD)
-					.params(
-						passiveParams()
-							.id('plow_cost_mod')
-							.onUpkeepPhase(
-								effect(Types.Passive, PassiveMethods.REMOVE)
-									.param('id', 'plow_cost_mod')
-									.build(),
-							),
-					)
+					.params(plowCostPenalty)
 					.effect(
 						effect(Types.CostMod, CostModMethods.ADD)
 							.params(

--- a/packages/contents/tests/passive-params-removal.test.ts
+++ b/packages/contents/tests/passive-params-removal.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { passiveParams, effect } from '../src/config/builders';
+import { Types, PassiveMethods } from '../src/config/builderShared';
+
+const REMOVE_ON_UPKEEP_STEP_MESSAGE =
+	'Passive removeOnUpkeepStep() requires id(). ' +
+	'Call id("your-passive-id") before removeOnUpkeepStep().';
+
+const REMOVE_ON_TRIGGER_MESSAGE =
+	"Passive removeOnTrigger('onBeforeAttacked') requires id(). " +
+	'Call id("your-passive-id") before ' +
+	"removeOnTrigger('onBeforeAttacked').";
+
+describe('passive removal helpers', () => {
+	it('errors when removeOnUpkeepStep() is used without id', () => {
+		expect(() => passiveParams().removeOnUpkeepStep()).toThrowError(
+			REMOVE_ON_UPKEEP_STEP_MESSAGE,
+		);
+	});
+
+	it('errors when removeOnTrigger() is used without id', () => {
+		expect(() =>
+			passiveParams().removeOnTrigger('onBeforeAttacked'),
+		).toThrowError(REMOVE_ON_TRIGGER_MESSAGE);
+	});
+
+	it('matches manual upkeep removal wiring', () => {
+		const manual = passiveParams()
+			.id('passive:manual')
+			.onUpkeepPhase(
+				effect(Types.Passive, PassiveMethods.REMOVE)
+					.param('id', 'passive:manual')
+					.build(),
+			)
+			.build();
+		const helper = passiveParams()
+			.id('passive:manual')
+			.removeOnUpkeepStep()
+			.build();
+		expect(helper).toEqual(manual);
+	});
+
+	it('matches manual trigger-based removal wiring', () => {
+		const manual = passiveParams()
+			.id('passive:trigger')
+			.onBeforeAttacked(
+				effect(Types.Passive, PassiveMethods.REMOVE)
+					.param('id', 'passive:trigger')
+					.build(),
+			)
+			.build();
+		const helper = passiveParams()
+			.id('passive:trigger')
+			.removeOnTrigger('onBeforeAttacked')
+			.build();
+		expect(helper).toEqual(manual);
+	});
+});


### PR DESCRIPTION
## Summary
- add convenience helpers to `passiveParams` that schedule passive removal via upkeep or arbitrary triggers while validating IDs【F:packages/contents/src/config/builders.ts†L602-L775】
- swap special action passive removal hooks to use the new helpers instead of inline `Passive:remove` definitions【F:packages/contents/src/actions/specialActions.ts†L120-L198】
- introduce regression tests for the removal helpers to cover validation and parity with the previous wiring【F:packages/contents/tests/passive-params-removal.test.ts†L1-L51】

## Text formatting audit (required)
1. **Translator/formatter reuse:** No translators or formatters were added or modified; existing messaging remains untouched.
2. **Canonical keywords/icons/helpers touched:** None—changes only add builder utilities and tests without altering canonical keyword/icon usage.
3. **Voice review:** Added messaging is developer-facing error text in builder helpers; no player-facing copy required voice review.

## Standards compliance (required)
1. **File length limits respected:** Updated files remain within existing limits (actions: 230 lines; new passive helper tests: 51 lines; legacy builders file unchanged in total length).【d868db†L1-L5】【e1fa25†L1-L5】
2. **Line length limits respected:** New helper implementations and test assertions wrap strings to stay within the 80-character limit.【F:packages/contents/src/config/builders.ts†L689-L706】【F:packages/contents/tests/passive-params-removal.test.ts†L6-L49】
3. **Domain separation upheld:** All modifications are confined to the content package and its tests; engine and web domains remain untouched by the new helpers.【F:packages/contents/src/config/builders.ts†L602-L775】【F:packages/contents/tests/passive-params-removal.test.ts†L1-L51】
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint, and quick tests) completed successfully during the amended commit.【9f3d95†L1-L13】【9a9f5f†L1-L7】【88a358†L1-L12】【29878a†L1-L13】【c44cbc†L1-L10】
5. **Tests updated:** New regression coverage lives in `packages/contents/tests/passive-params-removal.test.ts` and exercises the helper APIs.【F:packages/contents/tests/passive-params-removal.test.ts†L1-L51】
6. **Documentation updated:** Not required; no user-facing documentation changes were needed for these internal helpers.
7. **`npm run check` results:** See the successful run captured in the amend hook logs.【9f3d95†L1-L13】【9a9f5f†L1-L7】【88a358†L1-L12】【29878a†L1-L13】【c44cbc†L1-L10】
8. **`npm run test:coverage` results:** Coverage run completed with all files passing; see the coverage summary for details.【8dcd0b†L1-L74】

## Testing
- ✅ `npm run check`【9f3d95†L1-L13】【9a9f5f†L1-L7】【88a358†L1-L12】【29878a†L1-L13】【c44cbc†L1-L10】
- ✅ `npm test`【c44cbc†L1-L10】
- ✅ `npx vitest run packages/contents/tests/passive-params-removal.test.ts`【3771c6†L1-L24】
- ✅ `npm run test:coverage`【8dcd0b†L1-L74】

------
https://chatgpt.com/codex/tasks/task_e_68e2ae215ee48325b9da6a9396d2ac59