### PR TITLE
Add session selection utilities and tests

### DIFF
--- a/packages/web/src/state/sessionSelectors.ts
+++ b/packages/web/src/state/sessionSelectors.ts
@@ -1,0 +1,203 @@
+import type {
+	EngineSessionSnapshot,
+	PlayerStateSnapshot,
+} from '@kingdom-builder/engine';
+import type {
+	ActionDefinition,
+	BuildingDefinition,
+	DevelopmentDefinition,
+	RegistryLike,
+	SessionActionOption,
+	SessionBuildingOption,
+	SessionDevelopmentOption,
+	SessionLandView,
+	SessionOptionSelection,
+	SessionPlayerView,
+	SessionRegistries,
+	SessionSelectorHelpers,
+} from './sessionSelectors.types';
+
+const cloneRecord = <T>(record: Record<string, T>) => ({ ...record });
+const mapLand = (
+	land: PlayerStateSnapshot['lands'][number],
+): SessionLandView => ({
+	...land,
+	slotsFree: Math.max(0, land.slotsMax - land.slotsUsed),
+});
+const mapPlayer = (player: PlayerStateSnapshot): SessionPlayerView => ({
+	...player,
+	resources: cloneRecord(player.resources),
+	stats: cloneRecord(player.stats),
+	statsHistory: cloneRecord(player.statsHistory),
+	population: cloneRecord(player.population),
+	passives: [...player.passives],
+	lands: player.lands.map(mapLand),
+	buildings: new Set(player.buildings),
+	actions: new Set(player.actions),
+});
+const createActionOption = (
+	id: string,
+	definition: ActionDefinition,
+): SessionActionOption => ({
+	id: definition.id ?? id,
+	name: definition.name,
+	icon: definition.icon,
+	system: definition.system,
+	order: definition.order,
+	category: definition.category,
+	focus: definition.focus,
+});
+const createBuildingOption = (
+	id: string,
+	definition: BuildingDefinition,
+): SessionBuildingOption => ({
+	id: definition.id ?? id,
+	name: definition.name,
+	icon: definition.icon,
+	focus: definition.focus,
+	costs: cloneRecord(definition.costs),
+	upkeep: definition.upkeep ? cloneRecord(definition.upkeep) : undefined,
+});
+const createDevelopmentOption = (
+	id: string,
+	definition: DevelopmentDefinition,
+): SessionDevelopmentOption => ({
+	id: definition.id ?? id,
+	name: definition.name,
+	icon: definition.icon,
+	system: definition.system,
+	order: definition.order,
+	focus: definition.focus,
+	upkeep: definition.upkeep ? cloneRecord(definition.upkeep) : undefined,
+});
+const defaultActionSort = (
+	left: SessionActionOption,
+	right: SessionActionOption,
+) =>
+	(left.order ?? 0) - (right.order ?? 0) || left.name.localeCompare(right.name);
+const defaultBuildingSort = (
+	left: SessionBuildingOption,
+	right: SessionBuildingOption,
+) => left.name.localeCompare(right.name);
+const defaultDevelopmentSort = (
+	left: SessionDevelopmentOption,
+	right: SessionDevelopmentOption,
+) =>
+	(left.order ?? 0) - (right.order ?? 0) || left.name.localeCompare(right.name);
+
+export const selectSessionPlayers = (sessionState: EngineSessionSnapshot) => {
+	const list = sessionState.game.players.map(mapPlayer);
+	const byId = new Map(list.map((player) => [player.id, player]));
+	return {
+		list,
+		byId,
+		active: byId.get(sessionState.game.activePlayerId),
+		opponent: byId.get(sessionState.game.opponentId),
+	};
+};
+
+type SessionPlayersSelection = ReturnType<typeof selectSessionPlayers>;
+
+const buildActionSelections = (
+	players: SessionPlayerView[],
+	actions: RegistryLike<ActionDefinition>,
+	helpers: SessionSelectorHelpers,
+) => {
+	const unlocked = new Set<string>();
+	for (const player of players) {
+		for (const actionId of player.actions) {
+			unlocked.add(actionId);
+		}
+	}
+	const list = actions
+		.entries()
+		.map(([id, definition]) => createActionOption(id, definition))
+		.filter((option) => !option.system || unlocked.has(option.id))
+		.sort(helpers.sortActions ?? defaultActionSort);
+	const map = new Map(list.map((option) => [option.id, option]));
+	const byPlayer = new Map<string, SessionActionOption[]>();
+	for (const player of players) {
+		byPlayer.set(
+			player.id,
+			list.filter((option) => !option.system || player.actions.has(option.id)),
+		);
+	}
+	return { map, list, byPlayer };
+};
+
+const buildSimpleSelections = <TDefinition, TOption extends { id: string }>(
+	registry: RegistryLike<TDefinition>,
+	mapFn: (id: string, definition: TDefinition) => TOption,
+	sortFn: (left: TOption, right: TOption) => number,
+	filterFn?: (option: TOption) => boolean,
+) => {
+	const list = registry
+		.entries()
+		.map(([id, definition]) => mapFn(id, definition))
+		.filter((option) => (filterFn ? filterFn(option) : true))
+		.sort(sortFn);
+	return { map: new Map(list.map((option) => [option.id, option])), list };
+};
+
+const buildSessionOptionsFromPlayers = (
+	players: SessionPlayerView[],
+	registries: SessionRegistries,
+	helpers: SessionSelectorHelpers,
+): SessionOptionSelection => {
+	const actions = buildActionSelections(players, registries.actions, helpers);
+	const buildings = buildSimpleSelections(
+		registries.buildings,
+		createBuildingOption,
+		helpers.sortBuildings ?? defaultBuildingSort,
+	);
+	const developments = buildSimpleSelections(
+		registries.developments,
+		createDevelopmentOption,
+		helpers.sortDevelopments ?? defaultDevelopmentSort,
+		(option) => !option.system,
+	);
+	return {
+		actions: actions.map,
+		actionList: actions.list,
+		actionsByPlayer: actions.byPlayer,
+		buildings: buildings.map,
+		buildingList: buildings.list,
+		developments: developments.map,
+		developmentList: developments.list,
+	};
+};
+
+export const selectSessionOptions = (
+	sessionState: EngineSessionSnapshot,
+	registries: SessionRegistries,
+	helpers: SessionSelectorHelpers = {},
+): SessionOptionSelection =>
+	buildSessionOptionsFromPlayers(
+		selectSessionPlayers(sessionState).list,
+		registries,
+		helpers,
+	);
+
+export const selectSessionView = (
+	sessionState: EngineSessionSnapshot,
+	registries: SessionRegistries,
+	helpers: SessionSelectorHelpers = {},
+) => {
+	const players = selectSessionPlayers(sessionState);
+	return {
+		...players,
+		...buildSessionOptionsFromPlayers(players.list, registries, helpers),
+	};
+};
+
+export type {
+	SessionActionOption,
+	SessionBuildingOption,
+	SessionDevelopmentOption,
+	SessionLandView,
+	SessionOptionSelection,
+	SessionPlayerView,
+	SessionRegistries,
+	SessionSelectorHelpers,
+} from './sessionSelectors.types';
+export type { SessionPlayersSelection };

