### PR TITLE
Refine log diff contexts for translation snapshots

### DIFF
--- a/packages/web/src/state/useActionPerformer.log.ts
+++ b/packages/web/src/state/useActionPerformer.log.ts
@@ -1,0 +1,152 @@
+import {
+	resolveActionEffects,
+	type ActionParams,
+	type ActionTrace,
+	type ResolvedActionEffects,
+} from '@kingdom-builder/engine';
+import {
+	ActionId,
+	RESOURCES,
+	type ResourceKey,
+} from '@kingdom-builder/contents';
+import {
+	diffStepSnapshots,
+	logContent,
+	snapshotPlayer,
+	type PlayerSnapshot,
+	type TranslationContext,
+} from '../translation';
+import { type TranslationDiffContext } from '../translation/log';
+import {
+	formatActionLogLines,
+	formatDevelopActionLogLines,
+} from './actionLogFormat';
+import type { Action } from './actionTypes';
+
+interface BuildLogOptions {
+	action: Action;
+	params: ActionParams<string> | undefined;
+	translation: TranslationContext;
+	diffContext: TranslationDiffContext;
+	before: PlayerSnapshot;
+	after: PlayerSnapshot;
+	costs: Record<string, number | undefined>;
+	resourceKeys: ResourceKey[];
+	step: ResolvedActionEffects | undefined;
+	traces: ActionTrace[];
+}
+
+interface BuildLogResult {
+	logLines: string[];
+	filtered: string[];
+	logHeadline: string;
+}
+
+function normalizeChange(line: string): string {
+	const trimmed = line.trim();
+	if (!trimmed) {
+		return '';
+	}
+	return (trimmed.split(' (')[0] ?? '').replace(/\s[+-]?\d+$/, '').trim();
+}
+
+export function buildActionLogResult({
+	action,
+	params,
+	translation,
+	diffContext,
+	before,
+	after,
+	costs,
+	resourceKeys,
+	step,
+	traces,
+}: BuildLogOptions): BuildLogResult {
+	const messages = logContent('action', action.id, translation, params);
+	const logHeadline = messages[0] ?? '';
+	const stepEffects = step ? { effects: step.effects } : undefined;
+	const changes = diffStepSnapshots(
+		before,
+		after,
+		stepEffects,
+		diffContext,
+		resourceKeys,
+	);
+	const costLines: string[] = [];
+	for (const key of Object.keys(costs) as (keyof typeof RESOURCES)[]) {
+		const amount = costs[key] ?? 0;
+		if (!amount) {
+			continue;
+		}
+		const info = RESOURCES[key];
+		const icon = info?.icon ? `${info.icon} ` : '';
+		const label = info?.label ?? key;
+		const beforeAmount = before.resources[key] ?? 0;
+		const afterAmount = beforeAmount - amount;
+		costLines.push(
+			`    ${icon}${label} -${amount} (${beforeAmount}→${afterAmount})`,
+		);
+	}
+	if (costLines.length) {
+		messages.splice(1, 0, '  💲 Action cost', ...costLines);
+	}
+	const subLines: string[] = [];
+	for (const trace of traces) {
+		const subAction = translation.actions.get(trace.id);
+		if (!subAction) {
+			continue;
+		}
+		const subStep = resolveActionEffects(subAction);
+		const subStepEffects = { effects: subStep.effects };
+		const subResolved = diffStepSnapshots(
+			snapshotPlayer(trace.before),
+			snapshotPlayer(trace.after),
+			subStepEffects,
+			diffContext,
+			resourceKeys,
+		);
+		if (!subResolved.length) {
+			continue;
+		}
+		subLines.push(...subResolved);
+		const icon = subAction.icon || '';
+		const name = subAction.name;
+		const line = `  ${icon} ${name}`;
+		const index = messages.indexOf(line);
+		if (index !== -1) {
+			messages.splice(
+				index + 1,
+				0,
+				...subResolved.map((entry) => `    ${entry}`),
+			);
+		}
+	}
+	const messagePrefixes = new Set(
+		messages.map(normalizeChange).filter((entry) => entry.length > 0),
+	);
+	const subPrefixes = new Set(subLines.map(normalizeChange));
+	const costLabels = new Set(Object.keys(costs) as (keyof typeof RESOURCES)[]);
+	const filtered = changes.filter((line) => {
+		const normalizedLine = normalizeChange(line);
+		if (messagePrefixes.has(normalizedLine)) {
+			return false;
+		}
+		if (subPrefixes.has(normalizedLine)) {
+			return false;
+		}
+		for (const key of costLabels) {
+			const info = RESOURCES[key];
+			const prefix = info?.icon ? `${info.icon} ${info.label}` : info.label;
+			if (line.startsWith(prefix)) {
+				return false;
+			}
+		}
+		return true;
+	});
+	const formatter =
+		action.id === ActionId.develop
+			? formatDevelopActionLogLines
+			: formatActionLogLines;
+	const logLines = formatter(messages, filtered);
+	return { logLines, filtered, logHeadline };
+}

