### PR TITLE
Use player names in attack logs

### DIFF
--- a/packages/web/src/menu/PlayerNamePrompt.tsx
+++ b/packages/web/src/menu/PlayerNamePrompt.tsx
@@ -23,7 +23,7 @@ const ERROR_TEXT_CLASS = [
 
 const DESCRIPTION_TEXT = [
 	'Before we begin, tell us the name that will echo through your chronicles.',
-	'You can change it later from the Settings menu.',
+	'This title can change later from the Settings menu.',
 ].join(' ');
 
 export interface PlayerNamePromptProps {

--- a/packages/web/src/translation/effects/formatters/attack.ts
+++ b/packages/web/src/translation/effects/formatters/attack.ts
@@ -111,14 +111,14 @@ function buildActionLog(
 				: undefined;
 		items.push(
 			formatter.formatDiff(
-				ownerLabel('defender'),
+				ownerLabel(ctx, 'defender'),
 				diff,
 				percent !== undefined ? { percent } : { showPercent: true as const },
 			),
 		);
 	});
 	entry.attacker.forEach((diff) => {
-		items.push(formatter.formatDiff(ownerLabel('attacker'), diff));
+		items.push(formatter.formatDiff(ownerLabel(ctx, 'attacker'), diff));
 	});
 	return { title: `Triggered ${icon} ${name}`.trim(), items };
 }