--- a/packages/web/src/state/sessionSelectors.types.ts
+++ b/packages/web/src/state/sessionSelectors.types.ts
@@ -1,0 +1,91 @@
+import type { PlayerStateSnapshot } from '@kingdom-builder/engine';
+import type {
+	ActionConfig,
+	BuildingConfig,
+	DevelopmentConfig,
+} from '@kingdom-builder/protocol';
+
+type RegistryLike<T> = { entries(): [string, T][]; get(id: string): T };
+type ActionDefinition = ActionConfig &
+	Partial<{ id: string; category: string; order: number; focus: unknown }>;
+type BuildingDefinition = BuildingConfig &
+	Partial<{ id: string; focus: unknown }>;
+type DevelopmentDefinition = DevelopmentConfig &
+	Partial<{ id: string; order: number; focus: unknown; system: boolean }>;
+type SessionLandView = PlayerStateSnapshot['lands'][number] & {
+	slotsFree: number;
+};
+type SessionPlayerView = Omit<
+	PlayerStateSnapshot,
+	'lands' | 'buildings' | 'actions'
+> & {
+	lands: SessionLandView[];
+	buildings: Set<string>;
+	actions: Set<string>;
+};
+type SessionActionOption = {
+	id: string;
+	name: string;
+	icon?: string | undefined;
+	system?: boolean | undefined;
+	order?: number | undefined;
+	category?: string | undefined;
+	focus?: unknown;
+};
+type SessionBuildingOption = {
+	id: string;
+	name: string;
+	icon?: string | undefined;
+	focus?: unknown;
+	costs: BuildingDefinition['costs'];
+	upkeep?: BuildingDefinition['upkeep'] | undefined;
+};
+type SessionDevelopmentOption = {
+	id: string;
+	name: string;
+	icon?: string | undefined;
+	system?: boolean | undefined;
+	order?: number | undefined;
+	focus?: unknown;
+	upkeep?: DevelopmentDefinition['upkeep'] | undefined;
+};
+type SessionOptionSelection = {
+	actions: Map<string, SessionActionOption>;
+	actionList: SessionActionOption[];
+	actionsByPlayer: Map<string, SessionActionOption[]>;
+	buildings: Map<string, SessionBuildingOption>;
+	buildingList: SessionBuildingOption[];
+	developments: Map<string, SessionDevelopmentOption>;
+	developmentList: SessionDevelopmentOption[];
+};
+type SessionSelectorHelpers = {
+	sortActions?: (a: SessionActionOption, b: SessionActionOption) => number;
+	sortBuildings?: (
+		a: SessionBuildingOption,
+		b: SessionBuildingOption,
+	) => number;
+	sortDevelopments?: (
+		a: SessionDevelopmentOption,
+		b: SessionDevelopmentOption,
+	) => number;
+};
+type SessionRegistries = {
+	actions: RegistryLike<ActionDefinition>;
+	buildings: RegistryLike<BuildingDefinition>;
+	developments: RegistryLike<DevelopmentDefinition>;
+};
+
+export type {
+	ActionDefinition,
+	BuildingDefinition,
+	DevelopmentDefinition,
+	RegistryLike,
+	SessionActionOption,
+	SessionBuildingOption,
+	SessionDevelopmentOption,
+	SessionLandView,
+	SessionOptionSelection,
+	SessionPlayerView,
+	SessionRegistries,
+	SessionSelectorHelpers,
+};

