### PR TITLE
Expose rule snapshots and passive definitions across engine and web

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -25,6 +25,7 @@ export {
 	type PlayerStateSnapshot,
 	type LandSnapshot,
 	type RuleSnapshot,
+	type PassiveRecordSnapshot,
 	type ActionDefinitionSummary,
 	type EngineSessionGetActionCosts,
 	type EngineSessionGetActionRequirements,

--- a/packages/engine/src/runtime/session.ts
+++ b/packages/engine/src/runtime/session.ts
@@ -15,16 +15,19 @@ import type { ActionTrace } from '../log';
 import { cloneActionOptions } from './action_options';
 import { cloneActionTraces } from './player_snapshot';
 import { snapshotAdvance, snapshotEngine } from './engine_snapshot';
-import type { EngineAdvanceResult, EngineSessionSnapshot } from './types';
+import type {
+	EngineAdvanceResult,
+	EngineSessionSnapshot,
+	RuleSnapshot,
+} from './types';
 import type { EvaluationModifier } from '../services/passive_types';
 import {
 	simulateUpcomingPhases as runSimulation,
 	type SimulateUpcomingPhasesOptions,
 	type SimulateUpcomingPhasesResult,
 } from './simulate_upcoming_phases';
-import type { PlayerId, ResourceKey } from '../state';
+import type { PlayerId } from '../state';
 import type { AIDependencies } from '../ai';
-import type { HappinessTierDefinition } from '../services/tiered_resource_types';
 
 export interface ActionDefinitionSummary {
 	id: string;
@@ -87,11 +90,6 @@ export interface EngineSession {
 	getLegacyContext(): EngineContext;
 }
 
-export interface RuleSnapshot {
-	tieredResourceKey: ResourceKey;
-	tierDefinitions: HappinessTierDefinition[];
-}
-
 export type {
 	EngineAdvanceResult,
 	EngineSessionSnapshot,
@@ -100,6 +98,8 @@ export type {
 	GameSnapshot,
 	PlayerStateSnapshot,
 	LandSnapshot,
+	RuleSnapshot,
+	PassiveRecordSnapshot,
 } from './types';
 
 export function createEngineSession(

--- a/packages/engine/src/runtime/types.ts
+++ b/packages/engine/src/runtime/types.ts
@@ -3,7 +3,12 @@ import type { PhaseDef } from '../phases';
 import type { AdvanceSkip } from '../phases/advance';
 import type { PlayerStartConfig } from '@kingdom-builder/protocol';
 import type { PlayerId, StatSourceContribution, ResourceKey } from '../state';
-import type { PassiveMetadata, PassiveSummary } from '../services';
+import type {
+	HappinessTierDefinition,
+	PassiveMetadata,
+	PassiveSummary,
+	PhaseSkipConfig,
+} from '../services';
 
 export interface LandSnapshot {
 	id: string;
@@ -76,10 +81,29 @@ export interface EngineAdvanceResult {
 	skipped?: AdvanceSkipSnapshot;
 }
 
+export interface RuleSnapshot {
+	tieredResourceKey: ResourceKey;
+	tierDefinitions: HappinessTierDefinition[];
+}
+
+export type PassiveRecordSnapshot = PassiveSummary & {
+	owner: PlayerId;
+	detail?: string;
+	effects?: EffectDef[];
+	onGrowthPhase?: EffectDef[];
+	onUpkeepPhase?: EffectDef[];
+	onBeforeAttacked?: EffectDef[];
+	onAttackResolved?: EffectDef[];
+	skip?: PhaseSkipConfig;
+	[key: string]: unknown;
+};
+
 export interface EngineSessionSnapshot {
 	game: GameSnapshot;
 	phases: PhaseDef[];
 	actionCostResource: ResourceKey;
 	recentResourceGains: { key: ResourceKey; amount: number }[];
 	compensations: Record<PlayerId, PlayerStartConfig>;
+	rules: RuleSnapshot;
+	passiveRecords: Record<PlayerId, PassiveRecordSnapshot[]>;
 }

--- a/packages/web/src/components/player/ResourceBar.tsx
+++ b/packages/web/src/components/player/ResourceBar.tsx
@@ -105,14 +105,17 @@ const ResourceBar: React.FC<ResourceBarProps> = ({ player }) => {
 		population: {},
 	};
 	const resourceKeys = Object.keys(RESOURCES) as ResourceKey[];
-	const happinessKey = ctx.services.tieredResource.resourceKey as ResourceKey;
-	const tiers = ctx.services.rules.tierDefinitions;
+	const happinessKey =
+		(translationContext.rules?.tieredResourceKey as ResourceKey) ??
+		(ctx.services.tieredResource.resourceKey as ResourceKey);
+	const tiers =
+		translationContext.rules?.tierDefinitions ??
+		ctx.services.rules.tierDefinitions;
 	const showHappinessCard = (value: number) => {
 		const activeTier = ctx.services.tieredResource.definition(value);
 		const { summaries } = buildTierEntries(
 			tiers,
 			activeTier?.id,
-			ctx,
 			translationContext,
 		);
 		const info = RESOURCES[happinessKey];

--- a/packages/web/src/components/player/buildTierEntries.ts
+++ b/packages/web/src/components/player/buildTierEntries.ts
@@ -3,18 +3,17 @@ import {
 	RESOURCES,
 	type ResourceKey,
 } from '@kingdom-builder/contents';
-import type { EngineContext } from '@kingdom-builder/engine';
 import {
 	describeEffects,
 	splitSummary,
 	type TranslationContext,
+	type TranslationRuleSnapshot,
 } from '../../translation';
 import type { SummaryEntry, SummaryGroup } from '../../translation/content';
 
 export const MAX_TIER_SUMMARY_LINES = 4;
 
-export type TierDefinition =
-	EngineContext['services']['rules']['tierDefinitions'][number];
+export type TierDefinition = TranslationRuleSnapshot['tierDefinitions'][number];
 
 export interface TierSummary {
 	entry: TierSummaryGroup;
@@ -113,9 +112,8 @@ function normalizeSummary(summary: string | undefined): SummaryEntry[] {
 }
 
 export function buildTierEntries(
-	tiers: TierDefinition[],
+	tiers: ReadonlyArray<TierDefinition>,
 	activeId: string | undefined,
-	ctx: EngineContext,
 	translationContext: TranslationContext,
 ): TierEntriesResult {
 	const getRangeStart = (tier: TierDefinition) =>
@@ -123,7 +121,7 @@ export function buildTierEntries(
 	const orderedTiers = [...tiers].sort(
 		(a, b) => getRangeStart(b) - getRangeStart(a),
 	);
-	const tierResourceKey = ctx.services.tieredResource?.resourceKey as
+	const tierResourceKey = translationContext.rules?.tieredResourceKey as
 		| ResourceKey
 		| undefined;
 	const tierResourceIcon = tierResourceKey

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -122,6 +122,11 @@ export function GameProvider({
 		refresh();
 	}, [ctx, refresh, playerName]);
 
+	const ruleSnapshot = useMemo(
+		() => session.getRuleSnapshot(),
+		[session, tick],
+	);
+
 	const translationContext = useMemo(
 		() =>
 			createTranslationContext(
@@ -135,8 +140,12 @@ export function GameProvider({
 					pullEffectLog: <T,>(key: string) => session.pullEffectLog<T>(key),
 					evaluationMods: session.getPassiveEvaluationMods(),
 				},
+				{
+					rules: ruleSnapshot,
+					passiveRecords: sessionState.passiveRecords,
+				},
 			),
-		[sessionState, session],
+		[sessionState, session, ruleSnapshot],
 	);
 
 	const {

--- a/packages/web/src/translation/context/helpers.ts
+++ b/packages/web/src/translation/context/helpers.ts
@@ -1,0 +1,219 @@
+import type {
+	EngineSessionSnapshot,
+	PassiveRecordSnapshot,
+	PassiveSummary,
+	PlayerId,
+	RuleSnapshot,
+} from '@kingdom-builder/engine';
+import type { PlayerStartConfig } from '@kingdom-builder/protocol';
+import type {
+	TranslationPassiveDefinition,
+	TranslationPassiveDescriptor,
+	TranslationPassiveModifierMap,
+	TranslationPlayer,
+	TranslationRegistry,
+	TranslationRuleSnapshot,
+} from './types';
+
+function cloneRecord<T>(record: Record<string, T>): Record<string, T> {
+	return Object.freeze({ ...record });
+}
+
+function clonePassiveMeta(
+	meta: NonNullable<PassiveSummary['meta']>,
+): NonNullable<PassiveSummary['meta']> {
+	const cloned: NonNullable<PassiveSummary['meta']> = {};
+	if (meta.source !== undefined) {
+		cloned.source = { ...meta.source };
+	}
+	if (meta.removal !== undefined) {
+		cloned.removal = { ...meta.removal };
+	}
+	return Object.freeze(cloned);
+}
+
+export function clonePassiveSummary(summary: PassiveSummary): PassiveSummary {
+	const cloned: PassiveSummary = { id: summary.id };
+	if (summary.name !== undefined) {
+		cloned.name = summary.name;
+	}
+	if (summary.icon !== undefined) {
+		cloned.icon = summary.icon;
+	}
+	if (summary.detail !== undefined) {
+		cloned.detail = summary.detail;
+	}
+	if (summary.meta !== undefined) {
+		cloned.meta = clonePassiveMeta(summary.meta);
+	}
+	return Object.freeze(cloned);
+}
+
+function toPassiveDescriptor(
+	summary: PassiveSummary,
+): TranslationPassiveDescriptor {
+	const descriptor: TranslationPassiveDescriptor = {};
+	if (summary.icon !== undefined) {
+		descriptor.icon = summary.icon;
+	}
+	const sourceIcon = summary.meta?.source?.icon;
+	if (sourceIcon !== undefined) {
+		descriptor.meta = Object.freeze({
+			source: Object.freeze({ icon: sourceIcon }),
+		});
+	}
+	return Object.freeze(descriptor);
+}
+
+export function clonePlayer(
+	player: EngineSessionSnapshot['game']['players'][number],
+): TranslationPlayer {
+	return Object.freeze({
+		id: player.id,
+		name: player.name,
+		resources: cloneRecord(player.resources),
+		stats: cloneRecord(player.stats),
+		population: cloneRecord(player.population),
+	});
+}
+
+export function wrapRegistry<TDefinition>(registry: {
+	get(id: string): TDefinition;
+	has(id: string): boolean;
+}): TranslationRegistry<TDefinition> {
+	return Object.freeze({
+		get(id: string) {
+			return registry.get(id);
+		},
+		has(id: string) {
+			return registry.has(id);
+		},
+	});
+}
+
+function clonePlayerStartConfig(config: PlayerStartConfig): PlayerStartConfig {
+	return JSON.parse(JSON.stringify(config)) as PlayerStartConfig;
+}
+
+export function cloneCompensations(
+	compensations: EngineSessionSnapshot['compensations'],
+): Record<PlayerId, PlayerStartConfig> {
+	return Object.freeze(
+		Object.fromEntries(
+			Object.entries(compensations).map(([playerId, config]) => [
+				playerId,
+				clonePlayerStartConfig(config),
+			]),
+		),
+	) as Record<PlayerId, PlayerStartConfig>;
+}
+
+export function mapPassives(
+	players: EngineSessionSnapshot['game']['players'],
+): ReadonlyMap<PlayerId, PassiveSummary[]> {
+	return new Map(
+		players.map((player) => [
+			player.id,
+			player.passives.map(clonePassiveSummary),
+		]),
+	);
+}
+
+export function flattenPassives(
+	passives: ReadonlyMap<PlayerId, PassiveSummary[]>,
+): PassiveSummary[] {
+	return Array.from(passives.values()).flatMap((entries) =>
+		entries.map(clonePassiveSummary),
+	);
+}
+
+export function mapPassiveDescriptors(
+	passives: ReadonlyMap<PlayerId, PassiveSummary[]>,
+): ReadonlyMap<PlayerId, Map<string, TranslationPassiveDescriptor>> {
+	return new Map(
+		Array.from(passives.entries()).map(([owner, list]) => [
+			owner,
+			new Map(
+				list.map((summary) => [summary.id, toPassiveDescriptor(summary)]),
+			),
+		]),
+	);
+}
+
+export function cloneRecentResourceGains(
+	recent: EngineSessionSnapshot['recentResourceGains'],
+): ReadonlyArray<{ key: string; amount: number }> {
+	return Object.freeze(recent.map((entry) => ({ ...entry })));
+}
+
+export function cloneEvaluationModifiers(
+	evaluationMods?: ReadonlyMap<string, ReadonlyMap<string, unknown>>,
+): TranslationPassiveModifierMap {
+	if (!evaluationMods) {
+		return new Map();
+	}
+	return new Map(
+		Array.from(evaluationMods.entries()).map(([modifierId, mods]) => [
+			modifierId,
+			new Map(mods) as ReadonlyMap<string, unknown>,
+		]),
+	);
+}
+
+export function cloneRuleSnapshot(
+	snapshot: RuleSnapshot | undefined,
+): TranslationRuleSnapshot | undefined {
+	if (!snapshot) {
+		return undefined;
+	}
+	const tierDefinitions = snapshot.tierDefinitions.map((definition) =>
+		Object.freeze(
+			JSON.parse(
+				JSON.stringify(definition),
+			) as TranslationRuleSnapshot['tierDefinitions'][number],
+		),
+	);
+	return Object.freeze({
+		tieredResourceKey: snapshot.tieredResourceKey,
+		tierDefinitions: Object.freeze(tierDefinitions),
+	});
+}
+
+function clonePassiveDefinition(
+	record: PassiveRecordSnapshot,
+): TranslationPassiveDefinition {
+	const { owner: _owner, ...rest } = record;
+	const clone = JSON.parse(
+		JSON.stringify(rest),
+	) as TranslationPassiveDefinition;
+	return Object.freeze(clone);
+}
+
+export const EMPTY_DEFINITIONS: readonly TranslationPassiveDefinition[] =
+	Object.freeze([]);
+
+export function buildPassiveDefinitionLookup(
+	passiveRecords: Record<PlayerId, PassiveRecordSnapshot[]> | undefined,
+): ReadonlyMap<
+	PlayerId,
+	{
+		list: readonly TranslationPassiveDefinition[];
+		map: Map<string, TranslationPassiveDefinition>;
+	}
+> {
+	if (!passiveRecords) {
+		return new Map();
+	}
+	return new Map(
+		Object.entries(passiveRecords).map(([owner, records]) => {
+			const definitions = (records ?? []).map((record) =>
+				clonePassiveDefinition(record),
+			);
+			const frozenList = Object.freeze(definitions);
+			const lookup = new Map(
+				frozenList.map((definition) => [definition.id, definition]),
+			);
+			return [owner as PlayerId, { list: frozenList, map: lookup }];
+		}),
+	);
+}

--- a/packages/web/src/translation/context/types.ts
+++ b/packages/web/src/translation/context/types.ts
@@ -1,8 +1,13 @@
-import type { PassiveSummary, PlayerId } from '@kingdom-builder/engine';
+import type {
+	PassiveSummary,
+	PlayerId,
+	RuleSnapshot,
+} from '@kingdom-builder/engine';
 import type {
 	ActionConfig,
 	BuildingConfig,
 	DevelopmentConfig,
+	EffectDef,
 	PlayerStartConfig,
 } from '@kingdom-builder/protocol';
 
@@ -27,6 +32,25 @@ export type TranslationPassiveDescriptor = {
 };
 
 /**
+ * Full passive definition payload exposed to translation helpers. This mirrors
+ * the readonly subset of {@link PassiveRecordSnapshot} fields currently used by
+ * hover cards and tier summaries.
+ */
+export type TranslationPassiveDefinition = {
+	id: string;
+	name?: string;
+	icon?: string;
+	detail?: string;
+	meta?: PassiveSummary['meta'];
+	effects?: ReadonlyArray<EffectDef>;
+	onGrowthPhase?: ReadonlyArray<EffectDef>;
+	onUpkeepPhase?: ReadonlyArray<EffectDef>;
+	onBeforeAttacked?: ReadonlyArray<EffectDef>;
+	onAttackResolved?: ReadonlyArray<EffectDef>;
+	[key: string]: unknown;
+};
+
+/**
  * Map of evaluator modifier identifiers to the owning modifier instances. The
  * values remain intentionally untyped because translation formatters only
  * inspect presence and icon metadata.
@@ -44,6 +68,11 @@ export type TranslationPassiveModifierMap = ReadonlyMap<
 export interface TranslationPassives {
 	list(owner?: PlayerId): PassiveSummary[];
 	get(id: string, owner: PlayerId): TranslationPassiveDescriptor | undefined;
+	listDefinitions(owner: PlayerId): readonly TranslationPassiveDefinition[];
+	getDefinition(
+		id: string,
+		owner: PlayerId,
+	): TranslationPassiveDefinition | undefined;
 	readonly evaluationMods: TranslationPassiveModifierMap;
 }
 
@@ -75,6 +104,11 @@ export interface TranslationPlayer {
 	population: Record<string, number>;
 }
 
+export interface TranslationRuleSnapshot {
+	tieredResourceKey: RuleSnapshot['tieredResourceKey'];
+	tierDefinitions: ReadonlyArray<RuleSnapshot['tierDefinitions'][number]>;
+}
+
 /**
  * Translation-focused view over the engine context. Implementations are free to
  * wrap the full {@link LegacyEngineContext} as long as the read-only surface
@@ -88,6 +122,7 @@ export interface TranslationContext {
 	readonly phases: readonly TranslationPhase[];
 	readonly activePlayer: TranslationPlayer;
 	readonly opponent: TranslationPlayer;
+	readonly rules?: TranslationRuleSnapshot;
 	readonly recentResourceGains: ReadonlyArray<{
 		key: string;
 		amount: number;

--- a/packages/web/tests/helpers/createPassiveDisplayGame.ts
+++ b/packages/web/tests/helpers/createPassiveDisplayGame.ts
@@ -23,8 +23,9 @@ type PassiveGameContext = {
 function createPassiveGame(ctx: EngineContext): PassiveGameContext {
 	const handleHoverCard = vi.fn();
 	const clearHoverCard = vi.fn();
+	const snapshot = snapshotEngine(ctx);
 	const translationContext = createTranslationContext(
-		snapshotEngine(ctx),
+		snapshot,
 		{
 			actions: ACTIONS,
 			buildings: BUILDINGS,
@@ -33,6 +34,10 @@ function createPassiveGame(ctx: EngineContext): PassiveGameContext {
 		{
 			pullEffectLog: (key) => ctx.pullEffectLog(key),
 			evaluationMods: ctx.passives.evaluationMods,
+		},
+		{
+			rules: snapshot.rules,
+			passiveRecords: snapshot.passiveRecords,
 		},
 	);
 	const mockGame: MockGame = {

--- a/packages/web/tests/passive-display.test.tsx
+++ b/packages/web/tests/passive-display.test.tsx
@@ -16,7 +16,10 @@ import {
 	formatPassiveRemoval,
 	type ResourceKey,
 } from '@kingdom-builder/contents';
-import { resolvePassivePresentation } from '../src/translation/log/passives';
+import {
+	resolvePassivePresentation,
+	type PassiveDefinitionLike,
+} from '../src/translation/log/passives';
 import { buildTierEntries } from '../src/components/player/buildTierEntries';
 import {
 	createPassiveGame,
@@ -54,12 +57,23 @@ describe('<PassiveDisplay />', () => {
 		currentGame = mockGame;
 
 		render(<PassiveDisplay player={ctx.activePlayer} />);
-		const [summary] = ctx.passives.list(ctx.activePlayer.id);
+		const playerId = ctx.activePlayer.id;
+		const [summary] = translationContext.passives.list(playerId);
 		expect(summary).toBeDefined();
-		const definitions = ctx.passives.values(ctx.activePlayer.id);
-		const definition = definitions.find((def) => def.id === summary?.id);
+		const definition = summary
+			? translationContext.passives.getDefinition(summary.id, playerId)
+			: undefined;
 		expect(definition).toBeDefined();
-		const presentation = resolvePassivePresentation(summary!, { definition });
+		const passiveDefinition: PassiveDefinitionLike | undefined = definition
+			? {
+					detail: definition.detail,
+					meta: definition.meta,
+					...(definition.effects ? { effects: [...definition.effects] } : {}),
+				}
+			: undefined;
+		const presentation = resolvePassivePresentation(summary!, {
+			definition: passiveDefinition,
+		});
 		expect(presentation.removal).toBeDefined();
 		const hoverTarget = document.querySelector('div.hoverable');
 		expect(hoverTarget).not.toBeNull();
@@ -69,7 +83,7 @@ describe('<PassiveDisplay />', () => {
 		expect(handleHoverCard).toHaveBeenCalled();
 		const [hoverCard] = handleHoverCard.mock.calls.at(-1) ?? [{}];
 		expect(hoverCard?.description).toBeUndefined();
-		const tierDefinition = ctx.services.rules.tierDefinitions.find(
+		const tierDefinition = translationContext.rules?.tierDefinitions.find(
 			(tier) => tier.preview?.id === summary?.id,
 		);
 		expect(tierDefinition).toBeDefined();
@@ -77,7 +91,6 @@ describe('<PassiveDisplay />', () => {
 			const { entries } = buildTierEntries(
 				[tierDefinition],
 				tierDefinition.id,
-				ctx,
 				translationContext,
 			);
 			expect(hoverCard?.effects).toEqual(entries);
@@ -102,12 +115,23 @@ describe('<PassiveDisplay />', () => {
 		currentGame = mockGame;
 		const view = render(<PassiveDisplay player={ctx.activePlayer} />);
 		const { container } = view;
-		const [summary] = ctx.passives.list(ctx.activePlayer.id);
+		const playerId = ctx.activePlayer.id;
+		const [summary] = mockGame.translationContext.passives.list(playerId);
 		expect(summary).toBeDefined();
-		const definitions = ctx.passives.values(ctx.activePlayer.id);
-		const definition = definitions.find((def) => def.id === summary?.id);
+		const definition = summary
+			? mockGame.translationContext.passives.getDefinition(summary.id, playerId)
+			: undefined;
 		expect(definition).toBeDefined();
-		const presentation = resolvePassivePresentation(summary!, { definition });
+		const passiveDefinition: PassiveDefinitionLike | undefined = definition
+			? {
+					detail: definition.detail,
+					meta: definition.meta,
+					...(definition.effects ? { effects: [...definition.effects] } : {}),
+				}
+			: undefined;
+		const presentation = resolvePassivePresentation(summary!, {
+			definition: passiveDefinition,
+		});
 		expect(presentation.removal).toBeDefined();
 		const hoverTarget = container.querySelector('div.hoverable');
 		expect(hoverTarget).not.toBeNull();


### PR DESCRIPTION
## Summary
- extend `EngineSessionSnapshot` so rule tiers and passive records are cloned alongside the rest of the session state, and surface them via `EngineSession.getRuleSnapshot()`
- thread the new rule/passive data through `GameContext` into `createTranslationContext`, reorganizing the translation helpers to expose immutable registry lookups
- update passive- and tier-related UI plus their tests to rely solely on the enriched translation context

## Text formatting audit (required)
1. **Translator/formatter reuse:** `createTranslationContext`, `describeEffects`, `splitSummary`, and `buildTierEntries` were reused for all passive/tier surfaces.
2. **Canonical keywords/icons/helpers touched:** `PASSIVE_INFO`, `RESOURCES`, `PhaseId`, `describeEffects`, `splitSummary`, and `buildTierEntries`.
3. **Voice review:** Confirmed Summary, Description, and Log voices remain aligned with existing copy.

## Standards compliance (required)
1. **File length limits respected:** New helper module `packages/web/src/translation/context/helpers.ts` is 219 lines (≤250); all other touched files remain within existing limits. 【00a37b†L1-L2】
2. **Line length limits respected:** `npm run check` runs Prettier in check mode and passed without diffs. 【58d6f3†L1-L11】
3. **Domain separation upheld:** Engine changes only expose snapshots; web reads them via session APIs with no direct engine mutations. 【F:packages/engine/src/runtime/session.ts†L55-L188】【F:packages/web/src/state/GameContext.tsx†L125-L149】
4. **Code standards satisfied:** Linting succeeded as part of `npm run check`. 【b8d78a†L1-L11】【63b8cc†L1-L13】
5. **Tests updated:** Passive display tests now consume the new translation data. 【F:packages/web/tests/helpers/createPassiveDisplayGame.ts†L23-L52】【F:packages/web/tests/passive-display.test.tsx†L41-L150】
6. **Documentation updated:** Not required; existing docs already cover translation context usage.
7. **`npm run check` results:** `npm run check` (via pre-commit hook) passed. 【58d6f3†L1-L11】【8db2c0†L9-L13】
8. **`npm run test:coverage` results:** Not run; coverage suite was not requested for this change.

## Testing
- `npm run check` (pass)【58d6f3†L1-L11】【8db2c0†L9-L13】

------
https://chatgpt.com/codex/tasks/task_e_68e652851a8c832585bb39b0fb88a04c