### PR TITLE
Fix diff filtering for cost-and-reward actions

### DIFF
--- a/packages/web/src/state/useActionPerformer.ts
+++ b/packages/web/src/state/useActionPerformer.ts
@@ -135,7 +135,6 @@ export function useActionPerformer({
 					changes,
 					messages,
 					subLines,
-					costs,
 				});
 				const logLines = (
 					action.id === ActionId.develop

--- a/packages/web/tests/action-cost-reward-log.test.ts
+++ b/packages/web/tests/action-cost-reward-log.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+	createEngine,
+	performAction,
+	advance,
+	getActionCosts,
+} from '@kingdom-builder/engine';
+import {
+	createSyntheticTaxScenario,
+	SYNTHETIC_RESOURCE_KEYS,
+	SYNTHETIC_RESOURCES,
+	type SyntheticResourceKey,
+	SYNTHETIC_PHASE_IDS,
+} from './fixtures/syntheticTaxLog';
+import {
+	snapshotPlayer,
+	diffStepSnapshots,
+	logContent,
+	createTranslationDiffContext,
+} from '../src/translation';
+import { filterActionDiffChanges } from '../src/state/useActionPerformer.helpers';
+import { formatActionLogLines } from '../src/state/actionLogFormat';
+
+const RESOURCE_KEYS = Object.keys(
+	SYNTHETIC_RESOURCES,
+) as SyntheticResourceKey[];
+
+vi.mock('@kingdom-builder/engine', async () => {
+	return await import('../../engine/src');
+});
+
+describe('action cost and reward logging', () => {
+	it('shows both the cost block and reward highlight for the same resource', () => {
+		const scenario = createSyntheticTaxScenario();
+		const refundAction = scenario.factory.action({
+			id: 'action:synthetic:refund',
+			name: 'Synthetic Refund',
+			icon: '♻️',
+			baseCosts: {
+				[SYNTHETIC_RESOURCE_KEYS.actionPoints]: 1,
+				[SYNTHETIC_RESOURCE_KEYS.coin]: 4,
+			},
+			effects: [
+				{
+					type: 'resource',
+					method: 'add',
+					params: { key: SYNTHETIC_RESOURCE_KEYS.coin, amount: 6 },
+				},
+			],
+		});
+		const ctx = createEngine({
+			actions: scenario.factory.actions,
+			buildings: scenario.factory.buildings,
+			developments: scenario.factory.developments,
+			populations: scenario.factory.populations,
+			phases: scenario.phases,
+			start: scenario.start,
+			rules: scenario.rules,
+		});
+		ctx.activePlayer.actions.add(refundAction.id);
+		while (ctx.game.currentPhase !== SYNTHETIC_PHASE_IDS.main) {
+			advance(ctx);
+		}
+		const before = snapshotPlayer(ctx.activePlayer, ctx);
+		const costs = getActionCosts(refundAction.id, ctx);
+		performAction(refundAction.id, ctx);
+		const after = snapshotPlayer(ctx.activePlayer, ctx);
+		const diffContext = createTranslationDiffContext(ctx);
+		const actionDef = ctx.actions.get(refundAction.id);
+		if (!actionDef) {
+			throw new Error('Missing refund action definition');
+		}
+		const changes = diffStepSnapshots(
+			before,
+			after,
+			actionDef,
+			diffContext,
+			RESOURCE_KEYS,
+		);
+		const messages = logContent('action', refundAction.id, ctx);
+		const costLines: string[] = [];
+		for (const key of Object.keys(costs) as SyntheticResourceKey[]) {
+			const amount = costs[key] ?? 0;
+			if (!amount) {
+				continue;
+			}
+			const info = SYNTHETIC_RESOURCES[key];
+			const icon = info?.icon ? `${info.icon} ` : '';
+			const label = info?.label ?? key;
+			const beforeAmount = before.resources[key] ?? 0;
+			const afterAmount = beforeAmount - amount;
+			costLines.push(
+				`    ${icon}${label} -${amount} (${beforeAmount}→${afterAmount})`,
+			);
+		}
+		if (costLines.length) {
+			messages.splice(1, 0, '  💲 Action cost', ...costLines);
+		}
+		const filtered = filterActionDiffChanges({
+			changes,
+			messages,
+			subLines: [],
+		});
+		const logLines = formatActionLogLines(messages, filtered);
+		const coinInfo = SYNTHETIC_RESOURCES[SYNTHETIC_RESOURCE_KEYS.coin];
+		const coinCost = costs[SYNTHETIC_RESOURCE_KEYS.coin] ?? 0;
+		expect(logLines).toContain('  💲 Action cost');
+		const costEntry = logLines.find((line) =>
+			line.includes(`${coinInfo.icon} ${coinInfo.label} -${coinCost} `),
+		);
+		expect(costEntry).toBeDefined();
+		const beforeCoins = before.resources[SYNTHETIC_RESOURCE_KEYS.coin] ?? 0;
+		const afterCoins = after.resources[SYNTHETIC_RESOURCE_KEYS.coin] ?? 0;
+		const rewardLine = filtered.find(
+			(line) =>
+				line.startsWith(`${coinInfo.icon} ${coinInfo.label}`) &&
+				line.includes('+') &&
+				line.includes(`(${beforeCoins}→${afterCoins})`),
+		);
+		expect(rewardLine).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary
- ensure `filterActionDiffChanges` keeps reward summaries by normalizing lines without stripping signed amounts and dropping cost-prefix filtering
- adjust `useActionPerformer` to use the simplified diff filter signature
- add a regression test covering an action that pays and gains the same resource to confirm the cost block and reward highlight both render

## Text formatting audit (required)

1. **Translator/formatter reuse:** Existing action log helpers (`formatActionLogLines`) continue to handle the output; no new translators were added.
2. **Canonical keywords/icons/helpers touched:** None.
3. **Voice review:** No player-facing text changed; existing log voices remain consistent.

## Standards compliance (required)

1. **File length limits respected:** `useActionPerformer.helpers.ts` (90 lines), `useActionPerformer.ts` (225 lines), and the new test (122 lines) stay within allowed limits.【221bd6†L1-L6】
2. **Line length limits respected:** `npm run lint` passes with no max-line errors.【914027†L1-L9】
3. **Domain separation upheld:** Changes are confined to the Web state helpers and tests, reusing existing engine APIs without cross-layer shortcuts.【F:packages/web/src/state/useActionPerformer.helpers.ts†L53-L89】【F:packages/web/tests/action-cost-reward-log.test.ts†L1-L121】
4. **Code standards satisfied:** Linting succeeds after the updates.【914027†L1-L9】
5. **Tests updated:** Added `packages/web/tests/action-cost-reward-log.test.ts` and exercised it with Vitest.【F:packages/web/tests/action-cost-reward-log.test.ts†L1-L121】【bd4fb7†L1-L17】
6. **Documentation updated:** Not required; no docs reference these helpers or tests.
7. **`npm run check` results:** Ran successfully to cover format, type, and lint checks.【bfde73†L1-L10】【7a3387†L1-L25】
8. **`npm run test:coverage` results:** Not run (out of scope for this change).

## Testing

- `npm run format` (pass)【4192ba†L1-L5】【25f7d8†L1-L52】
- `npm run lint` (pass)【914027†L1-L9】
- `npm run check` (pass)【bfde73†L1-L10】【7a3387†L1-L25】
- `npx vitest packages/web/tests/action-cost-reward-log.test.ts` (pass)【bd4fb7†L1-L17】

------
https://chatgpt.com/codex/tasks/task_e_68e670bddb30832599c5316326add56d