--- a/packages/web/tests/state/sessionSelectors.test.ts
+++ b/packages/web/tests/state/sessionSelectors.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import { RESOURCES } from '@kingdom-builder/contents';
+import type {
+	EngineSessionSnapshot,
+	PlayerStateSnapshot,
+} from '@kingdom-builder/engine';
+import { createContentFactory } from '../../../engine/tests/factories/content';
+import {
+	selectSessionOptions,
+	selectSessionPlayers,
+	selectSessionView,
+} from '../../src/state/sessionSelectors';
+
+describe('sessionSelectors', () => {
+	const factory = createContentFactory();
+	const [primaryResource] = Object.keys(RESOURCES);
+	const actionA = factory.action({ name: 'Action A' });
+	const actionB = factory.action({ name: 'Action B' });
+	const systemLocked = factory.action({ name: 'System Locked', system: true });
+	const systemUnlocked = factory.action({
+		name: 'System Unlocked',
+		system: true,
+	});
+	Object.assign(actionA, { order: 2, category: 'basic', focus: 'economy' });
+	factory.actions.add(actionA.id, {
+		...factory.actions.get(actionA.id),
+		order: 2,
+		category: 'basic',
+		focus: 'economy',
+	});
+	Object.assign(actionB, { order: 1 });
+	factory.actions.add(actionB.id, {
+		...factory.actions.get(actionB.id),
+		order: 1,
+	});
+	Object.assign(systemLocked, { order: 3, category: 'basic' });
+	factory.actions.add(systemLocked.id, {
+		...factory.actions.get(systemLocked.id),
+		order: 3,
+		category: 'basic',
+	});
+	Object.assign(systemUnlocked, { order: 4, category: 'basic' });
+	factory.actions.add(systemUnlocked.id, {
+		...factory.actions.get(systemUnlocked.id),
+		order: 4,
+		category: 'basic',
+	});
+	const buildingA = factory.building({
+		name: 'Building A',
+		costs: { [primaryResource]: 1 },
+	});
+	const buildingB = factory.building({
+		name: 'Building B',
+		costs: { [primaryResource]: 2 },
+	});
+	const developmentA = factory.development({ name: 'Development A' });
+	const developmentB = factory.development({ name: 'Development B' });
+	factory.developments.add(developmentA.id, {
+		...factory.developments.get(developmentA.id),
+		order: 2,
+	});
+	factory.developments.add(developmentB.id, {
+		...factory.developments.get(developmentB.id),
+		order: 1,
+	});
+	const developmentSystem = factory.development({
+		name: 'Development System',
+		system: true,
+	});
+	const makePlayer = (
+		id: string,
+		overrides: Partial<PlayerStateSnapshot> = {},
+	): PlayerStateSnapshot => ({
+		id,
+		name: `Player ${id}`,
+		resources: { [primaryResource]: 5, ...(overrides.resources ?? {}) },
+		stats: { ...(overrides.stats ?? {}) },
+		statsHistory: { ...(overrides.statsHistory ?? {}) },
+		population: { ...(overrides.population ?? {}) },
+		lands: overrides.lands ?? [
+			{
+				id: `${id}-L1`,
+				slotsMax: 3,
+				slotsUsed: 1,
+				tilled: true,
+				developments: [],
+			},
+			{
+				id: `${id}-L2`,
+				slotsMax: 1,
+				slotsUsed: 1,
+				tilled: false,
+				developments: [],
+			},
+		],
+		buildings: overrides.buildings ?? [],
+		actions: overrides.actions ?? [],
+		statSources: overrides.statSources ?? {},
+		skipPhases: overrides.skipPhases ?? {},
+		skipSteps: overrides.skipSteps ?? {},
+		passives: overrides.passives ?? [],
+	});
+	const players: PlayerStateSnapshot[] = [
+		makePlayer('A', {
+			buildings: [buildingA.id],
+			actions: [actionA.id, systemUnlocked.id],
+		}),
+		makePlayer('B', {
+			buildings: [buildingB.id],
+			actions: [actionB.id],
+		}),
+	];
+	const sessionState: EngineSessionSnapshot = {
+		game: {
+			turn: 1,
+			currentPlayerIndex: 0,
+			currentPhase: 'main',
+			currentStep: 'step-0',
+			phaseIndex: 0,
+			stepIndex: 0,
+			devMode: false,
+			players,
+			activePlayerId: 'A',
+			opponentId: 'B',
+		},
+		phases: [],
+		actionCostResource: primaryResource,
+		recentResourceGains: [],
+		compensations: {},
+	};
+	const registries = {
+		actions: factory.actions,
+		buildings: factory.buildings,
+		developments: factory.developments,
+	};
+
+	it('builds player view models with computed properties', () => {
+		const selection = selectSessionPlayers(sessionState);
+		expect(selection.list).toHaveLength(2);
+		const first = selection.list[0]!;
+		expect(first.id).toBe('A');
+		expect(first.buildings.has(buildingA.id)).toBe(true);
+		expect(first.actions.has(actionA.id)).toBe(true);
+		expect(first.actions.has(systemUnlocked.id)).toBe(true);
+		expect(first.lands[0]!.slotsFree).toBe(2);
+		expect(selection.active?.id).toBe('A');
+		expect(selection.opponent?.id).toBe('B');
+	});
+
+	it('creates action, building, and development option lists', () => {
+		const options = selectSessionOptions(sessionState, registries);
+		expect(options.actions.get(actionA.id)?.name).toBe(actionA.name);
+		expect(options.actions.get(systemLocked.id)).toBeUndefined();
+		expect(options.buildings.get(buildingA.id)?.name).toBe(buildingA.name);
+		expect(options.developments.get(developmentSystem.id)).toBeUndefined();
+		const developmentOrder = options.developmentList
+			.filter((option) =>
+				[developmentA.id, developmentB.id].includes(option.id),
+			)
+			.map((option) => option.id);
+		expect(developmentOrder).toEqual([developmentB.id, developmentA.id]);
+		const actionsForA = options.actionsByPlayer.get('A') ?? [];
+		expect(
+			actionsForA
+				.filter((option) =>
+					[actionB.id, actionA.id, systemUnlocked.id].includes(option.id),
+				)
+				.map((option) => option.id),
+		).toEqual([actionB.id, actionA.id, systemUnlocked.id]);
+		const actionsForB = options.actionsByPlayer.get('B') ?? [];
+		expect(
+			actionsForB
+				.filter((option) => [actionB.id, actionA.id].includes(option.id))
+				.map((option) => option.id),
+		).toEqual([actionB.id, actionA.id]);
+	});
+
+	it('supports custom sort helpers', () => {
+		const options = selectSessionOptions(sessionState, registries, {
+			sortActions: (left, right) => right.name.localeCompare(left.name),
+			sortBuildings: (left, right) => right.name.localeCompare(left.name),
+			sortDevelopments: (left, right) => right.name.localeCompare(left.name),
+		});
+		const sortedActionIds = options.actionList
+			.filter((option) =>
+				[systemUnlocked.id, actionA.id, actionB.id].includes(option.id),
+			)
+			.map((option) => option.id);
+		expect(sortedActionIds).toEqual([
+			systemUnlocked.id,
+			actionB.id,
+			actionA.id,
+		]);
+		const sortedBuildingIds = options.buildingList
+			.filter((option) => [buildingA.id, buildingB.id].includes(option.id))
+			.map((option) => option.id);
+		expect(sortedBuildingIds).toEqual([buildingB.id, buildingA.id]);
+		const sortedDevelopmentIds = options.developmentList
+			.filter((option) =>
+				[developmentA.id, developmentB.id].includes(option.id),
+			)
+			.map((option) => option.id);
+		expect(sortedDevelopmentIds).toEqual([developmentB.id, developmentA.id]);
+	});
+
+	it('combines player and option selections', () => {
+		const view = selectSessionView(sessionState, registries);
+		expect(view.list[0]!.id).toBe('A');
+		expect(view.actions.get(actionB.id)?.id).toBe(actionB.id);
+	});
+});


