### PR TITLE
Refine settings audio toggle and player name flow

### DIFF
--- a/packages/web/src/components/settings/PlayerNameSetting.tsx
+++ b/packages/web/src/components/settings/PlayerNameSetting.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom';
 import {
 	type ChangeEvent,
 	type FormEvent,
@@ -8,10 +9,10 @@ import {
 import Button from '../common/Button';
 import { useOptionalGameEngine } from '../../state/GameContext';
 
-const INPUT_FORM_CLASS = [
+const DISPLAY_ROW_CLASS = [
 	'flex flex-col gap-4 rounded-2xl border border-white/20 bg-white/85 px-6 py-5',
-	'shadow-inner shadow-slate-900/5 dark:border-white/10 dark:bg-slate-900/80',
-	'dark:shadow-black/30',
+	'text-left shadow-inner shadow-slate-900/5 dark:border-white/10 dark:bg-slate-900/80',
+	'dark:shadow-black/30 sm:flex-row sm:items-center sm:justify-between',
 ].join(' ');
 
 const TITLE_CLASS = [
@@ -19,8 +20,24 @@ const TITLE_CLASS = [
 	'dark:text-slate-200',
 ].join(' ');
 
-const DESCRIPTION_CLASS = [
-	'text-sm text-slate-600 dark:text-slate-300/80',
+const NAME_TEXT_CLASS = [
+	'text-lg font-semibold text-slate-900 dark:text-slate-100',
+	'truncate max-w-xs sm:max-w-sm',
+].join(' ');
+
+const DIALOG_OVERLAY_CLASS = [
+	'fixed inset-0 z-50 flex items-center justify-center px-4 py-8',
+].join(' ');
+
+const OVERLAY_BACKDROP_CLASS = [
+	'absolute inset-0 bg-slate-900/70 backdrop-blur-sm',
+].join(' ');
+
+const DIALOG_SURFACE_CLASS = [
+	'relative z-10 w-full max-w-md rounded-3xl border border-white/20',
+	'bg-gradient-to-br from-white/95 via-white/90 to-white/85 p-7 text-slate-900',
+	'shadow-2xl shadow-slate-900/30 dark:border-white/10 dark:from-slate-900/95',
+	'dark:via-slate-900/90 dark:to-slate-900/80 dark:text-slate-100',
 ].join(' ');
 
 const INPUT_FIELD_CLASS = [
@@ -31,19 +48,14 @@ const INPUT_FIELD_CLASS = [
 	'dark:focus:border-emerald-300 dark:focus:ring-emerald-500/40',
 ].join(' ');
 
-const STATUS_CLASS: Record<'idle' | 'success' | 'error', string> = {
+const STATUS_CLASS: Record<'idle' | 'error', string> = {
 	idle: 'hidden',
-	success: 'text-xs font-semibold text-emerald-600 dark:text-emerald-400',
 	error: 'text-xs font-semibold text-rose-600 dark:text-rose-400',
 };
 
-const NOTE_TEXT_CLASS = ['text-xs text-slate-500 dark:text-slate-400'].join(
+const ACTIONS_LAYOUT_CLASS = ['mt-6 flex flex-wrap justify-end gap-3'].join(
 	' ',
 );
-
-const ACTIONS_LAYOUT_CLASS = [
-	'flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between',
-].join(' ');
 
 interface PlayerNameSettingProps {
 	open: boolean;
@@ -58,10 +70,69 @@ export function PlayerNameSetting({
 }: PlayerNameSettingProps) {
 	const gameEngine = useOptionalGameEngine();
 	const pushSuccessToast = gameEngine?.pushSuccessToast;
+	const [isDialogOpen, setDialogOpen] = useState(false);
+
+	useEffect(() => {
+		if (!open) {
+			setDialogOpen(false);
+		}
+	}, [open]);
+
+	const handleDialogClose = () => {
+		setDialogOpen(false);
+	};
+
+	const handleDialogOpen = () => {
+		setDialogOpen(true);
+	};
+
+	return (
+		<>
+			<div className={DISPLAY_ROW_CLASS}>
+				<div className="flex flex-col gap-2">
+					<h3 className={TITLE_CLASS}>Player name</h3>
+					<span className={NAME_TEXT_CLASS}>{playerName}</span>
+				</div>
+				<Button
+					type="button"
+					variant="secondary"
+					className="self-start sm:self-auto"
+					icon="✏️"
+					onClick={handleDialogOpen}
+				>
+					Change
+				</Button>
+			</div>
+			<PlayerNameDialog
+				open={isDialogOpen}
+				playerName={playerName}
+				onClose={handleDialogClose}
+				onSave={onSave}
+				pushSuccessToast={pushSuccessToast}
+			/>
+		</>
+	);
+}
+
+interface PlayerNameDialogProps {
+	open: boolean;
+	playerName: string;
+	onClose: () => void;
+	onSave: (name: string) => void;
+	pushSuccessToast?: ((message: string, title?: string) => void) | undefined;
+}
+
+function PlayerNameDialog({
+	open,
+	playerName,
+	onClose,
+	onSave,
+	pushSuccessToast,
+}: PlayerNameDialogProps) {
 	const inputId = useId();
 	const labelId = `${inputId}-label`;
 	const [draftName, setDraftName] = useState(playerName);
-	const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+	const [status, setStatus] = useState<'idle' | 'error'>('idle');
 	const [message, setMessage] = useState('');
 
 	useEffect(() => {
@@ -73,69 +144,103 @@ export function PlayerNameSetting({
 		setMessage('');
 	}, [open, playerName]);
 
+	useEffect(() => {
+		if (!open || typeof window === 'undefined') {
+			return;
+		}
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				onClose();
+			}
+		};
+		window.addEventListener('keydown', handleKeyDown);
+		return () => {
+			window.removeEventListener('keydown', handleKeyDown);
+		};
+	}, [open, onClose]);
+
 	const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
 		setDraftName(event.target.value);
 		setStatus('idle');
 		setMessage('');
 	};
 
-	const commitName = () => {
+	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
 		const trimmed = draftName.trim();
 		if (!trimmed) {
 			setStatus('error');
 			setMessage('Please enter a name.');
 			return;
 		}
-		if (trimmed === playerName) {
-			setStatus('success');
-			setMessage('Name updated.');
-			return;
+		if (trimmed !== playerName) {
+			onSave(trimmed);
+			pushSuccessToast?.(
+				'Your title now echoes across the realm.',
+				'Name saved',
+			);
 		}
-		onSave(trimmed);
-		setStatus('success');
-		setMessage('Name updated.');
-		pushSuccessToast?.('Your title now echoes across the realm.', 'Name saved');
-	};
-
-	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-		event.preventDefault();
-		commitName();
+		onClose();
 	};
 
 	const statusClass = STATUS_CLASS[status];
 
-	return (
-		<form className={INPUT_FORM_CLASS} onSubmit={handleSubmit} noValidate>
-			<div className="flex flex-col gap-2 text-left">
-				<h3 id={labelId} className={TITLE_CLASS}>
-					Player name
-				</h3>
-				<p className={DESCRIPTION_CLASS}>
-					This name appears across panels, logs, and history summaries.
-				</p>
-			</div>
-			<input
-				id={inputId}
+	if (!open || typeof document === 'undefined') {
+		return null;
+	}
+
+	return createPortal(
+		<div className={DIALOG_OVERLAY_CLASS}>
+			<div className={OVERLAY_BACKDROP_CLASS} onClick={onClose} aria-hidden />
+			<form
+				className={DIALOG_SURFACE_CLASS}
+				role="dialog"
+				aria-modal="true"
 				aria-labelledby={labelId}
-				className={INPUT_FIELD_CLASS}
-				value={draftName}
-				onChange={handleChange}
-				maxLength={40}
-			/>
-			<p
-				className={statusClass}
-				role={status === 'error' ? 'alert' : undefined}
+				onSubmit={handleSubmit}
+				noValidate
 			>
-				{message}
-			</p>
-			<div className={ACTIONS_LAYOUT_CLASS}>
-				<p className={NOTE_TEXT_CLASS}>
-					Save to see your title echoed immediately across the realm.
+				<div className="absolute -top-12 right-8 h-24 w-24 rounded-full bg-emerald-400/30 blur-3xl dark:bg-emerald-500/30" />
+				<h3 id={labelId} className="text-xl font-semibold tracking-tight">
+					Change player name
+				</h3>
+				<label
+					className="mt-5 block text-sm font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-200"
+					htmlFor={inputId}
+				>
+					Player name
+				</label>
+				<input
+					id={inputId}
+					className={INPUT_FIELD_CLASS}
+					value={draftName}
+					onChange={handleChange}
+					maxLength={40}
+					autoFocus
+				/>
+				<p
+					className={statusClass}
+					role={status === 'error' ? 'alert' : undefined}
+				>
+					{message}
 				</p>
-				<Button type="submit" variant="success" className="sm:w-auto" icon="💾">
-					Save name
-				</Button>
-			</div>
-		</form>
+				<div className={ACTIONS_LAYOUT_CLASS}>
+					<Button
+						type="button"
+						variant="secondary"
+						className="px-5"
+						icon="↩️"
+						onClick={onClose}
+					>
+						Cancel
+					</Button>
+					<Button type="submit" variant="success" className="px-5" icon="💾">
+						Save
+					</Button>
+				</div>
+			</form>
+		</div>,
+		document.body,
 	);
 }

--- a/packages/web/src/components/settings/SettingsDialog.tsx
+++ b/packages/web/src/components/settings/SettingsDialog.tsx
@@ -216,10 +216,10 @@ export default function SettingsDialog({
 								onToggle={onToggleSound}
 							/>
 							<SettingRow
-								id="settings-background-mute"
-								title="Mute in background"
-								description="Pause audio when you switch tabs or windows."
-								checked={backgroundAudioMuted}
+								id="settings-background-audio"
+								title="Play audio in background"
+								description="Keep music and effects playing when you switch tabs."
+								checked={!backgroundAudioMuted}
 								onToggle={onToggleBackgroundAudioMute}
 							/>
 						</div>


### PR DESCRIPTION
## Summary
- Clarified the background audio toggle copy so the enabled state consistently represents active audio.
- Replaced the inline player name form with a read-only summary and a dedicated modal for editing with validation.

## Text formatting audit (required)
1. **Translator/formatter reuse:** N/A – updated static UI copy without touching translators or formatters.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** Reviewed Settings dialog copy for consistent player-facing voice.

## Standards compliance (required)
1. **File length limits respected:** Modified files remain under the 250-line limit (PlayerNameSetting.tsx is 245 lines, SettingsDialog.tsx is 236 lines).
2. **Line length limits respected:** Prettier formatting keeps all lines within the configured width; `npm run check` passed.
3. **Domain separation upheld:** All changes are confined to web UI components; engine/content layers were untouched.
4. **Code standards satisfied:** `npm run lint` completed without issues.
5. **Tests updated:** No new tests were required; existing suite still passes after the UI-only change set.
6. **Documentation updated:** No documentation changes were necessary.
7. **`npm run check` results:** Ran locally (`npm run check`) and it completed successfully.
8. **`npm run test:coverage` results:** Not run; unchanged test coverage expectations for this UI-only update.

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68e65b72b82c83259fe027024db258cf