### PR TITLE
Refine requirement icon sourcing for translation context

### DIFF
--- a/packages/web/src/components/actions/BuildOptions.tsx
+++ b/packages/web/src/components/actions/BuildOptions.tsx
@@ -41,14 +41,15 @@ export default function BuildOptions({
 	const listRef = useAnimate<HTMLDivElement>();
 	const {
 		ctx,
+		translationContext,
 		handlePerform,
 		handleHoverCard,
 		clearHoverCard,
 		actionCostResource,
 	} = useGameEngine();
 	const requirementIcons = useMemo(
-		() => getRequirementIcons(action.id, ctx),
-		[action.id, ctx],
+		() => getRequirementIcons(action.id, translationContext),
+		[action.id, translationContext],
 	);
 	const entries = useMemo(() => {
 		const owned = player.buildings;

--- a/packages/web/src/components/actions/GenericActionCard.tsx
+++ b/packages/web/src/components/actions/GenericActionCard.tsx
@@ -70,7 +70,7 @@ function GenericActionCard({
 	const requirements = getActionRequirements(action.id, context).map(
 		formatRequirement,
 	);
-	const requirementIcons = getRequirementIcons(action.id, context);
+	const requirementIcons = getRequirementIcons(action.id, translationContext);
 	const canPay = Object.entries(costs).every(
 		([resourceKey, cost]) =>
 			(player.resources[resourceKey] || 0) >= (cost ?? 0),
@@ -118,7 +118,7 @@ function GenericActionCard({
 		handleHoverCard,
 		hoverBackground,
 	});
-	const rawAction = context.actions.get(action.id);
+	const rawAction = translationContext.actions.get(action.id);
 	let actionIcon = '';
 	let actionFocus: Action['focus'] | undefined;
 	if (rawAction && typeof rawAction === 'object') {

--- a/packages/web/src/components/actions/RaisePopOptions.tsx
+++ b/packages/web/src/components/actions/RaisePopOptions.tsx
@@ -51,8 +51,8 @@ export default function RaisePopOptions({
 		[ctx.actions, action.id],
 	);
 	const baseRequirementIcons = useMemo(
-		() => getRequirementIcons(action.id, ctx),
-		[action.id, ctx],
+		() => getRequirementIcons(action.id, translationContext),
+		[action.id, translationContext],
 	);
 	const roleOptions = useMemo(
 		() => determineRaisePopRoles(actionDefinition, populationRegistry),

--- a/packages/web/src/utils/getRequirementIcons.ts
+++ b/packages/web/src/utils/getRequirementIcons.ts
@@ -1,10 +1,10 @@
-import type { EngineContext } from '@kingdom-builder/engine';
 import {
 	STATS,
 	POPULATION_ROLES,
 	type StatKey,
 	type PopulationRoleId,
 } from '@kingdom-builder/contents';
+import type { TranslationContext } from '../translation';
 
 interface EvalConfig {
 	type: string;
@@ -41,7 +41,7 @@ interface RequirementConfig {
 
 export type RequirementIconGetter = (
 	requirement: RequirementConfig,
-	engineContext: EngineContext,
+	translationContext: TranslationContext,
 ) => string[];
 
 /**
@@ -91,9 +91,9 @@ registerRequirementIconGetter('evaluator', 'compare', (requirement) => {
 
 export function getRequirementIcons(
 	actionId: string,
-	engineContext: EngineContext,
+	translationContext: TranslationContext,
 ): string[] {
-	const actionDefinition = engineContext.actions.get(actionId);
+	const actionDefinition = translationContext.actions.get(actionId);
 	if (!actionDefinition?.requirements) {
 		return [];
 	}
@@ -105,7 +105,7 @@ export function getRequirementIcons(
 		if (!getter) {
 			continue;
 		}
-		icons.push(...getter(requirement, engineContext));
+		icons.push(...getter(requirement, translationContext));
 	}
 	return icons.filter(Boolean);
 }


### PR DESCRIPTION
## Summary
- Use the translation context registry when deriving action requirement icons so hover cards always read sanitized data.
- Forward the translation context to action option components to keep icons and hover metadata in sync with sanitized registries.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Existing translation helpers (`describeContent`, `splitSummary`, `summarizeContent`) continue to be reused in the action card and option components; no new translators were introduced.
2. **Canonical keywords/icons/helpers touched:** Only existing requirement icon metadata from the translation registries is read; no canonical keywords or icon definitions were added or changed.
3. **Voice review:** No player-facing strings were added or edited; existing voices remain valid.

## Standards compliance (required)
1. **File length limits respected:** Updated files remain well below the 250 line limit (GenericActionCard ~200 lines, BuildOptions ~120, RaisePopOptions ~200, getRequirementIcons ~110).
2. **Line length limits respected:** Prettier formatting (`npm run format`) verified line-length compliance.
3. **Domain separation upheld:** Changes are limited to the Web layer components/utilities and the translation helper; Engine, Content, and Protocol code were untouched.
4. **Code standards satisfied:** `npm run lint` completed without errors.
5. **Tests updated:** No new tests were required; existing suites cover requirement icon translation and hover behavior.
6. **Documentation updated:** Not required because no documentation surfaces changed.
7. **`npm run check` results:** PASS (see `npm run check`).
8. **`npm run test:coverage` results:** Not run; coverage was not requested for this refactor.

## Testing
- `npm run lint`
- `npm run format`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68e640c0cb448325bc30c7e3dfe254d0