### PR TITLE
Sanitize compensation diff context

### DIFF
--- a/packages/web/src/state/useCompensationLogger.ts
+++ b/packages/web/src/state/useCompensationLogger.ts
@@ -9,6 +9,7 @@ import {
 	diffStepSnapshots,
 	snapshotPlayer,
 	type PlayerSnapshot,
+	type TranslationDiffContext,
 } from '../translation';
 
 interface UseCompensationLoggerOptions {
@@ -37,7 +38,7 @@ export function useCompensationLogger({
 		if (sessionState.game.turn !== 1) {
 			return;
 		}
-		const diffContext = createTranslationDiffContext(
+		const baseDiffContext = createTranslationDiffContext(
 			session.getLegacyContext(),
 		);
 		sessionState.game.players.forEach((player) => {
@@ -76,6 +77,13 @@ export function useCompensationLogger({
 			)) {
 				before.stats[statKey] = (before.stats[statKey] || 0) - (statDelta ?? 0);
 			}
+			const diffContext: TranslationDiffContext = {
+				...baseDiffContext,
+				activePlayer: {
+					...baseDiffContext.activePlayer,
+					id: player.id,
+				},
+			};
 			const lines = diffStepSnapshots(
 				before,
 				after,

--- a/packages/web/tests/state/useCompensationLogger.test.tsx
+++ b/packages/web/tests/state/useCompensationLogger.test.tsx
@@ -9,10 +9,11 @@ import {
 import { type PlayerStartConfig } from '@kingdom-builder/protocol';
 import { type ResourceKey } from '@kingdom-builder/contents';
 import { useCompensationLogger } from '../../src/state/useCompensationLogger';
-import type * as TranslationModule from '../../src/translation';
+import * as TranslationModule from '../../src/translation';
+import type * as TranslationTypes from '../../src/translation';
 
 vi.mock('../../src/translation', async () => {
-	const actual = await vi.importActual<TranslationModule>(
+	const actual = await vi.importActual<TranslationTypes>(
 		'../../src/translation',
 	);
 	return {
@@ -20,6 +21,8 @@ vi.mock('../../src/translation', async () => {
 		diffStepSnapshots: vi.fn(() => ['+1 gold']),
 	};
 });
+
+const diffStepSnapshotsMock = vi.mocked(TranslationModule.diffStepSnapshots);
 
 const RESOURCE_KEYS: ResourceKey[] = ['gold' as ResourceKey];
 
@@ -123,6 +126,7 @@ function Harness({ session, state, addLog }: HarnessProps) {
 
 describe('useCompensationLogger', () => {
 	it('logs compensation once for a session', () => {
+		diffStepSnapshotsMock.mockClear();
 		const addLog = vi.fn();
 		const session = createSession();
 		const state = createSessionState(1);
@@ -130,12 +134,17 @@ describe('useCompensationLogger', () => {
 			<Harness session={session} state={state} addLog={addLog} />,
 		);
 		expect(addLog).toHaveBeenCalledTimes(1);
+		expect(diffStepSnapshotsMock).toHaveBeenCalledTimes(1);
+		const diffContext = diffStepSnapshotsMock.mock.calls[0]?.[3];
+		expect(diffContext?.activePlayer.id).toBe('B');
 		const nextState = createSessionState(1);
 		rerender(<Harness session={session} state={nextState} addLog={addLog} />);
 		expect(addLog).toHaveBeenCalledTimes(1);
+		expect(diffStepSnapshotsMock).toHaveBeenCalledTimes(1);
 	});
 
 	it('logs again when a new session starts', () => {
+		diffStepSnapshotsMock.mockClear();
 		const addLog = vi.fn();
 		const session = createSession();
 		const state = createSessionState(1);
@@ -143,9 +152,15 @@ describe('useCompensationLogger', () => {
 			<Harness session={session} state={state} addLog={addLog} />,
 		);
 		expect(addLog).toHaveBeenCalledTimes(1);
+		expect(diffStepSnapshotsMock).toHaveBeenCalledTimes(1);
 		const newSession = createSession();
 		const newState = createSessionState(1);
 		rerender(<Harness session={newSession} state={newState} addLog={addLog} />);
 		expect(addLog).toHaveBeenCalledTimes(2);
+		expect(diffStepSnapshotsMock).toHaveBeenCalledTimes(2);
+		const firstContext = diffStepSnapshotsMock.mock.calls[0]?.[3];
+		const secondContext = diffStepSnapshotsMock.mock.calls[1]?.[3];
+		expect(firstContext?.activePlayer.id).toBe('B');
+		expect(secondContext?.activePlayer.id).toBe('B');
 	});
 });


### PR DESCRIPTION
## Summary
- sanitize the compensation logger diff context before generating log entries and ensure the active player matches the compensated player
- extend the compensation logger tests to assert the sanitized diff context and reuse the mocked diff output

## Text formatting audit (required)
1. **Translator/formatter reuse:** No translator or formatter changes were required; existing diff formatting utilities are reused exclusively.
2. **Canonical keywords/icons/helpers touched:** None – no player-facing keywords, icons, or helpers were modified.
3. **Voice review:** Not applicable; the change only adjusts logging internals and associated tests without altering player-facing copy.

## Standards compliance (required)
1. **File length limits respected:** `packages/web/src/state/useCompensationLogger.ts` (103 lines) and `packages/web/tests/state/useCompensationLogger.test.tsx` (166 lines) remain under the 250-line limit. 【F:packages/web/src/state/useCompensationLogger.ts†L1-L103】【F:packages/web/tests/state/useCompensationLogger.test.tsx†L1-L166】
2. **Line length limits respected:** `npm run lint` completed without max-line violations, confirming compliance. 【58a019†L1-L9】【e52c58†L1-L1】
3. **Domain separation upheld:** All updates are confined to the Web layer and its tests, leaving Engine, Content, and Protocol domains untouched. 【F:packages/web/src/state/useCompensationLogger.ts†L1-L103】【F:packages/web/tests/state/useCompensationLogger.test.tsx†L1-L166】
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint) succeeded after the changes. 【0f2aa7†L1-L10】【0d2069†L1-L5】【66e361†L1-L12】【bfb415†L1-L13】【d28d2f†L1-L1】
5. **Tests updated:** The compensation logger test suite now resets and inspects the mocked diff output, verifying the sanitized context. 【F:packages/web/tests/state/useCompensationLogger.test.tsx†L125-L165】
6. **Documentation updated:** Not required; the change only adjusts runtime logic and its tests without affecting documented behavior.
7. **`npm run check` results:** `npm run check` (PASS) – see command output above. 【0f2aa7†L1-L10】【0d2069†L1-L5】【66e361†L1-L12】【bfb415†L1-L13】【d28d2f†L1-L1】
8. **`npm run test:coverage` results:** Not run; coverage was not requested for this update.

## Testing
- `npm run lint` (PASS) 【58a019†L1-L9】【e52c58†L1-L1】
- `npm run check` (PASS) 【0f2aa7†L1-L10】【0d2069†L1-L5】【66e361†L1-L12】【bfb415†L1-L13】【d28d2f†L1-L1】
- `npx vitest run packages/web/tests/state/useCompensationLogger.test.tsx` (PASS) 【d8c676†L1-L15】

------
https://chatgpt.com/codex/tasks/task_e_68e640a96c0483259fd34907f8c4d4c3