### PR TITLE
Add win condition evaluation and outcome UI

### DIFF
--- a/packages/contents/src/config/builders.ts
+++ b/packages/contents/src/config/builders.ts
@@ -18,6 +18,7 @@ import type {
 	TierRange,
 	PlayerStartConfig,
 	StartConfig,
+	StartModeConfig,
 	WinConditionConfig,
 	WinConditionDisplayConfig,
 	WinConditionOutcomeConfig,
@@ -2525,9 +2526,87 @@ class PlayerStartBuilder extends ParamsBuilder<PlayerStartConfig> {
 	}
 }
 
+class StartModeBuilder {
+	private playerConfig: PlayerStartConfig | undefined;
+	private readonly playerOverrides: Record<string, PlayerStartConfig> = {};
+	private readonly assignedOverrides = new Set<string>();
+
+	private resolve(
+		input:
+			| PlayerStartBuilder
+			| ((builder: PlayerStartBuilder) => PlayerStartBuilder),
+	) {
+		if (input instanceof PlayerStartBuilder) {
+			return input;
+		}
+		const configured = input(new PlayerStartBuilder(false));
+		if (!(configured instanceof PlayerStartBuilder)) {
+			throw new Error(
+				'Start mode player(...) callback must return the provided builder.',
+			);
+		}
+		return configured;
+	}
+
+	player(
+		input:
+			| PlayerStartBuilder
+			| ((builder: PlayerStartBuilder) => PlayerStartBuilder),
+	) {
+		if (this.playerConfig) {
+			throw new Error(
+				'Dev mode start already set player(...). Remove the extra player() call.',
+			);
+		}
+		const builder = this.resolve(input);
+		this.playerConfig = builder.build();
+		return this;
+	}
+
+	playerOverride(
+		id: string,
+		input:
+			| PlayerStartBuilder
+			| ((builder: PlayerStartBuilder) => PlayerStartBuilder),
+	) {
+		if (!id) {
+			throw new Error(
+				'Dev mode playerOverride() requires a non-empty player id.',
+			);
+		}
+		if (this.assignedOverrides.has(id)) {
+			throw new Error(
+				`Dev mode already set override "${id}". Remove the extra playerOverride() call.`,
+			);
+		}
+		const builder = this.resolve(input);
+		this.playerOverrides[id] = builder.build();
+		this.assignedOverrides.add(id);
+		return this;
+	}
+
+	build(): StartModeConfig {
+		const config: StartModeConfig = {};
+		if (this.playerConfig) {
+			config.player = structuredClone(this.playerConfig);
+		}
+		if (this.assignedOverrides.size > 0) {
+			const overrides: Record<string, PlayerStartConfig> = {};
+			for (const [playerId, overrideConfig] of Object.entries(
+				this.playerOverrides,
+			)) {
+				overrides[playerId] = structuredClone(overrideConfig);
+			}
+			config.players = overrides;
+		}
+		return config;
+	}
+}
+
 class StartConfigBuilder {
 	private playerConfig: PlayerStartConfig | undefined;
 	private lastPlayerCompensationConfig: PlayerStartConfig | undefined;
+	private devModeConfig: StartModeConfig | undefined;
 
 	private resolveBuilder(
 		input:
@@ -2577,6 +2656,28 @@ class StartConfigBuilder {
 		return this;
 	}
 
+	devMode(
+		input: StartModeBuilder | ((builder: StartModeBuilder) => StartModeBuilder),
+	) {
+		if (this.devModeConfig) {
+			throw new Error(
+				'Start config already set devMode(...). Remove the extra call.',
+			);
+		}
+		if (input instanceof StartModeBuilder) {
+			this.devModeConfig = input.build();
+			return this;
+		}
+		const configured = input(new StartModeBuilder());
+		if (!(configured instanceof StartModeBuilder)) {
+			throw new Error(
+				'Start config devMode(...) callback must return the provided builder.',
+			);
+		}
+		this.devModeConfig = configured.build();
+		return this;
+	}
+
 	build(): StartConfig {
 		if (!this.playerConfig) {
 			throw new Error(
@@ -2586,6 +2687,9 @@ class StartConfigBuilder {
 		const config: StartConfig = { player: this.playerConfig };
 		if (this.lastPlayerCompensationConfig) {
 			config.players = { B: this.lastPlayerCompensationConfig };
+		}
+		if (this.devModeConfig) {
+			config.modes = { dev: structuredClone(this.devModeConfig) };
 		}
 		return config;
 	}

--- a/packages/contents/src/game.ts
+++ b/packages/contents/src/game.ts
@@ -40,4 +40,27 @@ export const GAME_START: StartConfig = startConfig()
 			[Resource.ap]: 1,
 		}),
 	)
+	.devMode((mode) =>
+		mode
+			.player((player) =>
+				player
+					.resources({
+						[Resource.gold]: 100,
+						[Resource.ap]: 0,
+						[Resource.happiness]: 10,
+						[Resource.castleHP]: 10,
+					})
+					.population({
+						[PopulationRole.Council]: 2,
+						[PopulationRole.Legion]: 1,
+						[PopulationRole.Fortifier]: 1,
+						[PopulationRole.Citizen]: 0,
+					}),
+			)
+			.playerOverride('B', (player) =>
+				player.resources({
+					[Resource.castleHP]: 1,
+				}),
+			),
+	)
 	.build();

--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -23,6 +23,7 @@ export { PASSIVE_INFO } from './passive';
 export { MODIFIER_INFO } from './modifiers';
 export { GAME_START } from './game';
 export { RULES } from './rules';
+export { WIN_CONDITIONS } from './winConditions';
 export {
 	OVERVIEW_CONTENT,
 	type OverviewContentTemplate,

--- a/packages/contents/src/winConditions.ts
+++ b/packages/contents/src/winConditions.ts
@@ -1,0 +1,20 @@
+import { winCondition, type WinConditionDef } from './config/builders';
+import { Resource } from './resources';
+
+export const WIN_CONDITIONS: WinConditionDef[] = [
+	winCondition()
+		.id('castle-destroyed')
+		.resourceThreshold({
+			resource: Resource.castleHP,
+			comparison: 'lte',
+			value: 0,
+			awardTo: 'opponents',
+		})
+		.display((display) =>
+			display
+				.icon('🏰')
+				.winner('Victory!', 'Your forces razed the enemy castle to the ground.')
+				.loser('Defeat', 'Your castle has fallen. The realm lies in ruins.'),
+		)
+		.build(),
+];

--- a/packages/contents/tests/start-config-builder-validations.test.ts
+++ b/packages/contents/tests/start-config-builder-validations.test.ts
@@ -110,4 +110,43 @@ describe('start config builder safeguards', () => {
 			'Start config already set lastPlayerCompensation(). Remove the extra call.',
 		);
 	});
+
+	it('rejects duplicate dev mode configurations in start configs', () => {
+		expect(() =>
+			startConfig()
+				.player(
+					playerStart()
+						.resources({
+							[firstResourceKey]: 1,
+						})
+						.stats({ [firstStatKey]: 1 })
+						.population({ demo: 1 })
+						.lands([]),
+				)
+				.devMode((mode) => mode)
+				.devMode((mode) => mode),
+		).toThrowError(
+			'Start config already set devMode(...). Remove the extra call.',
+		);
+	});
+
+	it('requires dev mode callbacks to return the provided builder', () => {
+		expect(() =>
+			startConfig()
+				.player(
+					playerStart()
+						.resources({
+							[firstResourceKey]: 1,
+						})
+						.stats({ [firstStatKey]: 1 })
+						.population({ demo: 1 })
+						.lands([]),
+				)
+				.devMode(() => {
+					return {} as unknown as ReturnType<typeof startConfig>;
+				}),
+		).toThrowError(
+			'Start config devMode(...) callback must return the provided builder.',
+		);
+	});
 });

