### PR TITLE
Document and enforce test file max-lines exemption

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -110,6 +110,12 @@ module.exports = {
 	},
 	overrides: [
 		{
+			files: ['**/*.test.ts'],
+			rules: {
+				'max-lines': 'off',
+			},
+		},
+		{
 			files: [
 				'packages/**/tests/**/*.ts',
 				'packages/**/tests/**/*.tsx',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,14 +90,15 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.
 ### 2.2 Formatting & Linting
 
 - Run `npm run lint` to enforce mandatory braces, 80-character lines,
-  descriptive identifiers, and the ~250-line limit for new modules. Missing
+  descriptive identifiers, and the ~250-line limit for new modules (excluding
+  `*.test.ts` files). Missing
   plugins such as `eslint-plugin-import` are auto-installed; if tooling fails,
   install with `npm install --no-save eslint-plugin-import`.
 - `npm run format` runs `prettier . --write` to apply Prettier with **tab
   indentation** and an 80-character print width across TypeScript, JSON,
   Markdown, etc.
 - Legacy files above 250 lines remain until refactored; new code should respect
-  the limit.
+  the limit, but `*.test.ts` files are exempt.
 
 ### 2.3 Pull Request Submission Protocol
 
@@ -114,7 +115,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.
 
 - [ ] Wrap every conditional or loop body in braces, even for single statements.
 - [ ] Keep lines at or below 80 characters.
-- [ ] Ensure files stay at or under 250 lines unless grandfathered.
+- [ ] Ensure files stay at or under 250 lines unless grandfathered or the file
+      ends with `.test.ts`.
 - [ ] Use descriptive, human-readable identifiers instead of abbreviations.
 - [ ] Indent code with tabs to preserve consistent formatting.
 
@@ -126,7 +128,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.
 - Variables/functions use `camelCase`; classes/types use `PascalCase`.
 - Every conditional or loop uses braces, even with single-statement bodies.
 - Keep runtime-focused files (engine, shared packages, web, tests) under 250
-  lines by extracting helpers where logical.
+  lines by extracting helpers where logical; `*.test.ts` files may exceed the
+  limit when needed.
 - Documentation (`*.md`) and non-runtime tooling (e.g., `overview.tsx`) may
   adopt context-specific formatting.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ these rules:
   single statement.
 - Wrap lines at 80 characters to prevent horizontal scrolling in reviews.
 - Keep individual source files at or below 250 lines unless legacy code already
-  exceeds the limit.
+  exceeds the limit; `*.test.ts` files are exempt from this rule.
 - Choose descriptive, human-readable identifiers instead of terse abbreviations.
 - Indent code with tab characters so formatting remains consistent across
   editors.

--- a/docs/agent-quick-start.md
+++ b/docs/agent-quick-start.md
@@ -35,7 +35,8 @@ guide for rationale, lore, and extended background.
 | ----------- | ----------------------------------------------------------------- |
 | Braces      | Wrap every conditional and loop body in braces.                   |
 | Line length | Keep lines ≤ 80 characters.                                       |
-| File length | Keep new runtime files ≤ 250 lines (legacy exceptions ok).        |
+| File length | Keep new runtime files ≤ 250 lines (legacy exceptions ok;         |
+|             | `*.test.ts` files are exempt).                                    |
 | Naming      | Descriptive identifiers (`camelCase` values, `PascalCase` types). |
 | Formatting  | Use tabs and run Prettier via `npm run format`.                   |
 


### PR DESCRIPTION
## Summary

- Documented the exemption of `*.test.ts` files from the 250-line limit in `AGENTS.md`, `README.md`, and `docs/agent-quick-start.md`.
- Updated the ESLint configuration to disable the `max-lines` rule for `*.test.ts` files so automated checks match the documentation.

## Text formatting audit (required)

1. **Translator/formatter reuse:** N/A – no translation or formatter assets were touched.
2. **Canonical keywords/icons/helpers touched:** None – this change only affects tooling and contributor documentation.
3. **Voice review:** N/A – no player-facing copy was modified.

## Standards compliance (required)

1. **File length limits respected:** All modified files remain under their respective limits after the exemption clarification.
2. **Line length limits respected:** `npm run check` (which includes `prettier --check`) passed locally after formatting.
3. **Domain separation upheld:** Only repository configuration and documentation were updated; engine/web/content code was untouched.
4. **Code standards satisfied:** `npm run lint` and `npm run check` completed without errors locally.
5. **Tests updated:** Not required – no runtime behavior changed. `npm run check` executed the existing suite successfully.
6. **Documentation updated:** README, AGENTS, and the quick-start guide now note the exemption for `*.test.ts` files.
7. **`npm run check` results:** PASS – see local run in this change set (no artifact generated in this environment).
8. **`npm run test:coverage` results:** Not run – coverage workflows were not part of this task.

## Testing

- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68e2de7227148325ac37f7397ee04c54