### PR TITLE
Normalize action resolution headlines

### DIFF
--- a/packages/web/src/components/ActionResolutionCard.tsx
+++ b/packages/web/src/components/ActionResolutionCard.tsx
@@ -27,9 +27,9 @@ function ActionResolutionCard({
 	const leadingLine = resolution.lines[0]?.trim() ?? '';
 
 	const fallbackActionName = leadingLine
-		.replace(/^[\s✦•-]+/u, '')
-		.replace(/^\p{Extended_Pictographic}+\s*/u, '')
-		.replace(/\p{Extended_Pictographic}/gu, '')
+		.replace(/^[\s\p{Extended_Pictographic}\uFE0F\p{Pd}\p{Po}\p{So}]+/u, '')
+		.replace(/^Played\s+/u, '')
+		.replace(/[\p{Extended_Pictographic}\uFE0F]/gu, '')
 		.replace(/\s{2,}/g, ' ')
 		.trim();
 	const rawActionName = (resolution.action?.name ?? '').trim();

--- a/packages/web/src/state/deriveResolutionActionName.ts
+++ b/packages/web/src/state/deriveResolutionActionName.ts
@@ -5,9 +5,12 @@ function deriveResolutionActionName(
 	fallback: string,
 	icon?: string,
 ): string {
-	const normalizedHeadline = headline?.replace(/^Played\s+/u, '').trim() ?? '';
+	let normalizedHeadline = headline?.trim() ?? '';
 	if (!normalizedHeadline) {
 		return fallback;
+	}
+	if (normalizedHeadline.startsWith('Played ')) {
+		normalizedHeadline = normalizedHeadline.slice(7).trim();
 	}
 	const trimmedIcon = icon?.trim();
 	if (trimmedIcon) {

--- a/packages/web/src/translation/content/action.ts
+++ b/packages/web/src/translation/content/action.ts
@@ -62,9 +62,9 @@ class ActionTranslator
 		params?: Record<string, unknown>,
 	): string[] {
 		const def = ctx.actions.get(id);
-		const icon = def.icon || '';
-		const label = def.name;
-		let message = `Played ${icon} ${label}`;
+		const icon = def.icon?.trim();
+		const label = def.name.trim();
+		let message = icon ? `${icon} ${label}` : label;
 		const extra = getActionLogHook(def)?.(ctx, params);
 		if (extra) {
 			message += extra;

--- a/packages/web/tests/action-log-lines.test.ts
+++ b/packages/web/tests/action-log-lines.test.ts
@@ -7,7 +7,7 @@ import { LOG_KEYWORDS } from '../src/translation/log/logMessages';
 
 describe('action log line formatting', () => {
 	it('nests development changes under the development headline', () => {
-		const messages = ['Played 🏗️ Develop', '  💲 Action cost'];
+		const messages = ['🏗️ Develop', '  💲 Action cost'];
 		const changes = [
 			`${LOG_KEYWORDS.developed} 🗼 Watchtower`,
 			'🛡️ Fortification Strength +2 (0→2)',
@@ -22,15 +22,15 @@ describe('action log line formatting', () => {
 	});
 
 	it('falls back to default formatting without a development headline', () => {
-		const messages = ['Played 💰 Tax'];
+		const messages = ['💰 Tax'];
 		const changes = ['Gold +3', 'Happiness -1'];
 		expect(formatDevelopActionLogLines(messages, changes)).toEqual([
-			'Played 💰 Tax',
+			'💰 Tax',
 			'  Gold +3',
 			'  Happiness -1',
 		]);
 		expect(formatActionLogLines(messages, changes)).toEqual([
-			'Played 💰 Tax',
+			'💰 Tax',
 			'  Gold +3',
 			'  Happiness -1',
 		]);

--- a/packages/web/tests/army-attack-translation.log.test.ts
+++ b/packages/web/tests/army-attack-translation.log.test.ts
@@ -86,7 +86,7 @@ describe('army attack translation log', () => {
 		const castleValue = `${castle.icon}${castleBefore}`;
 		const castleAfterValue = `${castle.icon}${castleAfter}`;
 		expect(log).toEqual([
-			`Played ${attack.icon} ${attack.name}`,
+			`${attack.icon} ${attack.name}`,
 			`  Damage evaluation: ${powerValue(armyStrength)} vs. ${absorptionValue(0)} ${fortValue(fortBefore)} ${castleValue}`,
 			`    ${powerValue(armyStrength)} vs. ${absorptionValue(0)} --> ${powerValue(remainingAfterAbsorption)}`,
 			`    ${powerValue(remainingAfterAbsorption)} vs. ${fortValue(fortBefore)} --> ${fortValue(0)} ${powerValue(remainingAfterFort)}`,
@@ -142,7 +142,7 @@ describe('army attack translation log', () => {
 		const fortValue = (value: number) =>
 			statToken(fortStat, 'Fortification', formatNumber(value));
 		expect(log).toEqual([
-			`Played ${buildingAttack.icon} ${buildingAttack.name}`,
+			`${buildingAttack.icon} ${buildingAttack.name}`,
 			`  Damage evaluation: ${powerValue(armyStrength)} vs. ${absorptionValue(0)} ${fortValue(fortBefore)} ${buildingDisplay}`,
 			`    ${powerValue(armyStrength)} vs. ${absorptionValue(0)} --> ${powerValue(remainingAfterAbsorption)}`,
 			`    ${powerValue(remainingAfterAbsorption)} vs. ${fortValue(fortBefore)} --> ${fortValue(0)} ${powerValue(remainingAfterFort)}`,

--- a/packages/web/tests/hold-festival-action-translation.test.ts
+++ b/packages/web/tests/hold-festival-action-translation.test.ts
@@ -81,7 +81,7 @@ describe('hold festival action translation', () => {
 		}${details.upkeepLabel}`;
 
 		expect(log).toEqual([
-			`Played ${details.festival.icon} ${details.festival.name}`,
+			`${details.festival.icon} ${details.festival.name}`,
 			`  ${details.passiveIcon ? `${details.passiveIcon} ` : ''}${details.passiveName} added`,
 			`    ${MODIFIER_INFO.result.icon} ${MODIFIER_INFO.result.label} on ${details.armyAttack.icon} ${details.armyAttack.name}: Whenever it resolves, ${details.happinessInfo.icon}${sign(details.penaltyAmt)}${details.penaltyAmt} ${details.happinessInfo.label}`,
 			`    ${details.passiveIcon ? `${details.passiveIcon} ` : ''}${details.passiveName} duration: Until player's next ${upkeepDescriptionLabel}`,


### PR DESCRIPTION
## Summary
- update `ActionTranslator.log` so action headlines reuse the icon-first label and normalize spacing when icons are absent
- adjust resolution name derivation and card fallback parsing to accept the icon-first headline while preserving the existing player meta label
- refresh the log translator tests to cover the new headline format

## Text formatting audit (required)
1. **Translator/formatter reuse:** `packages/web/src/translation/content/action.ts` (`ActionTranslator.log`), existing `ActionResolutionCard` fallback parser, and downstream log formatters.
2. **Canonical keywords/icons/helpers touched:** Continued to rely on action definitions for icons/labels and the existing log/effect formatters; no new emoji or keywords introduced.
3. **Voice review:** Confirmed the action log retains past-tense voice, the resolution card still renders "Played by {player}", and nested log items remain consistent.

> **Quick reference — paste into your PR description**
>
> - [x] Linked the translator(s)/formatter(s) reused, referencing Sections 2–3.
> - [x] Listed every canonical keyword/icon/helper touched from Section 4.
> - [x] Confirmed Summary/Description/Log voices were audited for affected UI.

## Standards compliance (required)
1. **File length limits respected:** Longest touched file (`ActionResolutionCard.tsx`) ends at line 139 and stays within the 250-line budget; other edited files remain well below the threshold.
2. **Line length limits respected:** `npm run lint` passes without line-length violations.
3. **Domain separation upheld:** Changes are confined to web translators/components and companion tests; no engine/content cross-over.
4. **Code standards satisfied:** `npm run check` and `npm run lint` both completed successfully.
5. **Tests updated:** Updated log expectation suites in `packages/web/tests/action-log-lines.test.ts`, `packages/web/tests/army-attack-translation.log.test.ts`, and `packages/web/tests/hold-festival-action-translation.test.ts`.
6. **Documentation updated:** Not required; existing translation documentation still applies.
7. **`npm run check` results:** Executed directly (no artifact in this environment); command succeeded.
8. **`npm run test:coverage` results:** Not run for this change.

## Testing
- `npm run format`
- `npm run lint`
- `npm run check`
- `npm run test -- packages/web/tests/action-log-lines.test.ts packages/web/tests/army-attack-translation.log.test.ts packages/web/tests/hold-festival-action-translation.test.ts`
- `npm test` (pre-commit hook)


------
https://chatgpt.com/codex/tasks/task_e_68e6695efcf883259028a190ebd9b9ad