### PR TITLE
Expose rule snapshot and passive records through translation context

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -25,6 +25,7 @@ export {
 	type PlayerStateSnapshot,
 	type LandSnapshot,
 	type RuleSnapshot,
+	type PassiveRecordSnapshot,
 	type ActionDefinitionSummary,
 	type EngineSessionGetActionCosts,
 	type EngineSessionGetActionRequirements,

--- a/packages/engine/src/runtime/engine_snapshot.ts
+++ b/packages/engine/src/runtime/engine_snapshot.ts
@@ -1,4 +1,7 @@
-import { clonePassiveMetadata } from '../services/passive_helpers';
+import {
+	clonePassiveMetadata,
+	clonePassiveRecord,
+} from '../services/passive_helpers';
 import { cloneEffectList } from '../utils';
 import type { EngineContext } from '../context';
 import type { EffectDef } from '../effects';
@@ -15,6 +18,8 @@ import type {
 	AdvanceSkipSourceSnapshot,
 	EngineAdvanceResult,
 	EngineSessionSnapshot,
+	PassiveRecordSnapshot,
+	RuleSnapshot,
 } from './types';
 import {
 	cloneActionTraces,
@@ -97,6 +102,7 @@ function cloneSkip(
 }
 
 export function snapshotEngine(context: EngineContext): EngineSessionSnapshot {
+	const rules = cloneRuleSnapshot(context);
 	return {
 		game: {
 			turn: context.game.turn,
@@ -119,7 +125,34 @@ export function snapshotEngine(context: EngineContext): EngineSessionSnapshot {
 			amount: gain.amount,
 		})),
 		compensations: cloneCompensations(context.compensations),
+		rules,
+		passiveRecords: clonePassiveRecords(context),
 	};
+}
+
+function cloneRuleSnapshot(context: EngineContext): RuleSnapshot {
+	const { tieredResourceKey, tierDefinitions } = context.services.rules;
+	return {
+		tieredResourceKey,
+		tierDefinitions: structuredClone(tierDefinitions),
+	} satisfies RuleSnapshot;
+}
+
+function clonePassiveRecords(
+	context: EngineContext,
+): Record<PlayerId, PassiveRecordSnapshot[]> {
+	const result: Record<PlayerId, PassiveRecordSnapshot[]> = {} as Record<
+		PlayerId,
+		PassiveRecordSnapshot[]
+	>;
+	for (const player of context.game.players) {
+		const records = context.passives.values(player.id).map((record) => {
+			const { frames: _frames, ...snapshot } = clonePassiveRecord(record);
+			return snapshot as PassiveRecordSnapshot;
+		});
+		result[player.id] = records;
+	}
+	return result;
 }
 
 export function snapshotAdvance(

--- a/packages/engine/src/runtime/session.ts
+++ b/packages/engine/src/runtime/session.ts
@@ -15,16 +15,19 @@ import type { ActionTrace } from '../log';
 import { cloneActionOptions } from './action_options';
 import { cloneActionTraces } from './player_snapshot';
 import { snapshotAdvance, snapshotEngine } from './engine_snapshot';
-import type { EngineAdvanceResult, EngineSessionSnapshot } from './types';
+import type {
+	EngineAdvanceResult,
+	EngineSessionSnapshot,
+	RuleSnapshot,
+} from './types';
 import type { EvaluationModifier } from '../services/passive_types';
 import {
 	simulateUpcomingPhases as runSimulation,
 	type SimulateUpcomingPhasesOptions,
 	type SimulateUpcomingPhasesResult,
 } from './simulate_upcoming_phases';
-import type { PlayerId, ResourceKey } from '../state';
+import type { PlayerId } from '../state';
 import type { AIDependencies } from '../ai';
-import type { HappinessTierDefinition } from '../services/tiered_resource_types';
 
 export interface ActionDefinitionSummary {
 	id: string;
@@ -87,11 +90,6 @@ export interface EngineSession {
 	getLegacyContext(): EngineContext;
 }
 
-export interface RuleSnapshot {
-	tieredResourceKey: ResourceKey;
-	tierDefinitions: HappinessTierDefinition[];
-}
-
 export type {
 	EngineAdvanceResult,
 	EngineSessionSnapshot,
@@ -100,6 +98,8 @@ export type {
 	GameSnapshot,
 	PlayerStateSnapshot,
 	LandSnapshot,
+	RuleSnapshot,
+	PassiveRecordSnapshot,
 } from './types';
 
 export function createEngineSession(

--- a/packages/engine/src/runtime/types.ts
+++ b/packages/engine/src/runtime/types.ts
@@ -4,6 +4,8 @@ import type { AdvanceSkip } from '../phases/advance';
 import type { PlayerStartConfig } from '@kingdom-builder/protocol';
 import type { PlayerId, StatSourceContribution, ResourceKey } from '../state';
 import type { PassiveMetadata, PassiveSummary } from '../services';
+import type { PassiveRecord } from '../services/passive_types';
+import type { HappinessTierDefinition } from '../services/tiered_resource_types';
 
 export interface LandSnapshot {
 	id: string;
@@ -82,4 +84,13 @@ export interface EngineSessionSnapshot {
 	actionCostResource: ResourceKey;
 	recentResourceGains: { key: ResourceKey; amount: number }[];
 	compensations: Record<PlayerId, PlayerStartConfig>;
+	rules: RuleSnapshot;
+	passiveRecords: Record<PlayerId, PassiveRecordSnapshot[]>;
 }
+
+export interface RuleSnapshot {
+	tieredResourceKey: ResourceKey;
+	tierDefinitions: HappinessTierDefinition[];
+}
+
+export type PassiveRecordSnapshot = Omit<PassiveRecord, 'frames'>;

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -107,7 +107,10 @@ export function GameProvider({
 	const enqueue = <T,>(task: () => Promise<T> | T) => session.enqueue(task);
 
 	const sessionState = useMemo(() => session.getSnapshot(), [session, tick]);
-	const ruleSnapshot = useMemo(() => session.getRuleSnapshot(), [session]);
+	const ruleSnapshot = useMemo(
+		() => session.getRuleSnapshot(),
+		[session, tick],
+	);
 
 	useEffect(() => {
 		const [primary] = ctx.game.players;
@@ -135,8 +138,12 @@ export function GameProvider({
 					pullEffectLog: <T,>(key: string) => session.pullEffectLog<T>(key),
 					evaluationMods: session.getPassiveEvaluationMods(),
 				},
+				{
+					ruleSnapshot,
+					passiveRecords: sessionState.passiveRecords,
+				},
 			),
-		[sessionState, session],
+		[sessionState, session, ruleSnapshot, sessionState.passiveRecords],
 	);
 
 	const {

--- a/packages/web/src/state/getLegacySessionContext.ts
+++ b/packages/web/src/state/getLegacySessionContext.ts
@@ -214,6 +214,10 @@ export function getLegacySessionContext(
 			pullEffectLog: <T>(key: string) => session.pullEffectLog<T>(key),
 			evaluationMods: session.getPassiveEvaluationMods(),
 		},
+		{
+			ruleSnapshot: session.getRuleSnapshot(),
+			passiveRecords: snapshot.passiveRecords,
+		},
 	);
 	const diffContext = createDiffContext(snapshot, translationContext);
 	return { translationContext, diffContext };

--- a/packages/web/src/translation/context/contextHelpers.ts
+++ b/packages/web/src/translation/context/contextHelpers.ts
@@ -1,0 +1,157 @@
+import type {
+	EngineSessionSnapshot,
+	PassiveSummary,
+	PlayerId,
+} from '@kingdom-builder/engine';
+import type { PlayerStartConfig } from '@kingdom-builder/protocol';
+import type {
+	TranslationPassiveDescriptor,
+	TranslationPassiveModifierMap,
+	TranslationPlayer,
+	TranslationRegistry,
+} from './types';
+
+export function cloneRecord<T>(record: Record<string, T>): Record<string, T> {
+	return Object.freeze({ ...record });
+}
+
+export function clonePassiveMeta(
+	meta: NonNullable<PassiveSummary['meta']>,
+): NonNullable<PassiveSummary['meta']> {
+	const cloned: NonNullable<PassiveSummary['meta']> = {};
+	if (meta.source !== undefined) {
+		cloned.source = { ...meta.source };
+	}
+	if (meta.removal !== undefined) {
+		cloned.removal = { ...meta.removal };
+	}
+	return Object.freeze(cloned);
+}
+
+export function clonePassiveSummary(summary: PassiveSummary): PassiveSummary {
+	const cloned: PassiveSummary = { id: summary.id };
+	if (summary.name !== undefined) {
+		cloned.name = summary.name;
+	}
+	if (summary.icon !== undefined) {
+		cloned.icon = summary.icon;
+	}
+	if (summary.detail !== undefined) {
+		cloned.detail = summary.detail;
+	}
+	if (summary.meta !== undefined) {
+		cloned.meta = clonePassiveMeta(summary.meta);
+	}
+	return Object.freeze(cloned);
+}
+
+export function toPassiveDescriptor(
+	summary: PassiveSummary,
+): TranslationPassiveDescriptor {
+	const descriptor: TranslationPassiveDescriptor = {};
+	if (summary.icon !== undefined) {
+		descriptor.icon = summary.icon;
+	}
+	const sourceIcon = summary.meta?.source?.icon;
+	if (sourceIcon !== undefined) {
+		descriptor.meta = Object.freeze({
+			source: Object.freeze({ icon: sourceIcon }),
+		});
+	}
+	return Object.freeze(descriptor);
+}
+
+export function clonePlayer(
+	player: EngineSessionSnapshot['game']['players'][number],
+): TranslationPlayer {
+	return Object.freeze({
+		id: player.id,
+		name: player.name,
+		resources: cloneRecord(player.resources),
+		stats: cloneRecord(player.stats),
+		population: cloneRecord(player.population),
+	});
+}
+
+export function wrapRegistry<TDefinition>(registry: {
+	get(id: string): TDefinition;
+	has(id: string): boolean;
+}): TranslationRegistry<TDefinition> {
+	return Object.freeze({
+		get(id: string) {
+			return registry.get(id);
+		},
+		has(id: string) {
+			return registry.has(id);
+		},
+	});
+}
+
+function clonePlayerStartConfig(config: PlayerStartConfig): PlayerStartConfig {
+	return JSON.parse(JSON.stringify(config)) as PlayerStartConfig;
+}
+
+export function cloneCompensations(
+	compensations: EngineSessionSnapshot['compensations'],
+): Record<PlayerId, PlayerStartConfig> {
+	return Object.freeze(
+		Object.fromEntries(
+			Object.entries(compensations).map(([playerId, config]) => [
+				playerId,
+				clonePlayerStartConfig(config),
+			]),
+		),
+	) as Record<PlayerId, PlayerStartConfig>;
+}
+
+export function mapPassives(
+	players: EngineSessionSnapshot['game']['players'],
+): ReadonlyMap<PlayerId, PassiveSummary[]> {
+	return new Map(
+		players.map((player) => [
+			player.id,
+			player.passives.map(clonePassiveSummary),
+		]),
+	);
+}
+
+export function flattenPassives(
+	passives: ReadonlyMap<PlayerId, PassiveSummary[]>,
+): PassiveSummary[] {
+	return Array.from(passives.values()).flatMap((entries) =>
+		entries.map(clonePassiveSummary),
+	);
+}
+
+export function mapPassiveDescriptors(
+	passives: ReadonlyMap<PlayerId, PassiveSummary[]>,
+): ReadonlyMap<PlayerId, Map<string, TranslationPassiveDescriptor>> {
+	return new Map(
+		Array.from(passives.entries()).map(([owner, list]) => [
+			owner,
+			new Map(
+				list.map((summary) => [summary.id, toPassiveDescriptor(summary)]),
+			),
+		]),
+	);
+}
+
+export function cloneRecentResourceGains(
+	recent: EngineSessionSnapshot['recentResourceGains'],
+): ReadonlyArray<{ key: string; amount: number }> {
+	return Object.freeze(recent.map((entry) => ({ ...entry })));
+}
+
+export function cloneEvaluationModifiers(
+	evaluationMods?: ReadonlyMap<string, ReadonlyMap<string, unknown>>,
+): TranslationPassiveModifierMap {
+	if (!evaluationMods) {
+		return new Map();
+	}
+	return new Map(
+		Array.from(evaluationMods.entries()).map(([modifierId, mods]) => [
+			modifierId,
+			new Map(mods) as ReadonlyMap<string, unknown>,
+		]),
+	);
+}

--- a/packages/web/src/translation/context/createTranslationContext.ts
+++ b/packages/web/src/translation/context/createTranslationContext.ts
@@ -1,172 +1,41 @@
 import type {
 	EngineSessionSnapshot,
-	PassiveSummary,
 	PlayerId,
+	RuleSnapshot,
 } from '@kingdom-builder/engine';
 import type {
 	ACTIONS,
 	BUILDINGS,
 	DEVELOPMENTS,
 } from '@kingdom-builder/contents';
-import type { PlayerStartConfig } from '@kingdom-builder/protocol';
-import type {
-	TranslationContext,
-	TranslationPassiveDescriptor,
-	TranslationPassives,
-	TranslationPlayer,
-	TranslationPassiveModifierMap,
-	TranslationRegistry,
-} from './types';
+import type { TranslationContext, TranslationPassives } from './types';
+import {
+	cloneCompensations,
+	cloneEvaluationModifiers,
+	clonePassiveSummary,
+	clonePlayer,
+	cloneRecentResourceGains,
+	flattenPassives,
+	mapPassives,
+	mapPassiveDescriptors,
+	wrapRegistry,
+} from './contextHelpers';
+import {
+	EMPTY_PASSIVE_DEFINITIONS,
+	cloneRuleSnapshot,
+	mapPassiveDefinitionLists,
+	mapPassiveDefinitionLookup,
+} from './passiveDefinitions';
 
 type TranslationSessionHelpers = {
 	pullEffectLog?: <T>(key: string) => T | undefined;
 	evaluationMods?: ReadonlyMap<string, ReadonlyMap<string, unknown>>;
 };
 
-function cloneRecord<T>(record: Record<string, T>): Record<string, T> {
-	return Object.freeze({ ...record });
-}
-
-function clonePassiveMeta(
-	meta: NonNullable<PassiveSummary['meta']>,
-): NonNullable<PassiveSummary['meta']> {
-	const cloned: NonNullable<PassiveSummary['meta']> = {};
-	if (meta.source !== undefined) {
-		cloned.source = { ...meta.source };
-	}
-	if (meta.removal !== undefined) {
-		cloned.removal = { ...meta.removal };
-	}
-	return Object.freeze(cloned);
-}
-
-function clonePassiveSummary(summary: PassiveSummary): PassiveSummary {
-	const cloned: PassiveSummary = { id: summary.id };
-	if (summary.name !== undefined) {
-		cloned.name = summary.name;
-	}
-	if (summary.icon !== undefined) {
-		cloned.icon = summary.icon;
-	}
-	if (summary.detail !== undefined) {
-		cloned.detail = summary.detail;
-	}
-	if (summary.meta !== undefined) {
-		cloned.meta = clonePassiveMeta(summary.meta);
-	}
-	return Object.freeze(cloned);
-}
-
-function toPassiveDescriptor(
-	summary: PassiveSummary,
-): TranslationPassiveDescriptor {
-	const descriptor: TranslationPassiveDescriptor = {};
-	if (summary.icon !== undefined) {
-		descriptor.icon = summary.icon;
-	}
-	const sourceIcon = summary.meta?.source?.icon;
-	if (sourceIcon !== undefined) {
-		descriptor.meta = Object.freeze({
-			source: Object.freeze({ icon: sourceIcon }),
-		});
-	}
-	return Object.freeze(descriptor);
-}
-
-function clonePlayer(
-	player: EngineSessionSnapshot['game']['players'][number],
-): TranslationPlayer {
-	return Object.freeze({
-		id: player.id,
-		name: player.name,
-		resources: cloneRecord(player.resources),
-		stats: cloneRecord(player.stats),
-		population: cloneRecord(player.population),
-	});
-}
-
-function wrapRegistry<TDefinition>(registry: {
-	get(id: string): TDefinition;
-	has(id: string): boolean;
-}): TranslationRegistry<TDefinition> {
-	return Object.freeze({
-		get(id: string) {
-			return registry.get(id);
-		},
-		has(id: string) {
-			return registry.has(id);
-		},
-	});
-}
-
-function clonePlayerStartConfig(config: PlayerStartConfig): PlayerStartConfig {
-	return JSON.parse(JSON.stringify(config)) as PlayerStartConfig;
-}
-
-function cloneCompensations(
-	compensations: EngineSessionSnapshot['compensations'],
-): Record<PlayerId, PlayerStartConfig> {
-	return Object.freeze(
-		Object.fromEntries(
-			Object.entries(compensations).map(([playerId, config]) => [
-				playerId,
-				clonePlayerStartConfig(config),
-			]),
-		),
-	) as Record<PlayerId, PlayerStartConfig>;
-}
-
-function mapPassives(
-	players: EngineSessionSnapshot['game']['players'],
-): ReadonlyMap<PlayerId, PassiveSummary[]> {
-	return new Map(
-		players.map((player) => [
-			player.id,
-			player.passives.map(clonePassiveSummary),
-		]),
-	);
-}
-
-function flattenPassives(
-	passives: ReadonlyMap<PlayerId, PassiveSummary[]>,
-): PassiveSummary[] {
-	return Array.from(passives.values()).flatMap((entries) =>
-		entries.map(clonePassiveSummary),
-	);
-}
-
-function mapPassiveDescriptors(
-	passives: ReadonlyMap<PlayerId, PassiveSummary[]>,
-): ReadonlyMap<PlayerId, Map<string, TranslationPassiveDescriptor>> {
-	return new Map(
-		Array.from(passives.entries()).map(([owner, list]) => [
-			owner,
-			new Map(
-				list.map((summary) => [summary.id, toPassiveDescriptor(summary)]),
-			),
-		]),
-	);
-}
-
-function cloneRecentResourceGains(
-	recent: EngineSessionSnapshot['recentResourceGains'],
-): ReadonlyArray<{ key: string; amount: number }> {
-	return Object.freeze(recent.map((entry) => ({ ...entry })));
-}
-
-function cloneEvaluationModifiers(
-	evaluationMods?: ReadonlyMap<string, ReadonlyMap<string, unknown>>,
-): TranslationPassiveModifierMap {
-	if (!evaluationMods) {
-		return new Map();
-	}
-	return new Map(
-		Array.from(evaluationMods.entries()).map(([modifierId, mods]) => [
-			modifierId,
-			new Map(mods) as ReadonlyMap<string, unknown>,
-		]),
-	);
-}
+type TranslationContextOptions = {
+	ruleSnapshot: RuleSnapshot;
+	passiveRecords: EngineSessionSnapshot['passiveRecords'];
+};
 
 export function createTranslationContext(
 	session: EngineSessionSnapshot,
@@ -175,7 +44,8 @@ export function createTranslationContext(
 		buildings: typeof BUILDINGS;
 		developments: typeof DEVELOPMENTS;
 	},
-	helpers?: TranslationSessionHelpers,
+	helpers: TranslationSessionHelpers | undefined,
+	options: TranslationContextOptions,
 ): TranslationContext {
 	const players = new Map(
 		session.game.players.map((player) => [player.id, clonePlayer(player)]),
@@ -188,6 +58,13 @@ export function createTranslationContext(
 	const passives = mapPassives(session.game.players);
 	const passiveDescriptors = mapPassiveDescriptors(passives);
 	const evaluationMods = cloneEvaluationModifiers(helpers?.evaluationMods);
+	const ruleSnapshot = cloneRuleSnapshot(options.ruleSnapshot);
+	const passiveDefinitionLists = mapPassiveDefinitionLists(
+		options.passiveRecords,
+	);
+	const passiveDefinitionLookup = mapPassiveDefinitionLookup(
+		passiveDefinitionLists,
+	);
 	const translationPassives: TranslationPassives = Object.freeze({
 		list(owner?: PlayerId) {
 			if (owner) {
@@ -198,6 +75,13 @@ export function createTranslationContext(
 		get(id: string, owner: PlayerId) {
 			const ownerDescriptors = passiveDescriptors.get(owner);
 			return ownerDescriptors?.get(id);
+		},
+		getDefinition(id: string, owner: PlayerId) {
+			const definitions = passiveDefinitionLookup.get(owner);
+			return definitions?.get(id);
+		},
+		definitions(owner: PlayerId) {
+			return passiveDefinitionLists.get(owner) ?? EMPTY_PASSIVE_DEFINITIONS;
 		},
 		get evaluationMods() {
 			return evaluationMods;
@@ -254,5 +138,6 @@ export function createTranslationContext(
 		actionCostResource: session.actionCostResource,
 		recentResourceGains: cloneRecentResourceGains(session.recentResourceGains),
 		compensations: cloneCompensations(session.compensations),
+		rules: ruleSnapshot,
 	});
 }

--- a/packages/web/src/translation/context/passiveDefinitions.ts
+++ b/packages/web/src/translation/context/passiveDefinitions.ts
@@ -1,0 +1,56 @@
+import type {
+	EngineSessionSnapshot,
+	PassiveRecordSnapshot,
+	PlayerId,
+	RuleSnapshot,
+} from '@kingdom-builder/engine';
+import type { TranslationPassiveDefinition } from './types';
+
+export const EMPTY_PASSIVE_DEFINITIONS = Object.freeze(
+	[] as TranslationPassiveDefinition[],
+);
+
+export function clonePassiveDefinition(
+	definition: PassiveRecordSnapshot,
+): TranslationPassiveDefinition {
+	const cloned = structuredClone<TranslationPassiveDefinition>(definition);
+	return Object.freeze(cloned);
+}
+
+export function mapPassiveDefinitionLists(
+	records: EngineSessionSnapshot['passiveRecords'],
+): ReadonlyMap<PlayerId, ReadonlyArray<TranslationPassiveDefinition>> {
+	const lists = new Map<
+		PlayerId,
+		ReadonlyArray<TranslationPassiveDefinition>
+	>();
+	for (const ownerId of Object.keys(records) as PlayerId[]) {
+		const entries = records[ownerId] ?? [];
+		const clones = entries.map(clonePassiveDefinition);
+		lists.set(ownerId, Object.freeze(clones));
+	}
+	return lists;
+}
+
+export function mapPassiveDefinitionLookup(
+	lists: ReadonlyMap<PlayerId, ReadonlyArray<TranslationPassiveDefinition>>,
+): ReadonlyMap<PlayerId, ReadonlyMap<string, TranslationPassiveDefinition>> {
+	const lookup = new Map<
+		PlayerId,
+		ReadonlyMap<string, TranslationPassiveDefinition>
+	>();
+	for (const [owner, definitions] of lists.entries()) {
+		const entries = definitions.map<[string, TranslationPassiveDefinition]>(
+			(definition) => [definition.id as string, definition],
+		);
+		lookup.set(owner, new Map<string, TranslationPassiveDefinition>(entries));
+	}
+	return lookup;
+}
+
+export function cloneRuleSnapshot(ruleSnapshot: RuleSnapshot): RuleSnapshot {
+	return Object.freeze({
+		tieredResourceKey: ruleSnapshot.tieredResourceKey,
+		tierDefinitions: structuredClone(ruleSnapshot.tierDefinitions),
+	});
+}

--- a/packages/web/src/translation/context/types.ts
+++ b/packages/web/src/translation/context/types.ts
@@ -1,4 +1,9 @@
-import type { PassiveSummary, PlayerId } from '@kingdom-builder/engine';
+import type {
+	PassiveRecordSnapshot,
+	PassiveSummary,
+	PlayerId,
+	RuleSnapshot,
+} from '@kingdom-builder/engine';
 import type {
 	ActionConfig,
 	BuildingConfig,
@@ -26,6 +31,8 @@ export type TranslationPassiveDescriptor = {
 	meta?: { source?: { icon?: string } };
 };
 
+export type TranslationPassiveDefinition = PassiveRecordSnapshot;
+
 /**
  * Map of evaluator modifier identifiers to the owning modifier instances. The
  * values remain intentionally untyped because translation formatters only
@@ -44,6 +51,11 @@ export type TranslationPassiveModifierMap = ReadonlyMap<
 export interface TranslationPassives {
 	list(owner?: PlayerId): PassiveSummary[];
 	get(id: string, owner: PlayerId): TranslationPassiveDescriptor | undefined;
+	getDefinition(
+		id: string,
+		owner: PlayerId,
+	): TranslationPassiveDefinition | undefined;
+	definitions(owner: PlayerId): ReadonlyArray<TranslationPassiveDefinition>;
 	readonly evaluationMods: TranslationPassiveModifierMap;
 }
 
@@ -88,6 +100,7 @@ export interface TranslationContext {
 	readonly phases: readonly TranslationPhase[];
 	readonly activePlayer: TranslationPlayer;
 	readonly opponent: TranslationPlayer;
+	readonly rules: RuleSnapshot;
 	readonly recentResourceGains: ReadonlyArray<{
 		key: string;
 		amount: number;

--- a/packages/web/tests/HoverCard.test.tsx
+++ b/packages/web/tests/HoverCard.test.tsx
@@ -42,8 +42,9 @@ const ctx = createEngine({
 	rules: RULES,
 });
 const actionCostResource = ctx.actionCostResource;
+const engineSnapshot = snapshotEngine(ctx);
 const translationContext = createTranslationContext(
-	snapshotEngine(ctx),
+	engineSnapshot,
 	{
 		actions: ACTIONS,
 		buildings: BUILDINGS,
@@ -52,6 +53,10 @@ const translationContext = createTranslationContext(
 	{
 		pullEffectLog: (key) => ctx.pullEffectLog(key),
 		evaluationMods: ctx.passives.evaluationMods,
+	},
+	{
+		ruleSnapshot: engineSnapshot.rules,
+		passiveRecords: engineSnapshot.passiveRecords,
 	},
 );
 
@@ -76,10 +81,7 @@ const actionData = findActionWithReq();
 const mockGame = {
 	ctx,
 	translationContext,
-	ruleSnapshot: {
-		tieredResourceKey: ctx.services.rules.tieredResourceKey,
-		tierDefinitions: ctx.services.rules.tierDefinitions,
-	},
+	ruleSnapshot: engineSnapshot.rules,
 	log: [],
 	logOverflowed: false,
 	hoverCard: null as unknown as {

--- a/packages/web/tests/PhasePanel.test.tsx
+++ b/packages/web/tests/PhasePanel.test.tsx
@@ -31,8 +31,9 @@ const ctx = createEngine({
 	rules: RULES,
 });
 const actionCostResource = ctx.actionCostResource;
+const engineSnapshot = snapshotEngine(ctx);
 const translationContext = createTranslationContext(
-	snapshotEngine(ctx),
+	engineSnapshot,
 	{
 		actions: ACTIONS,
 		buildings: BUILDINGS,
@@ -42,14 +43,15 @@ const translationContext = createTranslationContext(
 		pullEffectLog: (key) => ctx.pullEffectLog(key),
 		evaluationMods: ctx.passives.evaluationMods,
 	},
+	{
+		ruleSnapshot: engineSnapshot.rules,
+		passiveRecords: engineSnapshot.passiveRecords,
+	},
 );
 const mockGame = {
 	ctx,
 	translationContext,
-	ruleSnapshot: {
-		tieredResourceKey: ctx.services.rules.tieredResourceKey,
-		tierDefinitions: ctx.services.rules.tierDefinitions,
-	},
+	ruleSnapshot: engineSnapshot.rules,
 	log: [],
 	logOverflowed: false,
 	hoverCard: null,

--- a/packages/web/tests/PlayerPanel.test.tsx
+++ b/packages/web/tests/PlayerPanel.test.tsx
@@ -34,8 +34,9 @@ const ctx = createEngine({
 	rules: RULES,
 });
 const actionCostResource = ctx.actionCostResource;
+const engineSnapshot = snapshotEngine(ctx);
 const translationContext = createTranslationContext(
-	snapshotEngine(ctx),
+	engineSnapshot,
 	{
 		actions: ACTIONS,
 		buildings: BUILDINGS,
@@ -43,16 +44,17 @@ const translationContext = createTranslationContext(
 	},
 	{
 		pullEffectLog: (key) => ctx.pullEffectLog(key),
-		passives: ctx.passives,
+		evaluationMods: ctx.passives.evaluationMods,
+	},
+	{
+		ruleSnapshot: engineSnapshot.rules,
+		passiveRecords: engineSnapshot.passiveRecords,
 	},
 );
 const mockGame = {
 	ctx,
 	translationContext,
-	ruleSnapshot: {
-		tieredResourceKey: ctx.services.rules.tieredResourceKey,
-		tierDefinitions: ctx.services.rules.tierDefinitions,
-	},
+	ruleSnapshot: engineSnapshot.rules,
 	log: [],
 	logOverflowed: false,
 	hoverCard: null,

--- a/packages/web/tests/attack-on-damage-registry.test.ts
+++ b/packages/web/tests/attack-on-damage-registry.test.ts
@@ -38,6 +38,8 @@ function createTranslationCtx(): TranslationContext {
 		passives: {
 			list: vi.fn(() => []),
 			get: vi.fn(() => undefined),
+			getDefinition: vi.fn(() => undefined),
+			definitions: vi.fn(() => []),
 			get evaluationMods() {
 				return emptyModifiers;
 			},
@@ -64,6 +66,7 @@ function createTranslationCtx(): TranslationContext {
 			A: {} as PlayerStartConfig,
 			B: {} as PlayerStartConfig,
 		},
+		rules: { tieredResourceKey: 'happiness', tierDefinitions: [] },
 	};
 }
 

--- a/packages/web/tests/helpers/createPassiveDisplayGame.ts
+++ b/packages/web/tests/helpers/createPassiveDisplayGame.ts
@@ -24,8 +24,9 @@ type PassiveGameContext = {
 function createPassiveGame(ctx: EngineContext): PassiveGameContext {
 	const handleHoverCard = vi.fn();
 	const clearHoverCard = vi.fn();
+	const engineSnapshot = snapshotEngine(ctx);
 	const translationContext = createTranslationContext(
-		snapshotEngine(ctx),
+		engineSnapshot,
 		{
 			actions: ACTIONS,
 			buildings: BUILDINGS,
@@ -35,14 +36,15 @@ function createPassiveGame(ctx: EngineContext): PassiveGameContext {
 			pullEffectLog: (key) => ctx.pullEffectLog(key),
 			evaluationMods: ctx.passives.evaluationMods,
 		},
+		{
+			ruleSnapshot: engineSnapshot.rules,
+			passiveRecords: engineSnapshot.passiveRecords,
+		},
 	);
 	const mockGame: MockGame = {
 		ctx,
 		translationContext,
-		ruleSnapshot: {
-			tieredResourceKey: ctx.services.rules.tieredResourceKey,
-			tierDefinitions: ctx.services.rules.tierDefinitions,
-		},
+		ruleSnapshot: engineSnapshot.rules,
 		handleHoverCard,
 		clearHoverCard,
 		resolution: null,

--- a/packages/web/tests/helpers/translationContextStub.ts
+++ b/packages/web/tests/helpers/translationContextStub.ts
@@ -4,6 +4,7 @@ import type {
 	TranslationPlayer,
 	TranslationRegistry,
 } from '../../src/translation/context';
+import type { RuleSnapshot } from '@kingdom-builder/engine';
 
 const EMPTY_MODIFIERS = new Map<string, ReadonlyMap<string, unknown>>();
 
@@ -13,6 +14,12 @@ const EMPTY_PASSIVES: TranslationPassives = {
 	},
 	get() {
 		return undefined;
+	},
+	getDefinition() {
+		return undefined;
+	},
+	definitions() {
+		return [];
 	},
 	get evaluationMods() {
 		return EMPTY_MODIFIERS;
@@ -55,8 +62,15 @@ export function createTranslationContextStub(
 		developments: TranslationRegistry<unknown>;
 		activePlayer: TranslationPlayer;
 		opponent: TranslationPlayer;
+		rules?: RuleSnapshot;
 	},
 ): TranslationContext {
+	const rules: RuleSnapshot =
+		options.rules ??
+		({
+			tieredResourceKey: 'happiness',
+			tierDefinitions: [],
+		} as RuleSnapshot);
 	return {
 		actions: options.actions,
 		buildings: options.buildings,
@@ -65,6 +79,7 @@ export function createTranslationContextStub(
 		phases: options.phases,
 		activePlayer: options.activePlayer,
 		opponent: options.opponent,
+		rules,
 		pullEffectLog() {
 			return undefined;
 		},

--- a/packages/web/tests/resource-bar.test.tsx
+++ b/packages/web/tests/resource-bar.test.tsx
@@ -93,6 +93,7 @@ describe('<ResourceBar /> happiness hover card', () => {
 		const handleHoverCard = vi.fn();
 		const clearHoverCard = vi.fn();
 		const sessionState = session.getSnapshot();
+		const ruleSnapshot = session.getRuleSnapshot();
 		const translationContext = createTranslationContext(
 			sessionState,
 			{
@@ -104,8 +105,11 @@ describe('<ResourceBar /> happiness hover card', () => {
 				pullEffectLog: (key) => session.pullEffectLog(key),
 				evaluationMods: session.getPassiveEvaluationMods(),
 			},
+			{
+				ruleSnapshot,
+				passiveRecords: sessionState.passiveRecords,
+			},
 		);
-		const ruleSnapshot = session.getRuleSnapshot();
 		const customRuleSnapshot = {
 			...ruleSnapshot,
 			tierDefinitions: ruleSnapshot.tierDefinitions.map((tier) => ({

--- a/packages/web/tests/state/useCompensationLogger.test.tsx
+++ b/packages/web/tests/state/useCompensationLogger.test.tsx
@@ -34,6 +34,10 @@ function createSession(): EngineSession {
 		advancePhase: vi.fn(),
 		pullEffectLog: vi.fn(),
 		getPassiveEvaluationMods: vi.fn(() => new Map()),
+		getRuleSnapshot: vi.fn(() => ({
+			tieredResourceKey: RESOURCE_KEYS[0]!,
+			tierDefinitions: [],
+		})),
 		getLegacyContext() {
 			return {
 				activePlayer: {
@@ -111,6 +115,14 @@ function createSessionState(turn: number): EngineSessionSnapshot {
 				resources: { gold: 1 },
 			},
 		} as Record<PlayerId, PlayerStartConfig>,
+		rules: {
+			tieredResourceKey: RESOURCE_KEYS[0]!,
+			tierDefinitions: [],
+		},
+		passiveRecords: {
+			A: [],
+			B: [],
+		},
 	};
 }
 

--- a/packages/web/tests/translation/createTranslationContext.test.ts
+++ b/packages/web/tests/translation/createTranslationContext.test.ts
@@ -123,6 +123,25 @@ describe('createTranslationContext', () => {
 				A: compensation(2),
 				B: compensation(1),
 			},
+			rules: {
+				tieredResourceKey: resourceKey,
+				tierDefinitions: [],
+			},
+			passiveRecords: {
+				A: [
+					{
+						id: passiveId,
+						owner: 'A',
+						icon: ACTIONS.get(actionId).icon,
+						meta: {
+							source: {
+								icon: BUILDINGS.get(buildingId).icon,
+							},
+						},
+					},
+				],
+				B: [],
+			},
 		};
 		const context = createTranslationContext(
 			session,
@@ -134,6 +153,10 @@ describe('createTranslationContext', () => {
 			{
 				pullEffectLog,
 				evaluationMods: passiveManager.evaluationMods,
+			},
+			{
+				ruleSnapshot: session.rules,
+				passiveRecords: session.passiveRecords,
 			},
 		);
 		expect(context.pullEffectLog<{ note: string }>('legacy')).toEqual({
@@ -163,82 +186,102 @@ describe('createTranslationContext', () => {
 					has: context.developments.has(developmentId),
 				},
 			},
+			rules: context.rules,
 			passives: {
 				list: context.passives.list().map(({ id }) => id),
 				owned: context.passives.list(activeId).map(({ id }) => id),
 				descriptor: context.passives.get(passiveId, activeId),
+				definition: context.passives.getDefinition(passiveId, activeId),
+				definitions: context.passives.definitions(activeId).map(({ id }) => id),
 				evaluationMods: evaluationSnapshot,
 			},
 		};
 		expect(contextSnapshot).toMatchInlineSnapshot(`
-			{
-			  "actionCostResource": "gold",
-			  "compensations": {
-			    "A": {
-			      "resources": {
-			        "gold": 2,
-			      },
-			    },
-			    "B": {
-			      "resources": {
-			        "gold": 1,
-			      },
-			    },
-			  },
-			  "passives": {
-			    "descriptor": {
-			      "icon": "🌱",
-			      "meta": {
-			        "source": {
-			          "icon": "🏘️",
-			        },
-			      },
-			    },
-			    "evaluationMods": [
-			      [
-			        "gold",
-			        [
-			          "modifier",
-			        ],
-			      ],
-			    ],
-			    "list": [
-			      "passive-a",
-			    ],
-			    "owned": [
-			      "passive-a",
-			    ],
-			  },
-			  "phases": [
-			    "growth",
-			    "upkeep",
-			    "main",
-			  ],
-			  "players": {
-			    "active": "A",
-			    "opponent": "B",
-			  },
-			  "recentResourceGains": [
-			    {
-			      "amount": 3,
-			      "key": "gold",
-			    },
-			  ],
-			  "registries": {
-			    "action": {
-			      "has": true,
-			      "id": "expand",
-			    },
-			    "building": {
-			      "has": true,
-			      "id": "town_charter",
-			    },
-			    "development": {
-			      "has": true,
-			      "id": "farm",
-			    },
-			  },
-			}
-		`);
+                        {
+                          "actionCostResource": "gold",
+                          "compensations": {
+                            "A": {
+                              "resources": {
+                                "gold": 2,
+                              },
+                            },
+                            "B": {
+                              "resources": {
+                                "gold": 1,
+                              },
+                            },
+                          },
+                          "passives": {
+                            "definition": {
+                              "icon": "🌱",
+                              "id": "passive-a",
+                              "meta": {
+                                "source": {
+                                  "icon": "🏘️",
+                                },
+                              },
+                              "owner": "A",
+                            },
+                            "definitions": [
+                              "passive-a",
+                            ],
+                            "descriptor": {
+                              "icon": "🌱",
+                              "meta": {
+                                "source": {
+                                  "icon": "🏘️",
+                                },
+                              },
+                            },
+                            "evaluationMods": [
+                              [
+                                "gold",
+                                [
+                                  "modifier",
+                                ],
+                              ],
+                            ],
+                            "list": [
+                              "passive-a",
+                            ],
+                            "owned": [
+                              "passive-a",
+                            ],
+                          },
+                          "phases": [
+                            "growth",
+                            "upkeep",
+                            "main",
+                          ],
+                          "players": {
+                            "active": "A",
+                            "opponent": "B",
+                          },
+                          "recentResourceGains": [
+                            {
+                              "amount": 3,
+                              "key": "gold",
+                            },
+                          ],
+                          "registries": {
+                            "action": {
+                              "has": true,
+                              "id": "expand",
+                            },
+                            "building": {
+                              "has": true,
+                              "id": "town_charter",
+                            },
+                            "development": {
+                              "has": true,
+                              "id": "farm",
+                            },
+                          },
+                          "rules": {
+                            "tierDefinitions": [],
+                            "tieredResourceKey": "gold",
+                          },
+                        }
+                `);
 	});
 });

--- a/packages/web/tests/utils/sessionStateHelpers.ts
+++ b/packages/web/tests/utils/sessionStateHelpers.ts
@@ -1,5 +1,6 @@
 import type {
 	EngineSessionSnapshot,
+	PassiveRecordSnapshot,
 	PlayerStateSnapshot,
 } from '@kingdom-builder/engine';
 import type { ResourceKey } from '@kingdom-builder/contents';
@@ -48,6 +49,16 @@ export function createSessionHelpers(
 			secondPlayer?.id ??
 			firstPlayer?.id ??
 			'player-1';
+		const passiveRecords: Record<string, PassiveRecordSnapshot[]> = {};
+		for (const player of players) {
+			passiveRecords[player.id] = [];
+		}
+		if (!(activeId in passiveRecords)) {
+			passiveRecords[activeId] = [];
+		}
+		if (!(opponentId in passiveRecords)) {
+			passiveRecords[opponentId] = [];
+		}
 		return {
 			game: {
 				turn: gameOverrides.turn ?? 1,
@@ -65,6 +76,11 @@ export function createSessionHelpers(
 			actionCostResource: primaryResource,
 			recentResourceGains: [],
 			compensations: {},
+			rules: {
+				tieredResourceKey: primaryResource,
+				tierDefinitions: [],
+			},
+			passiveRecords,
 		};
 	}
 

--- a/tests/integration/action-log-hooks.test.ts
+++ b/tests/integration/action-log-hooks.test.ts
@@ -87,8 +87,9 @@ describe('content-driven action log hooks', () => {
 				start: GAME_START,
 				rules: RULES,
 			});
+			const snapshot = session.getSnapshot();
 			const translationContext = createTranslationContext(
-				session.getSnapshot(),
+				snapshot,
 				{
 					actions: content.actions,
 					buildings,
@@ -97,6 +98,10 @@ describe('content-driven action log hooks', () => {
 				{
 					pullEffectLog: (key) => session.pullEffectLog(key),
 					evaluationMods: session.getPassiveEvaluationMods(),
+				},
+				{
+					ruleSnapshot: session.getRuleSnapshot(),
+					passiveRecords: snapshot.passiveRecords,
 				},
 			);
 


### PR DESCRIPTION
## Summary
- expose rule snapshots and passive record snapshots from the engine session facade
- thread the new snapshot data through the web game context and translation context helpers
- update translation-focused tests and helpers to assert rule/passive availability

## Text formatting audit (required)

1. **Translator/formatter reuse:** No translator or formatter strings were changed; existing translation helpers are reused as-is.
2. **Canonical keywords/icons/helpers touched:** None – the change only surfaces snapshot data.
3. **Voice review:** No player-facing copy changed.

## Standards compliance (required)

1. **File length limits respected:** New helper modules stay under the 250-line limit (contextHelpers.ts 157 lines, passiveDefinitions.ts 56 lines). 【83a373†L1-L5】
2. **Line length limits respected:** `npm run check` runs `prettier --check` with no reported violations. 【fca0d5†L1-L11】
3. **Domain separation upheld:** Engine changes only expose immutable snapshots (`session.ts`, `engine_snapshot.ts`), while the web layer consumes them via the translation context without crossing domain boundaries. 【F:packages/engine/src/runtime/session.ts†L70-L189】【F:packages/engine/src/runtime/engine_snapshot.ts†L104-L156】【F:packages/web/src/state/GameContext.tsx†L80-L147】【F:packages/web/src/translation/context/createTranslationContext.ts†L1-L142】
4. **Code standards satisfied:** `npm run check` executed eslint and the full test suite successfully. 【51d3e3†L1-L12】【55af8a†L1-L29】
5. **Tests updated:** Translation and state tests were updated to assert the new rule/passive data (`createTranslationContext.test.ts`, `useCompensationLogger.test.tsx`). 【F:packages/web/tests/translation/createTranslationContext.test.ts†L120-L205】【F:packages/web/tests/state/useCompensationLogger.test.tsx†L29-L160】
6. **Documentation updated:** Not required; no documentation references the internal snapshot structure.
7. **`npm run check` results:** Ran locally; see passing output. 【fca0d5†L1-L11】【55af8a†L1-L29】
8. **`npm run test:coverage` results:** Not run (not requested for this change).

## Testing

- `npm run check` (PASS) 【fca0d5†L1-L11】【55af8a†L1-L29】
- `npx vitest run packages/web/tests/state/useCompensationLogger.test.tsx` (PASS) 【9d2a25†L1-L14】

------
https://chatgpt.com/codex/tasks/task_e_68e6605ca4348325b4c0488a8790ebb5