### PR TITLE
Refine settings toggles and player name editing

### DIFF
--- a/packages/web/src/components/settings/PlayerNameSetting.tsx
+++ b/packages/web/src/components/settings/PlayerNameSetting.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom';
 import {
 	type ChangeEvent,
 	type FormEvent,
@@ -8,10 +9,10 @@ import {
 import Button from '../common/Button';
 import { useOptionalGameEngine } from '../../state/GameContext';
 
-const INPUT_FORM_CLASS = [
-	'flex flex-col gap-4 rounded-2xl border border-white/20 bg-white/85 px-6 py-5',
-	'shadow-inner shadow-slate-900/5 dark:border-white/10 dark:bg-slate-900/80',
-	'dark:shadow-black/30',
+const DISPLAY_CARD_CLASS = [
+	'flex items-center justify-between gap-4 rounded-2xl border',
+	'border-white/20 bg-white/85 px-6 py-5 shadow-inner shadow-slate-900/5',
+	'dark:border-white/10 dark:bg-slate-900/80 dark:shadow-black/30',
 ].join(' ');
 
 const TITLE_CLASS = [
@@ -19,36 +20,168 @@ const TITLE_CLASS = [
 	'dark:text-slate-200',
 ].join(' ');
 
-const DESCRIPTION_CLASS = [
-	'text-sm text-slate-600 dark:text-slate-300/80',
+const NAME_TEXT_CLASS = [
+	'text-base font-semibold text-slate-900',
+	'dark:text-slate-100',
+].join(' ');
+
+const DIALOG_BACKDROP_CLASS = [
+	'absolute inset-0 bg-slate-900/70 backdrop-blur-sm',
+].join(' ');
+
+const DIALOG_SURFACE_CLASS = [
+	'relative z-10 w-full max-w-md rounded-3xl border border-white/20',
+	'bg-gradient-to-br from-white/95 via-white/90 to-white/85 p-8 text-slate-900',
+	'shadow-2xl shadow-slate-900/30 dark:border-white/10',
+	'dark:from-slate-900/95 dark:via-slate-900/90 dark:to-slate-900/85',
+	'dark:text-slate-100',
 ].join(' ');
 
 const INPUT_FIELD_CLASS = [
 	'w-full rounded-full border border-slate-300 bg-white/90 px-5 py-3 text-sm',
-	'text-slate-900 shadow-inner shadow-slate-900/5 transition focus:border-emerald-400',
-	'focus:outline-none focus:ring-2 focus:ring-emerald-200 dark:border-white/10',
-	'dark:bg-slate-900/85 dark:text-slate-100 dark:shadow-black/30',
-	'dark:focus:border-emerald-300 dark:focus:ring-emerald-500/40',
+	'text-slate-900 shadow-inner shadow-slate-900/5 transition',
+	'focus:border-emerald-400 focus:outline-none focus:ring-2',
+	'focus:ring-emerald-200',
+	'dark:border-white/10 dark:bg-slate-900/85 dark:text-slate-100',
+	'dark:shadow-black/30 dark:focus:border-emerald-300',
+	'dark:focus:ring-emerald-500/40',
 ].join(' ');
 
-const STATUS_CLASS: Record<'idle' | 'success' | 'error', string> = {
-	idle: 'hidden',
-	success: 'text-xs font-semibold text-emerald-600 dark:text-emerald-400',
-	error: 'text-xs font-semibold text-rose-600 dark:text-rose-400',
-};
-
-const NOTE_TEXT_CLASS = ['text-xs text-slate-500 dark:text-slate-400'].join(
-	' ',
-);
-
-const ACTIONS_LAYOUT_CLASS = [
-	'flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between',
+const ERROR_TEXT_CLASS = [
+	'text-xs font-semibold text-rose-600',
+	'dark:text-rose-400',
 ].join(' ');
 
 interface PlayerNameSettingProps {
 	open: boolean;
 	playerName: string;
 	onSave: (name: string) => void;
+}
+
+interface PlayerNameDialogProps {
+	open: boolean;
+	initialName: string;
+	onClose: () => void;
+	onSave: (name: string) => void;
+}
+
+function PlayerNameDialog({
+	open,
+	initialName,
+	onClose,
+	onSave,
+}: PlayerNameDialogProps) {
+	const inputId = useId();
+	const labelId = `${inputId}-label`;
+	const [draftName, setDraftName] = useState(initialName);
+	const [error, setError] = useState('');
+
+	useEffect(() => {
+		if (!open) {
+			return;
+		}
+		setDraftName(initialName);
+		setError('');
+	}, [open, initialName]);
+
+	useEffect(() => {
+		if (!open || typeof window === 'undefined') {
+			return;
+		}
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				onClose();
+			}
+		};
+		window.addEventListener('keydown', handleKeyDown);
+		return () => {
+			window.removeEventListener('keydown', handleKeyDown);
+		};
+	}, [open, onClose]);
+
+	if (!open || typeof document === 'undefined') {
+		return null;
+	}
+
+	const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setDraftName(event.target.value);
+		if (error) {
+			setError('');
+		}
+	};
+
+	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const trimmed = draftName.trim();
+		if (!trimmed) {
+			setError('Enter a name.');
+			return;
+		}
+		if (trimmed === initialName) {
+			onClose();
+			return;
+		}
+		onSave(trimmed);
+		onClose();
+	};
+
+	return createPortal(
+		<div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8">
+			<div className={DIALOG_BACKDROP_CLASS} onClick={onClose} aria-hidden />
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby={labelId}
+				className={DIALOG_SURFACE_CLASS}
+			>
+				<h2 className="text-xl font-semibold tracking-tight">
+					Change player name
+				</h2>
+				<form
+					className="mt-6 flex flex-col gap-4"
+					onSubmit={handleSubmit}
+					noValidate
+				>
+					<label
+						id={labelId}
+						htmlFor={inputId}
+						className="text-sm font-semibold"
+					>
+						Player name
+					</label>
+					<input
+						id={inputId}
+						className={INPUT_FIELD_CLASS}
+						value={draftName}
+						onChange={handleChange}
+						maxLength={40}
+						autoFocus
+					/>
+					{error ? (
+						<p className={ERROR_TEXT_CLASS} role="alert">
+							{error}
+						</p>
+					) : null}
+					<div className="mt-2 flex justify-end gap-3">
+						<Button
+							type="button"
+							variant="secondary"
+							onClick={onClose}
+							className="px-5"
+							icon="↩️"
+						>
+							Cancel
+						</Button>
+						<Button type="submit" variant="success" className="px-5" icon="💾">
+							Save
+						</Button>
+					</div>
+				</form>
+			</div>
+		</div>,
+		document.body,
+	);
 }
 
 export function PlayerNameSetting({
@@ -58,84 +191,44 @@ export function PlayerNameSetting({
 }: PlayerNameSettingProps) {
 	const gameEngine = useOptionalGameEngine();
 	const pushSuccessToast = gameEngine?.pushSuccessToast;
-	const inputId = useId();
-	const labelId = `${inputId}-label`;
-	const [draftName, setDraftName] = useState(playerName);
-	const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
-	const [message, setMessage] = useState('');
+	const [isDialogOpen, setIsDialogOpen] = useState(false);
 
 	useEffect(() => {
 		if (!open) {
-			return;
+			setIsDialogOpen(false);
 		}
-		setDraftName(playerName);
-		setStatus('idle');
-		setMessage('');
-	}, [open, playerName]);
+	}, [open]);
 
-	const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-		setDraftName(event.target.value);
-		setStatus('idle');
-		setMessage('');
+	const handleSave = (name: string) => {
+		onSave(name);
+		pushSuccessToast?.('Player name updated.', 'Saved');
 	};
-
-	const commitName = () => {
-		const trimmed = draftName.trim();
-		if (!trimmed) {
-			setStatus('error');
-			setMessage('Please enter a name.');
-			return;
-		}
-		if (trimmed === playerName) {
-			setStatus('success');
-			setMessage('Name updated.');
-			return;
-		}
-		onSave(trimmed);
-		setStatus('success');
-		setMessage('Name updated.');
-		pushSuccessToast?.('Your title now echoes across the realm.', 'Name saved');
-	};
-
-	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-		event.preventDefault();
-		commitName();
-	};
-
-	const statusClass = STATUS_CLASS[status];
 
 	return (
-		<form className={INPUT_FORM_CLASS} onSubmit={handleSubmit} noValidate>
-			<div className="flex flex-col gap-2 text-left">
-				<h3 id={labelId} className={TITLE_CLASS}>
-					Player name
-				</h3>
-				<p className={DESCRIPTION_CLASS}>
-					This name appears across panels, logs, and history summaries.
-				</p>
-			</div>
-			<input
-				id={inputId}
-				aria-labelledby={labelId}
-				className={INPUT_FIELD_CLASS}
-				value={draftName}
-				onChange={handleChange}
-				maxLength={40}
-			/>
-			<p
-				className={statusClass}
-				role={status === 'error' ? 'alert' : undefined}
-			>
-				{message}
-			</p>
-			<div className={ACTIONS_LAYOUT_CLASS}>
-				<p className={NOTE_TEXT_CLASS}>
-					Save to see your title echoed immediately across the realm.
-				</p>
-				<Button type="submit" variant="success" className="sm:w-auto" icon="💾">
-					Save name
+		<>
+			<div className={DISPLAY_CARD_CLASS}>
+				<div className="text-left">
+					<h3 className={TITLE_CLASS}>Player name</h3>
+					<p className={NAME_TEXT_CLASS} aria-live="polite">
+						{playerName}
+					</p>
+				</div>
+				<Button
+					type="button"
+					variant="secondary"
+					onClick={() => setIsDialogOpen(true)}
+					className="sm:w-auto"
+					icon="✏️"
+				>
+					Change
 				</Button>
 			</div>
-		</form>
+			<PlayerNameDialog
+				open={isDialogOpen}
+				initialName={playerName}
+				onClose={() => setIsDialogOpen(false)}
+				onSave={handleSave}
+			/>
+		</>
 	);
 }

--- a/packages/web/src/components/settings/SettingsDialog.tsx
+++ b/packages/web/src/components/settings/SettingsDialog.tsx
@@ -216,10 +216,10 @@ export default function SettingsDialog({
 								onToggle={onToggleSound}
 							/>
 							<SettingRow
-								id="settings-background-mute"
-								title="Mute in background"
-								description="Pause audio when you switch tabs or windows."
-								checked={backgroundAudioMuted}
+								id="settings-background-audio"
+								title="Play audio in background"
+								description="Keep sound active when you switch tabs or windows."
+								checked={!backgroundAudioMuted}
 								onToggle={onToggleBackgroundAudioMute}
 							/>
 						</div>


### PR DESCRIPTION
## Summary
- align the background audio toggle label and checked state with actual playback behavior
- move player name editing into a dedicated modal and leave the settings row read-only

## Text formatting audit (required)
1. **Translator/formatter reuse:** N/A – adjusted existing static JSX copy only.
2. **Canonical keywords/icons/helpers touched:** None beyond reusing the existing ✏️ button icon.
3. **Voice review:** Reviewed the updated Settings copy and modal strings for concise UI voice.

## Standards compliance (required)
1. **File length limits respected:** `PlayerNameSetting.tsx` is 234 lines and `SettingsDialog.tsx` is 236 lines after changes.
2. **Line length limits respected:** Prettier formatting keeps modified lines within the 80-character limit.
3. **Domain separation upheld:** All updates are limited to the web UI layer; no engine, content, or protocol code touched.
4. **Code standards satisfied:** `npm run lint` passes on the changes (see Testing section).
5. **Tests updated:** No new tests needed; existing UI and integration coverage already exercises the settings dialog.
6. **Documentation updated:** Not required—UI adjustments are self-contained.
7. **`npm run check` results:** Not applicable; `npm run verify` was not run, but `npm run check` completed successfully (see Testing section).
8. **`npm run test:coverage` results:** Not run; coverage was not required for this UI refinement.

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68e65b72b82c83259fe027024db258cf