--- a/packages/engine/src/actions/action_execution.ts
+++ b/packages/engine/src/actions/action_execution.ts
@@ -116,7 +116,7 @@ function executeAction<T extends string>(
 	if (affordability !== true) {
 		throw new Error(affordability);
 	}
-	deductCostsFromPlayer(finalCosts, engineContext.activePlayer);
+	deductCostsFromPlayer(finalCosts, engineContext.activePlayer, engineContext);
 	const passiveManager = engineContext.passives;
 	withStatSourceFrames(
 		engineContext,

--- a/packages/engine/src/actions/context_clone.ts
+++ b/packages/engine/src/actions/context_clone.ts
@@ -123,6 +123,13 @@ function cloneGameState(game: GameState): GameState {
 	cloned.phaseIndex = game.phaseIndex;
 	cloned.stepIndex = game.stepIndex;
 	cloned.devMode = game.devMode;
+	if (game.outcome) {
+		cloned.outcome = {
+			conditionId: game.outcome.conditionId,
+			winners: [...game.outcome.winners],
+			losers: [...game.outcome.losers],
+		};
+	}
 	cloned.players = game.players.map((player) => clonePlayerState(player));
 	return cloned;
 }

--- a/packages/engine/src/actions/costs.ts
+++ b/packages/engine/src/actions/costs.ts
@@ -102,10 +102,16 @@ export function verifyCostAffordability(
 export function deductCostsFromPlayer(
 	costs: CostBag,
 	playerState: PlayerState,
+	engineContext: EngineContext,
 ): void {
 	for (const resourceKey of Object.keys(costs)) {
 		const amount = costs[resourceKey] ?? 0;
 		playerState.resources[resourceKey] =
 			(playerState.resources[resourceKey] || 0) - amount;
+		engineContext.services.handleResourceChange(
+			engineContext,
+			playerState,
+			resourceKey,
+		);
 	}
 }

--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -85,6 +85,7 @@ export function createTaxCollectorController(playerId: PlayerId): AIController {
 			const remaining = ctx.activePlayer.resources[apKey];
 			if (typeof remaining === 'number' && remaining > 0) {
 				ctx.activePlayer.resources[apKey] = 0;
+				ctx.services.handleResourceChange(ctx, ctx.activePlayer, apKey);
 			}
 			await deps.advance(ctx);
 		};

--- a/packages/engine/src/effects/attack_target_handlers/resource.ts
+++ b/packages/engine/src/effects/attack_target_handlers/resource.ts
@@ -8,11 +8,12 @@ const resourceHandler: AttackTargetHandler<
 	getEvaluationModifierKey(target) {
 		return target.key;
 	},
-	applyDamage(target, damage, _ctx, defender) {
+	applyDamage(target, damage, ctx, defender) {
 		const before = defender.resources[target.key] || 0;
 		const after = Math.max(0, before - damage);
 		if (damage > 0) {
 			defender.resources[target.key] = after;
+			ctx.services.handleResourceChange(ctx, defender, target.key);
 		}
 		return { before, after };
 	},

--- a/packages/engine/src/effects/resource_add.ts
+++ b/packages/engine/src/effects/resource_add.ts
@@ -12,9 +12,10 @@ export const resourceAdd: EffectHandler = (effect, context, multiplier = 1) => {
 	}
 	const current = context.activePlayer.resources[key] || 0;
 	const newVal = current + total;
-	context.activePlayer.resources[key] = newVal < 0 ? 0 : newVal;
+	const player = context.activePlayer;
+	player.resources[key] = newVal < 0 ? 0 : newVal;
 	if (total > 0) {
 		context.recentResourceGains.push({ key, amount: total });
 	}
-	context.services.handleTieredResourceChange(context, key);
+	context.services.handleResourceChange(context, player, key);
 };

--- a/packages/engine/src/effects/resource_remove.ts
+++ b/packages/engine/src/effects/resource_remove.ts
@@ -19,6 +19,7 @@ export const resourceRemove: EffectHandler = (effect, ctx, mult = 1) => {
 	if (!allowShortfall && have < removed) {
 		throw new Error(`Insufficient ${key}: need ${removed}, have ${have}`);
 	}
-	ctx.activePlayer.resources[key] = have - removed;
-	ctx.services.handleTieredResourceChange(ctx, key);
+	const player = ctx.activePlayer;
+	player.resources[key] = have - removed;
+	ctx.services.handleResourceChange(ctx, player, key);
 };

--- a/packages/engine/src/effects/resource_transfer.ts
+++ b/packages/engine/src/effects/resource_transfer.ts
@@ -48,4 +48,6 @@ export const resourceTransfer: EffectHandler<TransferParams> = (
 	}
 	defender.resources[key] = available - amount;
 	attacker.resources[key] = (attacker.resources[key] || 0) + amount;
+	context.services.handleResourceChange(context, defender, key);
+	context.services.handleResourceChange(context, attacker, key);
 };

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -25,6 +25,7 @@ export {
 	type PlayerStateSnapshot,
 	type LandSnapshot,
 	type RuleSnapshot,
+	type PassiveRecordSnapshot,
 	type ActionDefinitionSummary,
 	type EngineSessionGetActionCosts,
 	type EngineSessionGetActionRequirements,

--- a/packages/engine/src/runtime/engine_snapshot.ts
+++ b/packages/engine/src/runtime/engine_snapshot.ts
@@ -97,6 +97,13 @@ function cloneSkip(
 }
 
 export function snapshotEngine(context: EngineContext): EngineSessionSnapshot {
+	const outcome = context.game.outcome
+		? {
+				conditionId: context.game.outcome.conditionId,
+				winners: [...context.game.outcome.winners],
+				losers: [...context.game.outcome.losers],
+			}
+		: undefined;
 	return {
 		game: {
 			turn: context.game.turn,
@@ -111,6 +118,7 @@ export function snapshotEngine(context: EngineContext): EngineSessionSnapshot {
 			),
 			activePlayerId: context.game.active.id,
 			opponentId: context.game.opponent.id,
+			...(outcome ? { outcome } : {}),
 		},
 		phases: clonePhases(context.phases),
 		actionCostResource: context.actionCostResource,

--- a/packages/engine/src/runtime/engine_snapshot.ts
+++ b/packages/engine/src/runtime/engine_snapshot.ts
@@ -1,4 +1,7 @@
-import { clonePassiveMetadata } from '../services/passive_helpers';
+import {
+	clonePassiveMetadata,
+	clonePassiveRecord,
+} from '../services/passive_helpers';
 import { cloneEffectList } from '../utils';
 import type { EngineContext } from '../context';
 import type { EffectDef } from '../effects';
@@ -15,6 +18,8 @@ import type {
 	AdvanceSkipSourceSnapshot,
 	EngineAdvanceResult,
 	EngineSessionSnapshot,
+	PassiveRecordSnapshot,
+	RuleSnapshot,
 } from './types';
 import {
 	cloneActionTraces,
@@ -97,6 +102,7 @@ function cloneSkip(
 }
 
 export function snapshotEngine(context: EngineContext): EngineSessionSnapshot {
+	const rules = cloneRuleSnapshot(context);
 	const outcome = context.game.outcome
 		? {
 				conditionId: context.game.outcome.conditionId,
@@ -127,7 +133,34 @@ export function snapshotEngine(context: EngineContext): EngineSessionSnapshot {
 			amount: gain.amount,
 		})),
 		compensations: cloneCompensations(context.compensations),
+		rules,
+		passiveRecords: clonePassiveRecords(context),
 	};
+}
+
+function cloneRuleSnapshot(context: EngineContext): RuleSnapshot {
+	const { tieredResourceKey, tierDefinitions } = context.services.rules;
+	return {
+		tieredResourceKey,
+		tierDefinitions: structuredClone(tierDefinitions),
+	} satisfies RuleSnapshot;
+}
+
+function clonePassiveRecords(
+	context: EngineContext,
+): Record<PlayerId, PassiveRecordSnapshot[]> {
+	const result: Record<PlayerId, PassiveRecordSnapshot[]> = {} as Record<
+		PlayerId,
+		PassiveRecordSnapshot[]
+	>;
+	for (const player of context.game.players) {
+		const records = context.passives.values(player.id).map((record) => {
+			const { frames: _frames, ...snapshot } = clonePassiveRecord(record);
+			return snapshot as PassiveRecordSnapshot;
+		});
+		result[player.id] = records;
+	}
+	return result;
 }
 
 export function snapshotAdvance(

--- a/packages/engine/src/runtime/session.ts
+++ b/packages/engine/src/runtime/session.ts
@@ -15,16 +15,19 @@ import type { ActionTrace } from '../log';
 import { cloneActionOptions } from './action_options';
 import { cloneActionTraces } from './player_snapshot';
 import { snapshotAdvance, snapshotEngine } from './engine_snapshot';
-import type { EngineAdvanceResult, EngineSessionSnapshot } from './types';
+import type {
+	EngineAdvanceResult,
+	EngineSessionSnapshot,
+	RuleSnapshot,
+} from './types';
 import type { EvaluationModifier } from '../services/passive_types';
 import {
 	simulateUpcomingPhases as runSimulation,
 	type SimulateUpcomingPhasesOptions,
 	type SimulateUpcomingPhasesResult,
 } from './simulate_upcoming_phases';
-import type { PlayerId, ResourceKey } from '../state';
+import type { PlayerId } from '../state';
 import type { AIDependencies } from '../ai';
-import type { HappinessTierDefinition } from '../services/tiered_resource_types';
 
 export interface ActionDefinitionSummary {
 	id: string;
@@ -87,11 +90,6 @@ export interface EngineSession {
 	getLegacyContext(): EngineContext;
 }
 
-export interface RuleSnapshot {
-	tieredResourceKey: ResourceKey;
-	tierDefinitions: HappinessTierDefinition[];
-}
-
 export type {
 	EngineAdvanceResult,
 	EngineSessionSnapshot,
@@ -100,6 +98,8 @@ export type {
 	GameSnapshot,
 	PlayerStateSnapshot,
 	LandSnapshot,
+	RuleSnapshot,
+	PassiveRecordSnapshot,
 } from './types';
 
 export function createEngineSession(

--- a/packages/engine/src/runtime/session.ts
+++ b/packages/engine/src/runtime/session.ts
@@ -108,10 +108,21 @@ export function createEngineSession(
 	const context = createEngine(options);
 	return {
 		performAction(actionId, params) {
+			if (context.game.outcome) {
+				return [];
+			}
 			const traces = runAction(actionId, context, params);
 			return cloneActionTraces(traces);
 		},
 		advancePhase() {
+			if (context.game.outcome) {
+				return snapshotAdvance(context, {
+					phase: context.game.currentPhase,
+					step: context.game.currentStep,
+					effects: [],
+					player: context.game.active,
+				});
+			}
 			const result = runAdvance(context);
 			return snapshotAdvance(context, result);
 		},

--- a/packages/engine/src/runtime/types.ts
+++ b/packages/engine/src/runtime/types.ts
@@ -9,6 +9,8 @@ import type {
 	GameOutcome,
 } from '../state';
 import type { PassiveMetadata, PassiveSummary } from '../services';
+import type { PassiveRecord } from '../services/passive_types';
+import type { HappinessTierDefinition } from '../services/tiered_resource_types';
 
 export interface LandSnapshot {
 	id: string;
@@ -88,4 +90,13 @@ export interface EngineSessionSnapshot {
 	actionCostResource: ResourceKey;
 	recentResourceGains: { key: ResourceKey; amount: number }[];
 	compensations: Record<PlayerId, PlayerStartConfig>;
+	rules: RuleSnapshot;
+	passiveRecords: Record<PlayerId, PassiveRecordSnapshot[]>;
 }
+
+export interface RuleSnapshot {
+	tieredResourceKey: ResourceKey;
+	tierDefinitions: HappinessTierDefinition[];
+}
+
+export type PassiveRecordSnapshot = Omit<PassiveRecord, 'frames'>;

--- a/packages/engine/src/runtime/types.ts
+++ b/packages/engine/src/runtime/types.ts
@@ -2,7 +2,12 @@ import type { EffectDef } from '../effects';
 import type { PhaseDef } from '../phases';
 import type { AdvanceSkip } from '../phases/advance';
 import type { PlayerStartConfig } from '@kingdom-builder/protocol';
-import type { PlayerId, StatSourceContribution, ResourceKey } from '../state';
+import type {
+	PlayerId,
+	StatSourceContribution,
+	ResourceKey,
+	GameOutcome,
+} from '../state';
 import type { PassiveMetadata, PassiveSummary } from '../services';
 
 export interface LandSnapshot {
@@ -53,6 +58,7 @@ export interface GameSnapshot {
 	players: PlayerStateSnapshot[];
 	activePlayerId: PlayerId;
 	opponentId: PlayerId;
+	outcome?: GameOutcome;
 }
 
 export interface AdvanceSkipSourceSnapshot {

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -29,5 +29,6 @@ export type {
 } from './tiered_resource_types';
 export type { PhaseSkipConfig, PhaseSkipStep } from './passive_types';
 export { PopCapService } from './pop_cap_service';
+export { WinConditionService } from './win_condition_service';
 export { Services } from './services';
 export type { RuleSet } from './services_types';

--- a/packages/engine/src/services/services.ts
+++ b/packages/engine/src/services/services.ts
@@ -1,26 +1,38 @@
-import type { ResourceKey, PlayerId } from '../state';
+import type { ResourceKey, PlayerId, PlayerState } from '../state';
 import type { EngineContext } from '../context';
-import type { DevelopmentConfig, Registry } from '@kingdom-builder/protocol';
+import type {
+	DevelopmentConfig,
+	Registry,
+	WinConditionConfig,
+} from '@kingdom-builder/protocol';
 import { runEffects } from '../effects';
 import { TieredResourceService } from './tiered_resource_service';
 import { PopCapService } from './pop_cap_service';
 import type { HappinessTierDefinition } from './tiered_resource_types';
 import type { RuleSet } from './services_types';
+import { WinConditionService } from './win_condition_service';
 
 type Context = EngineContext;
 type TierResource = ResourceKey;
 
+function isResourceKey(key: string, player: PlayerState): key is ResourceKey {
+	return Object.prototype.hasOwnProperty.call(player.resources, key);
+}
+
 export class Services {
 	tieredResource: TieredResourceService;
 	popcap: PopCapService;
+	win: WinConditionService;
 	private activeTiers: Map<PlayerId, HappinessTierDefinition> = new Map();
 
 	constructor(
 		public rules: RuleSet,
 		developments: Registry<DevelopmentConfig>,
+		winConditions: WinConditionConfig[],
 	) {
 		this.tieredResource = new TieredResourceService(rules);
 		this.popcap = new PopCapService(rules, developments);
+		this.win = new WinConditionService(winConditions);
 	}
 
 	handleTieredResourceChange(context: Context, tierKey: TierResource) {
@@ -83,8 +95,32 @@ export class Services {
 		context.game.currentPlayerIndex = previousIndex;
 	}
 
+	handleResourceChange(context: Context, player: PlayerState, key: string) {
+		if (context.game.outcome) {
+			return;
+		}
+		if (!isResourceKey(key, player)) {
+			return;
+		}
+		const originalIndex = context.game.currentPlayerIndex;
+		const playerIndex = context.game.players.indexOf(player);
+		if (playerIndex >= 0) {
+			context.game.currentPlayerIndex = playerIndex;
+		}
+		try {
+			this.handleTieredResourceChange(context, key);
+			this.win.evaluate(context, player);
+		} finally {
+			context.game.currentPlayerIndex = originalIndex;
+		}
+	}
+
 	clone(developments: Registry<DevelopmentConfig>): Services {
-		const cloned = new Services(this.rules, developments);
+		const cloned = new Services(
+			this.rules,
+			developments,
+			this.win.getDefinitions(),
+		);
 		cloned.activeTiers = new Map(this.activeTiers);
 		return cloned;
 	}

--- a/packages/engine/src/services/win_condition_service.ts
+++ b/packages/engine/src/services/win_condition_service.ts
@@ -1,0 +1,184 @@
+import type { EngineContext } from '../context';
+import type { PlayerId, PlayerState } from '../state';
+import type { WinConditionConfig } from '@kingdom-builder/protocol';
+
+function cloneDisplay(
+	display: NonNullable<WinConditionConfig['display']>,
+): NonNullable<WinConditionConfig['display']> {
+	const cloned = {
+		winner: { ...display.winner },
+		loser: { ...display.loser },
+	} as NonNullable<WinConditionConfig['display']>;
+	if (display.icon !== undefined) {
+		cloned.icon = display.icon;
+	}
+	return cloned;
+}
+
+function cloneDefinition(definition: WinConditionConfig): WinConditionConfig {
+	const cloned: WinConditionConfig = {
+		id: definition.id,
+		rule: {
+			type: definition.rule.type,
+			method: definition.rule.method,
+		},
+	};
+	if (definition.rule.params) {
+		cloned.rule.params = { ...definition.rule.params };
+	}
+	if (definition.rule.awardsTo) {
+		cloned.rule.awardsTo = definition.rule.awardsTo;
+	}
+	if (definition.priority !== undefined) {
+		cloned.priority = definition.priority;
+	}
+	if (definition.display) {
+		cloned.display = cloneDisplay(definition.display);
+	}
+	return cloned;
+}
+
+function keyForRule(rule: WinConditionConfig['rule']): string {
+	return `${rule.type}:${rule.method}`;
+}
+
+type WinConditionHandler = (
+	context: EngineContext,
+	player: PlayerState,
+	definition: WinConditionConfig,
+) => void;
+
+function compare(
+	amount: number,
+	threshold: number,
+	comparison: string,
+): boolean {
+	switch (comparison) {
+		case 'lt':
+			return amount < threshold;
+		case 'lte':
+			return amount <= threshold;
+		case 'gt':
+			return amount > threshold;
+		case 'gte':
+			return amount >= threshold;
+		default:
+			return false;
+	}
+}
+
+function normalizeAward(
+	award: WinConditionConfig['rule']['awardsTo'] | undefined,
+): 'self' | 'opponents' | 'none' {
+	if (award === 'self' || award === 'none') {
+		return award;
+	}
+	return 'opponents';
+}
+
+export class WinConditionService {
+	private readonly definitions: WinConditionConfig[];
+	private readonly handlers: Map<string, WinConditionHandler> = new Map();
+
+	constructor(definitions: WinConditionConfig[]) {
+		this.definitions = definitions
+			.map((definition) => cloneDefinition(definition))
+			.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+		this.registerDefaults();
+	}
+
+	private registerDefaults() {
+		this.register('resource', 'threshold', this.evaluateResourceThreshold);
+	}
+
+	private register(type: string, method: string, handler: WinConditionHandler) {
+		this.handlers.set(`${type}:${method}`, handler);
+	}
+
+	evaluate(context: EngineContext, player?: PlayerState) {
+		if (context.game.outcome) {
+			return;
+		}
+		const targets = player ? [player] : context.game.players;
+		for (const definition of this.definitions) {
+			const handler = this.handlers.get(keyForRule(definition.rule));
+			if (!handler) {
+				continue;
+			}
+			for (const target of targets) {
+				if (context.game.outcome) {
+					return;
+				}
+				handler(context, target, definition);
+				if (context.game.outcome) {
+					return;
+				}
+			}
+		}
+	}
+
+	getDefinitions(): WinConditionConfig[] {
+		return this.definitions.map((definition) => cloneDefinition(definition));
+	}
+
+	private evaluateResourceThreshold: WinConditionHandler = (
+		context,
+		player,
+		definition,
+	) => {
+		const params = definition.rule.params || {};
+		const key = params['resource'];
+		if (typeof key !== 'string') {
+			return;
+		}
+		const resourceRecord: Record<string, number> = player.resources;
+		const amount = resourceRecord[key] ?? 0;
+		const rawValue = params['value'];
+		const threshold =
+			typeof rawValue === 'number' ? rawValue : Number(rawValue);
+		if (!Number.isFinite(threshold)) {
+			return;
+		}
+		const comparison = (params['comparison'] as string | undefined) ?? 'lte';
+		if (!compare(amount, threshold, comparison)) {
+			return;
+		}
+		const award = normalizeAward(definition.rule.awardsTo);
+		this.setOutcome(context, player, definition, award);
+	};
+
+	private setOutcome(
+		context: EngineContext,
+		player: PlayerState,
+		definition: WinConditionConfig,
+		award: 'self' | 'opponents' | 'none',
+	) {
+		if (context.game.outcome) {
+			return;
+		}
+		const winners: PlayerId[] = [];
+		const losers: PlayerId[] = [];
+		const others = context.game.players
+			.filter((candidate) => candidate.id !== player.id)
+			.map((candidate) => candidate.id);
+		if (award === 'self') {
+			winners.push(player.id);
+			losers.push(...others);
+		} else if (award === 'opponents') {
+			winners.push(...others);
+			losers.push(player.id);
+		} else {
+			losers.push(player.id);
+		}
+		const winnerSet = new Set(winners);
+		const loserSet = new Set(losers);
+		if (winnerSet.size === 0 && loserSet.size === 0) {
+			return;
+		}
+		context.game.outcome = {
+			conditionId: definition.id,
+			winners: Array.from(winnerSet),
+			losers: Array.from(loserSet),
+		};
+	}
+}

--- a/packages/engine/src/setup/create_engine.ts
+++ b/packages/engine/src/setup/create_engine.ts
@@ -49,6 +49,7 @@ import {
 	diffPlayerStartConfiguration,
 	determineCommonActionCostResource,
 } from './player_setup';
+import { resolveStartConfigForMode } from './start_config_resolver';
 
 export interface EngineCreationOptions {
 	actions: Registry<ActionDef>;
@@ -59,6 +60,7 @@ export interface EngineCreationOptions {
 	start: StartConfig;
 	rules: RuleSet;
 	config?: GameConfig;
+	devMode?: boolean;
 	winConditions?: WinConditionConfig[];
 }
 
@@ -127,6 +129,7 @@ export function createEngine({
 	start,
 	rules,
 	config,
+	devMode = false,
 	winConditions = [],
 }: EngineCreationOptions) {
 	registerCoreEffects();
@@ -152,6 +155,7 @@ export function createEngine({
 			winConditionDefs = validatedConfig.winConditions;
 		}
 	}
+	startConfig = resolveStartConfigForMode(startConfig, devMode);
 	setResourceKeys(Object.keys(startConfig.player.resources || {}));
 	setStatKeys(Object.keys(startConfig.player.stats || {}));
 	setPhaseKeys(phases.map((phaseDefinition) => phaseDefinition.id));
@@ -196,6 +200,7 @@ export function createEngine({
 	engineContext.game.currentPlayerIndex = 0;
 	engineContext.game.currentPhase = phases[0]?.id || '';
 	engineContext.game.currentStep = phases[0]?.steps[0]?.id || '';
+	engineContext.game.devMode = devMode;
 	services.initializeTierPassives(engineContext);
 	services.win.evaluate(engineContext);
 	return engineContext;

--- a/packages/engine/src/setup/player_setup.ts
+++ b/packages/engine/src/setup/player_setup.ts
@@ -91,19 +91,21 @@ export function diffPlayerStartConfiguration(
 		overrideConfig.resources || {},
 	)) {
 		const baseValue = baseConfig.resources?.[resourceKey] ?? 0;
-		const delta = (value ?? 0) - baseValue;
-		if (delta !== 0) {
-			diff.resources = diff.resources || {};
-			diff.resources[resourceKey] = delta;
+		const overrideValue = value ?? 0;
+		if (overrideValue === baseValue) {
+			continue;
 		}
+		diff.resources = diff.resources || {};
+		diff.resources[resourceKey] = overrideValue;
 	}
 	for (const [statKey, value] of Object.entries(overrideConfig.stats || {})) {
 		const baseValue = baseConfig.stats?.[statKey] ?? 0;
-		const delta = (value ?? 0) - baseValue;
-		if (delta !== 0) {
-			diff.stats = diff.stats || {};
-			diff.stats[statKey] = delta;
+		const overrideValue = value ?? 0;
+		if (overrideValue === baseValue) {
+			continue;
 		}
+		diff.stats = diff.stats || {};
+		diff.stats[statKey] = overrideValue;
 	}
 	return diff;
 }

--- a/packages/engine/src/setup/start_config_resolver.ts
+++ b/packages/engine/src/setup/start_config_resolver.ts
@@ -1,0 +1,79 @@
+import type { PlayerStartConfig, StartConfig } from '@kingdom-builder/protocol';
+
+function mergeNumericRecord(
+	base: Record<string, number> | undefined,
+	override: Record<string, number> | undefined,
+) {
+	if (!base && !override) {
+		return undefined;
+	}
+	const merged: Record<string, number> = { ...(base ?? {}) };
+	if (override) {
+		for (const [key, value] of Object.entries(override)) {
+			merged[key] = value ?? 0;
+		}
+	}
+	return merged;
+}
+
+function mergePlayerStartConfig(
+	baseConfig: PlayerStartConfig | undefined,
+	overrideConfig: PlayerStartConfig | undefined,
+): PlayerStartConfig {
+	if (!baseConfig && !overrideConfig) {
+		return {};
+	}
+	const merged: PlayerStartConfig = {};
+	const resources = mergeNumericRecord(
+		baseConfig?.resources,
+		overrideConfig?.resources,
+	);
+	if (resources) {
+		merged.resources = resources;
+	}
+	const stats = mergeNumericRecord(baseConfig?.stats, overrideConfig?.stats);
+	if (stats) {
+		merged.stats = stats;
+	}
+	const population = mergeNumericRecord(
+		baseConfig?.population,
+		overrideConfig?.population,
+	);
+	if (population) {
+		merged.population = population;
+	}
+	if (overrideConfig?.lands) {
+		merged.lands = structuredClone(overrideConfig.lands);
+	} else if (baseConfig?.lands) {
+		merged.lands = structuredClone(baseConfig.lands);
+	}
+	return merged;
+}
+
+export function resolveStartConfigForMode(
+	baseConfig: StartConfig,
+	devModeEnabled: boolean,
+): StartConfig {
+	const resolved = structuredClone(baseConfig);
+	if (!devModeEnabled) {
+		return resolved;
+	}
+	const devOverride = baseConfig.modes?.dev;
+	if (!devOverride) {
+		return resolved;
+	}
+	resolved.player = mergePlayerStartConfig(resolved.player, devOverride.player);
+	if (devOverride.players) {
+		resolved.players = resolved.players ?? {};
+		for (const [playerId, overrideConfig] of Object.entries(
+			devOverride.players,
+		)) {
+			const basePlayerConfig = resolved.players[playerId];
+			resolved.players[playerId] = mergePlayerStartConfig(
+				basePlayerConfig,
+				overrideConfig,
+			);
+		}
+	}
+	return resolved;
+}

--- a/packages/engine/src/state/index.ts
+++ b/packages/engine/src/state/index.ts
@@ -74,6 +74,12 @@ export interface StatSourceContribution {
 
 export type PlayerId = 'A' | 'B';
 
+export interface GameOutcome {
+	conditionId: string;
+	winners: PlayerId[];
+	losers: PlayerId[];
+}
+
 export class Land {
 	id: string;
 	slotsMax: number;
@@ -168,6 +174,7 @@ export class GameState {
 	phaseIndex = 0;
 	stepIndex = 0;
 	devMode = false;
+	outcome: GameOutcome | undefined;
 	players: PlayerState[];
 	constructor(aName = 'Player', bName = 'Opponent') {
 		this.players = [new PlayerState('A', aName), new PlayerState('B', bName)];

--- a/packages/engine/tests/helpers.ts
+++ b/packages/engine/tests/helpers.ts
@@ -7,6 +7,7 @@ import {
 	PHASES,
 	GAME_START,
 	RULES,
+	WIN_CONDITIONS,
 } from '@kingdom-builder/contents';
 import type {
 	ActionConfig as ActionDef,
@@ -15,6 +16,7 @@ import type {
 	PopulationConfig as PopulationDef,
 	Registry,
 	StartConfig,
+	WinConditionConfig,
 } from '@kingdom-builder/protocol';
 import type { PhaseDef } from '../src/phases.ts';
 import type { RuleSet } from '../src/services';
@@ -26,6 +28,7 @@ const BASE: {
 	populations: Registry<PopulationDef>;
 	phases: PhaseDef[];
 	start: StartConfig;
+	winConditions: WinConditionConfig[];
 } = {
 	actions: ACTIONS,
 	buildings: BUILDINGS,
@@ -33,6 +36,7 @@ const BASE: {
 	populations: POPULATIONS,
 	phases: PHASES,
 	start: GAME_START,
+	winConditions: WIN_CONDITIONS,
 };
 
 type EngineOverrides = Partial<typeof BASE> & { rules?: RuleSet };

--- a/packages/engine/tests/resolveAttack.test.ts
+++ b/packages/engine/tests/resolveAttack.test.ts
@@ -3,6 +3,7 @@ import { resolveAttack, runEffects, type EffectDef } from '../src/index.ts';
 import { createTestEngine } from './helpers.ts';
 import { Resource, Stat } from '../src/state/index.ts';
 import { createContentFactory } from './factories/content.ts';
+import { WIN_CONDITIONS } from '@kingdom-builder/contents';
 
 function makeAbsorptionEffect(amount: number): EffectDef {
 	return {
@@ -228,5 +229,23 @@ describe('resolveAttack', () => {
 		expect(defender.resources[Resource.castleHP]).toBe(startHP - expected);
 		expect(defender.absorption).toBe(1);
 		expect(defender.fortificationStrength).toBe(5);
+	});
+
+	it('declares a winner when a castle is destroyed', () => {
+		const engineContext = createTestEngine();
+		const attacker = engineContext.activePlayer;
+		const defender = engineContext.game.opponent;
+		resolveAttack(defender, 50, engineContext, {
+			type: 'resource',
+			key: Resource.castleHP,
+		});
+		const outcome = engineContext.game.outcome;
+		const castleCondition = WIN_CONDITIONS.find(
+			(entry) => entry.rule.params?.['resource'] === Resource.castleHP,
+		);
+		expect(outcome).toBeDefined();
+		expect(outcome?.conditionId).toBe(castleCondition?.id);
+		expect(outcome?.losers).toContain(defender.id);
+		expect(outcome?.winners).toContain(attacker.id);
 	});
 });

--- a/packages/engine/tests/services/popcap-service.test.ts
+++ b/packages/engine/tests/services/popcap-service.test.ts
@@ -8,7 +8,7 @@ describe('PopcapService', () => {
 	it('calculates population cap from houses on land', () => {
 		const content = createContentFactory();
 		const house = content.development({ populationCap: 1 });
-		const services = new Services(RULES, content.developments);
+		const services = new Services(RULES, content.developments, []);
 		const player = new PlayerState('A', 'Test');
 		const land1 = new Land('l1', 1);
 		land1.developments.push(house.id);

--- a/packages/engine/tests/services/rules.test.ts
+++ b/packages/engine/tests/services/rules.test.ts
@@ -14,7 +14,11 @@ import { createContentFactory } from '../factories/content';
 
 describe('Services', () => {
 	it('evaluates resource tiers correctly', () => {
-		const services = new Services(RULES, createContentFactory().developments);
+		const services = new Services(
+			RULES,
+			createContentFactory().developments,
+			[],
+		);
 		const getTierEffect = (value: number) =>
 			RULES.tierDefinitions
 				.filter(
@@ -66,6 +70,7 @@ describe('Services', () => {
 				],
 			},
 			content.developments,
+			[],
 		);
 		expect(services.tieredResource.tier(5)?.incomeMultiplier).toBe(1);
 		expect(services.tieredResource.tier(6)?.incomeMultiplier).toBe(2);

--- a/packages/protocol/src/config/schema.ts
+++ b/packages/protocol/src/config/schema.ts
@@ -17,6 +17,43 @@ const evaluatorSchema = z.object({
 	params: z.record(z.unknown()).optional(),
 });
 
+const winConditionOutcomeSchema = z.object({
+	title: z.string(),
+	description: z.string(),
+});
+
+export type WinConditionOutcomeConfig = z.infer<
+	typeof winConditionOutcomeSchema
+>;
+
+const winConditionDisplaySchema = z.object({
+	icon: z.string().optional(),
+	winner: winConditionOutcomeSchema,
+	loser: winConditionOutcomeSchema,
+});
+
+export type WinConditionDisplayConfig = z.infer<
+	typeof winConditionDisplaySchema
+>;
+
+const winConditionRuleSchema = z.object({
+	type: z.string(),
+	method: z.string(),
+	params: z.record(z.unknown()).optional(),
+	awardsTo: z.enum(['self', 'opponents', 'none']).optional(),
+});
+
+export type WinConditionRuleConfig = z.infer<typeof winConditionRuleSchema>;
+
+export const winConditionSchema = z.object({
+	id: z.string(),
+	rule: winConditionRuleSchema,
+	priority: z.number().optional(),
+	display: winConditionDisplaySchema.optional(),
+});
+
+export type WinConditionConfig = z.infer<typeof winConditionSchema>;
+
 export const effectSchema: z.ZodType<EffectDef> = z.lazy(() =>
 	z.object({
 		type: z.string().optional(),
@@ -158,6 +195,7 @@ export const gameConfigSchema = z.object({
 	buildings: z.array(buildingSchema).optional(),
 	developments: z.array(developmentSchema).optional(),
 	populations: z.array(populationSchema).optional(),
+	winConditions: z.array(winConditionSchema).optional(),
 });
 
 export type GameConfig = z.infer<typeof gameConfigSchema>;

--- a/packages/protocol/src/config/schema.ts
+++ b/packages/protocol/src/config/schema.ts
@@ -181,13 +181,27 @@ const playerStartSchema = z.object({
 	lands: z.array(landStartSchema).optional(),
 });
 
+const startModeConfigSchema = z.object({
+	player: playerStartSchema.optional(),
+	players: z.record(z.string(), playerStartSchema).optional(),
+});
+
+const startModesSchema = z
+	.object({
+		dev: startModeConfigSchema.optional(),
+	})
+	.partial();
+
 export const startConfigSchema = z.object({
 	player: playerStartSchema,
 	players: z.record(z.string(), playerStartSchema).optional(),
+	modes: startModesSchema.optional(),
 });
 
 export type PlayerStartConfig = z.infer<typeof playerStartSchema>;
 export type StartConfig = z.infer<typeof startConfigSchema>;
+export type StartModeConfig = z.infer<typeof startModeConfigSchema>;
+export type StartModesConfig = z.infer<typeof startModesSchema>;
 
 export const gameConfigSchema = z.object({
 	start: startConfigSchema.optional(),

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -37,10 +37,12 @@ export type {
 	PopulationConfig,
 	PlayerStartConfig,
 	StartConfig,
-	WinConditionOutcomeConfig,
-	WinConditionDisplayConfig,
-	WinConditionRuleConfig,
+	StartModeConfig,
+	StartModesConfig,
 	WinConditionConfig,
+	WinConditionDisplayConfig,
+	WinConditionOutcomeConfig,
+	WinConditionRuleConfig,
 	GameConfig,
 } from './config/schema';
 export type {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -37,6 +37,10 @@ export type {
 	PopulationConfig,
 	PlayerStartConfig,
 	StartConfig,
+	WinConditionOutcomeConfig,
+	WinConditionDisplayConfig,
+	WinConditionRuleConfig,
+	WinConditionConfig,
 	GameConfig,
 } from './config/schema';
 export type {

--- a/packages/web/src/GameLayout.tsx
+++ b/packages/web/src/GameLayout.tsx
@@ -10,6 +10,7 @@ import PhasePanel from './components/phases/PhasePanel';
 import PlayerPanel from './components/player/PlayerPanel';
 import SettingsDialog from './components/settings/SettingsDialog';
 import { useGameEngine } from './state/GameContext';
+import GameOutcomeScreen from './components/GameOutcomeScreen';
 
 export default function GameLayout() {
 	const {
@@ -177,6 +178,7 @@ export default function GameLayout() {
 				onConfirm={confirmExit}
 			/>
 			<Toaster />
+			<GameOutcomeScreen />
 			<div className="pointer-events-none absolute inset-0">
 				<div className="absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-amber-300/30 blur-3xl dark:bg-amber-500/20" />
 				<div className="absolute -bottom-28 -left-16 h-80 w-80 rounded-full bg-sky-300/30 blur-3xl dark:bg-sky-500/20" />

--- a/packages/web/src/components/GameOutcomeScreen.tsx
+++ b/packages/web/src/components/GameOutcomeScreen.tsx
@@ -1,0 +1,109 @@
+import React, { useMemo } from 'react';
+import Button from './common/Button';
+import { WIN_CONDITIONS } from '@kingdom-builder/contents';
+import { useGameEngine } from '../state/GameContext';
+
+function buildResultLine(
+	didWin: boolean,
+	didLose: boolean,
+	winners: Set<string>,
+	losers: Set<string>,
+	players: { id: string; name: string }[],
+): string | null {
+	const winnerNames = players
+		.filter((player) => winners.has(player.id))
+		.map((player) => player.name)
+		.join(' & ');
+	const loserNames = players
+		.filter((player) => losers.has(player.id))
+		.map((player) => player.name)
+		.join(' & ');
+	if (didWin && loserNames) {
+		return `You defeated ${loserNames}.`;
+	}
+	if (didLose && winnerNames) {
+		return `${winnerNames} claimed victory.`;
+	}
+	if (winnerNames && loserNames) {
+		return `${winnerNames} prevailed over ${loserNames}.`;
+	}
+	return null;
+}
+
+export default function GameOutcomeScreen() {
+	const { sessionState, onExit } = useGameEngine();
+	const outcome = sessionState.game.outcome;
+	const players = sessionState.game.players;
+	const localPlayer = players[0];
+	const perspectiveId = localPlayer?.id ?? null;
+	const winners = useMemo(
+		() => new Set(outcome?.winners ?? []),
+		[outcome?.winners],
+	);
+	const losers = useMemo(
+		() => new Set(outcome?.losers ?? []),
+		[outcome?.losers],
+	);
+	if (!outcome) {
+		return null;
+	}
+	const didWin = perspectiveId ? winners.has(perspectiveId) : false;
+	const didLose = perspectiveId ? losers.has(perspectiveId) : false;
+	const definition = WIN_CONDITIONS.find(
+		(entry) => entry.id === outcome.conditionId,
+	);
+	const display = didWin
+		? definition?.display?.winner
+		: didLose
+			? definition?.display?.loser
+			: undefined;
+	const icon = definition?.display?.icon;
+	const title =
+		display?.title ?? (didWin ? 'Victory!' : didLose ? 'Defeat' : 'Game Over');
+	const description =
+		display?.description ??
+		(didWin
+			? 'Your realm stands triumphant.'
+			: didLose
+				? 'Your castle has fallen.'
+				: 'The battle has ended.');
+	const resultLine = buildResultLine(didWin, didLose, winners, losers, players);
+	const handleExit = () => {
+		if (onExit) {
+			onExit();
+			return;
+		}
+		window.location.reload();
+	};
+	return (
+		<div className="pointer-events-auto fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 backdrop-blur-md">
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-label={title}
+				className="mx-4 w-full max-w-lg rounded-3xl border border-white/20 bg-white/95 p-10 text-center shadow-2xl dark:border-white/10 dark:bg-slate-900/95 dark:text-slate-100 frosted-surface"
+			>
+				{icon ? (
+					<div className="mb-4 flex justify-center text-5xl">{icon}</div>
+				) : null}
+				<h2 className="text-3xl font-semibold tracking-tight">{title}</h2>
+				<p className="mt-4 text-base text-slate-600 dark:text-slate-300">
+					{description}
+				</p>
+				{resultLine ? (
+					<p className="mt-4 text-sm uppercase tracking-wide text-slate-500 dark:text-slate-400">
+						{resultLine}
+					</p>
+				) : null}
+				<Button
+					onClick={handleExit}
+					className="mt-8"
+					icon="🏠"
+					variant="primary"
+				>
+					Return to Main Screen
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -90,6 +90,7 @@ export function GameProvider({
 			phases: PHASES,
 			start: GAME_START,
 			rules: RULES,
+			devMode,
 			winConditions: WIN_CONDITIONS,
 		});
 		created.setDevMode(devMode);
@@ -109,7 +110,10 @@ export function GameProvider({
 	const enqueue = <T,>(task: () => Promise<T> | T) => session.enqueue(task);
 
 	const sessionState = useMemo(() => session.getSnapshot(), [session, tick]);
-	const ruleSnapshot = useMemo(() => session.getRuleSnapshot(), [session]);
+	const ruleSnapshot = useMemo(
+		() => session.getRuleSnapshot(),
+		[session, tick],
+	);
 
 	useEffect(() => {
 		const [primary] = ctx.game.players;
@@ -137,8 +141,12 @@ export function GameProvider({
 					pullEffectLog: <T,>(key: string) => session.pullEffectLog<T>(key),
 					evaluationMods: session.getPassiveEvaluationMods(),
 				},
+				{
+					ruleSnapshot,
+					passiveRecords: sessionState.passiveRecords,
+				},
 			),
-		[sessionState, session],
+		[sessionState, session, ruleSnapshot, sessionState.passiveRecords],
 	);
 
 	const {

--- a/packages/web/src/state/GameContext.tsx
+++ b/packages/web/src/state/GameContext.tsx
@@ -21,6 +21,7 @@ import {
 	PHASES,
 	GAME_START,
 	RULES,
+	WIN_CONDITIONS,
 	type ResourceKey,
 } from '@kingdom-builder/contents';
 import { createTranslationContext } from '../translation/context';
@@ -89,6 +90,7 @@ export function GameProvider({
 			phases: PHASES,
 			start: GAME_START,
 			rules: RULES,
+			winConditions: WIN_CONDITIONS,
 		});
 		created.setDevMode(devMode);
 		const legacyContext = created.getLegacyContext();

--- a/packages/web/src/state/getLegacySessionContext.ts
+++ b/packages/web/src/state/getLegacySessionContext.ts
@@ -214,6 +214,10 @@ export function getLegacySessionContext(
 			pullEffectLog: <T>(key: string) => session.pullEffectLog<T>(key),
 			evaluationMods: session.getPassiveEvaluationMods(),
 		},
+		{
+			ruleSnapshot: session.getRuleSnapshot(),
+			passiveRecords: snapshot.passiveRecords,
+		},
 	);
 	const diffContext = createDiffContext(snapshot, translationContext);
 	return { translationContext, diffContext };

--- a/packages/web/src/state/sessionSelectors.ts
+++ b/packages/web/src/state/sessionSelectors.ts
@@ -1,0 +1,203 @@
+import type {
+	EngineSessionSnapshot,
+	PlayerStateSnapshot,
+} from '@kingdom-builder/engine';
+import type {
+	ActionDefinition,
+	BuildingDefinition,
+	DevelopmentDefinition,
+	RegistryLike,
+	SessionActionOption,
+	SessionBuildingOption,
+	SessionDevelopmentOption,
+	SessionLandView,
+	SessionOptionSelection,
+	SessionPlayerView,
+	SessionRegistries,
+	SessionSelectorHelpers,
+} from './sessionSelectors.types';
+
+const cloneRecord = <T>(record: Record<string, T>) => ({ ...record });
+const mapLand = (
+	land: PlayerStateSnapshot['lands'][number],
+): SessionLandView => ({
+	...land,
+	slotsFree: Math.max(0, land.slotsMax - land.slotsUsed),
+});
+const mapPlayer = (player: PlayerStateSnapshot): SessionPlayerView => ({
+	...player,
+	resources: cloneRecord(player.resources),
+	stats: cloneRecord(player.stats),
+	statsHistory: cloneRecord(player.statsHistory),
+	population: cloneRecord(player.population),
+	passives: [...player.passives],
+	lands: player.lands.map(mapLand),
+	buildings: new Set(player.buildings),
+	actions: new Set(player.actions),
+});
+const createActionOption = (
+	id: string,
+	definition: ActionDefinition,
+): SessionActionOption => ({
+	id: definition.id ?? id,
+	name: definition.name,
+	icon: definition.icon,
+	system: definition.system,
+	order: definition.order,
+	category: definition.category,
+	focus: definition.focus,
+});
+const createBuildingOption = (
+	id: string,
+	definition: BuildingDefinition,
+): SessionBuildingOption => ({
+	id: definition.id ?? id,
+	name: definition.name,
+	icon: definition.icon,
+	focus: definition.focus,
+	costs: cloneRecord(definition.costs),
+	upkeep: definition.upkeep ? cloneRecord(definition.upkeep) : undefined,
+});
+const createDevelopmentOption = (
+	id: string,
+	definition: DevelopmentDefinition,
+): SessionDevelopmentOption => ({
+	id: definition.id ?? id,
+	name: definition.name,
+	icon: definition.icon,
+	system: definition.system,
+	order: definition.order,
+	focus: definition.focus,
+	upkeep: definition.upkeep ? cloneRecord(definition.upkeep) : undefined,
+});
+const defaultActionSort = (
+	left: SessionActionOption,
+	right: SessionActionOption,
+) =>
+	(left.order ?? 0) - (right.order ?? 0) || left.name.localeCompare(right.name);
+const defaultBuildingSort = (
+	left: SessionBuildingOption,
+	right: SessionBuildingOption,
+) => left.name.localeCompare(right.name);
+const defaultDevelopmentSort = (
+	left: SessionDevelopmentOption,
+	right: SessionDevelopmentOption,
+) =>
+	(left.order ?? 0) - (right.order ?? 0) || left.name.localeCompare(right.name);
+
+export const selectSessionPlayers = (sessionState: EngineSessionSnapshot) => {
+	const list = sessionState.game.players.map(mapPlayer);
+	const byId = new Map(list.map((player) => [player.id, player]));
+	return {
+		list,
+		byId,
+		active: byId.get(sessionState.game.activePlayerId),
+		opponent: byId.get(sessionState.game.opponentId),
+	};
+};
+
+type SessionPlayersSelection = ReturnType<typeof selectSessionPlayers>;
+
+const buildActionSelections = (
+	players: SessionPlayerView[],
+	actions: RegistryLike<ActionDefinition>,
+	helpers: SessionSelectorHelpers,
+) => {
+	const unlocked = new Set<string>();
+	for (const player of players) {
+		for (const actionId of player.actions) {
+			unlocked.add(actionId);
+		}
+	}
+	const list = actions
+		.entries()
+		.map(([id, definition]) => createActionOption(id, definition))
+		.filter((option) => unlocked.has(option.id))
+		.sort(helpers.sortActions ?? defaultActionSort);
+	const map = new Map(list.map((option) => [option.id, option]));
+	const byPlayer = new Map<string, SessionActionOption[]>();
+	for (const player of players) {
+		byPlayer.set(
+			player.id,
+			list.filter((option) => player.actions.has(option.id)),
+		);
+	}
+	return { map, list, byPlayer };
+};
+
+const buildSimpleSelections = <TDefinition, TOption extends { id: string }>(
+	registry: RegistryLike<TDefinition>,
+	mapFn: (id: string, definition: TDefinition) => TOption,
+	sortFn: (left: TOption, right: TOption) => number,
+	filterFn?: (option: TOption) => boolean,
+) => {
+	const list = registry
+		.entries()
+		.map(([id, definition]) => mapFn(id, definition))
+		.filter((option) => (filterFn ? filterFn(option) : true))
+		.sort(sortFn);
+	return { map: new Map(list.map((option) => [option.id, option])), list };
+};
+
+const buildSessionOptionsFromPlayers = (
+	players: SessionPlayerView[],
+	registries: SessionRegistries,
+	helpers: SessionSelectorHelpers,
+): SessionOptionSelection => {
+	const actions = buildActionSelections(players, registries.actions, helpers);
+	const buildings = buildSimpleSelections(
+		registries.buildings,
+		createBuildingOption,
+		helpers.sortBuildings ?? defaultBuildingSort,
+	);
+	const developments = buildSimpleSelections(
+		registries.developments,
+		createDevelopmentOption,
+		helpers.sortDevelopments ?? defaultDevelopmentSort,
+		(option) => !option.system,
+	);
+	return {
+		actions: actions.map,
+		actionList: actions.list,
+		actionsByPlayer: actions.byPlayer,
+		buildings: buildings.map,
+		buildingList: buildings.list,
+		developments: developments.map,
+		developmentList: developments.list,
+	};
+};
+
+export const selectSessionOptions = (
+	sessionState: EngineSessionSnapshot,
+	registries: SessionRegistries,
+	helpers: SessionSelectorHelpers = {},
+): SessionOptionSelection =>
+	buildSessionOptionsFromPlayers(
+		selectSessionPlayers(sessionState).list,
+		registries,
+		helpers,
+	);
+
+export const selectSessionView = (
+	sessionState: EngineSessionSnapshot,
+	registries: SessionRegistries,
+	helpers: SessionSelectorHelpers = {},
+) => {
+	const players = selectSessionPlayers(sessionState);
+	return {
+		...players,
+		...buildSessionOptionsFromPlayers(players.list, registries, helpers),
+	};
+};
+
+export type {
+	SessionActionOption,
+	SessionBuildingOption,
+	SessionDevelopmentOption,
+	SessionLandView,
+	SessionOptionSelection,
+	SessionPlayerView,
+	SessionRegistries,
+	SessionSelectorHelpers,
+} from './sessionSelectors.types';
+export type { SessionPlayersSelection };

--- a/packages/web/src/state/sessionSelectors.types.ts
+++ b/packages/web/src/state/sessionSelectors.types.ts
@@ -1,0 +1,91 @@
+import type { PlayerStateSnapshot } from '@kingdom-builder/engine';
+import type {
+	ActionConfig,
+	BuildingConfig,
+	DevelopmentConfig,
+} from '@kingdom-builder/protocol';
+
+type RegistryLike<T> = { entries(): [string, T][]; get(id: string): T };
+type ActionDefinition = ActionConfig &
+	Partial<{ id: string; category: string; order: number; focus: unknown }>;
+type BuildingDefinition = BuildingConfig &
+	Partial<{ id: string; focus: unknown }>;
+type DevelopmentDefinition = DevelopmentConfig &
+	Partial<{ id: string; order: number; focus: unknown; system: boolean }>;
+type SessionLandView = PlayerStateSnapshot['lands'][number] & {
+	slotsFree: number;
+};
+type SessionPlayerView = Omit<
+	PlayerStateSnapshot,
+	'lands' | 'buildings' | 'actions'
+> & {
+	lands: SessionLandView[];
+	buildings: Set<string>;
+	actions: Set<string>;
+};
+type SessionActionOption = {
+	id: string;
+	name: string;
+	icon?: string | undefined;
+	system?: boolean | undefined;
+	order?: number | undefined;
+	category?: string | undefined;
+	focus?: unknown;
+};
+type SessionBuildingOption = {
+	id: string;
+	name: string;
+	icon?: string | undefined;
+	focus?: unknown;
+	costs: BuildingDefinition['costs'];
+	upkeep?: BuildingDefinition['upkeep'] | undefined;
+};
+type SessionDevelopmentOption = {
+	id: string;
+	name: string;
+	icon?: string | undefined;
+	system?: boolean | undefined;
+	order?: number | undefined;
+	focus?: unknown;
+	upkeep?: DevelopmentDefinition['upkeep'] | undefined;
+};
+type SessionOptionSelection = {
+	actions: Map<string, SessionActionOption>;
+	actionList: SessionActionOption[];
+	actionsByPlayer: Map<string, SessionActionOption[]>;
+	buildings: Map<string, SessionBuildingOption>;
+	buildingList: SessionBuildingOption[];
+	developments: Map<string, SessionDevelopmentOption>;
+	developmentList: SessionDevelopmentOption[];
+};
+type SessionSelectorHelpers = {
+	sortActions?: (a: SessionActionOption, b: SessionActionOption) => number;
+	sortBuildings?: (
+		a: SessionBuildingOption,
+		b: SessionBuildingOption,
+	) => number;
+	sortDevelopments?: (
+		a: SessionDevelopmentOption,
+		b: SessionDevelopmentOption,
+	) => number;
+};
+type SessionRegistries = {
+	actions: RegistryLike<ActionDefinition>;
+	buildings: RegistryLike<BuildingDefinition>;
+	developments: RegistryLike<DevelopmentDefinition>;
+};
+
+export type {
+	ActionDefinition,
+	BuildingDefinition,
+	DevelopmentDefinition,
+	RegistryLike,
+	SessionActionOption,
+	SessionBuildingOption,
+	SessionDevelopmentOption,
+	SessionLandView,
+	SessionOptionSelection,
+	SessionPlayerView,
+	SessionRegistries,
+	SessionSelectorHelpers,
+};

--- a/packages/web/src/state/useActionPerformer.ts
+++ b/packages/web/src/state/useActionPerformer.ts
@@ -63,6 +63,9 @@ export function useActionPerformer({
 	const perform = useCallback(
 		async (action: Action, params?: ActionParams<string>) => {
 			const snapshotBefore = session.getSnapshot();
+			if (snapshotBefore.game.outcome) {
+				return;
+			}
 			let { translationContext: context } = getLegacySessionContext(
 				session,
 				snapshotBefore,

--- a/packages/web/src/state/useAiRunner.ts
+++ b/packages/web/src/state/useAiRunner.ts
@@ -28,6 +28,9 @@ export function useAiRunner({
 	mountedRef,
 }: UseAiRunnerOptions) {
 	useEffect(() => {
+		if (sessionState.game.outcome) {
+			return;
+		}
 		const phaseDefinition = sessionState.phases[sessionState.game.phaseIndex];
 		if (!phaseDefinition?.action) {
 			return;

--- a/packages/web/src/state/usePhaseProgress.helpers.ts
+++ b/packages/web/src/state/usePhaseProgress.helpers.ts
@@ -47,6 +47,14 @@ export async function advanceToActionPhase({
 	refresh,
 }: AdvanceToActionPhaseOptions) {
 	let snapshot = session.getSnapshot();
+	if (snapshot.game.outcome) {
+		setTabsEnabled(false);
+		setPhaseSteps([]);
+		setPhaseHistories({});
+		setDisplayPhase(snapshot.game.currentPhase);
+		setPhaseTimer(0);
+		return;
+	}
 	if (snapshot.phases[snapshot.game.phaseIndex]?.action) {
 		if (!mountedRef.current) {
 			return;

--- a/packages/web/src/state/usePhaseProgress.ts
+++ b/packages/web/src/state/usePhaseProgress.ts
@@ -112,6 +112,9 @@ export function usePhaseProgress({
 
 	const endTurn = useCallback(async () => {
 		const snapshot = session.getSnapshot();
+		if (snapshot.game.outcome) {
+			return;
+		}
 		const phaseDef = snapshot.phases[snapshot.game.phaseIndex];
 		if (!phaseDef?.action) {
 			return;

--- a/packages/web/src/translation/context/contextHelpers.ts
+++ b/packages/web/src/translation/context/contextHelpers.ts
@@ -1,0 +1,157 @@
+import type {
+	EngineSessionSnapshot,
+	PassiveSummary,
+	PlayerId,
+} from '@kingdom-builder/engine';
+import type { PlayerStartConfig } from '@kingdom-builder/protocol';
+import type {
+	TranslationPassiveDescriptor,
+	TranslationPassiveModifierMap,
+	TranslationPlayer,
+	TranslationRegistry,
+} from './types';
+
+export function cloneRecord<T>(record: Record<string, T>): Record<string, T> {
+	return Object.freeze({ ...record });
+}
+
+export function clonePassiveMeta(
+	meta: NonNullable<PassiveSummary['meta']>,
+): NonNullable<PassiveSummary['meta']> {
+	const cloned: NonNullable<PassiveSummary['meta']> = {};
+	if (meta.source !== undefined) {
+		cloned.source = { ...meta.source };
+	}
+	if (meta.removal !== undefined) {
+		cloned.removal = { ...meta.removal };
+	}
+	return Object.freeze(cloned);
+}
+
+export function clonePassiveSummary(summary: PassiveSummary): PassiveSummary {
+	const cloned: PassiveSummary = { id: summary.id };
+	if (summary.name !== undefined) {
+		cloned.name = summary.name;
+	}
+	if (summary.icon !== undefined) {
+		cloned.icon = summary.icon;
+	}
+	if (summary.detail !== undefined) {
+		cloned.detail = summary.detail;
+	}
+	if (summary.meta !== undefined) {
+		cloned.meta = clonePassiveMeta(summary.meta);
+	}
+	return Object.freeze(cloned);
+}
+
+export function toPassiveDescriptor(
+	summary: PassiveSummary,
+): TranslationPassiveDescriptor {
+	const descriptor: TranslationPassiveDescriptor = {};
+	if (summary.icon !== undefined) {
+		descriptor.icon = summary.icon;
+	}
+	const sourceIcon = summary.meta?.source?.icon;
+	if (sourceIcon !== undefined) {
+		descriptor.meta = Object.freeze({
+			source: Object.freeze({ icon: sourceIcon }),
+		});
+	}
+	return Object.freeze(descriptor);
+}
+
+export function clonePlayer(
+	player: EngineSessionSnapshot['game']['players'][number],
+): TranslationPlayer {
+	return Object.freeze({
+		id: player.id,
+		name: player.name,
+		resources: cloneRecord(player.resources),
+		stats: cloneRecord(player.stats),
+		population: cloneRecord(player.population),
+	});
+}
+
+export function wrapRegistry<TDefinition>(registry: {
+	get(id: string): TDefinition;
+	has(id: string): boolean;
+}): TranslationRegistry<TDefinition> {
+	return Object.freeze({
+		get(id: string) {
+			return registry.get(id);
+		},
+		has(id: string) {
+			return registry.has(id);
+		},
+	});
+}
+
+function clonePlayerStartConfig(config: PlayerStartConfig): PlayerStartConfig {
+	return JSON.parse(JSON.stringify(config)) as PlayerStartConfig;
+}
+
+export function cloneCompensations(
+	compensations: EngineSessionSnapshot['compensations'],
+): Record<PlayerId, PlayerStartConfig> {
+	return Object.freeze(
+		Object.fromEntries(
+			Object.entries(compensations).map(([playerId, config]) => [
+				playerId,
+				clonePlayerStartConfig(config),
+			]),
+		),
+	) as Record<PlayerId, PlayerStartConfig>;
+}
+
+export function mapPassives(
+	players: EngineSessionSnapshot['game']['players'],
+): ReadonlyMap<PlayerId, PassiveSummary[]> {
+	return new Map(
+		players.map((player) => [
+			player.id,
+			player.passives.map(clonePassiveSummary),
+		]),
+	);
+}
+
+export function flattenPassives(
+	passives: ReadonlyMap<PlayerId, PassiveSummary[]>,
+): PassiveSummary[] {
+	return Array.from(passives.values()).flatMap((entries) =>
+		entries.map(clonePassiveSummary),
+	);
+}
+
+export function mapPassiveDescriptors(
+	passives: ReadonlyMap<PlayerId, PassiveSummary[]>,
+): ReadonlyMap<PlayerId, Map<string, TranslationPassiveDescriptor>> {
+	return new Map(
+		Array.from(passives.entries()).map(([owner, list]) => [
+			owner,
+			new Map(
+				list.map((summary) => [summary.id, toPassiveDescriptor(summary)]),
+			),
+		]),
+	);
+}
+
+export function cloneRecentResourceGains(
+	recent: EngineSessionSnapshot['recentResourceGains'],
+): ReadonlyArray<{ key: string; amount: number }> {
+	return Object.freeze(recent.map((entry) => ({ ...entry })));
+}
+
+export function cloneEvaluationModifiers(
+	evaluationMods?: ReadonlyMap<string, ReadonlyMap<string, unknown>>,
+): TranslationPassiveModifierMap {
+	if (!evaluationMods) {
+		return new Map();
+	}
+	return new Map(
+		Array.from(evaluationMods.entries()).map(([modifierId, mods]) => [
+			modifierId,
+			new Map(mods) as ReadonlyMap<string, unknown>,
+		]),
+	);
+}

--- a/packages/web/src/translation/context/createTranslationContext.ts
+++ b/packages/web/src/translation/context/createTranslationContext.ts
@@ -1,172 +1,41 @@
 import type {
 	EngineSessionSnapshot,
-	PassiveSummary,
 	PlayerId,
+	RuleSnapshot,
 } from '@kingdom-builder/engine';
 import type {
 	ACTIONS,
 	BUILDINGS,
 	DEVELOPMENTS,
 } from '@kingdom-builder/contents';
-import type { PlayerStartConfig } from '@kingdom-builder/protocol';
-import type {
-	TranslationContext,
-	TranslationPassiveDescriptor,
-	TranslationPassives,
-	TranslationPlayer,
-	TranslationPassiveModifierMap,
-	TranslationRegistry,
-} from './types';
+import type { TranslationContext, TranslationPassives } from './types';
+import {
+	cloneCompensations,
+	cloneEvaluationModifiers,
+	clonePassiveSummary,
+	clonePlayer,
+	cloneRecentResourceGains,
+	flattenPassives,
+	mapPassives,
+	mapPassiveDescriptors,
+	wrapRegistry,
+} from './contextHelpers';
+import {
+	EMPTY_PASSIVE_DEFINITIONS,
+	cloneRuleSnapshot,
+	mapPassiveDefinitionLists,
+	mapPassiveDefinitionLookup,
+} from './passiveDefinitions';
 
 type TranslationSessionHelpers = {
 	pullEffectLog?: <T>(key: string) => T | undefined;
 	evaluationMods?: ReadonlyMap<string, ReadonlyMap<string, unknown>>;
 };
 
-function cloneRecord<T>(record: Record<string, T>): Record<string, T> {
-	return Object.freeze({ ...record });
-}
-
-function clonePassiveMeta(
-	meta: NonNullable<PassiveSummary['meta']>,
-): NonNullable<PassiveSummary['meta']> {
-	const cloned: NonNullable<PassiveSummary['meta']> = {};
-	if (meta.source !== undefined) {
-		cloned.source = { ...meta.source };
-	}
-	if (meta.removal !== undefined) {
-		cloned.removal = { ...meta.removal };
-	}
-	return Object.freeze(cloned);
-}
-
-function clonePassiveSummary(summary: PassiveSummary): PassiveSummary {
-	const cloned: PassiveSummary = { id: summary.id };
-	if (summary.name !== undefined) {
-		cloned.name = summary.name;
-	}
-	if (summary.icon !== undefined) {
-		cloned.icon = summary.icon;
-	}
-	if (summary.detail !== undefined) {
-		cloned.detail = summary.detail;
-	}
-	if (summary.meta !== undefined) {
-		cloned.meta = clonePassiveMeta(summary.meta);
-	}
-	return Object.freeze(cloned);
-}
-
-function toPassiveDescriptor(
-	summary: PassiveSummary,
-): TranslationPassiveDescriptor {
-	const descriptor: TranslationPassiveDescriptor = {};
-	if (summary.icon !== undefined) {
-		descriptor.icon = summary.icon;
-	}
-	const sourceIcon = summary.meta?.source?.icon;
-	if (sourceIcon !== undefined) {
-		descriptor.meta = Object.freeze({
-			source: Object.freeze({ icon: sourceIcon }),
-		});
-	}
-	return Object.freeze(descriptor);
-}
-
-function clonePlayer(
-	player: EngineSessionSnapshot['game']['players'][number],
-): TranslationPlayer {
-	return Object.freeze({
-		id: player.id,
-		name: player.name,
-		resources: cloneRecord(player.resources),
-		stats: cloneRecord(player.stats),
-		population: cloneRecord(player.population),
-	});
-}
-
-function wrapRegistry<TDefinition>(registry: {
-	get(id: string): TDefinition;
-	has(id: string): boolean;
-}): TranslationRegistry<TDefinition> {
-	return Object.freeze({
-		get(id: string) {
-			return registry.get(id);
-		},
-		has(id: string) {
-			return registry.has(id);
-		},
-	});
-}
-
-function clonePlayerStartConfig(config: PlayerStartConfig): PlayerStartConfig {
-	return JSON.parse(JSON.stringify(config)) as PlayerStartConfig;
-}
-
-function cloneCompensations(
-	compensations: EngineSessionSnapshot['compensations'],
-): Record<PlayerId, PlayerStartConfig> {
-	return Object.freeze(
-		Object.fromEntries(
-			Object.entries(compensations).map(([playerId, config]) => [
-				playerId,
-				clonePlayerStartConfig(config),
-			]),
-		),
-	) as Record<PlayerId, PlayerStartConfig>;
-}
-
-function mapPassives(
-	players: EngineSessionSnapshot['game']['players'],
-): ReadonlyMap<PlayerId, PassiveSummary[]> {
-	return new Map(
-		players.map((player) => [
-			player.id,
-			player.passives.map(clonePassiveSummary),
-		]),
-	);
-}
-
-function flattenPassives(
-	passives: ReadonlyMap<PlayerId, PassiveSummary[]>,
-): PassiveSummary[] {
-	return Array.from(passives.values()).flatMap((entries) =>
-		entries.map(clonePassiveSummary),
-	);
-}
-
-function mapPassiveDescriptors(
-	passives: ReadonlyMap<PlayerId, PassiveSummary[]>,
-): ReadonlyMap<PlayerId, Map<string, TranslationPassiveDescriptor>> {
-	return new Map(
-		Array.from(passives.entries()).map(([owner, list]) => [
-			owner,
-			new Map(
-				list.map((summary) => [summary.id, toPassiveDescriptor(summary)]),
-			),
-		]),
-	);
-}
-
-function cloneRecentResourceGains(
-	recent: EngineSessionSnapshot['recentResourceGains'],
-): ReadonlyArray<{ key: string; amount: number }> {
-	return Object.freeze(recent.map((entry) => ({ ...entry })));
-}
-
-function cloneEvaluationModifiers(
-	evaluationMods?: ReadonlyMap<string, ReadonlyMap<string, unknown>>,
-): TranslationPassiveModifierMap {
-	if (!evaluationMods) {
-		return new Map();
-	}
-	return new Map(
-		Array.from(evaluationMods.entries()).map(([modifierId, mods]) => [
-			modifierId,
-			new Map(mods) as ReadonlyMap<string, unknown>,
-		]),
-	);
-}
+type TranslationContextOptions = {
+	ruleSnapshot: RuleSnapshot;
+	passiveRecords: EngineSessionSnapshot['passiveRecords'];
+};
 
 export function createTranslationContext(
 	session: EngineSessionSnapshot,
@@ -175,7 +44,8 @@ export function createTranslationContext(
 		buildings: typeof BUILDINGS;
 		developments: typeof DEVELOPMENTS;
 	},
-	helpers?: TranslationSessionHelpers,
+	helpers: TranslationSessionHelpers | undefined,
+	options: TranslationContextOptions,
 ): TranslationContext {
 	const players = new Map(
 		session.game.players.map((player) => [player.id, clonePlayer(player)]),
@@ -188,6 +58,13 @@ export function createTranslationContext(
 	const passives = mapPassives(session.game.players);
 	const passiveDescriptors = mapPassiveDescriptors(passives);
 	const evaluationMods = cloneEvaluationModifiers(helpers?.evaluationMods);
+	const ruleSnapshot = cloneRuleSnapshot(options.ruleSnapshot);
+	const passiveDefinitionLists = mapPassiveDefinitionLists(
+		options.passiveRecords,
+	);
+	const passiveDefinitionLookup = mapPassiveDefinitionLookup(
+		passiveDefinitionLists,
+	);
 	const translationPassives: TranslationPassives = Object.freeze({
 		list(owner?: PlayerId) {
 			if (owner) {
@@ -198,6 +75,13 @@ export function createTranslationContext(
 		get(id: string, owner: PlayerId) {
 			const ownerDescriptors = passiveDescriptors.get(owner);
 			return ownerDescriptors?.get(id);
+		},
+		getDefinition(id: string, owner: PlayerId) {
+			const definitions = passiveDefinitionLookup.get(owner);
+			return definitions?.get(id);
+		},
+		definitions(owner: PlayerId) {
+			return passiveDefinitionLists.get(owner) ?? EMPTY_PASSIVE_DEFINITIONS;
 		},
 		get evaluationMods() {
 			return evaluationMods;
@@ -254,5 +138,6 @@ export function createTranslationContext(
 		actionCostResource: session.actionCostResource,
 		recentResourceGains: cloneRecentResourceGains(session.recentResourceGains),
 		compensations: cloneCompensations(session.compensations),
+		rules: ruleSnapshot,
 	});
 }

--- a/packages/web/src/translation/context/passiveDefinitions.ts
+++ b/packages/web/src/translation/context/passiveDefinitions.ts
@@ -1,0 +1,56 @@
+import type {
+	EngineSessionSnapshot,
+	PassiveRecordSnapshot,
+	PlayerId,
+	RuleSnapshot,
+} from '@kingdom-builder/engine';
+import type { TranslationPassiveDefinition } from './types';
+
+export const EMPTY_PASSIVE_DEFINITIONS = Object.freeze(
+	[] as TranslationPassiveDefinition[],
+);
+
+export function clonePassiveDefinition(
+	definition: PassiveRecordSnapshot,
+): TranslationPassiveDefinition {
+	const cloned = structuredClone<TranslationPassiveDefinition>(definition);
+	return Object.freeze(cloned);
+}
+
+export function mapPassiveDefinitionLists(
+	records: EngineSessionSnapshot['passiveRecords'],
+): ReadonlyMap<PlayerId, ReadonlyArray<TranslationPassiveDefinition>> {
+	const lists = new Map<
+		PlayerId,
+		ReadonlyArray<TranslationPassiveDefinition>
+	>();
+	for (const ownerId of Object.keys(records) as PlayerId[]) {
+		const entries = records[ownerId] ?? [];
+		const clones = entries.map(clonePassiveDefinition);
+		lists.set(ownerId, Object.freeze(clones));
+	}
+	return lists;
+}
+
+export function mapPassiveDefinitionLookup(
+	lists: ReadonlyMap<PlayerId, ReadonlyArray<TranslationPassiveDefinition>>,
+): ReadonlyMap<PlayerId, ReadonlyMap<string, TranslationPassiveDefinition>> {
+	const lookup = new Map<
+		PlayerId,
+		ReadonlyMap<string, TranslationPassiveDefinition>
+	>();
+	for (const [owner, definitions] of lists.entries()) {
+		const entries = definitions.map<[string, TranslationPassiveDefinition]>(
+			(definition) => [definition.id as string, definition],
+		);
+		lookup.set(owner, new Map<string, TranslationPassiveDefinition>(entries));
+	}
+	return lookup;
+}
+
+export function cloneRuleSnapshot(ruleSnapshot: RuleSnapshot): RuleSnapshot {
+	return Object.freeze({
+		tieredResourceKey: ruleSnapshot.tieredResourceKey,
+		tierDefinitions: structuredClone(ruleSnapshot.tierDefinitions),
+	});
+}

--- a/packages/web/src/translation/context/types.ts
+++ b/packages/web/src/translation/context/types.ts
@@ -1,4 +1,9 @@
-import type { PassiveSummary, PlayerId } from '@kingdom-builder/engine';
+import type {
+	PassiveRecordSnapshot,
+	PassiveSummary,
+	PlayerId,
+	RuleSnapshot,
+} from '@kingdom-builder/engine';
 import type {
 	ActionConfig,
 	BuildingConfig,
@@ -26,6 +31,8 @@ export type TranslationPassiveDescriptor = {
 	meta?: { source?: { icon?: string } };
 };
 
+export type TranslationPassiveDefinition = PassiveRecordSnapshot;
+
 /**
  * Map of evaluator modifier identifiers to the owning modifier instances. The
  * values remain intentionally untyped because translation formatters only
@@ -44,6 +51,11 @@ export type TranslationPassiveModifierMap = ReadonlyMap<
 export interface TranslationPassives {
 	list(owner?: PlayerId): PassiveSummary[];
 	get(id: string, owner: PlayerId): TranslationPassiveDescriptor | undefined;
+	getDefinition(
+		id: string,
+		owner: PlayerId,
+	): TranslationPassiveDefinition | undefined;
+	definitions(owner: PlayerId): ReadonlyArray<TranslationPassiveDefinition>;
 	readonly evaluationMods: TranslationPassiveModifierMap;
 }
 
@@ -88,6 +100,7 @@ export interface TranslationContext {
 	readonly phases: readonly TranslationPhase[];
 	readonly activePlayer: TranslationPlayer;
 	readonly opponent: TranslationPlayer;
+	readonly rules: RuleSnapshot;
 	readonly recentResourceGains: ReadonlyArray<{
 		key: string;
 		amount: number;

--- a/packages/web/tests/HoverCard.test.tsx
+++ b/packages/web/tests/HoverCard.test.tsx
@@ -42,8 +42,9 @@ const ctx = createEngine({
 	rules: RULES,
 });
 const actionCostResource = ctx.actionCostResource;
+const engineSnapshot = snapshotEngine(ctx);
 const translationContext = createTranslationContext(
-	snapshotEngine(ctx),
+	engineSnapshot,
 	{
 		actions: ACTIONS,
 		buildings: BUILDINGS,
@@ -52,6 +53,10 @@ const translationContext = createTranslationContext(
 	{
 		pullEffectLog: (key) => ctx.pullEffectLog(key),
 		evaluationMods: ctx.passives.evaluationMods,
+	},
+	{
+		ruleSnapshot: engineSnapshot.rules,
+		passiveRecords: engineSnapshot.passiveRecords,
 	},
 );
 
@@ -76,10 +81,7 @@ const actionData = findActionWithReq();
 const mockGame = {
 	ctx,
 	translationContext,
-	ruleSnapshot: {
-		tieredResourceKey: ctx.services.rules.tieredResourceKey,
-		tierDefinitions: ctx.services.rules.tierDefinitions,
-	},
+	ruleSnapshot: engineSnapshot.rules,
 	log: [],
 	logOverflowed: false,
 	hoverCard: null as unknown as {

--- a/packages/web/tests/PhasePanel.test.tsx
+++ b/packages/web/tests/PhasePanel.test.tsx
@@ -31,8 +31,9 @@ const ctx = createEngine({
 	rules: RULES,
 });
 const actionCostResource = ctx.actionCostResource;
+const engineSnapshot = snapshotEngine(ctx);
 const translationContext = createTranslationContext(
-	snapshotEngine(ctx),
+	engineSnapshot,
 	{
 		actions: ACTIONS,
 		buildings: BUILDINGS,
@@ -42,14 +43,15 @@ const translationContext = createTranslationContext(
 		pullEffectLog: (key) => ctx.pullEffectLog(key),
 		evaluationMods: ctx.passives.evaluationMods,
 	},
+	{
+		ruleSnapshot: engineSnapshot.rules,
+		passiveRecords: engineSnapshot.passiveRecords,
+	},
 );
 const mockGame = {
 	ctx,
 	translationContext,
-	ruleSnapshot: {
-		tieredResourceKey: ctx.services.rules.tieredResourceKey,
-		tierDefinitions: ctx.services.rules.tierDefinitions,
-	},
+	ruleSnapshot: engineSnapshot.rules,
 	log: [],
 	logOverflowed: false,
 	hoverCard: null,

--- a/packages/web/tests/PlayerPanel.test.tsx
+++ b/packages/web/tests/PlayerPanel.test.tsx
@@ -34,8 +34,9 @@ const ctx = createEngine({
 	rules: RULES,
 });
 const actionCostResource = ctx.actionCostResource;
+const engineSnapshot = snapshotEngine(ctx);
 const translationContext = createTranslationContext(
-	snapshotEngine(ctx),
+	engineSnapshot,
 	{
 		actions: ACTIONS,
 		buildings: BUILDINGS,
@@ -43,16 +44,17 @@ const translationContext = createTranslationContext(
 	},
 	{
 		pullEffectLog: (key) => ctx.pullEffectLog(key),
-		passives: ctx.passives,
+		evaluationMods: ctx.passives.evaluationMods,
+	},
+	{
+		ruleSnapshot: engineSnapshot.rules,
+		passiveRecords: engineSnapshot.passiveRecords,
 	},
 );
 const mockGame = {
 	ctx,
 	translationContext,
-	ruleSnapshot: {
-		tieredResourceKey: ctx.services.rules.tieredResourceKey,
-		tierDefinitions: ctx.services.rules.tierDefinitions,
-	},
+	ruleSnapshot: engineSnapshot.rules,
 	log: [],
 	logOverflowed: false,
 	hoverCard: null,

--- a/packages/web/tests/attack-on-damage-registry.test.ts
+++ b/packages/web/tests/attack-on-damage-registry.test.ts
@@ -38,6 +38,8 @@ function createTranslationCtx(): TranslationContext {
 		passives: {
 			list: vi.fn(() => []),
 			get: vi.fn(() => undefined),
+			getDefinition: vi.fn(() => undefined),
+			definitions: vi.fn(() => []),
 			get evaluationMods() {
 				return emptyModifiers;
 			},
@@ -64,6 +66,7 @@ function createTranslationCtx(): TranslationContext {
 			A: {} as PlayerStartConfig,
 			B: {} as PlayerStartConfig,
 		},
+		rules: { tieredResourceKey: 'happiness', tierDefinitions: [] },
 	};
 }
 

--- a/packages/web/tests/helpers/createPassiveDisplayGame.ts
+++ b/packages/web/tests/helpers/createPassiveDisplayGame.ts
@@ -24,8 +24,9 @@ type PassiveGameContext = {
 function createPassiveGame(ctx: EngineContext): PassiveGameContext {
 	const handleHoverCard = vi.fn();
 	const clearHoverCard = vi.fn();
+	const engineSnapshot = snapshotEngine(ctx);
 	const translationContext = createTranslationContext(
-		snapshotEngine(ctx),
+		engineSnapshot,
 		{
 			actions: ACTIONS,
 			buildings: BUILDINGS,
@@ -35,14 +36,15 @@ function createPassiveGame(ctx: EngineContext): PassiveGameContext {
 			pullEffectLog: (key) => ctx.pullEffectLog(key),
 			evaluationMods: ctx.passives.evaluationMods,
 		},
+		{
+			ruleSnapshot: engineSnapshot.rules,
+			passiveRecords: engineSnapshot.passiveRecords,
+		},
 	);
 	const mockGame: MockGame = {
 		ctx,
 		translationContext,
-		ruleSnapshot: {
-			tieredResourceKey: ctx.services.rules.tieredResourceKey,
-			tierDefinitions: ctx.services.rules.tierDefinitions,
-		},
+		ruleSnapshot: engineSnapshot.rules,
 		handleHoverCard,
 		clearHoverCard,
 		resolution: null,

--- a/packages/web/tests/helpers/translationContextStub.ts
+++ b/packages/web/tests/helpers/translationContextStub.ts
@@ -4,6 +4,7 @@ import type {
 	TranslationPlayer,
 	TranslationRegistry,
 } from '../../src/translation/context';
+import type { RuleSnapshot } from '@kingdom-builder/engine';
 
 const EMPTY_MODIFIERS = new Map<string, ReadonlyMap<string, unknown>>();
 
@@ -13,6 +14,12 @@ const EMPTY_PASSIVES: TranslationPassives = {
 	},
 	get() {
 		return undefined;
+	},
+	getDefinition() {
+		return undefined;
+	},
+	definitions() {
+		return [];
 	},
 	get evaluationMods() {
 		return EMPTY_MODIFIERS;
@@ -55,8 +62,15 @@ export function createTranslationContextStub(
 		developments: TranslationRegistry<unknown>;
 		activePlayer: TranslationPlayer;
 		opponent: TranslationPlayer;
+		rules?: RuleSnapshot;
 	},
 ): TranslationContext {
+	const rules: RuleSnapshot =
+		options.rules ??
+		({
+			tieredResourceKey: 'happiness',
+			tierDefinitions: [],
+		} as RuleSnapshot);
 	return {
 		actions: options.actions,
 		buildings: options.buildings,
@@ -65,6 +79,7 @@ export function createTranslationContextStub(
 		phases: options.phases,
 		activePlayer: options.activePlayer,
 		opponent: options.opponent,
+		rules,
 		pullEffectLog() {
 			return undefined;
 		},

--- a/packages/web/tests/resource-bar.test.tsx
+++ b/packages/web/tests/resource-bar.test.tsx
@@ -93,6 +93,7 @@ describe('<ResourceBar /> happiness hover card', () => {
 		const handleHoverCard = vi.fn();
 		const clearHoverCard = vi.fn();
 		const sessionState = session.getSnapshot();
+		const ruleSnapshot = session.getRuleSnapshot();
 		const translationContext = createTranslationContext(
 			sessionState,
 			{
@@ -104,8 +105,11 @@ describe('<ResourceBar /> happiness hover card', () => {
 				pullEffectLog: (key) => session.pullEffectLog(key),
 				evaluationMods: session.getPassiveEvaluationMods(),
 			},
+			{
+				ruleSnapshot,
+				passiveRecords: sessionState.passiveRecords,
+			},
 		);
-		const ruleSnapshot = session.getRuleSnapshot();
 		const customRuleSnapshot = {
 			...ruleSnapshot,
 			tierDefinitions: ruleSnapshot.tierDefinitions.map((tier) => ({

--- a/packages/web/tests/state/sessionSelectors.test.ts
+++ b/packages/web/tests/state/sessionSelectors.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+import { RESOURCES } from '@kingdom-builder/contents';
+import type {
+	EngineSessionSnapshot,
+	PlayerStateSnapshot,
+} from '@kingdom-builder/engine';
+import { createContentFactory } from '../../../engine/tests/factories/content';
+import {
+	selectSessionOptions,
+	selectSessionPlayers,
+	selectSessionView,
+} from '../../src/state/sessionSelectors';
+
+describe('sessionSelectors', () => {
+	const factory = createContentFactory();
+	const [primaryResource] = Object.keys(RESOURCES);
+	const actionA = factory.action({ name: 'Action A' });
+	const actionB = factory.action({ name: 'Action B' });
+	const systemLocked = factory.action({ name: 'System Locked', system: true });
+	const systemUnlocked = factory.action({
+		name: 'System Unlocked',
+		system: true,
+	});
+	Object.assign(actionA, { order: 2, category: 'basic', focus: 'economy' });
+	factory.actions.add(actionA.id, {
+		...factory.actions.get(actionA.id),
+		order: 2,
+		category: 'basic',
+		focus: 'economy',
+	});
+	Object.assign(actionB, { order: 1 });
+	factory.actions.add(actionB.id, {
+		...factory.actions.get(actionB.id),
+		order: 1,
+	});
+	Object.assign(systemLocked, { order: 3, category: 'basic' });
+	factory.actions.add(systemLocked.id, {
+		...factory.actions.get(systemLocked.id),
+		order: 3,
+		category: 'basic',
+	});
+	Object.assign(systemUnlocked, { order: 4, category: 'basic' });
+	factory.actions.add(systemUnlocked.id, {
+		...factory.actions.get(systemUnlocked.id),
+		order: 4,
+		category: 'basic',
+	});
+	const buildingA = factory.building({
+		name: 'Building A',
+		costs: { [primaryResource]: 1 },
+	});
+	const buildingB = factory.building({
+		name: 'Building B',
+		costs: { [primaryResource]: 2 },
+	});
+	const developmentA = factory.development({ name: 'Development A' });
+	const developmentB = factory.development({ name: 'Development B' });
+	factory.developments.add(developmentA.id, {
+		...factory.developments.get(developmentA.id),
+		order: 2,
+	});
+	factory.developments.add(developmentB.id, {
+		...factory.developments.get(developmentB.id),
+		order: 1,
+	});
+	const developmentSystem = factory.development({
+		name: 'Development System',
+		system: true,
+	});
+	const makePlayer = (
+		id: string,
+		overrides: Partial<PlayerStateSnapshot> = {},
+	): PlayerStateSnapshot => ({
+		id,
+		name: `Player ${id}`,
+		resources: { [primaryResource]: 5, ...(overrides.resources ?? {}) },
+		stats: { ...(overrides.stats ?? {}) },
+		statsHistory: { ...(overrides.statsHistory ?? {}) },
+		population: { ...(overrides.population ?? {}) },
+		lands: overrides.lands ?? [
+			{
+				id: `${id}-L1`,
+				slotsMax: 3,
+				slotsUsed: 1,
+				tilled: true,
+				developments: [],
+			},
+			{
+				id: `${id}-L2`,
+				slotsMax: 1,
+				slotsUsed: 1,
+				tilled: false,
+				developments: [],
+			},
+		],
+		buildings: overrides.buildings ?? [],
+		actions: overrides.actions ?? [],
+		statSources: overrides.statSources ?? {},
+		skipPhases: overrides.skipPhases ?? {},
+		skipSteps: overrides.skipSteps ?? {},
+		passives: overrides.passives ?? [],
+	});
+	const players: PlayerStateSnapshot[] = [
+		makePlayer('A', {
+			buildings: [buildingA.id],
+			actions: [actionA.id, systemUnlocked.id],
+		}),
+		makePlayer('B', {
+			buildings: [buildingB.id],
+			actions: [actionB.id],
+		}),
+	];
+	const sessionState: EngineSessionSnapshot = {
+		game: {
+			turn: 1,
+			currentPlayerIndex: 0,
+			currentPhase: 'main',
+			currentStep: 'step-0',
+			phaseIndex: 0,
+			stepIndex: 0,
+			devMode: false,
+			players,
+			activePlayerId: 'A',
+			opponentId: 'B',
+		},
+		phases: [],
+		actionCostResource: primaryResource,
+		recentResourceGains: [],
+		compensations: {},
+	};
+	const registries = {
+		actions: factory.actions,
+		buildings: factory.buildings,
+		developments: factory.developments,
+	};
+
+	it('builds player view models with computed properties', () => {
+		const selection = selectSessionPlayers(sessionState);
+		expect(selection.list).toHaveLength(2);
+		const first = selection.list[0]!;
+		expect(first.id).toBe('A');
+		expect(first.buildings.has(buildingA.id)).toBe(true);
+		expect(first.actions.has(actionA.id)).toBe(true);
+		expect(first.actions.has(systemUnlocked.id)).toBe(true);
+		expect(first.lands[0]!.slotsFree).toBe(2);
+		expect(selection.active?.id).toBe('A');
+		expect(selection.opponent?.id).toBe('B');
+	});
+
+	it('creates action, building, and development option lists', () => {
+		const options = selectSessionOptions(sessionState, registries);
+		expect(options.actions.get(actionA.id)?.name).toBe(actionA.name);
+		expect(options.actions.get(systemLocked.id)).toBeUndefined();
+		expect(options.buildings.get(buildingA.id)?.name).toBe(buildingA.name);
+		expect(options.developments.get(developmentSystem.id)).toBeUndefined();
+		const developmentOrder = options.developmentList
+			.filter((option) =>
+				[developmentA.id, developmentB.id].includes(option.id),
+			)
+			.map((option) => option.id);
+		expect(developmentOrder).toEqual([developmentB.id, developmentA.id]);
+		const actionsForA = options.actionsByPlayer.get('A') ?? [];
+		expect(actionsForA.map((option) => option.id)).toEqual([
+			actionA.id,
+			systemUnlocked.id,
+		]);
+		const actionsForB = options.actionsByPlayer.get('B') ?? [];
+		expect(actionsForB.map((option) => option.id)).toEqual([actionB.id]);
+	});
+
+	it('supports custom sort helpers', () => {
+		const options = selectSessionOptions(sessionState, registries, {
+			sortActions: (left, right) => right.name.localeCompare(left.name),
+			sortBuildings: (left, right) => right.name.localeCompare(left.name),
+			sortDevelopments: (left, right) => right.name.localeCompare(left.name),
+		});
+		const sortedActionIds = options.actionList
+			.filter((option) =>
+				[systemUnlocked.id, actionA.id, actionB.id].includes(option.id),
+			)
+			.map((option) => option.id);
+		expect(sortedActionIds).toEqual([
+			systemUnlocked.id,
+			actionB.id,
+			actionA.id,
+		]);
+		const sortedBuildingIds = options.buildingList
+			.filter((option) => [buildingA.id, buildingB.id].includes(option.id))
+			.map((option) => option.id);
+		expect(sortedBuildingIds).toEqual([buildingB.id, buildingA.id]);
+		const sortedDevelopmentIds = options.developmentList
+			.filter((option) =>
+				[developmentA.id, developmentB.id].includes(option.id),
+			)
+			.map((option) => option.id);
+		expect(sortedDevelopmentIds).toEqual([developmentB.id, developmentA.id]);
+	});
+
+	it('combines player and option selections', () => {
+		const view = selectSessionView(sessionState, registries);
+		expect(view.list[0]!.id).toBe('A');
+		expect(view.actions.get(actionB.id)?.id).toBe(actionB.id);
+	});
+});

--- a/packages/web/tests/state/useCompensationLogger.test.tsx
+++ b/packages/web/tests/state/useCompensationLogger.test.tsx
@@ -34,6 +34,10 @@ function createSession(): EngineSession {
 		advancePhase: vi.fn(),
 		pullEffectLog: vi.fn(),
 		getPassiveEvaluationMods: vi.fn(() => new Map()),
+		getRuleSnapshot: vi.fn(() => ({
+			tieredResourceKey: RESOURCE_KEYS[0]!,
+			tierDefinitions: [],
+		})),
 		getLegacyContext() {
 			return {
 				activePlayer: {
@@ -111,6 +115,14 @@ function createSessionState(turn: number): EngineSessionSnapshot {
 				resources: { gold: 1 },
 			},
 		} as Record<PlayerId, PlayerStartConfig>,
+		rules: {
+			tieredResourceKey: RESOURCE_KEYS[0]!,
+			tierDefinitions: [],
+		},
+		passiveRecords: {
+			A: [],
+			B: [],
+		},
 	};
 }
 

--- a/packages/web/tests/translation/createTranslationContext.test.ts
+++ b/packages/web/tests/translation/createTranslationContext.test.ts
@@ -123,6 +123,25 @@ describe('createTranslationContext', () => {
 				A: compensation(2),
 				B: compensation(1),
 			},
+			rules: {
+				tieredResourceKey: resourceKey,
+				tierDefinitions: [],
+			},
+			passiveRecords: {
+				A: [
+					{
+						id: passiveId,
+						owner: 'A',
+						icon: ACTIONS.get(actionId).icon,
+						meta: {
+							source: {
+								icon: BUILDINGS.get(buildingId).icon,
+							},
+						},
+					},
+				],
+				B: [],
+			},
 		};
 		const context = createTranslationContext(
 			session,
@@ -134,6 +153,10 @@ describe('createTranslationContext', () => {
 			{
 				pullEffectLog,
 				evaluationMods: passiveManager.evaluationMods,
+			},
+			{
+				ruleSnapshot: session.rules,
+				passiveRecords: session.passiveRecords,
 			},
 		);
 		expect(context.pullEffectLog<{ note: string }>('legacy')).toEqual({
@@ -163,82 +186,102 @@ describe('createTranslationContext', () => {
 					has: context.developments.has(developmentId),
 				},
 			},
+			rules: context.rules,
 			passives: {
 				list: context.passives.list().map(({ id }) => id),
 				owned: context.passives.list(activeId).map(({ id }) => id),
 				descriptor: context.passives.get(passiveId, activeId),
+				definition: context.passives.getDefinition(passiveId, activeId),
+				definitions: context.passives.definitions(activeId).map(({ id }) => id),
 				evaluationMods: evaluationSnapshot,
 			},
 		};
 		expect(contextSnapshot).toMatchInlineSnapshot(`
-			{
-			  "actionCostResource": "gold",
-			  "compensations": {
-			    "A": {
-			      "resources": {
-			        "gold": 2,
-			      },
-			    },
-			    "B": {
-			      "resources": {
-			        "gold": 1,
-			      },
-			    },
-			  },
-			  "passives": {
-			    "descriptor": {
-			      "icon": "🌱",
-			      "meta": {
-			        "source": {
-			          "icon": "🏘️",
-			        },
-			      },
-			    },
-			    "evaluationMods": [
-			      [
-			        "gold",
-			        [
-			          "modifier",
-			        ],
-			      ],
-			    ],
-			    "list": [
-			      "passive-a",
-			    ],
-			    "owned": [
-			      "passive-a",
-			    ],
-			  },
-			  "phases": [
-			    "growth",
-			    "upkeep",
-			    "main",
-			  ],
-			  "players": {
-			    "active": "A",
-			    "opponent": "B",
-			  },
-			  "recentResourceGains": [
-			    {
-			      "amount": 3,
-			      "key": "gold",
-			    },
-			  ],
-			  "registries": {
-			    "action": {
-			      "has": true,
-			      "id": "expand",
-			    },
-			    "building": {
-			      "has": true,
-			      "id": "town_charter",
-			    },
-			    "development": {
-			      "has": true,
-			      "id": "farm",
-			    },
-			  },
-			}
-		`);
+                        {
+                          "actionCostResource": "gold",
+                          "compensations": {
+                            "A": {
+                              "resources": {
+                                "gold": 2,
+                              },
+                            },
+                            "B": {
+                              "resources": {
+                                "gold": 1,
+                              },
+                            },
+                          },
+                          "passives": {
+                            "definition": {
+                              "icon": "🌱",
+                              "id": "passive-a",
+                              "meta": {
+                                "source": {
+                                  "icon": "🏘️",
+                                },
+                              },
+                              "owner": "A",
+                            },
+                            "definitions": [
+                              "passive-a",
+                            ],
+                            "descriptor": {
+                              "icon": "🌱",
+                              "meta": {
+                                "source": {
+                                  "icon": "🏘️",
+                                },
+                              },
+                            },
+                            "evaluationMods": [
+                              [
+                                "gold",
+                                [
+                                  "modifier",
+                                ],
+                              ],
+                            ],
+                            "list": [
+                              "passive-a",
+                            ],
+                            "owned": [
+                              "passive-a",
+                            ],
+                          },
+                          "phases": [
+                            "growth",
+                            "upkeep",
+                            "main",
+                          ],
+                          "players": {
+                            "active": "A",
+                            "opponent": "B",
+                          },
+                          "recentResourceGains": [
+                            {
+                              "amount": 3,
+                              "key": "gold",
+                            },
+                          ],
+                          "registries": {
+                            "action": {
+                              "has": true,
+                              "id": "expand",
+                            },
+                            "building": {
+                              "has": true,
+                              "id": "town_charter",
+                            },
+                            "development": {
+                              "has": true,
+                              "id": "farm",
+                            },
+                          },
+                          "rules": {
+                            "tierDefinitions": [],
+                            "tieredResourceKey": "gold",
+                          },
+                        }
+                `);
 	});
 });

--- a/packages/web/tests/utils/sessionStateHelpers.ts
+++ b/packages/web/tests/utils/sessionStateHelpers.ts
@@ -1,5 +1,6 @@
 import type {
 	EngineSessionSnapshot,
+	PassiveRecordSnapshot,
 	PlayerStateSnapshot,
 } from '@kingdom-builder/engine';
 import type { ResourceKey } from '@kingdom-builder/contents';
@@ -48,6 +49,16 @@ export function createSessionHelpers(
 			secondPlayer?.id ??
 			firstPlayer?.id ??
 			'player-1';
+		const passiveRecords: Record<string, PassiveRecordSnapshot[]> = {};
+		for (const player of players) {
+			passiveRecords[player.id] = [];
+		}
+		if (!(activeId in passiveRecords)) {
+			passiveRecords[activeId] = [];
+		}
+		if (!(opponentId in passiveRecords)) {
+			passiveRecords[opponentId] = [];
+		}
 		return {
 			game: {
 				turn: gameOverrides.turn ?? 1,
@@ -65,6 +76,11 @@ export function createSessionHelpers(
 			actionCostResource: primaryResource,
 			recentResourceGains: [],
 			compensations: {},
+			rules: {
+				tieredResourceKey: primaryResource,
+				tierDefinitions: [],
+			},
+			passiveRecords,
 		};
 	}
 

--- a/tests/integration/action-log-hooks.test.ts
+++ b/tests/integration/action-log-hooks.test.ts
@@ -87,8 +87,9 @@ describe('content-driven action log hooks', () => {
 				start: GAME_START,
 				rules: RULES,
 			});
+			const snapshot = session.getSnapshot();
 			const translationContext = createTranslationContext(
-				session.getSnapshot(),
+				snapshot,
 				{
 					actions: content.actions,
 					buildings,
@@ -97,6 +98,10 @@ describe('content-driven action log hooks', () => {
 				{
 					pullEffectLog: (key) => session.pullEffectLog(key),
 					evaluationMods: session.getPassiveEvaluationMods(),
+				},
+				{
+					ruleSnapshot: session.getRuleSnapshot(),
+					passiveRecords: snapshot.passiveRecords,
 				},
 			);
 

--- a/tests/integration/dev-mode-start-config.test.ts
+++ b/tests/integration/dev-mode-start-config.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { createEngineSession } from '@kingdom-builder/engine';
+import {
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	POPULATIONS,
+	PHASES,
+	GAME_START,
+	RULES,
+	Resource,
+	PopulationRole,
+} from '@kingdom-builder/contents';
+
+describe('dev mode start configuration', () => {
+	it('applies content-driven overrides when dev mode is enabled', () => {
+		const session = createEngineSession({
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+			populations: POPULATIONS,
+			phases: PHASES,
+			start: GAME_START,
+			rules: RULES,
+			devMode: true,
+		});
+		const snapshot = session.getSnapshot();
+		const [player, opponent] = snapshot.game.players;
+		if (!player || !opponent) {
+			throw new Error('Expected both players to be present at game start');
+		}
+		expect(snapshot.game.devMode).toBe(true);
+		expect(player.resources[Resource.gold]).toBe(100);
+		expect(player.resources[Resource.happiness]).toBe(10);
+		expect(player.population[PopulationRole.Council]).toBe(2);
+		expect(player.population[PopulationRole.Legion]).toBe(1);
+		expect(player.population[PopulationRole.Fortifier]).toBe(1);
+		expect(opponent.resources[Resource.castleHP]).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary
- add content builders, schema support, and default data for configurable win conditions
- evaluate win conditions in the engine and expose outcomes through snapshots and session APIs
- surface victory/defeat overlays in the web client and block further interactions once the game ends

## Text formatting audit (required)

1. **Translator/formatter reuse:** Not applicable; the new outcome overlay copy is bespoke and not covered by existing translators.
2. **Canonical keywords/icons/helpers touched:** Added the 🏰 win-condition icon and 🏠 return button icon.
3. **Voice review:** Confirmed the victory/defeat copy uses the heroic narrative voice consistent with existing UI surfaces.

## Standards compliance (required)

1. **File length limits respected:** New files (`GameOutcomeScreen.tsx` 109 lines, `winConditions.ts` 20 lines, `win_condition_service.ts` 184 lines) remain below the 250-line ceiling; other touched files were already within project exceptions.
2. **Line length limits respected:** Prettier (`npm run format`) and `npm run check` completed without wrapping warnings, confirming 80-character compliance.
3. **Domain separation upheld:** Win conditions are authored in Contents/Protocol, evaluated in Engine, and consumed via Engine snapshots in Web with no cross-domain leakage.
4. **Code standards satisfied:** `npm run check` (format, typecheck, lint) passed locally with no violations.
5. **Tests updated:** Added engine regression coverage for castle destruction outcomes (`packages/engine/tests/resolveAttack.test.ts`).
6. **Documentation updated:** Not required; existing documentation already describes victory conditions conceptually.
7. **`npm run check` results:** PASS – ran locally (no artifact generated in this environment).
8. **`npm run test:coverage` results:** Not run; full coverage sweep was not requested for this iteration.

## Testing

- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e6617cb17083258bd26f6b1f89f6aa