### PR DESCRIPTION
## Summary
- add `sessionSelectors.ts` to derive session players and option selections with registry-driven sorting helpers.【F:packages/web/src/state/sessionSelectors.ts†L20-L190】
- extract shared selector types into `sessionSelectors.types.ts` for reuse across the web state layer.【F:packages/web/src/state/sessionSelectors.types.ts†L1-L91】
- cover the new selectors with unit tests exercising player views, option filtering, and custom sort hooks.【F:packages/web/tests/state/sessionSelectors.test.ts†L1-L211】

## Text formatting audit (required)

1. **Translator/formatter reuse:** Not applicable — no translators or formatters were touched for this state-only change.
2. **Canonical keywords/icons/helpers touched:** None; the selectors only consume existing registry data without modifying canonical keyword/icon helpers.
3. **Voice review:** No user-facing copy changed, so no voice adjustments were required.

## Standards compliance (required)

1. **File length limits respected:** The new files remain below the 250-line limit (sessionSelectors.ts 203 lines; sessionSelectors.types.ts 91 lines).【eae88a†L1-L4】
2. **Line length limits respected:** All additions rely on Prettier formatting, keeping lines within the configured width (see multi-line layout in the selector implementation).【F:packages/web/src/state/sessionSelectors.ts†L20-L190】
3. **Domain separation upheld:** The selectors operate exclusively in the web layer, consuming engine snapshots and registries without crossing into other domains.【F:packages/web/src/state/sessionSelectors.ts†L20-L190】
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint) passes on the updated workspace.【6eabd7†L1-L17】
5. **Tests updated:** Added `sessionSelectors.test.ts` to validate player views and option ordering, and the targeted suite passes.【F:packages/web/tests/state/sessionSelectors.test.ts†L1-L211】【824ebe†L1-L26】
6. **Documentation updated:** Not required; the change adds internal selectors without altering documented behavior.
7. **`npm run check` results:** `npm run check` (format/typecheck/lint) — PASS.【6eabd7†L1-L17】
8. **`npm run test:coverage` results:** Not run; full coverage generation was not requested for this update.

## Testing
- `npm run check`【6eabd7†L1-L17】
- `npm run test -- sessionSelectors`【824ebe†L1-L26】

------
https://chatgpt.com/codex/tasks/task_e_68e658d2ed5483258e1619d9c9d6c29b