### PR TITLE
Add icons to Basic and Hire action categories

### DIFF
--- a/packages/web/src/components/actions/ActionCategoryHeader.tsx
+++ b/packages/web/src/components/actions/ActionCategoryHeader.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 const HEADING_CLASS = [
-	'flex items-center gap-2 text-base font-medium',
+	'flex flex-wrap items-center gap-2 text-base font-medium',
 	'text-slate-900 dark:text-slate-100',
 ].join(' ');
 const SUBTITLE_CLASS = [
-	'pl-9 text-sm italic text-slate-600',
+	'italic text-sm font-normal text-slate-600',
 	'dark:text-slate-300',
 ].join(' ');
 const ICON_CLASS = 'text-lg leading-none';
@@ -22,14 +22,14 @@ export default function ActionCategoryHeader({
 	subtitle,
 }: ActionCategoryHeaderProps) {
 	return (
-		<header className="space-y-1">
+		<header>
 			<h3 className={HEADING_CLASS}>
 				<span aria-hidden className={ICON_CLASS}>
 					{icon}
 				</span>
 				<span>{title}</span>
+				<span className={SUBTITLE_CLASS}>{subtitle}</span>
 			</h3>
-			<p className={SUBTITLE_CLASS}>{subtitle}</p>
 		</header>
 	);
 }

--- a/packages/web/src/components/actions/ActionCategoryHeader.tsx
+++ b/packages/web/src/components/actions/ActionCategoryHeader.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const HEADING_CLASS = [
+	'flex items-center gap-2 text-base font-medium',
+	'text-slate-900 dark:text-slate-100',
+].join(' ');
+const SUBTITLE_CLASS = [
+	'pl-9 text-sm italic text-slate-600',
+	'dark:text-slate-300',
+].join(' ');
+const ICON_CLASS = 'text-lg leading-none';
+
+interface ActionCategoryHeaderProps {
+	icon: React.ReactNode;
+	title: string;
+	subtitle: string;
+}
+
+export default function ActionCategoryHeader({
+	icon,
+	title,
+	subtitle,
+}: ActionCategoryHeaderProps) {
+	return (
+		<header className="space-y-1">
+			<h3 className={HEADING_CLASS}>
+				<span aria-hidden className={ICON_CLASS}>
+					{icon}
+				</span>
+				<span>{title}</span>
+			</h3>
+			<p className={SUBTITLE_CLASS}>{subtitle}</p>
+		</header>
+	);
+}

--- a/packages/web/src/components/actions/BasicOptions.tsx
+++ b/packages/web/src/components/actions/BasicOptions.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { type Summary } from '../../translation';
 import { useAnimate } from '../../utils/useAutoAnimate';
+import ActionCategoryHeader from './ActionCategoryHeader';
 import GenericActions from './GenericActions';
 import type { Action, DisplayPlayer } from './types';
+
+const BASIC_CATEGORY_ICON = '⚙️';
+const BASIC_CATEGORY_DESCRIPTION =
+	'(Effects take place immediately, unless stated otherwise)';
 
 interface BasicOptionsProps {
 	actions: Action[];
@@ -19,16 +24,15 @@ export default function BasicOptions({
 }: BasicOptionsProps) {
 	const listRef = useAnimate<HTMLDivElement>();
 	return (
-		<div>
-			<h3 className="font-medium">
-				Basic{' '}
-				<span className="italic text-sm font-normal">
-					(Effects take place immediately, unless stated otherwise)
-				</span>
-			</h3>
+		<div className="space-y-2">
+			<ActionCategoryHeader
+				icon={BASIC_CATEGORY_ICON}
+				title="Basic"
+				subtitle={BASIC_CATEGORY_DESCRIPTION}
+			/>
 			<div
 				ref={listRef}
-				className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+				className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2"
 			>
 				<GenericActions
 					actions={actions}

--- a/packages/web/src/components/actions/HireOptions.tsx
+++ b/packages/web/src/components/actions/HireOptions.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { useAnimate } from '../../utils/useAutoAnimate';
+import ActionCategoryHeader from './ActionCategoryHeader';
 import type { Action, DisplayPlayer } from './types';
 import RaisePopOptions from './RaisePopOptions';
+
+const HIRE_CATEGORY_DESCRIPTION =
+	'(Recruit population instantly; upkeep and role effects apply while ' +
+	'they remain)';
 
 interface HireOptionsProps {
 	action: Action;
@@ -15,18 +20,17 @@ export default function HireOptions({
 	canInteract,
 }: HireOptionsProps) {
 	const listRef = useAnimate<HTMLDivElement>();
+	const icon = action.icon ?? '👶';
 	return (
-		<div>
-			<h3 className="font-medium">
-				Hire{' '}
-				<span className="italic text-sm font-normal">
-					(Recruit population instantly; upkeep and role effects apply while
-					they remain)
-				</span>
-			</h3>
+		<div className="space-y-2">
+			<ActionCategoryHeader
+				icon={icon}
+				title="Hire"
+				subtitle={HIRE_CATEGORY_DESCRIPTION}
+			/>
 			<div
 				ref={listRef}
-				className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 mt-1"
+				className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2"
 			>
 				<RaisePopOptions
 					action={action}

--- a/packages/web/src/components/actions/types.ts
+++ b/packages/web/src/components/actions/types.ts
@@ -8,6 +8,7 @@ export interface Action {
 	order?: number;
 	category?: string;
 	focus?: Focus;
+	icon?: string;
 	requirements?: unknown[];
 	effects?: unknown[];
 }


### PR DESCRIPTION
## Summary
- add a shared `ActionCategoryHeader` so action category sections present icons consistently
- show a ⚙️ icon for Basic options and reuse the 👶 Hire icon when rendering the action headers
- expose optional `icon` metadata on the action type so the UI can surface existing action symbols

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no translators or formatters were modified or reused for this UI-only change.
2. **Canonical keywords/icons/helpers touched:** Reused the existing Hire icon (👶) and introduced a Basic category icon (⚙️) within the action panel UI.
3. **Voice review:** No new copy was added; existing helper text was preserved in its original voice.

## Standards compliance (required)
1. **File length limits respected:** Updated files remain well below 250 lines (e.g., ActionCategoryHeader.tsx 35 lines, BasicOptions.tsx 46 lines, HireOptions.tsx 41 lines, types.ts 34 lines).
2. **Line length limits respected:** `npm run format` ensured all modified lines comply with the 80-character limit.
3. **Domain separation upheld:** All updates stay within the web UI layer and associated typings; engine/content modules were untouched.
4. **Code standards satisfied:** `npm run lint` (pass).
5. **Tests updated:** No new automated tests were required; existing action panel coverage remains valid.
6. **Documentation updated:** Not required—no behavioral documentation changed.
7. **`npm run check` results:** `npm run check` (pass); no additional artifacts were generated.
8. **`npm run test:coverage` results:** Not run; outside the scope of this UI polish.

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68e2c50a74ac8325b744bb6c6aaeed1f