### PR TITLE
Add session helpers for action costs and requirements

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -24,6 +24,8 @@ export {
 	type GameSnapshot,
 	type PlayerStateSnapshot,
 	type LandSnapshot,
+	type EngineSessionGetActionCosts,
+	type EngineSessionGetActionRequirements,
 	cloneEffectLogEntry,
 	clonePassiveEvaluationMods,
 } from './runtime/session';

--- a/packages/engine/src/runtime/session.ts
+++ b/packages/engine/src/runtime/session.ts
@@ -6,6 +6,10 @@ import type { EngineContext } from '../context';
 import { performAction as runAction } from '../actions/action_execution';
 import { advance as runAdvance } from '../phases/advance';
 import { getActionEffectGroups } from '../actions/effect_groups';
+import {
+	getActionCosts as resolveActionCosts,
+	getActionRequirements as resolveActionRequirements,
+} from '../actions/costs';
 import type { ActionParameters } from '../actions/action_parameters';
 import type { ActionTrace } from '../log';
 import { cloneActionOptions } from './action_options';
@@ -39,6 +43,14 @@ export interface EngineSession {
 	advancePhase(): EngineAdvanceResult;
 	getSnapshot(): EngineSessionSnapshot;
 	getActionOptions(actionId: string): ReturnType<typeof cloneActionOptions>;
+	getActionCosts<T extends string>(
+		actionId: T,
+		params?: ActionParameters<T>,
+	): ReturnType<typeof resolveActionCosts>;
+	getActionRequirements<T extends string>(
+		actionId: T,
+		params?: ActionParameters<T>,
+	): string[];
 	pullEffectLog<T>(key: string): T | undefined;
 	getPassiveEvaluationMods(): Map<string, Map<string, EvaluationModifier>>;
 	enqueue<T>(taskFactory: () => Promise<T> | T): Promise<T>;
@@ -80,6 +92,14 @@ export function createEngineSession(
 			const groups = getActionEffectGroups(actionId, context);
 			return cloneActionOptions(groups);
 		},
+		getActionCosts(actionId, params) {
+			const costs = resolveActionCosts(actionId, context, params);
+			return { ...costs };
+		},
+		getActionRequirements(actionId, params) {
+			const requirements = resolveActionRequirements(actionId, context, params);
+			return [...requirements];
+		},
 		pullEffectLog<T>(key: string) {
 			const entry = context.pullEffectLog<T>(key);
 			if (entry === undefined) {
@@ -103,3 +123,6 @@ export function createEngineSession(
 }
 
 export { cloneEffectLogEntry, clonePassiveEvaluationMods };
+export type EngineSessionGetActionCosts = EngineSession['getActionCosts'];
+export type EngineSessionGetActionRequirements =
+	EngineSession['getActionRequirements'];

--- a/packages/engine/tests/runtime/session.test.ts
+++ b/packages/engine/tests/runtime/session.test.ts
@@ -22,6 +22,7 @@ import type {
 import type { PhaseDef } from '../../src/phases.ts';
 import type { RuleSet } from '../../src/services';
 import { createContentFactory } from '../factories/content.ts';
+import { REQUIREMENTS } from '../../src/requirements/index.ts';
 import type { EvaluationModifier } from '../../src/services/passive_types.ts';
 
 const BASE: {
@@ -190,5 +191,57 @@ describe('EngineSession', () => {
 		clonedInner.set('mod:other', () => ({ percent: 0 }));
 		expect(originalInner.has('mod:other')).toBe(false);
 		expect(originalInner.get('mod:test')).toBe(modifier);
+	});
+
+	it('clones action cost lookups from the session', () => {
+		const content = createContentFactory();
+		const goldCost = 5;
+		const action = content.action({
+			baseCosts: { [CResource.gold]: goldCost },
+		});
+		const session = createTestSession({
+			actions: content.actions,
+			buildings: content.buildings,
+			developments: content.developments,
+			populations: content.populations,
+		});
+		advanceToMain(session);
+		const costs = session.getActionCosts(action.id);
+		expect(costs[CResource.gold]).toBe(goldCost);
+		costs[CResource.gold] = 999;
+		const refreshed = session.getActionCosts(action.id);
+		expect(refreshed).not.toBe(costs);
+		expect(refreshed[CResource.gold]).toBe(goldCost);
+	});
+
+	it('clones action requirement lookups from the session', () => {
+		const requirementId = 'vitest:fail';
+		const requirementMessage = 'Requirement failed for test';
+		if (!REQUIREMENTS.has(requirementId)) {
+			REQUIREMENTS.add(requirementId, () => requirementMessage);
+		}
+		const content = createContentFactory();
+		const action = content.action({
+			requirements: [
+				{
+					type: 'vitest',
+					method: 'fail',
+					message: requirementMessage,
+				},
+			],
+		});
+		const session = createTestSession({
+			actions: content.actions,
+			buildings: content.buildings,
+			developments: content.developments,
+			populations: content.populations,
+		});
+		advanceToMain(session);
+		const requirements = session.getActionRequirements(action.id);
+		expect(requirements).toEqual([requirementMessage]);
+		requirements.push('mutated');
+		const refreshed = session.getActionRequirements(action.id);
+		expect(refreshed).not.toBe(requirements);
+		expect(refreshed).toEqual([requirementMessage]);
 	});
 });

--- a/packages/web/src/state/useActionPerformer.ts
+++ b/packages/web/src/state/useActionPerformer.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
 import {
-	getActionCosts,
 	resolveActionEffects,
 	type ActionParams,
 	type EngineSession,
@@ -62,7 +61,7 @@ export function useActionPerformer({
 				throw new Error('Missing active player before action');
 			}
 			const before = snapshotPlayer(playerBefore);
-			const costs = getActionCosts(action.id, context, params);
+			const costs = session.getActionCosts(action.id, params);
 			try {
 				const traces = session.performAction(action.id, params);
 				const snapshotAfter = session.getSnapshot();


### PR DESCRIPTION
## Summary
- add EngineSession helpers that clone action costs and requirement arrays before returning them so callers cannot mutate engine state.
- export the new helper method types from the engine package entry point for downstream consumption.
- cover the helpers with regression tests and update the web performer hook to call the session facade.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no player-facing copy changes were made.
2. **Canonical keywords/icons/helpers touched:** None; the change stays within engine/session plumbing.
3. **Voice review:** Not applicable; no summary/description/log strings were modified.

## Standards compliance (required)
1. **File length limits respected:** `wc -l` confirms the touched files remain at or below the allowed limits (128/247/245 lines). 【589af9†L1-L5】
2. **Line length limits respected:** `npm run lint` passes without max-length errors. 【a4cf2a†L1-L9】【b0e7fb†L1-L3】
3. **Domain separation upheld:** Engine changes interact only with engine helpers, and web updates consume the new facade method without bypassing session boundaries. 【F:packages/engine/src/runtime/session.ts†L46-L121】【F:packages/web/src/state/useActionPerformer.ts†L1-L102】
4. **Code standards satisfied:** `npm run lint` completed successfully. 【a4cf2a†L1-L9】【b0e7fb†L1-L3】
5. **Tests updated:** Added engine session immutability regressions and executed the full Vitest suite. 【F:packages/engine/tests/runtime/session.test.ts†L196-L245】【319f0c†L1-L18】
6. **Documentation updated:** Not required; no public docs reference these internal helpers.
7. **`npm run check` results:** Command executed locally with no failures (no artifact generated in this environment). 【0d08ab†L1-L10】
8. **`npm run test:coverage` results:** Not run; existing workflow does not require coverage for this change.

## Testing
- `npm run lint`
- `npm run format`
- `npm run check`
- `vitest run` (via commit hook)


------
https://chatgpt.com/codex/tasks/task_e_68e2d6d742248325b007e4200313a725