### PR TITLE
Implement developer mode boosted starting resources

### DIFF
--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -34,6 +34,7 @@ import { useActionPerformer } from './useActionPerformer';
 import { useToasts } from './useToasts';
 import { useCompensationLogger } from './useCompensationLogger';
 import { useAiRunner } from './useAiRunner';
+import { initializeDeveloperMode } from './developerModeSetup';
 import type { GameEngineContextValue } from './GameContext.types';
 import { DEFAULT_PLAYER_NAME } from './playerIdentity';
 
@@ -87,6 +88,9 @@ export function GameProvider({
 		});
 		created.setDevMode(devMode);
 		const legacyContext = created.getLegacyContext();
+		if (devMode) {
+			initializeDeveloperMode(legacyContext);
+		}
 		const [primary] = legacyContext.game.players;
 		if (primary) {
 			primary.name = playerNameRef.current ?? DEFAULT_PLAYER_NAME;

--- a/packages/web/src/state/developerModeSetup.ts
+++ b/packages/web/src/state/developerModeSetup.ts
@@ -1,0 +1,190 @@
+import {
+	createDevelopmentRegistry,
+	BuildingId,
+	PopulationRole,
+	Resource,
+	type DevelopmentDef,
+	type PopulationRoleId,
+	type ResourceKey,
+} from '@kingdom-builder/contents';
+import {
+	runEffects,
+	type EffectDef,
+	type EngineContext,
+} from '@kingdom-builder/engine';
+
+const TARGET_GOLD = 100;
+const TARGET_HAPPINESS = 10;
+const DEVELOPMENT_REGISTRY = createDevelopmentRegistry();
+const DEVELOPMENT_PLAN = toDevelopmentPlan();
+const TARGET_LAND_COUNT = 5;
+const POPULATION_PLAN: Array<{ role: PopulationRoleId; count: number }> = [
+	{ role: PopulationRole.Council, count: 2 },
+	{ role: PopulationRole.Legion, count: 1 },
+	{ role: PopulationRole.Fortifier, count: 1 },
+];
+
+function toDevelopmentPlan(): string[] {
+	const identifiers: string[] = [];
+	for (const identifier of DEVELOPMENT_REGISTRY.keys()) {
+		if (isDevelopmentId(identifier)) {
+			identifiers.push(identifier);
+		}
+	}
+	identifiers.sort((left, right) => {
+		const leftOrder = getDevelopmentOrder(
+			DEVELOPMENT_REGISTRY.get(String(left)),
+		);
+		const rightOrder = getDevelopmentOrder(
+			DEVELOPMENT_REGISTRY.get(String(right)),
+		);
+		if (leftOrder !== rightOrder) {
+			return leftOrder - rightOrder;
+		}
+		return String(left).localeCompare(String(right));
+	});
+	return identifiers;
+}
+
+function getDevelopmentOrder(definition: DevelopmentDef): number {
+	return typeof definition.order === 'number'
+		? definition.order
+		: Number.MAX_SAFE_INTEGER;
+}
+
+function isDevelopmentId(id: string): boolean {
+	return DEVELOPMENT_REGISTRY.has(id);
+}
+
+function applyEffect(
+	context: EngineContext,
+	effect: EffectDef,
+	multiplier = 1,
+): void {
+	runEffects([effect], context, multiplier);
+}
+
+function ensureResource(
+	context: EngineContext,
+	key: ResourceKey,
+	target: number,
+): void {
+	const player = context.activePlayer;
+	const current = player.resources[key] ?? 0;
+	if (current === target) {
+		return;
+	}
+	const amount = Math.abs(target - current);
+	if (amount === 0) {
+		return;
+	}
+	const method = target > current ? 'add' : 'remove';
+	const resourceEffect: EffectDef = {
+		type: 'resource',
+		method,
+		params: { key, amount },
+	};
+	applyEffect(context, resourceEffect);
+}
+
+function ensurePopulation(
+	context: EngineContext,
+	role: PopulationRoleId,
+	target: number,
+): void {
+	const player = context.activePlayer;
+	const current = player.population[role] ?? 0;
+	if (current === target) {
+		return;
+	}
+	const delta = target - current;
+	const method = delta > 0 ? 'add' : 'remove';
+	const populationEffect: EffectDef = {
+		type: 'population',
+		method,
+		params: { role },
+	};
+	applyEffect(context, populationEffect, Math.abs(delta));
+}
+
+function ensureLandCount(context: EngineContext, target: number): void {
+	const player = context.activePlayer;
+	if (player.lands.length >= target) {
+		return;
+	}
+	const landEffect: EffectDef<{ count: number }> = {
+		type: 'land',
+		method: 'add',
+		params: { count: target - player.lands.length },
+	};
+	applyEffect(context, landEffect);
+}
+
+function ensureDevelopment(
+	context: EngineContext,
+	index: number,
+	id: string,
+): void {
+	const player = context.activePlayer;
+	const land = player.lands[index];
+	if (!land) {
+		return;
+	}
+	const developmentId = String(id);
+	if (land.developments.includes(developmentId)) {
+		return;
+	}
+	const developmentEffect: EffectDef<{ id: string; landId: string }> = {
+		type: 'development',
+		method: 'add',
+		params: { id: developmentId, landId: land.id },
+	};
+	applyEffect(context, developmentEffect);
+}
+
+function ensureMill(context: EngineContext): void {
+	const player = context.activePlayer;
+	if (player.buildings.has(BuildingId.Mill)) {
+		return;
+	}
+	const millEffect: EffectDef<{ id: string }> = {
+		type: 'building',
+		method: 'add',
+		params: { id: BuildingId.Mill },
+	};
+	applyEffect(context, millEffect);
+}
+
+function withPrimaryPlayer(context: EngineContext, action: () => void): void {
+	const previousIndex = context.game.currentPlayerIndex;
+	if (previousIndex !== 0) {
+		context.game.currentPlayerIndex = 0;
+	}
+	try {
+		action();
+	} finally {
+		context.game.currentPlayerIndex = previousIndex;
+	}
+}
+
+export function initializeDeveloperMode(context: EngineContext): void {
+	const player = context.game.players[0];
+	if (!player) {
+		return;
+	}
+	if (context.game.turn > 1 || player.buildings.has(BuildingId.Mill)) {
+		return;
+	}
+	withPrimaryPlayer(context, () => {
+		ensureResource(context, Resource.gold, TARGET_GOLD);
+		ensureResource(context, Resource.happiness, TARGET_HAPPINESS);
+		POPULATION_PLAN.forEach(({ role, count }) => {
+			ensurePopulation(context, role, count);
+		});
+		ensureLandCount(context, TARGET_LAND_COUNT);
+		DEVELOPMENT_PLAN.forEach((id, index) => {
+			ensureDevelopment(context, index, id);
+		});
+		ensureMill(context);
+	});
+}


### PR DESCRIPTION
## Summary
- ensure developer-mode sessions start with the specified gold, happiness, lands, population, developments, and Mill
- hook the new developer-mode initialization into the game session bootstrap

## Text formatting audit (required)
1. **Translator/formatter reuse:** N/A – no player-facing text or formatting changed.
2. **Canonical keywords/icons/helpers touched:** N/A – no keyword/icon helper usage changed.
3. **Voice review:** N/A – no user-facing copy affected.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/src/state/developerModeSetup.ts` is 190 lines; the touched section of `GameContext.tsx` remains under 250 lines.
2. **Line length limits respected:** Prettier formatting keeps all modified lines at or under the 80-character limit.
3. **Domain separation upheld:** Web logic pulls content via `@kingdom-builder/contents` registries and only uses exported engine APIs; no cross-domain shortcuts were introduced.
4. **Code standards satisfied:** `npm run lint` completes successfully for the repository.
5. **Tests updated:** No new tests were required; the existing suite (`npm test`) passes with the new developer-mode behavior.
6. **Documentation updated:** Not needed; the change only alters developer-mode bootstrap logic.
7. **`npm run check` results:** Ran locally (`npm run check`), which finished with a PASS; no artifact is generated in this environment.
8. **`npm run test:coverage` results:** Not run; coverage is unchanged by these state-initialization adjustments.

## Testing
- `npm run format -- packages/web/src/state/developerModeSetup.ts` (PASS)
- `npm run lint -- packages/web/src/state/developerModeSetup.ts` (PASS)
- `npm run lint` (PASS)
- `npm run check` (PASS)
- `npm test` (PASS)


------
https://chatgpt.com/codex/tasks/task_e_68e2d360e6ec832581583aba57961840