### PR TITLE
Add background audio mute toggle and settings fixes

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -15,6 +15,7 @@ export default function App() {
 		isDevMode,
 		isMusicEnabled,
 		isSoundEnabled,
+		isBackgroundAudioMuted,
 		startStandardGame,
 		startDeveloperGame,
 		openOverview,
@@ -23,6 +24,7 @@ export default function App() {
 		toggleDarkMode,
 		toggleMusic,
 		toggleSound,
+		toggleBackgroundAudioMute,
 	} = useAppNavigation();
 	const { playerName, hasStoredName, setPlayerName } = usePlayerIdentity();
 
@@ -46,6 +48,8 @@ export default function App() {
 					onToggleMusic={toggleMusic}
 					soundEnabled={isSoundEnabled}
 					onToggleSound={toggleSound}
+					backgroundAudioMuted={isBackgroundAudioMuted}
+					onToggleBackgroundAudioMute={toggleBackgroundAudioMute}
 					playerName={playerName}
 					onChangePlayerName={setPlayerName}
 				/>
@@ -65,6 +69,8 @@ export default function App() {
 					onToggleMusic={toggleMusic}
 					soundEnabled={isSoundEnabled}
 					onToggleSound={toggleSound}
+					backgroundAudioMuted={isBackgroundAudioMuted}
+					onToggleBackgroundAudioMute={toggleBackgroundAudioMute}
 					playerName={playerName}
 					onChangePlayerName={setPlayerName}
 					hasStoredName={hasStoredName}
@@ -75,7 +81,10 @@ export default function App() {
 
 	return (
 		<>
-			<BackgroundMusic enabled={isMusicEnabled} />
+			<BackgroundMusic
+				enabled={isMusicEnabled}
+				muteWhenBackground={isBackgroundAudioMuted}
+			/>
 			{screen}
 		</>
 	);

--- a/packages/web/src/Game.tsx
+++ b/packages/web/src/Game.tsx
@@ -1,221 +1,20 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { GameProvider, useGameEngine } from './state/GameContext';
-import PlayerPanel from './components/player/PlayerPanel';
-import HoverCard from './components/HoverCard';
-import ActionsPanel from './components/actions/ActionsPanel';
-import PhasePanel from './components/phases/PhasePanel';
-import LogPanel from './components/LogPanel';
-import Button from './components/common/Button';
-import TimeControl from './components/common/TimeControl';
-import Toaster from './components/common/Toaster';
-import ConfirmDialog from './components/common/ConfirmDialog';
-import SettingsDialog from './components/settings/SettingsDialog';
+import React from 'react';
+import GameLayout from './GameLayout';
+import { GameProvider } from './state/GameContext';
 
-function GameLayout() {
-	const {
-		ctx,
-		onExit,
-		darkMode,
-		onToggleDark,
-		musicEnabled,
-		onToggleMusic,
-		soundEnabled,
-		onToggleSound,
-		playerName,
-		onChangePlayerName,
-	} = useGameEngine();
-	const [isQuitDialogOpen, setQuitDialogOpen] = useState(false);
-	const [isSettingsOpen, setSettingsOpen] = useState(false);
-	const [isLogOpen, setLogOpen] = useState(false);
-	const requestQuit = useCallback(() => {
-		if (!onExit) {
-			return;
-		}
-		setQuitDialogOpen(true);
-	}, [onExit]);
-	const closeDialog = useCallback(() => {
-		setQuitDialogOpen(false);
-	}, []);
-	const toggleLog = useCallback(() => {
-		setLogOpen((prev) => !prev);
-	}, []);
-	const closeLog = useCallback(() => {
-		setLogOpen(false);
-	}, []);
-	const confirmExit = useCallback(() => {
-		if (!onExit) {
-			return;
-		}
-		setQuitDialogOpen(false);
-		onExit();
-	}, [onExit]);
-	const playerAreaRef = useRef<HTMLElement | null>(null);
-	const [phasePanelHeight, setPhasePanelHeight] = useState(320);
-	useEffect(() => {
-		const node = playerAreaRef.current;
-		if (!node) {
-			return;
-		}
-
-		let frame = 0;
-		const updateHeight = () => {
-			if (!playerAreaRef.current) {
-				return;
-			}
-			const { height } = playerAreaRef.current.getBoundingClientRect();
-			setPhasePanelHeight((prev) => {
-				const nextHeight = Math.max(320, Math.ceil(height));
-				if (prev === nextHeight) {
-					return prev;
-				}
-				return nextHeight;
-			});
-		};
-
-		updateHeight();
-
-		if (typeof ResizeObserver === 'undefined') {
-			window.addEventListener('resize', updateHeight);
-			return () => {
-				window.removeEventListener('resize', updateHeight);
-			};
-		}
-
-		const observer = new ResizeObserver(() => {
-			frame = window.requestAnimationFrame(updateHeight);
-		});
-
-		observer.observe(node);
-
-		return () => {
-			observer.disconnect();
-			if (frame) {
-				window.cancelAnimationFrame(frame);
-			}
-		};
-	}, [ctx.game.players.length]);
-	const playerPanels = ctx.game.players.map((player, index) => {
-		const isActive = player.id === ctx.activePlayer.id;
-		const sideClass = index === 0 ? 'pr-6' : 'pl-6';
-		const colorClass =
-			index === 0
-				? isActive
-					? 'player-bg-blue-active'
-					: 'player-bg-blue'
-				: isActive
-					? 'player-bg-red-active'
-					: 'player-bg-red';
-		const bgClass = [
-			'player-bg',
-			sideClass,
-			colorClass,
-			isActive ? 'player-bg-animated' : null,
-		]
-			.filter(Boolean)
-			.join(' ');
-		return (
-			<PlayerPanel
-				key={player.id}
-				player={player}
-				className={`grow basis-[calc(50%-1rem)] max-w-[calc(50%-1rem)] p-4 ${bgClass}`}
-				isActive={isActive}
-			/>
-		);
-	});
-	const phasePanelElement = (
-		<div className="w-full lg:col-start-2">
-			<PhasePanel height={phasePanelHeight} />
-		</div>
-	);
-	const logButton = (
-		<Button
-			onClick={toggleLog}
-			variant="secondary"
-			icon="📜"
-			aria-pressed={isLogOpen}
-			aria-expanded={isLogOpen}
-			aria-controls="game-log-panel"
-		>
-			Log
-		</Button>
-	);
-	const settingsButton = (
-		<Button onClick={() => setSettingsOpen(true)} variant="secondary" icon="⚙️">
-			Settings
-		</Button>
-	);
-	const quitButton = (
-		<Button onClick={requestQuit} variant="danger" icon="🏳️">
-			Quit Game
-		</Button>
-	);
-	return (
-		<div className="relative min-h-screen w-full overflow-hidden bg-gradient-to-br from-amber-100 via-rose-100 to-sky-100 text-slate-900 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 dark:text-slate-100">
-			<SettingsDialog
-				open={isSettingsOpen}
-				onClose={() => setSettingsOpen(false)}
-				darkMode={darkMode}
-				onToggleDark={onToggleDark}
-				musicEnabled={musicEnabled}
-				onToggleMusic={onToggleMusic}
-				soundEnabled={soundEnabled}
-				onToggleSound={onToggleSound}
-				playerName={playerName}
-				onChangePlayerName={onChangePlayerName}
-			/>
-			<ConfirmDialog
-				open={isQuitDialogOpen}
-				title="Leave the battlefield?"
-				description="If you quit now, the current game will end and any progress will be lost. Are you sure you want to retreat?"
-				confirmLabel="Quit game"
-				cancelLabel="Continue playing"
-				onCancel={closeDialog}
-				onConfirm={confirmExit}
-			/>
-			<Toaster />
-			<div className="pointer-events-none absolute inset-0">
-				<div className="absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-amber-300/30 blur-3xl dark:bg-amber-500/20" />
-				<div className="absolute -bottom-28 -left-16 h-80 w-80 rounded-full bg-sky-300/30 blur-3xl dark:bg-sky-500/20" />
-				<div className="absolute top-1/4 right-0 h-72 w-72 translate-x-1/3 rounded-full bg-rose-300/30 blur-3xl dark:bg-rose-500/20" />
-				<div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.55),_rgba(255,255,255,0)_55%)] dark:bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.6),_rgba(15,23,42,0)_60%)]" />
-			</div>
-
-			<div className="relative z-10 flex min-h-screen flex-col gap-8 px-4 py-8 sm:px-8 lg:px-12">
-				<div className="flex items-center justify-between rounded-3xl border border-white/50 bg-white/70 px-6 py-4 shadow-xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/40 frosted-surface">
-					<h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
-						Kingdom Builder
-					</h1>
-					{onExit && (
-						<div className="ml-4 flex items-center gap-3">
-							{logButton}
-							<TimeControl />
-							{settingsButton}
-							{quitButton}
-						</div>
-					)}
-				</div>
-
-				<div className="grid grid-cols-1 gap-y-8 gap-x-6 lg:grid-cols-[minmax(0,1fr)_30rem]">
-					<section
-						ref={playerAreaRef}
-						className="relative flex min-h-[275px] items-stretch rounded-3xl border border-white/60 bg-white/80 p-6 shadow-2xl dark:border-white/10 dark:bg-slate-900/75 dark:shadow-slate-900/50 frosted-surface"
-					>
-						<div className="flex flex-1 items-stretch gap-6">
-							{playerPanels}
-						</div>
-					</section>
-					{phasePanelElement}
-					<div className="lg:col-start-1 lg:row-start-2">
-						<ActionsPanel />
-					</div>
-					<div className="lg:col-start-2 lg:row-start-2">
-						<HoverCard />
-					</div>
-				</div>
-				<LogPanel isOpen={isLogOpen} onClose={closeLog} />
-			</div>
-		</div>
-	);
+interface GameProps {
+	onExit?: () => void;
+	darkMode?: boolean;
+	onToggleDark?: () => void;
+	devMode?: boolean;
+	musicEnabled?: boolean;
+	onToggleMusic?: () => void;
+	soundEnabled?: boolean;
+	onToggleSound?: () => void;
+	backgroundAudioMuted?: boolean;
+	onToggleBackgroundAudioMute?: () => void;
+	playerName: string;
+	onChangePlayerName: (name: string) => void;
 }
 
 export default function Game({
@@ -227,20 +26,11 @@ export default function Game({
 	onToggleMusic = () => {},
 	soundEnabled = true,
 	onToggleSound = () => {},
+	backgroundAudioMuted = true,
+	onToggleBackgroundAudioMute = () => {},
 	playerName,
 	onChangePlayerName,
-}: {
-	onExit?: () => void;
-	darkMode?: boolean;
-	onToggleDark?: () => void;
-	devMode?: boolean;
-	musicEnabled?: boolean;
-	onToggleMusic?: () => void;
-	soundEnabled?: boolean;
-	onToggleSound?: () => void;
-	playerName: string;
-	onChangePlayerName: (name: string) => void;
-}) {
+}: GameProps) {
 	return (
 		<GameProvider
 			{...(onExit ? { onExit } : {})}
@@ -251,6 +41,8 @@ export default function Game({
 			onToggleMusic={onToggleMusic}
 			soundEnabled={soundEnabled}
 			onToggleSound={onToggleSound}
+			backgroundAudioMuted={backgroundAudioMuted}
+			onToggleBackgroundAudioMute={onToggleBackgroundAudioMute}
 			playerName={playerName}
 			onChangePlayerName={onChangePlayerName}
 		>

--- a/packages/web/src/GameLayout.tsx
+++ b/packages/web/src/GameLayout.tsx
@@ -1,0 +1,223 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Button from './components/common/Button';
+import ConfirmDialog from './components/common/ConfirmDialog';
+import TimeControl from './components/common/TimeControl';
+import Toaster from './components/common/Toaster';
+import ActionsPanel from './components/actions/ActionsPanel';
+import HoverCard from './components/HoverCard';
+import LogPanel from './components/LogPanel';
+import PhasePanel from './components/phases/PhasePanel';
+import PlayerPanel from './components/player/PlayerPanel';
+import SettingsDialog from './components/settings/SettingsDialog';
+import { useGameEngine } from './state/GameContext';
+
+export default function GameLayout() {
+	const {
+		ctx,
+		onExit,
+		darkMode,
+		onToggleDark,
+		musicEnabled,
+		onToggleMusic,
+		soundEnabled,
+		onToggleSound,
+		backgroundAudioMuted,
+		onToggleBackgroundAudioMute,
+		playerName,
+		onChangePlayerName,
+	} = useGameEngine();
+	const [isQuitDialogOpen, setQuitDialogOpen] = useState(false);
+	const [isSettingsOpen, setSettingsOpen] = useState(false);
+	const [isLogOpen, setLogOpen] = useState(false);
+	const requestQuit = useCallback(() => {
+		if (!onExit) {
+			return;
+		}
+		setQuitDialogOpen(true);
+	}, [onExit]);
+	const closeDialog = useCallback(() => {
+		setQuitDialogOpen(false);
+	}, []);
+	const toggleLog = useCallback(() => {
+		setLogOpen((prev) => !prev);
+	}, []);
+	const closeLog = useCallback(() => {
+		setLogOpen(false);
+	}, []);
+	const confirmExit = useCallback(() => {
+		if (!onExit) {
+			return;
+		}
+		setQuitDialogOpen(false);
+		onExit();
+	}, [onExit]);
+	const playerAreaRef = useRef<HTMLElement | null>(null);
+	const [phasePanelHeight, setPhasePanelHeight] = useState(320);
+	useEffect(() => {
+		const node = playerAreaRef.current;
+		if (!node) {
+			return;
+		}
+
+		let frame = 0;
+		const updateHeight = () => {
+			if (!playerAreaRef.current) {
+				return;
+			}
+			const { height } = playerAreaRef.current.getBoundingClientRect();
+			setPhasePanelHeight((prev) => {
+				const nextHeight = Math.max(320, Math.ceil(height));
+				if (prev === nextHeight) {
+					return prev;
+				}
+				return nextHeight;
+			});
+		};
+
+		updateHeight();
+
+		if (typeof ResizeObserver === 'undefined') {
+			window.addEventListener('resize', updateHeight);
+			return () => {
+				window.removeEventListener('resize', updateHeight);
+			};
+		}
+
+		const observer = new ResizeObserver(() => {
+			frame = window.requestAnimationFrame(updateHeight);
+		});
+
+		observer.observe(node);
+
+		return () => {
+			observer.disconnect();
+			if (frame) {
+				window.cancelAnimationFrame(frame);
+			}
+		};
+	}, [ctx.game.players.length]);
+	const playerPanels = ctx.game.players.map((player, index) => {
+		const isActive = player.id === ctx.activePlayer.id;
+		const sideClass = index === 0 ? 'pr-6' : 'pl-6';
+		const colorClass =
+			index === 0
+				? isActive
+					? 'player-bg-blue-active'
+					: 'player-bg-blue'
+				: isActive
+					? 'player-bg-red-active'
+					: 'player-bg-red';
+		const bgClass = [
+			'player-bg',
+			sideClass,
+			colorClass,
+			isActive ? 'player-bg-animated' : null,
+		]
+			.filter(Boolean)
+			.join(' ');
+		return (
+			<PlayerPanel
+				key={player.id}
+				player={player}
+				className={`grow basis-[calc(50%-1rem)] max-w-[calc(50%-1rem)] p-4 ${bgClass}`}
+				isActive={isActive}
+			/>
+		);
+	});
+	const phasePanelElement = (
+		<div className="w-full lg:col-start-2">
+			<PhasePanel height={phasePanelHeight} />
+		</div>
+	);
+	const logButton = (
+		<Button
+			onClick={toggleLog}
+			variant="secondary"
+			icon="📜"
+			aria-pressed={isLogOpen}
+			aria-expanded={isLogOpen}
+			aria-controls="game-log-panel"
+		>
+			Log
+		</Button>
+	);
+	const settingsButton = (
+		<Button onClick={() => setSettingsOpen(true)} variant="secondary" icon="⚙️">
+			Settings
+		</Button>
+	);
+	const quitButton = (
+		<Button onClick={requestQuit} variant="danger" icon="🏳️">
+			Quit Game
+		</Button>
+	);
+	return (
+		<div className="relative min-h-screen w-full overflow-hidden bg-gradient-to-br from-amber-100 via-rose-100 to-sky-100 text-slate-900 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 dark:text-slate-100">
+			<SettingsDialog
+				open={isSettingsOpen}
+				onClose={() => setSettingsOpen(false)}
+				darkMode={darkMode}
+				onToggleDark={onToggleDark}
+				musicEnabled={musicEnabled}
+				onToggleMusic={onToggleMusic}
+				soundEnabled={soundEnabled}
+				onToggleSound={onToggleSound}
+				backgroundAudioMuted={backgroundAudioMuted}
+				onToggleBackgroundAudioMute={onToggleBackgroundAudioMute}
+				playerName={playerName}
+				onChangePlayerName={onChangePlayerName}
+			/>
+			<ConfirmDialog
+				open={isQuitDialogOpen}
+				title="Leave the battlefield?"
+				description="If you quit now, the current game will end and any progress will be lost. Are you sure you want to retreat?"
+				confirmLabel="Quit game"
+				cancelLabel="Continue playing"
+				onCancel={closeDialog}
+				onConfirm={confirmExit}
+			/>
+			<Toaster />
+			<div className="pointer-events-none absolute inset-0">
+				<div className="absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-amber-300/30 blur-3xl dark:bg-amber-500/20" />
+				<div className="absolute -bottom-28 -left-16 h-80 w-80 rounded-full bg-sky-300/30 blur-3xl dark:bg-sky-500/20" />
+				<div className="absolute top-1/4 right-0 h-72 w-72 translate-x-1/3 rounded-full bg-rose-300/30 blur-3xl dark:bg-rose-500/20" />
+				<div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.55),_rgba(255,255,255,0)_55%)] dark:bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.6),_rgba(15,23,42,0)_60%)]" />
+			</div>
+
+			<div className="relative z-10 flex min-h-screen flex-col gap-8 px-4 py-8 sm:px-8 lg:px-12">
+				<div className="flex items-center justify-between rounded-3xl border border-white/50 bg-white/70 px-6 py-4 shadow-xl dark:border-white/10 dark:bg-slate-900/70 dark:shadow-slate-900/40 frosted-surface">
+					<h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+						Kingdom Builder
+					</h1>
+					{onExit && (
+						<div className="ml-4 flex items-center gap-3">
+							{logButton}
+							<TimeControl />
+							{settingsButton}
+							{quitButton}
+						</div>
+					)}
+				</div>
+
+				<div className="grid grid-cols-1 gap-y-8 gap-x-6 lg:grid-cols-[minmax(0,1fr)_30rem]">
+					<section
+						ref={playerAreaRef}
+						className="relative flex min-h-[275px] items-stretch rounded-3xl border border-white/60 bg-white/80 p-6 shadow-2xl dark:border-white/10 dark:bg-slate-900/75 dark:shadow-slate-900/50 frosted-surface"
+					>
+						<div className="flex flex-1 items-stretch gap-6">
+							{playerPanels}
+						</div>
+					</section>
+					{phasePanelElement}
+					<div className="lg:col-start-1 lg:row-start-2">
+						<ActionsPanel />
+					</div>
+					<div className="lg:col-start-2 lg:row-start-2">
+						<HoverCard />
+					</div>
+				</div>
+				<LogPanel isOpen={isLogOpen} onClose={closeLog} />
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/Menu.tsx
+++ b/packages/web/src/Menu.tsx
@@ -20,6 +20,8 @@ interface MenuProps {
 	onToggleMusic: () => void;
 	soundEnabled: boolean;
 	onToggleSound: () => void;
+	backgroundAudioMuted: boolean;
+	onToggleBackgroundAudioMute: () => void;
 	playerName: string;
 	onChangePlayerName: (name: string) => void;
 	hasStoredName: boolean;
@@ -36,6 +38,8 @@ export default function Menu({
 	onToggleMusic,
 	soundEnabled,
 	onToggleSound,
+	backgroundAudioMuted,
+	onToggleBackgroundAudioMute,
 	playerName,
 	onChangePlayerName,
 	hasStoredName,
@@ -70,6 +74,8 @@ export default function Menu({
 				onToggleMusic={onToggleMusic}
 				soundEnabled={soundEnabled}
 				onToggleSound={onToggleSound}
+				backgroundAudioMuted={backgroundAudioMuted}
+				onToggleBackgroundAudioMute={onToggleBackgroundAudioMute}
 				playerName={playerName}
 				onChangePlayerName={onChangePlayerName}
 			/>

--- a/packages/web/src/components/settings/PlayerNameSetting.tsx
+++ b/packages/web/src/components/settings/PlayerNameSetting.tsx
@@ -6,7 +6,7 @@ import {
 	useState,
 } from 'react';
 import Button from '../common/Button';
-import { useGameEngine } from '../../state/GameContext';
+import { useOptionalGameEngine } from '../../state/GameContext';
 
 const INPUT_FORM_CLASS = [
 	'flex flex-col gap-4 rounded-2xl border border-white/20 bg-white/85 px-6 py-5',
@@ -56,7 +56,8 @@ export function PlayerNameSetting({
 	playerName,
 	onSave,
 }: PlayerNameSettingProps) {
-	const { pushSuccessToast } = useGameEngine();
+	const gameEngine = useOptionalGameEngine();
+	const pushSuccessToast = gameEngine?.pushSuccessToast;
 	const inputId = useId();
 	const labelId = `${inputId}-label`;
 	const [draftName, setDraftName] = useState(playerName);
@@ -93,7 +94,7 @@ export function PlayerNameSetting({
 		onSave(trimmed);
 		setStatus('success');
 		setMessage('Name updated.');
-		pushSuccessToast('Your title now echoes across the realm.', 'Name saved');
+		pushSuccessToast?.('Your title now echoes across the realm.', 'Name saved');
 	};
 
 	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {

--- a/packages/web/src/components/settings/SettingsDialog.tsx
+++ b/packages/web/src/components/settings/SettingsDialog.tsx
@@ -44,6 +44,8 @@ interface SettingsDialogProps {
 	onToggleMusic: () => void;
 	soundEnabled: boolean;
 	onToggleSound: () => void;
+	backgroundAudioMuted: boolean;
+	onToggleBackgroundAudioMute: () => void;
 	playerName: string;
 	onChangePlayerName: (name: string) => void;
 }
@@ -89,6 +91,8 @@ export default function SettingsDialog({
 	onToggleMusic,
 	soundEnabled,
 	onToggleSound,
+	backgroundAudioMuted,
+	onToggleBackgroundAudioMute,
 	playerName,
 	onChangePlayerName,
 }: SettingsDialogProps) {
@@ -146,9 +150,16 @@ export default function SettingsDialog({
 					<SettingRow
 						id="settings-sound"
 						title="Game sounds"
-						description={'Toggle sound effects. (Coming soon)'}
+						description="Toggle sound effects."
 						checked={soundEnabled}
 						onToggle={onToggleSound}
+					/>
+					<SettingRow
+						id="settings-background-mute"
+						title="Mute in background"
+						description="Pause audio when you switch tabs or windows."
+						checked={backgroundAudioMuted}
+						onToggle={onToggleBackgroundAudioMute}
 					/>
 					<SettingRow
 						id="settings-theme"

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -56,6 +56,8 @@ export function GameProvider({
 	onToggleMusic = () => {},
 	soundEnabled = true,
 	onToggleSound = () => {},
+	backgroundAudioMuted = true,
+	onToggleBackgroundAudioMute = () => {},
 	playerName = DEFAULT_PLAYER_NAME,
 	onChangePlayerName = () => {},
 }: {
@@ -68,6 +70,8 @@ export function GameProvider({
 	onToggleMusic?: () => void;
 	soundEnabled?: boolean;
 	onToggleSound?: () => void;
+	backgroundAudioMuted?: boolean;
+	onToggleBackgroundAudioMute?: () => void;
 	playerName?: string;
 	onChangePlayerName?: (name: string) => void;
 }) {
@@ -282,6 +286,8 @@ export function GameProvider({
 		onToggleMusic,
 		soundEnabled,
 		onToggleSound,
+		backgroundAudioMuted,
+		onToggleBackgroundAudioMute,
 		timeScale,
 		setTimeScale,
 		toasts,
@@ -308,3 +314,6 @@ export const useGameEngine = (): GameEngineContextValue => {
 	}
 	return value;
 };
+
+export const useOptionalGameEngine = (): GameEngineContextValue | null =>
+	useContext(GameEngineContext);

--- a/packages/web/src/state/GameContext.types.ts
+++ b/packages/web/src/state/GameContext.types.ts
@@ -53,6 +53,8 @@ export interface GameEngineContextValue {
 	onToggleMusic: () => void;
 	soundEnabled: boolean;
 	onToggleSound: () => void;
+	backgroundAudioMuted: boolean;
+	onToggleBackgroundAudioMute: () => void;
 	timeScale: TimeScale;
 	setTimeScale: (value: TimeScale) => void;
 	toasts: Toast[];

--- a/packages/web/src/state/appHistory.ts
+++ b/packages/web/src/state/appHistory.ts
@@ -30,4 +30,5 @@ export interface HistoryState {
 	isDevModeEnabled: boolean;
 	isMusicEnabled: boolean;
 	isSoundEnabled: boolean;
+	isBackgroundAudioMuted: boolean;
 }

--- a/packages/web/src/state/appNavigationState.ts
+++ b/packages/web/src/state/appNavigationState.ts
@@ -7,6 +7,7 @@ export interface AppNavigationState {
 	isDevMode: boolean;
 	isMusicEnabled: boolean;
 	isSoundEnabled: boolean;
+	isBackgroundAudioMuted: boolean;
 	startStandardGame: () => void;
 	startDeveloperGame: () => void;
 	openOverview: () => void;
@@ -15,4 +16,5 @@ export interface AppNavigationState {
 	toggleDarkMode: () => void;
 	toggleMusic: () => void;
 	toggleSound: () => void;
+	toggleBackgroundAudioMute: () => void;
 }

--- a/packages/web/src/state/audioPreferences.ts
+++ b/packages/web/src/state/audioPreferences.ts
@@ -4,6 +4,8 @@ export const MUSIC_PREFERENCE_STORAGE_KEY =
 	'kingdom-builder.preferences.musicEnabled';
 export const SOUND_PREFERENCE_STORAGE_KEY =
 	'kingdom-builder.preferences.soundEnabled';
+export const BACKGROUND_AUDIO_MUTE_STORAGE_KEY =
+	'kingdom-builder.preferences.backgroundAudioMuted';
 
 type PreferenceUpdater = boolean | ((previousValue: boolean) => boolean);
 
@@ -67,10 +69,15 @@ function useStoredBooleanPreference(
 export function getStoredAudioPreferences(): {
 	music: boolean;
 	sound: boolean;
+	backgroundMute: boolean;
 } {
 	return {
 		music: readBooleanPreference(MUSIC_PREFERENCE_STORAGE_KEY, true),
 		sound: readBooleanPreference(SOUND_PREFERENCE_STORAGE_KEY, true),
+		backgroundMute: readBooleanPreference(
+			BACKGROUND_AUDIO_MUTE_STORAGE_KEY,
+			true,
+		),
 	};
 }
 
@@ -83,11 +90,15 @@ export function useAudioPreferences() {
 		SOUND_PREFERENCE_STORAGE_KEY,
 		true,
 	);
+	const [isBackgroundAudioMuted, setIsBackgroundAudioMuted] =
+		useStoredBooleanPreference(BACKGROUND_AUDIO_MUTE_STORAGE_KEY, true);
 
 	return {
 		isMusicEnabled,
 		setIsMusicEnabled,
 		isSoundEnabled,
 		setIsSoundEnabled,
+		isBackgroundAudioMuted,
+		setIsBackgroundAudioMuted,
 	} as const;
 }

--- a/packages/web/src/state/useAppNavigation.ts
+++ b/packages/web/src/state/useAppNavigation.ts
@@ -10,6 +10,7 @@ import {
 	useAudioPreferences,
 } from './audioPreferences';
 import type { AppNavigationState } from './appNavigationState';
+import { useAudioPreferenceToggles } from './useAudioPreferenceToggles';
 
 export function useAppNavigation(): AppNavigationState {
 	const [currentScreen, setCurrentScreen] = useState<Screen>(Screen.Menu);
@@ -21,6 +22,8 @@ export function useAppNavigation(): AppNavigationState {
 		setIsMusicEnabled,
 		isSoundEnabled,
 		setIsSoundEnabled,
+		isBackgroundAudioMuted,
+		setIsBackgroundAudioMuted,
 	} = useAudioPreferences();
 	const buildHistoryState = useCallback(
 		(overrides?: Partial<HistoryState>): HistoryState => {
@@ -31,11 +34,14 @@ export function useAppNavigation(): AppNavigationState {
 				isDevModeEnabled: overrideDev,
 				isMusicEnabled: overrideMusic,
 				isSoundEnabled: overrideSound,
+				isBackgroundAudioMuted: overrideBackgroundMute,
 			} = overrides ?? {};
 			const nextDarkMode = overrideDark ?? isDarkMode;
 			const nextDevMode = overrideDev ?? isDevMode;
 			const nextMusic = overrideMusic ?? isMusicEnabled;
 			const nextSound = overrideSound ?? isSoundEnabled;
+			const nextBackgroundMute =
+				overrideBackgroundMute ?? isBackgroundAudioMuted;
 
 			return {
 				screen: nextScreen,
@@ -44,6 +50,7 @@ export function useAppNavigation(): AppNavigationState {
 				isDevModeEnabled: nextDevMode,
 				isMusicEnabled: nextMusic,
 				isSoundEnabled: nextSound,
+				isBackgroundAudioMuted: nextBackgroundMute,
 			};
 		},
 		[
@@ -53,11 +60,12 @@ export function useAppNavigation(): AppNavigationState {
 			isDevMode,
 			isMusicEnabled,
 			isSoundEnabled,
+			isBackgroundAudioMuted,
 		],
 	);
 	const applyHistoryState = useCallback(
 		(state: HistoryState | null, fallbackScreen: Screen): HistoryState => {
-			const { music, sound } = getStoredAudioPreferences();
+			const { music, sound, backgroundMute } = getStoredAudioPreferences();
 			const nextState: HistoryState = {
 				screen: state?.screen ?? fallbackScreen,
 				gameKey: state?.gameKey ?? 0,
@@ -65,6 +73,7 @@ export function useAppNavigation(): AppNavigationState {
 				isDevModeEnabled: state?.isDevModeEnabled ?? false,
 				isMusicEnabled: state?.isMusicEnabled ?? music,
 				isSoundEnabled: state?.isSoundEnabled ?? sound,
+				isBackgroundAudioMuted: state?.isBackgroundAudioMuted ?? backgroundMute,
 			};
 
 			setCurrentScreen(nextState.screen);
@@ -73,6 +82,7 @@ export function useAppNavigation(): AppNavigationState {
 			setIsDevMode(nextState.isDevModeEnabled);
 			setIsMusicEnabled(nextState.isMusicEnabled);
 			setIsSoundEnabled(nextState.isSoundEnabled);
+			setIsBackgroundAudioMuted(nextState.isBackgroundAudioMuted);
 
 			return nextState;
 		},
@@ -83,6 +93,7 @@ export function useAppNavigation(): AppNavigationState {
 			setIsDevMode,
 			setIsMusicEnabled,
 			setIsSoundEnabled,
+			setIsBackgroundAudioMuted,
 		],
 	);
 	const pushHistoryState = useCallback(
@@ -201,29 +212,12 @@ export function useAppNavigation(): AppNavigationState {
 		pushHistoryState(tutorialState, SCREEN_PATHS[Screen.Tutorial]);
 	}, [buildHistoryState, pushHistoryState]);
 
-	const toggleMusic = useCallback(() => {
-		setIsMusicEnabled((previousValue) => {
-			const nextValue = !previousValue;
-			replaceHistoryState(
-				buildHistoryState({
-					isMusicEnabled: nextValue,
-				}),
-			);
-			return nextValue;
+	const { toggleMusic, toggleSound, toggleBackgroundAudioMute } =
+		useAudioPreferenceToggles(buildHistoryState, replaceHistoryState, {
+			setIsMusicEnabled,
+			setIsSoundEnabled,
+			setIsBackgroundAudioMuted,
 		});
-	}, [buildHistoryState, replaceHistoryState, setIsMusicEnabled]);
-
-	const toggleSound = useCallback(() => {
-		setIsSoundEnabled((previousValue) => {
-			const nextValue = !previousValue;
-			replaceHistoryState(
-				buildHistoryState({
-					isSoundEnabled: nextValue,
-				}),
-			);
-			return nextValue;
-		});
-	}, [buildHistoryState, replaceHistoryState, setIsSoundEnabled]);
 
 	return {
 		currentScreen,
@@ -232,6 +226,7 @@ export function useAppNavigation(): AppNavigationState {
 		isDevMode,
 		isMusicEnabled,
 		isSoundEnabled,
+		isBackgroundAudioMuted,
 		startStandardGame,
 		startDeveloperGame,
 		openOverview,
@@ -240,5 +235,6 @@ export function useAppNavigation(): AppNavigationState {
 		toggleDarkMode,
 		toggleMusic,
 		toggleSound,
+		toggleBackgroundAudioMute,
 	};
 }

--- a/packages/web/src/state/useAudioPreferenceToggles.ts
+++ b/packages/web/src/state/useAudioPreferenceToggles.ts
@@ -1,0 +1,65 @@
+import { useCallback, useMemo } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { HistoryState } from './appHistory';
+
+type AudioHistoryKey =
+	| 'isMusicEnabled'
+	| 'isSoundEnabled'
+	| 'isBackgroundAudioMuted';
+
+interface PreferenceSetters {
+	setIsMusicEnabled: Dispatch<SetStateAction<boolean>>;
+	setIsSoundEnabled: Dispatch<SetStateAction<boolean>>;
+	setIsBackgroundAudioMuted: Dispatch<SetStateAction<boolean>>;
+}
+
+type BuildHistoryState = (overrides?: Partial<HistoryState>) => HistoryState;
+type ReplaceHistoryState = (nextState: HistoryState, path?: string) => void;
+
+export function useAudioPreferenceToggles(
+	buildHistoryState: BuildHistoryState,
+	replaceHistoryState: ReplaceHistoryState,
+	{
+		setIsMusicEnabled,
+		setIsSoundEnabled,
+		setIsBackgroundAudioMuted,
+	}: PreferenceSetters,
+) {
+	const createPreferenceToggle = useCallback(
+		(setter: Dispatch<SetStateAction<boolean>>, key: AudioHistoryKey) => {
+			return () => {
+				setter((previousValue) => {
+					const nextValue = !previousValue;
+					replaceHistoryState(
+						buildHistoryState({
+							[key]: nextValue,
+						}),
+					);
+					return nextValue;
+				});
+			};
+		},
+		[buildHistoryState, replaceHistoryState],
+	);
+
+	const toggleMusic = useMemo(
+		() => createPreferenceToggle(setIsMusicEnabled, 'isMusicEnabled'),
+		[createPreferenceToggle, setIsMusicEnabled],
+	);
+
+	const toggleSound = useMemo(
+		() => createPreferenceToggle(setIsSoundEnabled, 'isSoundEnabled'),
+		[createPreferenceToggle, setIsSoundEnabled],
+	);
+
+	const toggleBackgroundAudioMute = useMemo(
+		() =>
+			createPreferenceToggle(
+				setIsBackgroundAudioMuted,
+				'isBackgroundAudioMuted',
+			),
+		[createPreferenceToggle, setIsBackgroundAudioMuted],
+	);
+
+	return { toggleMusic, toggleSound, toggleBackgroundAudioMute } as const;
+}


### PR DESCRIPTION
## Summary
- Persist a background audio mute preference and thread it through app navigation, menu, and game providers so the toggle is available on every screen.
- Split the in-game layout into its own component, exposing the new preference alongside existing settings.
- Update the background music player to pause when the preference hides the tab and ensure player-name toasts remain optional outside the game provider.

## Text formatting audit (required)
- [x] Linked the translator(s)/formatter(s) reused, referencing Sections 2–3.
- [x] Listed every canonical keyword/icon/helper touched from Section 4.
- [x] Confirmed Summary/Description/Log voices were audited for affected UI.
1. **Translator/formatter reuse:** N/A — updated existing settings copy without touching translator files.
2. **Canonical keywords/icons/helpers touched:** None — reused existing settings terminology.
3. **Voice review:** Confirmed the new toggle label and description match existing Settings dialog tone.

## Standards compliance (required)
1. **File length limits respected:** New and modified files remain below 250 lines (e.g., `GameLayout.tsx` 223 lines, `useAppNavigation.ts` 243 lines). 【F:packages/web/src/GameLayout.tsx†L1-L223】【e405a9†L1-L2】
2. **Line length limits respected:** Ran `npm run format` to enforce Prettier’s 80-character limit. 【6ec0d6†L1-L5】
3. **Domain separation upheld:** Changes are confined to the web client; engine/content code was untouched. 【F:packages/web/src/App.tsx†L1-L91】【F:packages/web/src/state/audioPreferences.ts†L1-L104】
4. **Code standards satisfied:** `npm run lint` completed without errors. 【6b804e†L1-L9】
5. **Tests updated:** No new tests were required; existing settings coverage already exercises dialog state changes.
6. **Documentation updated:** Not needed; the UI change is self-explanatory and matches existing patterns.
7. **`npm run check` results:** PASS — see combined format/typecheck/lint run. 【351ca8†L1-L10】【db0f1d†L1-L12】
8. **`npm run test:coverage` results:** Not run; full coverage was not required for this UI preference tweak.

## Testing
- `npm run format` 【6ec0d6†L1-L5】
- `npm run lint` 【6b804e†L1-L9】
- `npm run check` 【351ca8†L1-L10】

------
https://chatgpt.com/codex/tasks/task_e_68e63ff8575c8325a0ad2a8a351a9c2a