### PR TITLE
Refine passive phase metadata resolution

### DIFF
--- a/packages/web/tests/passive-duration-formatter.test.ts
+++ b/packages/web/tests/passive-duration-formatter.test.ts
@@ -4,15 +4,64 @@ import {
 	describeEffects,
 	logEffects,
 } from '../src/translation/effects';
-import { createEngine, type EffectDef } from '@kingdom-builder/engine';
+import {
+	createEngine,
+	type EffectDef,
+	type PlayerId,
+} from '@kingdom-builder/engine';
 import { createContentFactory } from '../../engine/tests/factories/content';
 import type { PhaseDef } from '@kingdom-builder/engine/phases';
 import type { StartConfig } from '@kingdom-builder/protocol';
 import type { RuleSet } from '@kingdom-builder/engine/services';
+import { PhaseId } from '@kingdom-builder/contents';
+import {
+	createTranslationContextStub,
+	toTranslationPlayer,
+	wrapTranslationRegistry,
+} from './helpers/translationContextStub';
 
 vi.mock('@kingdom-builder/engine', async () => {
 	return await import('../../engine/src');
 });
+
+const PASSIVE_REGISTRY = wrapTranslationRegistry<unknown>({
+	get(id: string) {
+		return { id };
+	},
+	has() {
+		return true;
+	},
+});
+
+const ACTIVE_PLAYER = toTranslationPlayer({
+	id: 'A' as PlayerId,
+	name: 'Player A',
+	resources: {},
+	population: {},
+	stats: {},
+});
+
+const OPPONENT_PLAYER = toTranslationPlayer({
+	id: 'B' as PlayerId,
+	name: 'Player B',
+	resources: {},
+	population: {},
+	stats: {},
+});
+
+function createStubFormatterContext(
+	phases: Parameters<typeof createTranslationContextStub>[0]['phases'],
+) {
+	return createTranslationContextStub({
+		phases,
+		actionCostResource: undefined,
+		actions: PASSIVE_REGISTRY,
+		buildings: PASSIVE_REGISTRY,
+		developments: PASSIVE_REGISTRY,
+		activePlayer: ACTIVE_PLAYER,
+		opponent: OPPONENT_PLAYER,
+	});
+}
 
 function createSyntheticCtx() {
 	const content = createContentFactory();
@@ -87,6 +136,82 @@ describe('passive formatter duration metadata', () => {
 				title: '✨ Festival Spirit added',
 				items: ["✨ Festival Spirit duration: Until player's next 🎉 Festival"],
 			},
+		]);
+	});
+
+	it('fills missing context metadata from static phase definitions', () => {
+		const ctx = createStubFormatterContext([
+			{ id: PhaseId.Growth },
+			{ id: PhaseId.Upkeep },
+		]);
+		const passive: EffectDef = {
+			type: 'passive',
+			method: 'add',
+			params: {
+				id: 'synthetic:passive:static-growth',
+				durationPhaseId: PhaseId.Growth,
+			},
+			effects: [],
+		};
+
+		const summary = summarizeEffects([passive], ctx);
+
+		expect(summary).toEqual([{ title: '⏳ Until next 🏗️ Growth', items: [] }]);
+	});
+
+	it('prefers contextual metadata over static phase definitions', () => {
+		const ctx = createStubFormatterContext([
+			{
+				id: PhaseId.Growth,
+				label: 'Rapid Growth',
+				icon: '🌱',
+			},
+		]);
+		const passive: EffectDef = {
+			type: 'passive',
+			method: 'add',
+			params: {
+				id: 'synthetic:passive:context-growth',
+				durationPhaseId: PhaseId.Growth,
+			},
+			effects: [],
+		};
+
+		const summary = summarizeEffects([passive], ctx);
+
+		expect(summary).toEqual([
+			{ title: '⏳ Until next 🌱 Rapid Growth', items: [] },
+		]);
+	});
+
+	it('resolves phase metadata via trigger keys when duration id is missing', () => {
+		const ctx = createStubFormatterContext([
+			{
+				id: PhaseId.Upkeep,
+				label: 'Rest & Recover',
+				icon: '🛏️',
+				steps: [
+					{
+						id: 'custom:upkeep',
+						triggers: ['onUpkeepPhase'],
+					},
+				],
+			},
+		]);
+		const passive: EffectDef = {
+			type: 'passive',
+			method: 'add',
+			params: {
+				id: 'synthetic:passive:trigger-upkeep',
+				onUpkeepPhase: [],
+			},
+			effects: [],
+		};
+
+		const summary = summarizeEffects([passive], ctx);
+
+		expect(summary).toEqual([
+			{ title: '⏳ Until next 🛏️ Rest & Recover', items: [] },
 		]);
 	});
 });


### PR DESCRIPTION
## Summary
- derive passive duration metadata solely from translation context phases and static PHASES definitions
- remove legacy phase label fallbacks and clean up passive duration formatting helpers
- add regression coverage for context override, static fallback, and trigger-based duration resolution

## Text formatting audit (required)

1. **Translator/formatter reuse:** Updated the existing passive effect formatter in `packages/web/src/translation/effects/formatters/passive.ts`.
2. **Canonical keywords/icons/helpers touched:** `PHASES`, `PASSIVE_INFO`, `PhaseId`.
3. **Voice review:** Confirmed Summary, Description, and Log outputs continue to use the established voices.

## Standards compliance (required)

1. **File length limits respected:** Verified updated files remain under the 250-line limit.
2. **Line length limits respected:** Prettier and ESLint confirm no lines exceed 80 characters.
3. **Domain separation upheld:** Changes are scoped to the web translation layer and its tests; engine/content boundaries remain intact.
4. **Code standards satisfied:** `npm run lint` (see Testing) passed without errors.
5. **Tests updated:** Added targeted cases in `packages/web/tests/passive-duration-formatter.test.ts` covering the new resolution order.
6. **Documentation updated:** Not required; no user-facing documentation changed.
7. **`npm run check` results:** `npm run check` (chunk `777f7e`) completed successfully.
8. **`npm run test:coverage` results:** Not run; coverage was not requested for this change.

## Testing

- `npm run format` (chunk `5fd8ef`)
- `npm run lint` (chunk `82e0be`)
- `npm run check` (chunk `777f7e`)
- Commit hook executed `npm test` via `npm run check`, all 118 vitest files passed (chunk `beab1e`).

------
https://chatgpt.com/codex/tasks/task_e_68e2d6d6a0108325a447e36669f59d92