### PR TITLE
Use EngineSession helpers for AI turns

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -25,6 +25,7 @@ export {
 	type PlayerStateSnapshot,
 	type LandSnapshot,
 	type RuleSnapshot,
+	type ActionDefinitionSummary,
 	type EngineSessionGetActionCosts,
 	type EngineSessionGetActionRequirements,
 	cloneEffectLogEntry,

--- a/packages/web/src/state/useAiRunner.ts
+++ b/packages/web/src/state/useAiRunner.ts
@@ -32,20 +32,18 @@ export function useAiRunner({
 		if (!phaseDefinition?.action) {
 			return;
 		}
-		const context = session.getLegacyContext();
-		const aiSystem = context.aiSystem;
 		const activeId = sessionState.game.activePlayerId;
-		if (!aiSystem?.has(activeId)) {
+		if (!session.hasAiController(activeId)) {
 			return;
 		}
 		void session.enqueue(async () => {
-			await aiSystem.run(activeId, context, {
+			const ranTurn = await session.runAiTurn(activeId, {
 				performAction: async (
 					actionId: string,
-					engineCtx,
+					_ignored: unknown,
 					params?: ActionParams<string>,
 				) => {
-					const definition = engineCtx.actions.get(actionId);
+					const definition = session.getActionDefinition(actionId);
 					if (!definition) {
 						throw new Error(`Unknown action ${String(actionId)} for AI`);
 					}
@@ -62,7 +60,7 @@ export function useAiRunner({
 					session.advancePhase();
 				},
 			});
-			if (!mountedRef.current) {
+			if (!ranTurn || !mountedRef.current) {
 				return;
 			}
 			setPhaseHistories({});

--- a/packages/web/tests/state/useCompensationLogger.test.tsx
+++ b/packages/web/tests/state/useCompensationLogger.test.tsx
@@ -25,6 +25,10 @@ const RESOURCE_KEYS: ResourceKey[] = ['gold' as ResourceKey];
 
 function createSession(): EngineSession {
 	return {
+		hasAiController: () => false,
+		getActionDefinition: () => undefined,
+		runAiTurn: vi.fn().mockResolvedValue(false),
+		advancePhase: vi.fn(),
 		getLegacyContext() {
 			return {
 				activePlayer: {

--- a/packages/web/tests/useNextTurnForecast.test.ts
+++ b/packages/web/tests/useNextTurnForecast.test.ts
@@ -33,7 +33,13 @@ vi.mock('@kingdom-builder/engine', async () => {
 });
 
 interface MockGameEngine {
-	session: { getLegacyContext: ReturnType<typeof vi.fn> };
+	session: {
+		getLegacyContext: ReturnType<typeof vi.fn>;
+		hasAiController: () => boolean;
+		getActionDefinition: () => undefined;
+		runAiTurn: ReturnType<typeof vi.fn>;
+		advancePhase: ReturnType<typeof vi.fn>;
+	};
 	sessionState: EngineSessionSnapshot;
 	resolution: null;
 	showResolution: ReturnType<typeof vi.fn>;
@@ -96,7 +102,13 @@ function createDelta(amount: number): PlayerSnapshotDeltaBucket {
 
 const contextStub = { context: true } as const;
 const engineValue: MockGameEngine = {
-	session: { getLegacyContext: vi.fn(() => contextStub) },
+	session: {
+		getLegacyContext: vi.fn(() => contextStub),
+		hasAiController: () => false,
+		getActionDefinition: () => undefined,
+		runAiTurn: vi.fn().mockResolvedValue(false),
+		advancePhase: vi.fn(),
+	},
 	sessionState: undefined as unknown as EngineSessionSnapshot,
 	resolution: null,
 	showResolution: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary
* Added `ActionDefinitionSummary` and new `EngineSession` helpers for retrieving action metadata and checking for AI controllers. 
* Updated the web AI runner to consume the new helpers instead of the legacy engine context when running turns.
* Extended session stubs in existing web tests to cover the new helper surface.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Not applicable; no translation or formatter changes were needed.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** Not applicable; no player-facing text changed.

## Standards compliance (required)
1. **File length limits respected:** All modified files remain under 250 lines (e.g., `useAiRunner.ts` is 79 lines and `session.ts` is 196 lines).
2. **Line length limits respected:** Linting confirms all lines stay within the configured 80-character limit.
3. **Domain separation upheld:** Engine changes only expose new session helpers while the web layer consumes the public API; no domain boundaries were crossed.
4. **Code standards satisfied:** `npm run lint` (PASS).【ccea2a†L1-L6】【8a1943†L1-L14】
5. **Tests updated:** Adjusted existing unit tests to stub the new session methods.【F:packages/web/tests/state/useCompensationLogger.test.tsx†L26-L61】【F:packages/web/tests/useNextTurnForecast.test.ts†L35-L116】
6. **Documentation updated:** Not required; no docs reference these internals.
7. **`npm run check` results:** `npm run check` (PASS).【4ff3e5†L1-L9】【20287e†L1-L5】
8. **`npm run test:coverage` results:** Not run; coverage suite was not required for this targeted change.

## Testing
* `npm run format` (PASS).【1c27c9†L1-L6】
* `npm run lint` (PASS).【ccea2a†L1-L6】【8a1943†L1-L14】
* `npm run check` (PASS).【4ff3e5†L1-L9】【20287e†L1-L5】

------
https://chatgpt.com/codex/tasks/task_e_68e640afbb888325b991f7edb708ac13