### PR TITLE
Refine attack evaluation phrasing

### DIFF
--- a/packages/web/src/translation/effects/formatters/attack.ts
+++ b/packages/web/src/translation/effects/formatters/attack.ts
@@ -120,7 +120,7 @@ function buildActionLog(
 	entry.attacker.forEach((diff) => {
 		items.push(formatter.formatDiff(ownerLabel(ctx, 'attacker'), diff));
 	});
-	return { title: `Triggered ${icon} ${name}`.trim(), items };
+	return { title: `Trigger ${icon} ${name}`.trim(), items };
 }
 
 export function buildOnDamageEntry(

--- a/packages/web/src/translation/effects/formatters/attack/shared.ts
+++ b/packages/web/src/translation/effects/formatters/attack/shared.ts
@@ -6,10 +6,26 @@ import {
 } from '@kingdom-builder/contents';
 import type { AttackPlayerDiff } from '@kingdom-builder/engine';
 import { formatStatValue } from '../../../../utils/stats';
-import type { DiffFormatOptions } from './types';
+import type { AttackStatDescriptor, DiffFormatOptions } from './types';
 
 export function iconLabel(icon: string | undefined, label: string): string {
 	return icon ? `${icon} ${label}` : label;
+}
+
+export function attackStatLabel(
+	stat: AttackStatDescriptor | undefined,
+	fallback: string,
+): string {
+	return stat ? iconLabel(stat.icon, stat.label) : fallback;
+}
+
+export function attackStatValue(
+	stat: AttackStatDescriptor | undefined,
+	fallback: string,
+	value: string,
+): string {
+	const label = attackStatLabel(stat, fallback);
+	return `${label} ${value}`;
 }
 
 const NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
@@ -26,6 +42,15 @@ export function formatNumber(value: number): string {
 
 export function formatPercent(value: number): string {
 	return `${formatNumber(value * 100)}%`;
+}
+
+export function formatSignedValue(
+	value: number,
+	formatter: (value: number) => string,
+): string {
+	const magnitude = formatter(Math.abs(value));
+	const prefix = value >= 0 ? '+' : '-';
+	return `${prefix}${magnitude}`;
 }
 
 function formatSigned(value: number): string {

--- a/packages/web/tests/army-attack-translation.log.test.ts
+++ b/packages/web/tests/army-attack-translation.log.test.ts
@@ -5,6 +5,7 @@ import { Resource, Stat, performAction } from '@kingdom-builder/engine';
 import {
 	formatNumber,
 	formatPercent,
+	formatSignedValue,
 } from '../src/translation/effects/formatters/attack/shared';
 import {
 	createSyntheticCtx,
@@ -78,25 +79,32 @@ describe('army attack translation log', () => {
 
 		const log = logContent('action', attack.id, ctx);
 		const powerValue = (value: number) =>
-			statToken(powerStat, 'Attack', formatNumber(value));
+			statToken(powerStat, 'Attack', formatSignedValue(value, formatNumber));
 		const absorptionValue = (value: number) =>
-			statToken(absorptionStat, 'Absorption', formatPercent(value));
+			statToken(
+				absorptionStat,
+				'Absorption',
+				formatSignedValue(value, formatPercent),
+			);
 		const fortValue = (value: number) =>
-			statToken(fortStat, 'Fortification', formatNumber(value));
-		const castleValue = `${castle.icon}${castleBefore}`;
-		const castleAfterValue = `${castle.icon}${castleAfter}`;
+			statToken(
+				fortStat,
+				'Fortification',
+				formatSignedValue(value, formatNumber),
+			);
+		const castleAfterValue = `${castle.icon} ${castle.label} ${castleAfter}`;
 		expect(log).toEqual([
 			`Played ${attack.icon} ${attack.name}`,
-			`  Damage evaluation: ${powerValue(armyStrength)} vs. ${absorptionValue(0)} ${fortValue(fortBefore)} ${castleValue}`,
-			`    ${powerValue(armyStrength)} vs. ${absorptionValue(0)} --> ${powerValue(remainingAfterAbsorption)}`,
-			`    ${powerValue(remainingAfterAbsorption)} vs. ${fortValue(fortBefore)} --> ${fortValue(0)} ${powerValue(remainingAfterFort)}`,
-			`    ${powerValue(remainingAfterFort)} vs. ${castleValue} --> ${castleAfterValue}`,
+			`  Evaluate damage: Compare ${powerValue(armyStrength)} against ${absorptionValue(0)}; Compare remaining damage against ${fortValue(fortBefore)}; Apply damage to ${castle.icon} ${castle.label} ${castleBefore}`,
+			`    Compare ${powerValue(armyStrength)} against ${absorptionValue(0)} → ${powerValue(remainingAfterAbsorption)}`,
+			`    Compare ${powerValue(remainingAfterAbsorption)} against ${fortValue(fortBefore)} → ${fortValue(0)} and carry forward ${powerValue(remainingAfterFort)}`,
+			`    Apply ${powerValue(remainingAfterFort)} to ${castle.icon} ${castle.label} ${castleBefore} → ${castleAfterValue}`,
 			`  ${castle.icon} ${castle.label} damage trigger evaluation`,
 			`    ${defenderName}: ${happiness.icon} ${happiness.label} ${opponentHappinessDelta} (${opponentHappinessBefore}→${opponentHappinessAfter})`,
 			`    ${attackerName}: ${happiness.icon} ${happiness.label} ${
 				attackerHappinessDelta >= 0 ? '+' : ''
 			}${attackerHappinessDelta} (${attackerHappinessBefore}→${attackerHappinessAfter})`,
-			`    Triggered ${plunder.icon} ${plunder.name}`,
+			`    Trigger ${plunder.icon} ${plunder.name}`,
 			`      ${defenderName}: ${gold.icon} ${gold.label} -${PLUNDER_PERCENT}% (${opponentGoldBefore}→${opponentGoldAfter}) (${opponentGoldDelta})`,
 			`      ${attackerName}: ${gold.icon} ${gold.label} ${
 				playerGoldDelta >= 0 ? '+' : ''
@@ -136,17 +144,25 @@ describe('army attack translation log', () => {
 		const playerGoldDelta = playerGoldAfter - playerGoldBefore;
 		const log = logContent('action', buildingAttack.id, ctx);
 		const powerValue = (value: number) =>
-			statToken(powerStat, 'Attack', formatNumber(value));
+			statToken(powerStat, 'Attack', formatSignedValue(value, formatNumber));
 		const absorptionValue = (value: number) =>
-			statToken(absorptionStat, 'Absorption', formatPercent(value));
+			statToken(
+				absorptionStat,
+				'Absorption',
+				formatSignedValue(value, formatPercent),
+			);
 		const fortValue = (value: number) =>
-			statToken(fortStat, 'Fortification', formatNumber(value));
+			statToken(
+				fortStat,
+				'Fortification',
+				formatSignedValue(value, formatNumber),
+			);
 		expect(log).toEqual([
 			`Played ${buildingAttack.icon} ${buildingAttack.name}`,
-			`  Damage evaluation: ${powerValue(armyStrength)} vs. ${absorptionValue(0)} ${fortValue(fortBefore)} ${buildingDisplay}`,
-			`    ${powerValue(armyStrength)} vs. ${absorptionValue(0)} --> ${powerValue(remainingAfterAbsorption)}`,
-			`    ${powerValue(remainingAfterAbsorption)} vs. ${fortValue(fortBefore)} --> ${fortValue(0)} ${powerValue(remainingAfterFort)}`,
-			`    ${powerValue(remainingAfterFort)} destroys ${buildingDisplay}`,
+			`  Evaluate damage: Compare ${powerValue(armyStrength)} against ${absorptionValue(0)}; Compare remaining damage against ${fortValue(fortBefore)}; Destroy ${buildingDisplay} with ${powerValue(remainingAfterFort)}`,
+			`    Compare ${powerValue(armyStrength)} against ${absorptionValue(0)} → ${powerValue(remainingAfterAbsorption)}`,
+			`    Compare ${powerValue(remainingAfterAbsorption)} against ${fortValue(fortBefore)} → ${fortValue(0)} and carry forward ${powerValue(remainingAfterFort)}`,
+			`    Destroy ${buildingDisplay} with ${powerValue(remainingAfterFort)}`,
 			`  ${buildingDisplay} destruction trigger evaluation`,
 			`    ${attackerName}: ${gold.icon} ${gold.label} ${
 				playerGoldDelta >= 0 ? '+' : ''

--- a/packages/web/tests/army-attack-translation.summary.test.ts
+++ b/packages/web/tests/army-attack-translation.summary.test.ts
@@ -137,8 +137,8 @@ describe('army attack translation summary', () => {
 				)}`,
 				items: [
 					'Damage reduction applied',
-					`Damage applied to opponent's defenses`,
-					`If opponent defenses fall, overflow remaining damage on opponent ${targetDisplay}`,
+					'Apply damage to opponent defenses',
+					`If opponent defenses fall, overflow remaining damage onto opponent ${targetDisplay}`,
 				],
 			},
 		]);

--- a/packages/web/tests/helpers/armyAttackFactories.ts
+++ b/packages/web/tests/helpers/armyAttackFactories.ts
@@ -135,13 +135,8 @@ export function statToken(
 	fallback: string,
 	value: string,
 ) {
-	if (stat?.icon) {
-		return `${stat.icon}${value}`;
-	}
-	if (stat?.label) {
-		return `${stat.label} ${value}`;
-	}
-	return `${fallback} ${value}`;
+	const label = iconLabel(stat?.icon, stat?.label, fallback);
+	return `${label} ${value}`;
 }
 
 export const SYNTH_COMBAT_STATS: Record<CombatStatKey, { key: string }> = {


### PR DESCRIPTION
## Summary
- Restyled attack evaluation helpers to prepend icons to labels and show signed values in imperative summaries. 【F:packages/web/src/translation/effects/formatters/attack/shared.ts†L11-L54】【F:packages/web/src/translation/effects/formatters/attack/evaluation.ts†L20-L174】【F:packages/web/src/translation/effects/formatters/attack/building.ts†L40-L154】
- Updated attack action logs and expectations to use the new imperative phrasing and signed damage displays. 【F:packages/web/src/translation/effects/formatters/attack.ts†L110-L123】【F:packages/web/tests/army-attack-translation.log.test.ts†L80-L170】
- Synced summary fixtures and helpers with the revised attack wording. 【F:packages/web/tests/army-attack-translation.summary.test.ts†L120-L145】【F:packages/web/tests/helpers/armyAttackFactories.ts†L120-L139】

## Text formatting audit (required)
1. **Translator/formatter reuse:** Updated existing attack formatters in `packages/web/src/translation/effects/formatters/attack/evaluation.ts`, `.../attack/building.ts`, and `.../attack.ts` instead of introducing new translators. 【F:packages/web/src/translation/effects/formatters/attack/evaluation.ts†L20-L174】【F:packages/web/src/translation/effects/formatters/attack/building.ts†L40-L154】【F:packages/web/src/translation/effects/formatters/attack.ts†L110-L123】
2. **Canonical keywords/icons/helpers touched:** Adjusted shared helpers `attackStatLabel`, `attackStatValue`, `iconLabel`, and `formatSignedValue` to maintain icon-leading labels with signed numeric output. 【F:packages/web/src/translation/effects/formatters/attack/shared.ts†L11-L54】
3. **Voice review:** Verified imperative tone across damage summaries, descriptions, and log lines in the updated attack formatters and tests. 【F:packages/web/src/translation/effects/formatters/attack/evaluation.ts†L83-L174】【F:packages/web/src/translation/effects/formatters/attack/building.ts†L62-L154】【F:packages/web/tests/army-attack-translation.log.test.ts†L96-L170】

## Standards compliance (required)
1. **File length limits respected:** Updated files remain below the 250-line ceiling (e.g., `attack/evaluation.ts` ends at line 183, `attack/building.ts` at 164). 【F:packages/web/src/translation/effects/formatters/attack/evaluation.ts†L20-L174】【F:packages/web/src/translation/effects/formatters/attack/building.ts†L40-L154】
2. **Line length limits respected:** Prettier ran over the repo (`npm run format`) confirming all lines adhere to the configured width. 【7dcc24†L1-L8】
3. **Domain separation upheld:** Changes are confined to the Web translation layer and its tests; Engine/Content logic remains untouched. 【F:packages/web/src/translation/effects/formatters/attack/evaluation.ts†L20-L174】【F:packages/web/tests/army-attack-translation.log.test.ts†L80-L170】
4. **Code standards satisfied:** `npm run lint` completed without errors after the edits. 【10361a†L1-L9】
5. **Tests updated:** Attack translation tests were refreshed to cover the new phrasing and formatting. 【F:packages/web/tests/army-attack-translation.log.test.ts†L80-L170】【F:packages/web/tests/army-attack-translation.summary.test.ts†L120-L145】
6. **Documentation updated:** Not required—no documentation references were affected by the text-only formatter adjustments.
7. **`npm run check` results:** Ran locally with a passing suite. 【bb70d1†L1-L10】【7eeeba†L1-L33】
8. **`npm run test:coverage` results:** Not run (coverage not requested for formatter copy updates).

## Testing
- ✅ `npm run lint` 【10361a†L1-L9】
- ✅ `npm run check` 【bb70d1†L1-L10】【7eeeba†L1-L33】
- ✅ `npx vitest run packages/web/tests/army-attack-translation.log.test.ts` 【a521db†L1-L23】

------
https://chatgpt.com/codex/tasks/task_e_68e6695c883c8325bafa5a143240c1f6