@@ -145,7 +145,7 @@ export function buildOnDamageEntry(
 		const handler = resolveAttackOnDamageFormatter(entry);
 		const formatted = handler
 			? handler({ entry, ctx, formatter })
-			: formatDiffEntries(entry, formatter);
+			: formatDiffEntries(entry, formatter, ctx);
 		items.push(...formatted);
 	}
 	if (!items.length) {
@@ -166,21 +166,21 @@ registerAttackOnDamageFormatter(
 registerAttackOnDamageFormatter(
 	'resource',
 	'transfer',
-	({ entry, formatter }) => {
+	({ entry, ctx, formatter }) => {
 		const percent = entry.effect.params
 			? (entry.effect.params['percent'] as number | undefined)
 			: undefined;
 		if (percent === undefined) {
-			return formatDiffEntries(entry, formatter);
+			return formatDiffEntries(entry, formatter, ctx);
 		}
 		const parts: SummaryEntry[] = [];
 		entry.defender.forEach((diff) => {
 			parts.push(
-				formatter.formatDiff(ownerLabel('defender'), diff, { percent }),
+				formatter.formatDiff(ownerLabel(ctx, 'defender'), diff, { percent }),
 			);
 		});
 		entry.attacker.forEach((diff) => {
-			parts.push(formatter.formatDiff(ownerLabel('attacker'), diff));
+			parts.push(formatter.formatDiff(ownerLabel(ctx, 'attacker'), diff));
 		});
 		return parts;
 	},

--- a/packages/web/tests/army-attack-translation.log.test.ts
+++ b/packages/web/tests/army-attack-translation.log.test.ts
@@ -32,6 +32,8 @@ afterAll(() => {
 describe('army attack translation log', () => {
 	it('logs army attack action with concrete evaluation', () => {
 		const { ctx, attack, plunder } = createSyntheticCtx();
+		const attackerName = ctx.activePlayer.name ?? 'Player';
+		const defenderName = ctx.opponent.name ?? 'Opponent';
 		const castle = RESOURCES[Resource.castleHP];
 		const powerStat = getStat(SYNTH_COMBAT_STATS.power.key)!;
 		const absorptionStat = getStat(SYNTH_COMBAT_STATS.absorption.key)!;
@@ -90,13 +92,13 @@ describe('army attack translation log', () => {
 			`    ${powerValue(remainingAfterAbsorption)} vs. ${fortValue(fortBefore)} --> ${fortValue(0)} ${powerValue(remainingAfterFort)}`,
 			`    ${powerValue(remainingAfterFort)} vs. ${castleValue} --> ${castleAfterValue}`,
 			`  ${castle.icon} ${castle.label} damage trigger evaluation`,
-			`    Opponent: ${happiness.icon} ${happiness.label} ${opponentHappinessDelta} (${opponentHappinessBefore}→${opponentHappinessAfter})`,
-			`    You: ${happiness.icon} ${happiness.label} ${
+			`    ${defenderName}: ${happiness.icon} ${happiness.label} ${opponentHappinessDelta} (${opponentHappinessBefore}→${opponentHappinessAfter})`,
+			`    ${attackerName}: ${happiness.icon} ${happiness.label} ${
 				attackerHappinessDelta >= 0 ? '+' : ''
 			}${attackerHappinessDelta} (${attackerHappinessBefore}→${attackerHappinessAfter})`,
 			`    Triggered ${plunder.icon} ${plunder.name}`,
-			`      Opponent: ${gold.icon} ${gold.label} -${PLUNDER_PERCENT}% (${opponentGoldBefore}→${opponentGoldAfter}) (${opponentGoldDelta})`,
-			`      You: ${gold.icon} ${gold.label} ${
+			`      ${defenderName}: ${gold.icon} ${gold.label} -${PLUNDER_PERCENT}% (${opponentGoldBefore}→${opponentGoldAfter}) (${opponentGoldDelta})`,
+			`      ${attackerName}: ${gold.icon} ${gold.label} ${
 				playerGoldDelta >= 0 ? '+' : ''
 			}${playerGoldDelta} (${playerGoldBefore}→${playerGoldAfter})`,
 		]);
@@ -104,6 +106,7 @@ describe('army attack translation log', () => {
 
 	it('logs building attack action with destruction evaluation', () => {
 		const { ctx, buildingAttack, building } = createSyntheticCtx();
+		const attackerName = ctx.activePlayer.name ?? 'Player';
 		const powerStat = getStat(SYNTH_COMBAT_STATS.power.key)!;
 		const absorptionStat = getStat(SYNTH_COMBAT_STATS.absorption.key)!;
 		const fortStat = getStat(SYNTH_COMBAT_STATS.fortification.key)!;
@@ -145,7 +148,7 @@ describe('army attack translation log', () => {
 			`    ${powerValue(remainingAfterAbsorption)} vs. ${fortValue(fortBefore)} --> ${fortValue(0)} ${powerValue(remainingAfterFort)}`,
 			`    ${powerValue(remainingAfterFort)} destroys ${buildingDisplay}`,
 			`  ${buildingDisplay} destruction trigger evaluation`,
-			`    You: ${gold.icon} ${gold.label} ${
+			`    ${attackerName}: ${gold.icon} ${gold.label} ${
 				playerGoldDelta >= 0 ? '+' : ''
 			}${playerGoldDelta} (${playerGoldBefore}→${playerGoldAfter})`,
 		]);

--- a/packages/web/tests/attack-on-damage-registry.test.ts
+++ b/packages/web/tests/attack-on-damage-registry.test.ts
@@ -14,10 +14,58 @@ vi.mock('../src/translation/effects/factory', () => ({
 }));
 import type {
 	AttackOnDamageLogEntry,
-	EngineContext,
 	EffectDef,
 } from '@kingdom-builder/engine';
 import { Resource, RESOURCES } from '@kingdom-builder/contents';
+import type { TranslationContext } from '../src/translation/context';
+import type { PlayerStartConfig } from '@kingdom-builder/protocol';
+
+function createTranslationCtx(): TranslationContext {
+	const emptyModifiers = new Map<string, ReadonlyMap<string, unknown>>();
+	return {
+		actions: {
+			get: vi.fn(),
+			has: vi.fn(),
+		},
+		buildings: {
+			get: vi.fn(),
+			has: vi.fn(),
+		},
+		developments: {
+			get: vi.fn(),
+			has: vi.fn(),
+		},
+		passives: {
+			list: vi.fn(() => []),
+			get: vi.fn(() => undefined),
+			get evaluationMods() {
+				return emptyModifiers;
+			},
+		},
+		phases: [],
+		activePlayer: {
+			id: 'A',
+			name: 'Player',
+			resources: {},
+			stats: {},
+			population: {},
+		},
+		opponent: {
+			id: 'B',
+			name: 'Opponent',
+			resources: {},
+			stats: {},
+			population: {},
+		},
+		pullEffectLog: vi.fn(),
+		actionCostResource: undefined,
+		recentResourceGains: [],
+		compensations: {
+			A: {} as PlayerStartConfig,
+			B: {} as PlayerStartConfig,
+		},
+	};
+}
 
 describe('attack on-damage formatter registry', () => {
 	const attackEffect = {
@@ -25,7 +73,7 @@ describe('attack on-damage formatter registry', () => {
 		method: 'perform',
 		params: {},
 	} as EffectDef<Record<string, unknown>>;
-	const ctx = {} as EngineContext;
+	const ctx = createTranslationCtx();
 
 	it('delegates to registered handler for matching entries', () => {
 		const logEntry: AttackOnDamageLogEntry = {
@@ -84,7 +132,7 @@ describe('attack on-damage formatter registry', () => {
 		const label = gold.icon ? `${gold.icon} ${gold.label}` : gold.label;
 		expect(result?.items).toEqual([
 			`Opponent: ${label} -2 (5→3)`,
-			`You: ${label} +3 (1→4)`,
+			`${ctx.activePlayer.name}: ${label} +3 (1→4)`,
 		]);
 	});
 
@@ -121,7 +169,7 @@ describe('attack on-damage formatter registry', () => {
 		const label = gold.icon ? `${gold.icon} ${gold.label}` : gold.label;
 		expect(result?.items).toEqual([
 			`Opponent: ${label} -0.5% (10→5) (-5)`,
-			`You: ${label} +5 (2→7)`,
+			`${ctx.activePlayer.name}: ${label} +5 (2→7)`,
 		]);
 	});
 });


### PR DESCRIPTION
## Summary
- Replace hard-coded "You" labels in the attack formatter utilities with dynamic player names drawn from the translation context, ensuring on-damage suffixes reference each participant explicitly. 
- Propagate the translation context through attack log helpers and update unit tests to expect attacker/defender names while stubbing translation contexts where necessary.
- Reword the player name prompt description so the onboarding copy avoids second-person phrasing.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Updated the existing `attack` effect formatter and helpers listed in [Section 3](docs/text-formatting.md#3-effect-formatter-inventory) (`packages/web/src/translation/effects/formatters/attack.ts` and `attackFormatterUtils.ts`).
2. **Canonical keywords/icons/helpers touched:** Reused existing stat tokens and resource icons provided by the formatter helpers; no new keywords or icons were introduced from Section 4.
3. **Voice review:** Reviewed the attack log summaries/descriptions and the player name prompt copy to confirm they match the required log and description voices.

- [x] Linked the translator(s)/formatter(s) reused, referencing Sections 2–3.
- [x] Listed every canonical keyword/icon/helper touched from Section 4.
- [x] Confirmed Summary/Description/Log voices were audited for affected UI.

## Standards compliance (required)
1. **File length limits respected:** Updated files remain within limits (e.g., `attackFormatterUtils.ts` 221 lines, `attack.ts` 223 lines, `PlayerNamePrompt.tsx` 93 lines). 【170b9b†L1-L5】
2. **Line length limits respected:** `npm run format` reflowed the sources and reported no issues. 【5ad22b†L1-L200】
3. **Domain separation upheld:** Changes are confined to the web translation layer and associated web tests; engine/content data were only accessed via existing APIs, preserving domain boundaries.
4. **Code standards satisfied:** `npm run lint` completed without errors (TypeScript version warning only). 【3d2a93†L1-L12】
5. **Tests updated:** Adjusted web translation tests to cover the new player-name output expectations (`army-attack-translation.log.test.ts`, `attack-on-damage-registry.test.ts`).
6. **Documentation updated:** Not required; the change refines existing formatter output without altering documented behaviors.
7. **`npm run check` results:** Ran `npm run check`; all phases completed successfully (see logs). 【f97e3a†L1-L10】【136a28†L1-L20】
8. **`npm run test:coverage` results:** Not run; no coverage-affecting code paths were introduced beyond existing test updates.

## Testing
- `npm run format` (pass) 【5ad22b†L1-L200】
- `npm run lint` (pass with TS version warning) 【3d2a93†L1-L12】
- `npm run check` (pass) 【f97e3a†L1-L10】【136a28†L1-L20】

------
https://chatgpt.com/codex/tasks/task_e_68e2e7e1a7e483258921d26f1bb6f52e