### PR TITLE
Add session helpers for effect log and passive modifier cloning

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -24,6 +24,8 @@ export {
 	type GameSnapshot,
 	type PlayerStateSnapshot,
 	type LandSnapshot,
+	cloneEffectLogEntry,
+	clonePassiveEvaluationMods,
 } from './runtime/session';
 export {
 	simulateUpcomingPhases,


### PR DESCRIPTION
## Summary
* add cloning helpers and new `EngineSession` accessors to expose effect log entries and passive evaluation modifiers without leaking engine state
* export the new helpers through the engine entrypoint for downstream consumption
* extend the runtime session tests to cover the cloning behaviour for effect logs and passive modifiers

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no player-facing text or translators were touched.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** Not applicable; no player-facing copy was updated.

## Standards compliance (required)
1. **File length limits respected:** Updated files remain well under the 250 line limit (e.g., `packages/engine/src/runtime/session.ts` is 105 lines).
2. **Line length limits respected:** Prettier formatting (`npm run format`) was executed to enforce the 80-character limit.
3. **Domain separation upheld:** Changes were limited to engine runtime code and accompanying engine tests; no cross-domain coupling was introduced.
4. **Code standards satisfied:** `npm run lint` completed successfully.
5. **Tests updated:** `packages/engine/tests/runtime/session.test.ts` now includes coverage for the new cloning helpers.
6. **Documentation updated:** Not required for this change set.
7. **`npm run check` results:** `npm run check` was run locally (no artifact produced by `npm run verify`).
8. **`npm run test:coverage` results:** Not run for this update.

## Testing
* `npm run format`
* `npm run lint`
* `npm run check`
* `npm run test -- packages/engine/tests/runtime/session.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e2cafb9f5483258d166cfa1a6cefae