### PR TITLE
Refactor action diff context to sanitized snapshot data

### DIFF
--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -201,6 +201,7 @@ export function GameProvider({
 	} = usePhaseProgress({
 		session,
 		sessionState,
+		translationContext,
 		actionPhaseId,
 		actionCostResource,
 		addLog,
@@ -223,6 +224,7 @@ export function GameProvider({
 		sessionState,
 		addLog,
 		resourceKeys: RESOURCE_KEYS,
+		translationContext,
 	});
 
 	const { handlePerform, performRef } = useActionPerformer({
@@ -237,6 +239,7 @@ export function GameProvider({
 		endTurn,
 		enqueue,
 		resourceKeys: RESOURCE_KEYS,
+		translationContext,
 	});
 
 	useAiRunner({

--- a/packages/web/src/state/useActionPerformer.helpers.ts
+++ b/packages/web/src/state/useActionPerformer.helpers.ts
@@ -1,0 +1,167 @@
+import {
+	resolveActionEffects,
+	type ActionTrace,
+	type EngineSession,
+	type PlayerId,
+} from '@kingdom-builder/engine';
+import { RESOURCES, type ResourceKey } from '@kingdom-builder/contents';
+import {
+	createSnapshotDiffPlayer,
+	createSnapshotTranslationDiffContext,
+	diffStepSnapshots,
+	snapshotPlayer,
+	type PlayerSnapshot,
+	type TranslationDiffContext,
+} from '../translation';
+import type { TranslationContext } from '../translation/context';
+
+export function resolveActionDefinition(
+	context: TranslationContext,
+	id: string,
+) {
+	try {
+		return context.actions.get(id);
+	} catch {
+		return undefined;
+	}
+}
+
+export function buildActionDiffContext(
+	translationContext: TranslationContext,
+	session: EngineSession,
+	player: PlayerSnapshot & { id: PlayerId },
+): TranslationDiffContext {
+	const diffPlayer = createSnapshotDiffPlayer({
+		id: player.id,
+		lands: player.lands,
+		population: player.population,
+		passives: player.passives,
+	});
+	return createSnapshotTranslationDiffContext({
+		player: diffPlayer,
+		translation: {
+			buildings: translationContext.buildings,
+			developments: translationContext.developments,
+			passives: {
+				evaluationMods: translationContext.passives.evaluationMods,
+			},
+		},
+		evaluationMods: session.getPassiveEvaluationMods(),
+	});
+}
+
+export function buildCostLines(
+	costs: Record<string, number | undefined>,
+	before: PlayerSnapshot,
+): string[] {
+	const costLines: string[] = [];
+	for (const key of Object.keys(costs)) {
+		const amount = costs[key] ?? 0;
+		if (!amount) {
+			continue;
+		}
+		const info = RESOURCES[key as keyof typeof RESOURCES];
+		const icon = info?.icon ? `${info.icon} ` : '';
+		const label = info?.label ?? key;
+		const beforeAmount = before.resources[key] ?? 0;
+		const afterAmount = beforeAmount - amount;
+		costLines.push(
+			`    ${icon}${label} -${amount} (${beforeAmount}→${afterAmount})`,
+		);
+	}
+	return costLines;
+}
+
+export function collectSubActionChanges({
+	traces,
+	diffContext,
+	resourceKeys,
+	messages,
+	resolveDefinition,
+}: {
+	traces: ActionTrace[];
+	diffContext: TranslationDiffContext;
+	resourceKeys: ResourceKey[];
+	messages: string[];
+	resolveDefinition: (id: string) => ReturnType<typeof resolveActionDefinition>;
+}): string[] {
+	const subLines: string[] = [];
+	for (const trace of traces) {
+		const subStep = resolveDefinition(trace.id);
+		if (!subStep) {
+			continue;
+		}
+		const subResolved = resolveActionEffects(subStep);
+		const subChanges = diffStepSnapshots(
+			snapshotPlayer(trace.before),
+			snapshotPlayer(trace.after),
+			subResolved,
+			diffContext,
+			resourceKeys,
+		);
+		if (!subChanges.length) {
+			continue;
+		}
+		subLines.push(...subChanges);
+		const icon = typeof subStep.icon === 'string' ? subStep.icon : '';
+		const name = subStep.name;
+		const line = `  ${icon} ${name}`;
+		const index = messages.indexOf(line);
+		if (index !== -1) {
+			messages.splice(
+				index + 1,
+				0,
+				...subChanges.map((change) => `    ${change}`),
+			);
+		}
+	}
+	return subLines;
+}
+
+export function normalizeLogLine(line: string): string {
+	const trimmed = line.trim();
+	if (!trimmed) {
+		return '';
+	}
+	return (trimmed.split(' (')[0] ?? '').replace(/\s[+-]?\d+$/, '').trim();
+}
+
+export function filterActionChanges({
+	changes,
+	messages,
+	subLines,
+	costs,
+}: {
+	changes: string[];
+	messages: string[];
+	subLines: string[];
+	costs: Record<string, number | undefined>;
+}): string[] {
+	const subPrefixes = subLines.map(normalizeLogLine);
+	const messagePrefixes = new Set<string>();
+	for (const line of messages) {
+		const normalized = normalizeLogLine(line);
+		if (normalized) {
+			messagePrefixes.add(normalized);
+		}
+	}
+	const costKeys = Object.keys(costs);
+	return changes.filter((line) => {
+		const normalizedLine = normalizeLogLine(line);
+		if (messagePrefixes.has(normalizedLine)) {
+			return false;
+		}
+		if (subPrefixes.includes(normalizedLine)) {
+			return false;
+		}
+		for (const key of costKeys) {
+			const info = RESOURCES[key as keyof typeof RESOURCES];
+			const label = info?.label ?? key;
+			const prefix = info?.icon ? `${info.icon} ${label}` : label;
+			if (line.startsWith(prefix)) {
+				return false;
+			}
+		}
+		return true;
+	});
+}

--- a/packages/web/src/state/usePhaseProgress.ts
+++ b/packages/web/src/state/usePhaseProgress.ts
@@ -5,6 +5,7 @@ import {
 	type PlayerStateSnapshot,
 } from '@kingdom-builder/engine';
 import { type ResourceKey } from '@kingdom-builder/contents';
+import type { TranslationContext } from '../translation/context';
 import type { PhaseStep } from './phaseTypes';
 import { usePhaseDelays } from './usePhaseDelays';
 import { useMainPhaseTracker } from './useMainPhaseTracker';
@@ -13,6 +14,7 @@ import { advanceToActionPhase } from './usePhaseProgress.helpers';
 interface PhaseProgressOptions {
 	session: EngineSession;
 	sessionState: EngineSessionSnapshot;
+	translationContext: TranslationContext;
 	actionPhaseId: string | undefined;
 	actionCostResource: ResourceKey;
 	addLog: (entry: string | string[], player?: PlayerStateSnapshot) => void;
@@ -28,6 +30,7 @@ interface PhaseProgressOptions {
 export function usePhaseProgress({
 	session,
 	sessionState,
+	translationContext,
 	actionPhaseId,
 	actionCostResource,
 	addLog,
@@ -71,6 +74,7 @@ export function usePhaseProgress({
 		() =>
 			advanceToActionPhase({
 				session,
+				translationContext,
 				actionCostResource,
 				resourceKeys,
 				runDelay,
@@ -91,6 +95,7 @@ export function usePhaseProgress({
 			addLog,
 			mountedRef,
 			refresh,
+			translationContext,
 			resourceKeys,
 			runDelay,
 			runStepDelay,

--- a/packages/web/src/translation/log.ts
+++ b/packages/web/src/translation/log.ts
@@ -3,6 +3,8 @@ export { diffSnapshots } from './log/snapshots';
 export { diffStepSnapshots } from './log/diff';
 export {
 	createTranslationDiffContext,
+	createSnapshotTranslationDiffContext,
+	createSnapshotDiffPlayer,
 	type TranslationDiffContext,
 } from './log/resourceSources/context';
 export {

--- a/packages/web/src/translation/log/resourceSources/context.ts
+++ b/packages/web/src/translation/log/resourceSources/context.ts
@@ -1,8 +1,11 @@
 import {
 	EVALUATORS,
 	type EngineContext,
+	type PassiveSummary,
 	type PlayerId,
 } from '@kingdom-builder/engine';
+import { type TranslationContext } from '../../context/types';
+import type { PlayerSnapshot } from '../snapshots';
 import { type PassiveDescriptor, type PassiveModifierMap } from './types';
 
 interface PassiveLookup {
@@ -15,8 +18,17 @@ export interface TranslationDiffPassives {
 	get?: (id: string, owner: PlayerId) => PassiveDescriptor | undefined;
 }
 
+export interface TranslationDiffActivePlayer {
+	readonly id: PlayerId;
+	readonly lands: ReadonlyArray<{
+		readonly id: string;
+		readonly developments: readonly string[];
+	}>;
+	readonly population: Record<string, number>;
+}
+
 export interface TranslationDiffContext {
-	readonly activePlayer: EngineContext['activePlayer'];
+	readonly activePlayer: TranslationDiffActivePlayer;
 	readonly buildings: EngineContext['buildings'];
 	readonly developments: EngineContext['developments'];
 	readonly passives: TranslationDiffPassives;
@@ -26,25 +38,88 @@ export interface TranslationDiffContext {
 	}): number;
 }
 
+function cloneModifierMap(
+	source?: ReadonlyMap<string, ReadonlyMap<string, unknown>>,
+): PassiveModifierMap {
+	const entries: Array<[string, Map<string, unknown>]> = [];
+	if (!source) {
+		return new Map(entries);
+	}
+	for (const [target, modifiers] of source.entries()) {
+		entries.push([target, new Map(modifiers)]);
+	}
+	return new Map(entries);
+}
+
+function toPassiveDescriptor(summary: PassiveSummary): PassiveDescriptor {
+	const descriptor: PassiveDescriptor = {};
+	if (summary.icon !== undefined) {
+		descriptor.icon = summary.icon;
+	}
+	const sourceIcon = summary.meta?.source?.icon;
+	if (sourceIcon !== undefined) {
+		descriptor.meta = { source: { icon: sourceIcon } };
+	}
+	return descriptor;
+}
+
+function createDiffContext(options: {
+	activePlayer: TranslationDiffActivePlayer;
+	buildings: EngineContext['buildings'];
+	developments: EngineContext['developments'];
+	evaluationMods?: ReadonlyMap<string, ReadonlyMap<string, unknown>>;
+	passiveSummaries?: readonly PassiveSummary[];
+	passiveLookup?: (
+		id: string,
+		owner: PlayerId,
+	) => PassiveDescriptor | undefined;
+	evaluate: (evaluator: {
+		type: string;
+		params?: Record<string, unknown>;
+	}) => number;
+}): TranslationDiffContext {
+	const evaluationMods = cloneModifierMap(
+		options.evaluationMods ?? new Map<string, ReadonlyMap<string, unknown>>(),
+	);
+	const passives: TranslationDiffPassives = { evaluationMods };
+	if (options.passiveLookup) {
+		passives.get = options.passiveLookup;
+	} else {
+		const summaries = options.passiveSummaries ?? [];
+		const descriptors = new Map(
+			summaries.map((summary) => [summary.id, toPassiveDescriptor(summary)]),
+		);
+		passives.get = (id, owner) => {
+			if (owner !== options.activePlayer.id) {
+				return undefined;
+			}
+			return descriptors.get(id);
+		};
+	}
+	return {
+		activePlayer: options.activePlayer,
+		buildings: options.buildings,
+		developments: options.developments,
+		passives,
+		evaluate: options.evaluate,
+	};
+}
+
 export function createTranslationDiffContext(
 	context: EngineContext,
 ): TranslationDiffContext {
 	const rawPassives = context.passives as unknown;
 	const passiveLookup = rawPassives as PassiveLookup | undefined;
-	const evaluationMods = (passiveLookup?.evaluationMods ??
-		new Map()) as PassiveModifierMap;
-	const getPassive = passiveLookup?.get
+	const evaluationMods = passiveLookup?.evaluationMods;
+	const passiveLookupFn = passiveLookup?.get
 		? passiveLookup.get.bind(passiveLookup)
 		: undefined;
-	const passives: TranslationDiffPassives = { evaluationMods };
-	if (getPassive) {
-		passives.get = getPassive;
-	}
-	return {
+	return createDiffContext({
 		activePlayer: context.activePlayer,
 		buildings: context.buildings,
 		developments: context.developments,
-		passives,
+		...(evaluationMods ? { evaluationMods } : {}),
+		...(passiveLookupFn ? { passiveLookup: passiveLookupFn } : {}),
 		evaluate(evaluator) {
 			const handler = EVALUATORS.get(evaluator.type);
 			if (!handler) {
@@ -52,5 +127,85 @@ export function createTranslationDiffContext(
 			}
 			return Number(handler(evaluator, context));
 		},
+	});
+}
+
+export interface SnapshotDiffPlayer
+	extends Pick<TranslationDiffActivePlayer, 'id' | 'lands' | 'population'> {
+	readonly passives?: readonly PassiveSummary[];
+}
+
+export interface SnapshotDiffContextOptions {
+	readonly player: SnapshotDiffPlayer;
+	readonly translation: Pick<
+		TranslationContext,
+		'buildings' | 'developments'
+	> & {
+		readonly passives: Pick<TranslationContext['passives'], 'evaluationMods'>;
+	};
+	readonly evaluationMods?: ReadonlyMap<string, ReadonlyMap<string, unknown>>;
+}
+
+export function createSnapshotTranslationDiffContext({
+	player,
+	translation,
+	evaluationMods,
+}: SnapshotDiffContextOptions): TranslationDiffContext {
+	return createDiffContext({
+		activePlayer: player,
+		buildings: translation.buildings as EngineContext['buildings'],
+		developments: translation.developments as EngineContext['developments'],
+		evaluationMods: evaluationMods ?? translation.passives.evaluationMods,
+		passiveSummaries: player.passives ?? [],
+		evaluate(evaluator) {
+			if (evaluator.type === 'development') {
+				const id = evaluator.params?.['id'];
+				if (typeof id !== 'string') {
+					return 0;
+				}
+				let total = 0;
+				for (const land of player.lands) {
+					total += land.developments.filter((item) => item === id).length;
+				}
+				return total;
+			}
+			if (evaluator.type === 'population') {
+				const role = evaluator.params?.['role'];
+				if (typeof role === 'string') {
+					return Number(player.population[role] ?? 0);
+				}
+				return Object.values(player.population).reduce<number>(
+					(total, amount) => {
+						return total + Number(amount ?? 0);
+					},
+					0,
+				);
+			}
+			throw new Error(`Unsupported evaluator handler for ${evaluator.type}`);
+		},
+	});
+}
+
+interface SnapshotDiffPlayerInput {
+	id: PlayerId;
+	lands: PlayerSnapshot['lands'];
+	population: PlayerSnapshot['population'];
+	passives?: readonly PassiveSummary[];
+}
+
+export function createSnapshotDiffPlayer({
+	id,
+	lands,
+	population,
+	passives,
+}: SnapshotDiffPlayerInput): SnapshotDiffPlayer {
+	return {
+		id,
+		lands: lands.map((land) => ({
+			id: land.id,
+			developments: [...land.developments],
+		})),
+		population: { ...population },
+		passives: passives ?? [],
 	};
 }

--- a/packages/web/tests/state/useCompensationLogger.test.tsx
+++ b/packages/web/tests/state/useCompensationLogger.test.tsx
@@ -11,6 +11,7 @@ import { type ResourceKey } from '@kingdom-builder/contents';
 import { useCompensationLogger } from '../../src/state/useCompensationLogger';
 import * as TranslationModule from '../../src/translation';
 import type * as TranslationTypes from '../../src/translation';
+import type { TranslationContext } from '../../src/translation/context';
 
 vi.mock('../../src/translation', async () => {
 	const actual = await vi.importActual<TranslationTypes>(
@@ -26,40 +27,32 @@ const diffStepSnapshotsMock = vi.mocked(TranslationModule.diffStepSnapshots);
 
 const RESOURCE_KEYS: ResourceKey[] = ['gold' as ResourceKey];
 
+const translationContextStub = {
+	buildings: {
+		get: vi.fn(() => ({ icon: '', name: '' })),
+		has: vi.fn(() => true),
+	},
+	developments: {
+		get: vi.fn(() => ({ icon: '', name: '' })),
+		has: vi.fn(() => true),
+	},
+	passives: {
+		evaluationMods: new Map(),
+		list: vi.fn(() => []),
+		get: vi.fn(() => undefined),
+	},
+} as unknown as TranslationContext;
+
 function createSession(): EngineSession {
 	return {
 		hasAiController: () => false,
 		getActionDefinition: () => undefined,
 		runAiTurn: vi.fn().mockResolvedValue(false),
 		advancePhase: vi.fn(),
-		getLegacyContext() {
-			return {
-				activePlayer: {
-					id: 'A',
-					lands: [],
-					buildings: [],
-					resources: {},
-					stats: {},
-				},
-				buildings: {
-					get() {
-						return { icon: '', name: '' };
-					},
-				},
-				developments: {
-					get() {
-						return { icon: '', name: '' };
-					},
-				},
-				passives: {
-					list() {
-						return [];
-					},
-				},
-			} as unknown as EngineSession['getLegacyContext'] extends () => infer R
-				? R
-				: never;
-		},
+		getSnapshot: vi.fn(),
+		performAction: vi.fn(),
+		getActionCosts: vi.fn(() => ({})),
+		getPassiveEvaluationMods: vi.fn(() => new Map()),
 	} as unknown as EngineSession;
 }
 
@@ -124,6 +117,7 @@ function Harness({ session, state, addLog }: HarnessProps) {
 		sessionState: state,
 		addLog,
 		resourceKeys: RESOURCE_KEYS,
+		translationContext: translationContextStub,
 	});
 	return null;
 }

--- a/tests/integration/action-log-hooks.test.ts
+++ b/tests/integration/action-log-hooks.test.ts
@@ -113,7 +113,7 @@ describe('content-driven action log hooks', () => {
 			}
 			expect(buildingLog[0]).toContain(hall.name);
 
-			const landId = session.getLegacyContext().activePlayer.lands[0]?.id;
+			const landId = session.getSnapshot().game.players[0]?.lands[0]?.id;
 			const developmentLog = logContent(
 				'action',
 				establish.id,


### PR DESCRIPTION
## Summary
- Replace legacy diff context usage with sanitized snapshot-based translation contexts across action logging hooks.
- Update action performer utilities to share cost/change filtering helpers and route translation lookups through the live translation context.
- Refresh integration and unit tests to supply the new translation context data and snapshot diff player stubs.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Reused `logContent`, `diffStepSnapshots`, and existing translation registries without introducing new formatters.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** No player-facing copy changed; existing summaries/log lines remain unchanged.

## Standards compliance (required)
1. **File length limits respected:** Confirmed all modified non-test files remain below the project limits via `wc -l` spot checks.
2. **Line length limits respected:** `npm run lint` (see Testing) verifies enforced line-length rules.
3. **Domain separation upheld:** Changes are confined to the web translation/action logging layers; engine/content boundaries remain untouched.
4. **Code standards satisfied:** `npm run lint` completed successfully (see Testing).
5. **Tests updated:** Updated `tests/integration/action-log-hooks.test.ts` and `packages/web/tests/state/useCompensationLogger.test.tsx` to exercise the new diff context wiring.
6. **Documentation updated:** Not required; behavior changes are internal to existing hooks.
7. **`npm run check` results:** `npm run check` completed successfully (see Testing for command output).
8. **`npm run test:coverage` results:** Not run (not required for this change).

## Testing
- `npm run lint`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68e6493920708325825f704da146951c