--- a/packages/web/src/state/useActionPerformer.ts
+++ b/packages/web/src/state/useActionPerformer.ts
@@ -3,26 +3,30 @@ import {
 	resolveActionEffects,
 	type ActionParams,
 	type EngineSession,
+	type EngineSessionSnapshot,
 	type PlayerStateSnapshot,
 } from '@kingdom-builder/engine';
 import {
-	ActionId,
-	RESOURCES,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
 	type ResourceKey,
 } from '@kingdom-builder/contents';
 import {
+	createTranslationContext,
 	createTranslationDiffContext,
-	diffStepSnapshots,
-	logContent,
 	snapshotPlayer,
 } from '../translation';
 import type { Action } from './actionTypes';
 import type { ShowResolutionOptions } from './useActionResolution';
-import {
-	formatActionLogLines,
-	formatDevelopActionLogLines,
-} from './actionLogFormat';
 import { buildResolutionActionMeta } from './deriveResolutionActionName';
+import { buildActionLogResult } from './useActionPerformer.log';
+
+const TRANSLATION_REGISTRIES = {
+	actions: ACTIONS,
+	buildings: BUILDINGS,
+	developments: DEVELOPMENTS,
+} as const;
 
 interface UseActionPerformerOptions {
 	session: EngineSession;
@@ -56,8 +60,13 @@ export function useActionPerformer({
 }: UseActionPerformerOptions) {
 	const perform = useCallback(
 		async (action: Action, params?: ActionParams<string>) => {
-			const context = session.getLegacyContext();
+			const buildTranslationContext = (state: EngineSessionSnapshot) =>
+				createTranslationContext(state, TRANSLATION_REGISTRIES, {
+					pullEffectLog: <T>(key: string) => session.pullEffectLog<T>(key),
+					evaluationMods: session.getPassiveEvaluationMods(),
+				});
 			const snapshotBefore = session.getSnapshot();
+			const translationBefore = buildTranslationContext(snapshotBefore);
 			const activePlayerId = snapshotBefore.game.activePlayerId;
 			const playerBefore = snapshotBefore.game.players.find(
 				(entry) => entry.id === activePlayerId,
@@ -67,9 +76,11 @@ export function useActionPerformer({
 			}
 			const before = snapshotPlayer(playerBefore);
 			const costs = session.getActionCosts(action.id, params);
+			const stepDef = translationBefore.actions.get(action.id);
 			try {
 				const traces = session.performAction(action.id, params);
 				const snapshotAfter = session.getSnapshot();
+				const translationAfter = buildTranslationContext(snapshotAfter);
 				const playerAfter = snapshotAfter.game.players.find(
 					(entry) => entry.id === activePlayerId,
 				);
@@ -77,107 +88,28 @@ export function useActionPerformer({
 					throw new Error('Missing active player after action');
 				}
 				const after = snapshotPlayer(playerAfter);
-				const stepDef = context.actions.get(action.id);
+				const diffContext = createTranslationDiffContext(
+					translationAfter,
+					playerAfter.id,
+					after,
+					snapshotAfter.game.players.map((playerState) => ({
+						id: playerState.id,
+						passives: snapshotPlayer(playerState).passives,
+					})),
+				);
 				const resolvedStep = resolveActionEffects(stepDef, params);
-				const diffContext = createTranslationDiffContext(context);
-				const changes = diffStepSnapshots(
+				const { logLines, filtered, logHeadline } = buildActionLogResult({
+					action,
+					params,
+					translation: translationAfter,
+					diffContext,
 					before,
 					after,
-					resolvedStep,
-					diffContext,
+					costs,
 					resourceKeys,
-				);
-				const messages = logContent('action', action.id, context, params);
-				const logHeadline = messages[0];
-				const costLines: string[] = [];
-				for (const key of Object.keys(costs) as (keyof typeof RESOURCES)[]) {
-					const amt = costs[key] ?? 0;
-					if (!amt) {
-						continue;
-					}
-					const info = RESOURCES[key];
-					const icon = info?.icon ? `${info.icon} ` : '';
-					const label = info?.label ?? key;
-					const beforeAmount = before.resources[key] ?? 0;
-					const afterAmount = beforeAmount - amt;
-					costLines.push(
-						`    ${icon}${label} -${amt} (${beforeAmount}→${afterAmount})`,
-					);
-				}
-				if (costLines.length) {
-					messages.splice(1, 0, '  💲 Action cost', ...costLines);
-				}
-
-				const normalize = (line: string) => {
-					const trimmed = line.trim();
-					if (!trimmed) {
-						return '';
-					}
-					return (trimmed.split(' (')[0] ?? '')
-						.replace(/\s[+-]?\d+$/, '')
-						.trim();
-				};
-
-				const subLines: string[] = [];
-				for (const trace of traces) {
-					const subStep = context.actions.get(trace.id);
-					const subResolved = resolveActionEffects(subStep);
-					const subChanges = diffStepSnapshots(
-						snapshotPlayer(trace.before),
-						snapshotPlayer(trace.after),
-						subResolved,
-						diffContext,
-						resourceKeys,
-					);
-					if (!subChanges.length) {
-						continue;
-					}
-					subLines.push(...subChanges);
-					const icon = context.actions.get(trace.id)?.icon || '';
-					const name = context.actions.get(trace.id).name;
-					const line = `  ${icon} ${name}`;
-					const index = messages.indexOf(line);
-					if (index !== -1) {
-						messages.splice(index + 1, 0, ...subChanges.map((c) => `    ${c}`));
-					}
-				}
-
-				const subPrefixes = subLines.map(normalize);
-				const messagePrefixes = new Set<string>();
-				for (const line of messages) {
-					const normalized = normalize(line);
-					if (normalized) {
-						messagePrefixes.add(normalized);
-					}
-				}
-
-				const costLabels = new Set(
-					Object.keys(costs) as (keyof typeof RESOURCES)[],
-				);
-				const filtered = changes.filter((line) => {
-					const normalizedLine = normalize(line);
-					if (messagePrefixes.has(normalizedLine)) {
-						return false;
-					}
-					if (subPrefixes.includes(normalizedLine)) {
-						return false;
-					}
-					for (const key of costLabels) {
-						const info = RESOURCES[key];
-						const prefix = info?.icon
-							? `${info.icon} ${info.label}`
-							: info.label;
-						if (line.startsWith(prefix)) {
-							return false;
-						}
-					}
-					return true;
+					step: resolvedStep,
+					traces,
 				});
-				const logLines = (
-					action.id === ActionId.develop
-						? formatDevelopActionLogLines
-						: formatActionLogLines
-				)(messages, filtered);
 				const actionMeta = buildResolutionActionMeta(
 					action,
 					stepDef,
@@ -212,7 +144,12 @@ export function useActionPerformer({
 					await endTurn();
 				}
 			} catch (error) {
-				const icon = context.actions.get(action.id)?.icon || '';
+				let icon = '';
+				try {
+					icon = translationBefore.actions.get(action.id)?.icon || '';
+				} catch {
+					icon = '';
+				}
 				const message = (error as Error).message || 'Action failed';
 				pushErrorToast(message);
 				addLog(`Failed to play ${icon} ${action.name}: ${message}`, {

--- a/packages/web/src/translation/log/resourceSources/context.ts
+++ b/packages/web/src/translation/log/resourceSources/context.ts
@@ -1,14 +1,11 @@
-import {
-	EVALUATORS,
-	type EngineContext,
-	type PlayerId,
-} from '@kingdom-builder/engine';
+import { type PlayerId } from '@kingdom-builder/engine';
+import { type EvaluatorDef } from '@kingdom-builder/protocol';
+import type {
+	TranslationContext,
+	TranslationPassiveModifierMap,
+} from '../../context';
+import { type PlayerSnapshot } from '../snapshots';
 import { type PassiveDescriptor, type PassiveModifierMap } from './types';
-
-interface PassiveLookup {
-	evaluationMods?: PassiveModifierMap;
-	get?: (id: string, owner: PlayerId) => PassiveDescriptor | undefined;
-}
 
 export interface TranslationDiffPassives {
 	evaluationMods: PassiveModifierMap;
@@ -16,9 +13,9 @@ export interface TranslationDiffPassives {
 }
 
 export interface TranslationDiffContext {
-	readonly activePlayer: EngineContext['activePlayer'];
-	readonly buildings: EngineContext['buildings'];
-	readonly developments: EngineContext['developments'];
+	readonly activePlayer: { id: PlayerId };
+	readonly buildings: TranslationContext['buildings'];
+	readonly developments: TranslationContext['developments'];
 	readonly passives: TranslationDiffPassives;
 	evaluate(evaluator: {
 		type: string;
@@ -26,31 +23,195 @@ export interface TranslationDiffContext {
 	}): number;
 }
 
-export function createTranslationDiffContext(
-	context: EngineContext,
-): TranslationDiffContext {
-	const rawPassives = context.passives as unknown;
-	const passiveLookup = rawPassives as PassiveLookup | undefined;
-	const evaluationMods = (passiveLookup?.evaluationMods ??
-		new Map()) as PassiveModifierMap;
-	const getPassive = passiveLookup?.get
-		? passiveLookup.get.bind(passiveLookup)
-		: undefined;
-	const passives: TranslationDiffPassives = { evaluationMods };
-	if (getPassive) {
-		passives.get = getPassive;
+interface CompareEvaluatorParams {
+	left?: EvaluatorDef | number;
+	right?: EvaluatorDef | number;
+	operator?: 'lt' | 'lte' | 'gt' | 'gte' | 'eq' | 'ne';
+}
+
+function countDevelopments(player: PlayerSnapshot, id: string): number {
+	return player.lands.reduce((total, land) => {
+		return (
+			total +
+			land.developments.filter((development) => development === id).length
+		);
+	}, 0);
+}
+
+function evaluatePopulation(
+	player: PlayerSnapshot,
+	params: Record<string, unknown> | undefined,
+): number {
+	const role = params?.['role'];
+	if (typeof role === 'string') {
+		return Number(player.population[role] ?? 0);
 	}
+	return Object.values(player.population).reduce((total, count) => {
+		const value = Number(count ?? 0);
+		return Number.isFinite(value) ? total + value : total;
+	}, 0);
+}
+
+function evaluateStat(
+	player: PlayerSnapshot,
+	params: Record<string, unknown> | undefined,
+): number {
+	const key = params?.['key'];
+	if (typeof key !== 'string') {
+		return 0;
+	}
+	return Number(player.stats[key] ?? 0);
+}
+
+function evaluateDefinition(
+	definition: EvaluatorDef,
+	player: PlayerSnapshot,
+): number {
+	switch (definition.type) {
+		case 'development': {
+			const id = definition.params?.['id'];
+			if (typeof id !== 'string') {
+				return 0;
+			}
+			return countDevelopments(player, id);
+		}
+		case 'population':
+			return evaluatePopulation(player, definition.params);
+		case 'stat':
+			return evaluateStat(player, definition.params);
+		case 'compare':
+			return evaluateCompare(definition, player);
+		default:
+			return 0;
+	}
+}
+
+function toEvaluatorDefinition(value: unknown): EvaluatorDef | undefined {
+	if (!value || typeof value !== 'object') {
+		return undefined;
+	}
+	if (!('type' in value)) {
+		return undefined;
+	}
+	const type = (value as { type?: unknown }).type;
+	if (typeof type !== 'string') {
+		return undefined;
+	}
+	return value as EvaluatorDef;
+}
+
+function resolveComparableValue(
+	value: EvaluatorDef | number | undefined,
+	player: PlayerSnapshot,
+): number {
+	if (typeof value === 'number') {
+		return value;
+	}
+	const definition = toEvaluatorDefinition(value);
+	if (!definition) {
+		return 0;
+	}
+	return evaluateDefinition(definition, player);
+}
+
+function evaluateCompare(
+	definition: EvaluatorDef,
+	player: PlayerSnapshot,
+): number {
+	const params = definition.params as CompareEvaluatorParams | undefined;
+	if (!params) {
+		return 0;
+	}
+	const left = resolveComparableValue(params.left, player);
+	const right = resolveComparableValue(params.right, player);
+	switch (params.operator) {
+		case 'lt':
+			return left < right ? 1 : 0;
+		case 'lte':
+			return left <= right ? 1 : 0;
+		case 'gt':
+			return left > right ? 1 : 0;
+		case 'gte':
+			return left >= right ? 1 : 0;
+		case 'eq':
+			return left === right ? 1 : 0;
+		case 'ne':
+			return left !== right ? 1 : 0;
+		default:
+			return 0;
+	}
+}
+
+function mapPassiveDescriptors(
+	players: ReadonlyArray<{
+		id: PlayerId;
+		passives: PlayerSnapshot['passives'];
+	}>,
+): ReadonlyMap<PlayerId, Map<string, PassiveDescriptor>> {
+	return new Map(
+		players.map(({ id, passives }) => [
+			id,
+			new Map(
+				passives.map((passive) => {
+					const descriptor: PassiveDescriptor = {};
+					if (passive.icon !== undefined) {
+						descriptor.icon = passive.icon;
+					}
+					const sourceIcon = passive.meta?.source?.icon;
+					if (sourceIcon !== undefined) {
+						descriptor.meta = Object.freeze({
+							source: Object.freeze({ icon: sourceIcon }),
+						});
+					}
+					return [passive.id, Object.freeze(descriptor)] as const;
+				}),
+			),
+		]),
+	);
+}
+
+function cloneEvaluationModifiers(
+	mods: TranslationPassiveModifierMap | PassiveModifierMap | undefined,
+): PassiveModifierMap {
+	if (!mods) {
+		return new Map();
+	}
+	return new Map(
+		Array.from(mods.entries()).map(([modifierId, entries]) => [
+			modifierId,
+			new Map(entries),
+		]),
+	);
+}
+
+export function createTranslationDiffContext(
+	translation: Pick<
+		TranslationContext,
+		'buildings' | 'developments' | 'passives'
+	>,
+	activePlayerId: PlayerId,
+	activePlayer: PlayerSnapshot,
+	players: ReadonlyArray<{
+		id: PlayerId;
+		passives: PlayerSnapshot['passives'];
+	}> = [{ id: activePlayerId, passives: activePlayer.passives }],
+): TranslationDiffContext {
+	const descriptors = mapPassiveDescriptors(players);
+	const evaluationMods = cloneEvaluationModifiers(
+		translation.passives.evaluationMods,
+	);
+	const passives: TranslationDiffPassives = { evaluationMods };
+	passives.get = (id, owner) => {
+		const ownerDescriptors = descriptors.get(owner);
+		return ownerDescriptors?.get(id);
+	};
 	return {
-		activePlayer: context.activePlayer,
-		buildings: context.buildings,
-		developments: context.developments,
+		activePlayer: { id: activePlayerId },
+		buildings: translation.buildings,
+		developments: translation.developments,
 		passives,
 		evaluate(evaluator) {
-			const handler = EVALUATORS.get(evaluator.type);
-			if (!handler) {
-				throw new Error(`Unknown evaluator handler for ${evaluator.type}`);
-			}
-			return Number(handler(evaluator, context));
+			return evaluateDefinition(evaluator as EvaluatorDef, activePlayer);
 		},
 	};
 }

--- a/packages/web/src/translation/log/snapshots.ts
+++ b/packages/web/src/translation/log/snapshots.ts
@@ -6,6 +6,7 @@ import {
 	type PlayerSnapshot as EnginePlayerSnapshot,
 } from '@kingdom-builder/engine';
 import { type ResourceKey } from '@kingdom-builder/contents';
+import type { TranslationContext } from '../context';
 import { type Land } from '../content';
 import {
 	appendResourceChanges,
@@ -102,11 +103,19 @@ export function collectResourceKeys(
 export function diffSnapshots(
 	previousSnapshot: PlayerSnapshot,
 	nextSnapshot: PlayerSnapshot,
-	context: EngineContext,
+	translation: Pick<
+		TranslationContext,
+		'buildings' | 'developments' | 'passives'
+	>,
+	activePlayerId: PlayerId,
 	resourceKeys: ResourceKey[] = collectResourceKeys(
 		previousSnapshot,
 		nextSnapshot,
 	),
+	players: ReadonlyArray<{
+		id: PlayerId;
+		passives: PlayerSnapshot['passives'];
+	}> = [{ id: activePlayerId, passives: nextSnapshot.passives }],
 ): string[] {
 	const changeSummaries: string[] = [];
 	appendResourceChanges(
@@ -122,7 +131,12 @@ export function diffSnapshots(
 		nextSnapshot,
 		undefined,
 	);
-	const diffContext = createTranslationDiffContext(context);
+	const diffContext = createTranslationDiffContext(
+		translation,
+		activePlayerId,
+		nextSnapshot,
+		players,
+	);
 	appendBuildingChanges(
 		changeSummaries,
 		previousSnapshot,

--- a/packages/web/tests/helpers/createDiffContext.ts
+++ b/packages/web/tests/helpers/createDiffContext.ts
@@ -1,0 +1,64 @@
+import type { EngineContext, PlayerId } from '@kingdom-builder/engine';
+import type {
+	TranslationContext,
+	TranslationPassiveDescriptor,
+} from '../../src/translation/context';
+import {
+	createTranslationDiffContext,
+	snapshotPlayer,
+} from '../../src/translation/log';
+import { wrapTranslationRegistry } from './translationContextStub';
+
+function toPassiveDescriptor(
+	context: EngineContext,
+	id: string,
+	owner: PlayerId,
+): TranslationPassiveDescriptor | undefined {
+	const passive = context.passives.list(owner).find((entry) => entry.id === id);
+	if (!passive) {
+		return undefined;
+	}
+	const descriptor: TranslationPassiveDescriptor = {};
+	if (passive.icon !== undefined) {
+		descriptor.icon = passive.icon;
+	}
+	const sourceIcon = passive.meta?.source?.icon;
+	if (sourceIcon !== undefined) {
+		descriptor.meta = { source: { icon: sourceIcon } };
+	}
+	return descriptor;
+}
+
+export function createDiffContextFromEngine(
+	context: EngineContext,
+): ReturnType<typeof createTranslationDiffContext> {
+	const active = snapshotPlayer(context.activePlayer, context);
+	const translation = {
+		buildings: wrapTranslationRegistry(context.buildings),
+		developments: wrapTranslationRegistry(context.developments),
+		passives: {
+			list(owner?: PlayerId) {
+				return context.passives.list(owner);
+			},
+			get(id: string, owner: PlayerId) {
+				return toPassiveDescriptor(context, id, owner);
+			},
+			get evaluationMods() {
+				return context.passives.evaluationMods;
+			},
+		},
+	} satisfies Pick<
+		TranslationContext,
+		'buildings' | 'developments' | 'passives'
+	>;
+	const players = context.game.players.map((player) => ({
+		id: player.id,
+		passives: snapshotPlayer(player, context).passives,
+	}));
+	return createTranslationDiffContext(
+		translation,
+		context.activePlayer.id,
+		active,
+		players,
+	);
+}

--- a/packages/web/tests/land-change-log.test.ts
+++ b/packages/web/tests/land-change-log.test.ts
@@ -11,16 +11,13 @@ import {
 	LAND_INFO,
 } from '@kingdom-builder/contents';
 import { logContent } from '../src/translation/content';
-import {
-	snapshotPlayer,
-	diffStepSnapshots,
-	createTranslationDiffContext,
-} from '../src/translation/log';
+import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
 import {
 	formatIconLabel,
 	formatLogHeadline,
 	LOG_KEYWORDS,
 } from '../src/translation/log/logMessages';
+import { createDiffContextFromEngine } from './helpers/createDiffContext';
 
 vi.mock('@kingdom-builder/engine', async () => {
 	return await import('../../engine/src');
@@ -52,7 +49,7 @@ describe('land change log formatting', () => {
 			ctx,
 		);
 		const after = snapshotPlayer(ctx.activePlayer, ctx);
-		const diffContext = createTranslationDiffContext(ctx);
+		const diffContext = createDiffContextFromEngine(ctx);
 		const lines = diffStepSnapshots(before, after, undefined, diffContext);
 		const landLine = lines.find((line) => {
 			return line.startsWith(LOG_KEYWORDS.gained);
@@ -111,7 +108,7 @@ describe('land change log formatting', () => {
 			ctx,
 		);
 		const after = snapshotPlayer(ctx.activePlayer, ctx);
-		const diffContext = createTranslationDiffContext(ctx);
+		const diffContext = createDiffContextFromEngine(ctx);
 		const lines = diffStepSnapshots(before, after, undefined, diffContext);
 		const developmentLine = lines.find((line) => {
 			return line.startsWith(LOG_KEYWORDS.developed);

--- a/packages/web/tests/log-source-icons.test.ts
+++ b/packages/web/tests/log-source-icons.test.ts
@@ -13,11 +13,8 @@ import {
 	LAND_INFO,
 	POPULATION_INFO,
 } from '@kingdom-builder/contents';
-import {
-	snapshotPlayer,
-	diffStepSnapshots,
-	createTranslationDiffContext,
-} from '../src/translation/log';
+import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
+import { createDiffContextFromEngine } from './helpers/createDiffContext';
 
 const RESOURCE_KEYS = [Resource.gold] as const;
 
@@ -107,7 +104,7 @@ describe('log resource source icon registry', () => {
 			const before = snapshotPlayer(ctx.activePlayer, ctx);
 			runEffects([effect], ctx);
 			const after = snapshotPlayer(ctx.activePlayer, ctx);
-			const diffContext = createTranslationDiffContext(ctx);
+			const diffContext = createDiffContextFromEngine(ctx);
 			const lines = diffStepSnapshots(
 				before,
 				after,

--- a/packages/web/tests/log-source.test.ts
+++ b/packages/web/tests/log-source.test.ts
@@ -19,11 +19,8 @@ import {
 	SYNTHETIC_POPULATION_ROLE_ID,
 	SYNTHETIC_LAND_INFO,
 } from './fixtures/syntheticTaxLog';
-import {
-	snapshotPlayer,
-	diffStepSnapshots,
-	createTranslationDiffContext,
-} from '../src/translation/log';
+import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
+import { createDiffContextFromEngine } from './helpers/createDiffContext';
 
 const RESOURCE_KEYS = Object.keys(
 	SYNTHETIC_RESOURCES,
@@ -72,7 +69,7 @@ describe('log resource sources', () => {
 		}
 		const effects = bundles.flatMap((bundle) => bundle.effects);
 		const after = snapshotPlayer(ctx.activePlayer, ctx);
-		const diffContext = createTranslationDiffContext(ctx);
+		const diffContext = createDiffContextFromEngine(ctx);
 		const lines = diffStepSnapshots(
 			before,
 			after,
@@ -122,7 +119,7 @@ describe('log resource sources', () => {
 		const before = snapshotPlayer(ctx.activePlayer, ctx);
 		performAction(SYNTHETIC_IDS.taxAction, ctx);
 		const after = snapshotPlayer(ctx.activePlayer, ctx);
-		const diffContext = createTranslationDiffContext(ctx);
+		const diffContext = createDiffContextFromEngine(ctx);
 		const lines = diffStepSnapshots(
 			before,
 			after,
@@ -178,7 +175,7 @@ describe('log resource sources', () => {
 		}
 		const effects = bundles.flatMap((bundle) => bundle.effects);
 		const after = snapshotPlayer(ctx.activePlayer, ctx);
-		const diffContext = createTranslationDiffContext(ctx);
+		const diffContext = createDiffContextFromEngine(ctx);
 		const lines = diffStepSnapshots(
 			before,
 			after,

--- a/packages/web/tests/passive-log-labels.test.ts
+++ b/packages/web/tests/passive-log-labels.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createEngine, runEffects } from '@kingdom-builder/engine';
-import {
-	snapshotPlayer,
-	diffStepSnapshots,
-	createTranslationDiffContext,
-} from '../src/translation/log';
+import { snapshotPlayer, diffStepSnapshots } from '../src/translation/log';
+import { createDiffContextFromEngine } from './helpers/createDiffContext';
 import { logContent } from '../src/translation/content';
 import { LOG_KEYWORDS } from '../src/translation/log/logMessages';
 import {
@@ -48,7 +45,7 @@ describe('passive log labels', () => {
 		setHappiness(6);
 		const afterActivation = snapshotPlayer(ctx.activePlayer, ctx);
 
-		const diffContext = createTranslationDiffContext(ctx);
+		const diffContext = createDiffContextFromEngine(ctx);
 		const activationLines = diffStepSnapshots(
 			beforeActivation,
 			afterActivation,
@@ -110,7 +107,7 @@ describe('passive log labels', () => {
 		);
 		const after = snapshotPlayer(ctx.activePlayer, ctx);
 
-		const diffContext = createTranslationDiffContext(ctx);
+		const diffContext = createDiffContextFromEngine(ctx);
 		const lines = diffStepSnapshots(before, after, undefined, diffContext);
 		expect(lines.some((line) => line.includes('Castle Walls activated'))).toBe(
 			false,
@@ -163,7 +160,7 @@ describe('passive log labels', () => {
 		);
 		const after = snapshotPlayer(ctx.activePlayer, ctx);
 
-		const diffContext = createTranslationDiffContext(ctx);
+		const diffContext = createDiffContextFromEngine(ctx);
 		const lines = diffStepSnapshots(before, after, undefined, diffContext);
 		expect(lines.some((line) => line.includes('activated'))).toBe(false);
 

--- a/packages/web/tests/state/useCompensationLogger.test.tsx
+++ b/packages/web/tests/state/useCompensationLogger.test.tsx
@@ -25,34 +25,10 @@ const RESOURCE_KEYS: ResourceKey[] = ['gold' as ResourceKey];
 
 function createSession(): EngineSession {
 	return {
-		getLegacyContext() {
-			return {
-				activePlayer: {
-					id: 'A',
-					lands: [],
-					buildings: [],
-					resources: {},
-					stats: {},
-				},
-				buildings: {
-					get() {
-						return { icon: '', name: '' };
-					},
-				},
-				developments: {
-					get() {
-						return { icon: '', name: '' };
-					},
-				},
-				passives: {
-					list() {
-						return [];
-					},
-				},
-			} as unknown as EngineSession['getLegacyContext'] extends () => infer R
-				? R
-				: never;
+		getPassiveEvaluationMods() {
+			return new Map();
 		},
+		pullEffectLog: vi.fn(),
 	} as unknown as EngineSession;
 }
 

--- a/packages/web/tests/subaction-log.test.ts
+++ b/packages/web/tests/subaction-log.test.ts
@@ -14,8 +14,8 @@ import {
 	snapshotPlayer,
 	diffStepSnapshots,
 	logContent,
-	createTranslationDiffContext,
 } from '../src/translation';
+import { createDiffContextFromEngine } from './helpers/createDiffContext';
 
 const RESOURCE_KEYS = Object.keys(
 	SYNTHETIC_RESOURCES,
@@ -44,7 +44,7 @@ describe('sub-action logging', () => {
 		const costs = getActionCosts(synthetic.plow.id, ctx);
 		const traces = performAction(synthetic.plow.id, ctx);
 		const after = snapshotPlayer(ctx.activePlayer, ctx);
-		const diffContext = createTranslationDiffContext(ctx);
+		const diffContext = createDiffContextFromEngine(ctx);
 		const changes = diffStepSnapshots(
 			before,
 			after,

--- a/packages/web/tests/tax-market-log.test.ts
+++ b/packages/web/tests/tax-market-log.test.ts
@@ -22,8 +22,8 @@ import {
 	snapshotPlayer,
 	diffStepSnapshots,
 	logContent,
-	createTranslationDiffContext,
 } from '../src/translation';
+import { createDiffContextFromEngine } from './helpers/createDiffContext';
 
 const RESOURCE_KEYS = Object.keys(
 	SYNTHETIC_RESOURCES,
@@ -64,7 +64,7 @@ describe('tax action logging with market', () => {
 		const costs = getActionCosts(SYNTHETIC_IDS.taxAction, ctx);
 		const traces: ActionTrace[] = performAction(SYNTHETIC_IDS.taxAction, ctx);
 		const after = snapshotPlayer(ctx.activePlayer, ctx);
-		const diffContext = createTranslationDiffContext(ctx);
+		const diffContext = createDiffContextFromEngine(ctx);
 		const changes = diffStepSnapshots(
 			before,
 			after,


### PR DESCRIPTION
## Summary
- Build translation contexts from engine snapshots before actions, phase steps, and compensation logs to remove legacy context usage.
- Add `buildActionLogResult` helper to consolidate action log formatting logic around sanitized diff contexts.
- Update translation diff context to derive passives and evaluation modifiers from translation data and adjust tests to exercise the new helper.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Reused `createTranslationContext`, `createTranslationDiffContext`, `diffStepSnapshots`, `formatActionLogLines`, and `formatDevelopActionLogLines` for all updated log surfaces.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** Verified Summary, Description, and Log voices remain consistent because only underlying context plumbing changed.

## Standards compliance (required)
1. **File length limits respected:** All modified production files remain ≤250 lines (largest new file `useActionPerformer.log.ts` is 152 lines; helper test file is 64 lines).
2. **Line length limits respected:** Prettier formatting keeps all lines ≤80 characters.
3. **Domain separation upheld:** Translation helpers now source data from web translation registries without leaking engine legacy context.
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint) completed successfully. See logs referenced below.
5. **Tests updated:** Updated action, land, passive, and tax log tests plus new diff-context helper to cover sanitized translation contexts.
6. **Documentation updated:** Not required; behaviour changes are internal plumbing.
7. **`npm run check` results:** PASS (see `npm run check` invocation and completion in command logs).
8. **`npm run test:coverage` results:** Not run (not requested for this change).

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e640a8ad8083259aa580f160dafc06