### PR TITLE
Silence passive add log output and dedupe passive changes

### DIFF
--- a/packages/web/src/translation/effects/formatters/passive.ts
+++ b/packages/web/src/translation/effects/formatters/passive.ts
@@ -239,20 +239,5 @@ registerEffectFormatter('passive', 'add', {
 			},
 		];
 	},
-	log: (eff, ctx) => {
-		const icon =
-			(eff.params?.['icon'] as string | undefined) ?? PASSIVE_INFO.icon;
-		const name =
-			(eff.params?.['name'] as string | undefined) ?? PASSIVE_INFO.label;
-		const prefix = icon ? `${icon} ` : '';
-		const inner = describeEffects(eff.effects || [], ctx);
-		const items = [...(inner.length ? inner : [])];
-		const duration = resolveDurationMeta(eff, ctx);
-		if (duration) {
-			items.push(
-				`${prefix}${name} duration: Until player's next ${formatDuration(duration)}`,
-			);
-		}
-		return { title: `${prefix}${name} added`, items };
-	},
+	log: () => [],
 });

--- a/packages/web/src/translation/log/passiveChanges.ts
+++ b/packages/web/src/translation/log/passiveChanges.ts
@@ -45,7 +45,10 @@ export function appendPassiveChanges(
 		}
 		const { icon, label } = resolvePassivePresentation(passive);
 		const decoratedLabel = decoratePassiveLabel(icon, label);
-		changes.push(`${decoratedLabel} activated`);
+		const entry = `${decoratedLabel} activated`;
+		if (!changes.includes(entry)) {
+			changes.push(entry);
+		}
 	}
 	for (const [id, passive] of previous) {
 		if (next.has(id)) {
@@ -56,6 +59,9 @@ export function appendPassiveChanges(
 		}
 		const { icon, label } = resolvePassivePresentation(passive);
 		const decoratedLabel = decoratePassiveLabel(icon, label);
-		changes.push(`${decoratedLabel} deactivated`);
+		const entry = `${decoratedLabel} deactivated`;
+		if (!changes.includes(entry)) {
+			changes.push(entry);
+		}
 	}
 }

--- a/packages/web/tests/hold-festival-action-translation.test.ts
+++ b/packages/web/tests/hold-festival-action-translation.test.ts
@@ -76,15 +76,8 @@ describe('hold festival action translation', () => {
 			festivalActionId,
 			attackActionId,
 		);
-		const upkeepDescriptionLabel = `${
-			details.upkeepIcon ? `${details.upkeepIcon} ` : ''
-		}${details.upkeepLabel}`;
-
 		expect(log).toEqual([
 			`Played ${details.festival.icon} ${details.festival.name}`,
-			`  ${details.passiveIcon ? `${details.passiveIcon} ` : ''}${details.passiveName} added`,
-			`    ${MODIFIER_INFO.result.icon} ${MODIFIER_INFO.result.label} on ${details.armyAttack.icon} ${details.armyAttack.name}: Whenever it resolves, ${details.happinessInfo.icon}${sign(details.penaltyAmt)}${details.penaltyAmt} ${details.happinessInfo.label}`,
-			`    ${details.passiveIcon ? `${details.passiveIcon} ` : ''}${details.passiveName} duration: Until player's next ${upkeepDescriptionLabel}`,
 		]);
 	});
 });

--- a/packages/web/tests/passive-duration-formatter.test.ts
+++ b/packages/web/tests/passive-duration-formatter.test.ts
@@ -131,12 +131,7 @@ describe('passive formatter duration metadata', () => {
 				items: [],
 			},
 		]);
-		expect(log).toEqual([
-			{
-				title: '✨ Festival Spirit added',
-				items: ["✨ Festival Spirit duration: Until player's next 🎉 Festival"],
-			},
-		]);
+		expect(log).toEqual([]);
 	});
 
 	it('fills missing context metadata from static phase definitions', () => {


### PR DESCRIPTION
## Summary
- stop the `passive:add` formatter from emitting action-log blocks so only passive status changes remain in the feed
- ensure passive change logging ignores duplicate activation/deactivation strings when other sources are silent
- update hold festival and passive duration tests to reflect the streamlined log output

## Text formatting audit (required)
1. **Translator/formatter reuse:** Updated the existing `registerEffectFormatter('passive', 'add')` implementation rather than introducing a new formatter.【F:packages/web/src/translation/effects/formatters/passive.ts†L230-L243】
2. **Canonical keywords/icons/helpers touched:** None – no new keywords, icons, or helpers were introduced.
3. **Voice review:** Confirmed the summary/description voices remain unchanged and the log voice now relies on the passive change summary without redundant “added” headlines.

## Standards compliance (required)
1. **File length limits respected:** Touched files remain well under their respective limits (e.g., `passive.ts` ends at line 243; the others are shorter).【F:packages/web/src/translation/effects/formatters/passive.ts†L230-L243】【F:packages/web/src/translation/log/passiveChanges.ts†L30-L67】
2. **Line length limits respected:** `npm run check` (executed via the pre-commit hook) completed without flagging any line-length violations.【ba4327†L1-L11】【39f424†L1-L20】
3. **Domain separation upheld:** Changes are confined to the Web translation layer and its tests; no engine/content code paths were crossed.【F:packages/web/src/translation/effects/formatters/passive.ts†L230-L243】【F:packages/web/tests/hold-festival-action-translation.test.ts†L70-L82】
4. **Code standards satisfied:** The pre-commit hook re-ran `npm run check`, including ESLint, and completed successfully before committing.【ba4327†L1-L11】【39f424†L1-L20】
5. **Tests updated:** Hold festival and passive duration tests were updated to match the quieter log output.【F:packages/web/tests/hold-festival-action-translation.test.ts†L70-L82】【F:packages/web/tests/passive-duration-formatter.test.ts†L106-L134】
6. **Documentation updated:** Not required; this change only adjusts log formatting and matching tests.
7. **`npm run check` results:** Executed automatically during the pre-commit hook; no separate artifact was generated, and the command completed without errors.【ba4327†L1-L11】【39f424†L1-L20】
8. **`npm run test:coverage` results:** Not run for this change because unit-level updates already exercise the affected behavior.

## Testing
- `npm run test -- packages/web/tests/passive-duration-formatter.test.ts`【80429c†L1-L20】
- `npm run test -- packages/web/tests/hold-festival-action-translation.test.ts`【0df924†L1-L17】
- `npm run test -- packages/web/tests/passive-log-labels.test.ts`【c58264†L1-L19】

------
https://chatgpt.com/codex/tasks/task_e_68e6695b04b8832597142db6df7670f2