### PR TITLE
Refactor web component tests to use snapshot-driven fixtures

### DIFF
--- a/packages/web/tests/helpers/passiveDisplayFixtures.ts
+++ b/packages/web/tests/helpers/passiveDisplayFixtures.ts
@@ -1,0 +1,213 @@
+import type {
+	PlayerId,
+	PlayerStateSnapshot,
+	RuleSnapshot,
+} from '@kingdom-builder/engine';
+import {
+	BUILDINGS,
+	PHASES,
+	RULES,
+	type ResourceKey,
+} from '@kingdom-builder/contents';
+import {
+	createPassiveRecord,
+	createSessionSnapshot,
+	createSnapshotPlayer,
+} from './sessionFixtures';
+import {
+	createPassiveGame,
+	type PassiveGameContext,
+} from './createPassiveDisplayGame';
+
+export type TierPassiveScenario = PassiveGameContext & {
+	activePlayer: PlayerStateSnapshot;
+	ruleSnapshot: RuleSnapshot;
+};
+
+export type NeutralPassiveScenario = PassiveGameContext & {
+	activePlayer: PlayerStateSnapshot;
+};
+
+export type BuildingPassiveScenario = PassiveGameContext & {
+	activePlayer: PlayerStateSnapshot;
+};
+
+const happinessKey = RULES.tieredResourceKey as ResourceKey;
+
+function cloneRuleSnapshot(): RuleSnapshot {
+	return {
+		...RULES,
+		tierDefinitions: RULES.tierDefinitions.map((tier) => ({
+			...tier,
+			display: {
+				...(tier.display ?? {}),
+				title: `Snapshot ${tier.id}`,
+			},
+		})),
+	};
+}
+
+function sampleValueForTier(
+	tier: RuleSnapshot['tierDefinitions'][number],
+): number {
+	const min = tier.range.min ?? 0;
+	const max = tier.range.max;
+	if (max !== undefined && max >= min) {
+		return min;
+	}
+	return min;
+}
+
+export function createTierPassiveScenario(): TierPassiveScenario {
+	const ruleSnapshot = cloneRuleSnapshot();
+	const tier = ruleSnapshot.tierDefinitions.find(
+		(entry) => entry.preview?.id && (entry.range.min ?? 0) >= 0,
+	);
+	if (!tier?.preview?.id) {
+		throw new Error('Unable to locate a happiness tier with a passive.');
+	}
+	const removalDetail =
+		tier.display?.removalCondition ??
+		tier.text?.removal ??
+		'the current happiness threshold holds';
+	const passiveMeta = {
+		source: {
+			type: 'tier',
+			id: tier.id,
+			icon: tier.display?.icon,
+			labelToken: tier.display?.summaryToken,
+			name: tier.display?.title,
+		},
+		removal: {
+			token: removalDetail,
+		},
+	};
+	const activePlayerId = 'player-1' as PlayerId;
+	const opponentId = 'player-2' as PlayerId;
+	const activePlayer = createSnapshotPlayer({
+		id: activePlayerId,
+		name: 'Player One',
+		resources: { [happinessKey]: sampleValueForTier(tier) },
+		passives: [
+			{
+				id: tier.preview.id,
+				name: tier.display?.title,
+				icon: tier.display?.icon,
+				detail: tier.text?.summary,
+				meta: passiveMeta,
+			},
+		],
+	});
+	const opponent = createSnapshotPlayer({
+		id: opponentId,
+		name: 'Player Two',
+	});
+	const passiveRecord = createPassiveRecord({
+		id: tier.preview.id,
+		owner: activePlayerId,
+		name: tier.display?.title,
+		icon: tier.display?.icon,
+		detail: tier.text?.summary,
+		meta: passiveMeta,
+		effects: tier.preview.effects,
+	});
+	const sessionState = createSessionSnapshot({
+		players: [activePlayer, opponent],
+		activePlayerId,
+		opponentId,
+		phases: PHASES,
+		actionCostResource: RULES.tieredResourceKey as ResourceKey,
+		ruleSnapshot,
+		passiveRecords: {
+			[activePlayerId]: [passiveRecord],
+			[opponentId]: [],
+		},
+	});
+	const context = createPassiveGame(sessionState, { ruleSnapshot });
+	return { ...context, activePlayer, ruleSnapshot };
+}
+
+export function createNeutralScenario(): NeutralPassiveScenario {
+	const ruleSnapshot = cloneRuleSnapshot();
+	const neutralTier = ruleSnapshot.tierDefinitions.find(
+		(entry) => !entry.preview?.id,
+	);
+	if (!neutralTier) {
+		throw new Error('No neutral tier definition available.');
+	}
+	const activePlayerId = 'player-1' as PlayerId;
+	const opponentId = 'player-2' as PlayerId;
+	const activePlayer = createSnapshotPlayer({
+		id: activePlayerId,
+		name: 'Player One',
+		resources: { [happinessKey]: sampleValueForTier(neutralTier) },
+	});
+	const opponent = createSnapshotPlayer({
+		id: opponentId,
+		name: 'Player Two',
+	});
+	const sessionState = createSessionSnapshot({
+		players: [activePlayer, opponent],
+		activePlayerId,
+		opponentId,
+		phases: PHASES,
+		actionCostResource: RULES.tieredResourceKey as ResourceKey,
+		ruleSnapshot,
+		passiveRecords: {
+			[activePlayerId]: [],
+			[opponentId]: [],
+		},
+	});
+	return { ...createPassiveGame(sessionState, { ruleSnapshot }), activePlayer };
+}
+
+export function createBuildingScenario(): BuildingPassiveScenario {
+	const ruleSnapshot = cloneRuleSnapshot();
+	const activePlayerId = 'player-1' as PlayerId;
+	const opponentId = 'player-2' as PlayerId;
+	const buildingId = 'castle_walls';
+	const buildingInfo = BUILDINGS.get(buildingId);
+	const passiveId = `${buildingId}_bonus`;
+	const passiveMeta = {
+		source: {
+			type: 'building',
+			id: buildingId,
+			icon: buildingInfo?.icon,
+			name: buildingInfo?.name,
+		},
+	};
+	const activePlayer = createSnapshotPlayer({
+		id: activePlayerId,
+		name: 'Player One',
+		resources: { [happinessKey]: 0 },
+		passives: [
+			{
+				id: passiveId,
+				meta: passiveMeta,
+			},
+		],
+		buildings: [buildingId],
+	});
+	const opponent = createSnapshotPlayer({
+		id: opponentId,
+		name: 'Player Two',
+	});
+	const passiveRecord = createPassiveRecord({
+		id: passiveId,
+		owner: activePlayerId,
+		meta: passiveMeta,
+	});
+	const sessionState = createSessionSnapshot({
+		players: [activePlayer, opponent],
+		activePlayerId,
+		opponentId,
+		phases: PHASES,
+		actionCostResource: RULES.tieredResourceKey as ResourceKey,
+		ruleSnapshot,
+		passiveRecords: {
+			[activePlayerId]: [passiveRecord],
+			[opponentId]: [],
+		},
+	});
+	return { ...createPassiveGame(sessionState, { ruleSnapshot }), activePlayer };
+}

--- a/packages/web/tests/helpers/playerPanelFixtures.ts
+++ b/packages/web/tests/helpers/playerPanelFixtures.ts
@@ -1,0 +1,171 @@
+import { vi } from 'vitest';
+import type {
+	EngineContext,
+	EngineSession,
+	PlayerId,
+	RuleSnapshot,
+} from '@kingdom-builder/engine';
+import {
+	RESOURCES,
+	ACTIONS,
+	BUILDINGS,
+	DEVELOPMENTS,
+	PHASES,
+	RULES,
+	STATS,
+	type ResourceKey,
+} from '@kingdom-builder/contents';
+import { createTranslationContext } from '../../src/translation/context';
+import type { GameEngineContextValue } from '../../src/state/GameContext.types';
+import { createSessionSnapshot, createSnapshotPlayer } from './sessionFixtures';
+
+export interface PlayerPanelFixtures {
+	activePlayer: ReturnType<typeof createSnapshotPlayer>;
+	mockGame: GameEngineContextValue;
+	resourceForecast: Record<string, number>;
+	displayableStatKeys: string[];
+	statForecast: Record<string, number>;
+}
+
+export function createPlayerPanelFixtures(): PlayerPanelFixtures {
+	const activePlayerId = 'player-1' as PlayerId;
+	const opponentId = 'player-2' as PlayerId;
+	const ruleSnapshot: RuleSnapshot = {
+		...RULES,
+		tierDefinitions: RULES.tierDefinitions.map((tier) => ({ ...tier })),
+	};
+	const resourceValues = Object.keys(RESOURCES).reduce<Record<string, number>>(
+		(acc, key, index) => {
+			acc[key] = index + 2;
+			return acc;
+		},
+		{},
+	);
+	const nonCapacityStatEntries = Object.entries(STATS).filter(
+		([, info]) => !info.capacity,
+	);
+	const stats: Record<string, number> = {};
+	const statsHistory: Record<string, boolean> = {};
+	nonCapacityStatEntries.forEach(([statKey], index) => {
+		const value = index % 2 === 0 ? index + 1 : 0;
+		stats[statKey] = value;
+		if (value === 0) {
+			statsHistory[statKey] = true;
+		}
+	});
+	const activePlayer = createSnapshotPlayer({
+		id: activePlayerId,
+		name: 'Player One',
+		resources: resourceValues,
+		stats,
+		statsHistory,
+		population: {},
+	});
+	const opponent = createSnapshotPlayer({
+		id: opponentId,
+		name: 'Player Two',
+		resources: {},
+		stats: {},
+		population: {},
+	});
+	const sessionState = createSessionSnapshot({
+		players: [activePlayer, opponent],
+		activePlayerId,
+		opponentId,
+		phases: PHASES,
+		actionCostResource: RULES.tieredResourceKey as ResourceKey,
+		ruleSnapshot,
+	});
+	const translationContext = createTranslationContext(
+		sessionState,
+		{
+			actions: ACTIONS,
+			buildings: BUILDINGS,
+			developments: DEVELOPMENTS,
+		},
+		undefined,
+		{
+			ruleSnapshot,
+			passiveRecords: sessionState.passiveRecords,
+		},
+	);
+	const mockGame: GameEngineContextValue = {
+		session: {} as EngineSession,
+		sessionState,
+		ctx: {} as EngineContext,
+		translationContext,
+		ruleSnapshot,
+		log: [],
+		logOverflowed: false,
+		hoverCard: null,
+		handleHoverCard: vi.fn(),
+		clearHoverCard: vi.fn(),
+		phaseSteps: [],
+		setPhaseSteps: vi.fn(),
+		phaseTimer: 0,
+		mainApStart: 0,
+		displayPhase: sessionState.game.currentPhase,
+		setDisplayPhase: vi.fn(),
+		phaseHistories: {},
+		tabsEnabled: true,
+		actionCostResource: sessionState.actionCostResource,
+		handlePerform: vi.fn().mockResolvedValue(undefined),
+		runUntilActionPhase: vi.fn(),
+		handleEndTurn: vi.fn().mockResolvedValue(undefined),
+		updateMainPhaseStep: vi.fn(),
+		darkMode: false,
+		onToggleDark: vi.fn(),
+		resolution: null,
+		showResolution: vi.fn().mockResolvedValue(undefined),
+		acknowledgeResolution: vi.fn(),
+		musicEnabled: true,
+		onToggleMusic: vi.fn(),
+		soundEnabled: true,
+		onToggleSound: vi.fn(),
+		backgroundAudioMuted: false,
+		onToggleBackgroundAudioMute: vi.fn(),
+		timeScale: 1,
+		setTimeScale: vi.fn(),
+		toasts: [],
+		pushToast: vi.fn(),
+		pushErrorToast: vi.fn(),
+		pushSuccessToast: vi.fn(),
+		dismissToast: vi.fn(),
+		playerName: 'Player',
+		onChangePlayerName: vi.fn(),
+	};
+	const resourceForecast = Object.keys(RESOURCES).reduce<
+		Record<string, number>
+	>((acc, key, index) => {
+		const offset = index + 1;
+		acc[key] = index % 2 === 0 ? offset : -offset;
+		return acc;
+	}, {});
+	const displayableStatKeys = Object.entries(activePlayer.stats)
+		.filter(([statKey, statValue]) => {
+			const info = STATS[statKey as keyof typeof STATS];
+			if (info.capacity) {
+				return false;
+			}
+			if (statValue !== 0) {
+				return true;
+			}
+			return Boolean(activePlayer.statsHistory?.[statKey]);
+		})
+		.map(([statKey]) => statKey);
+	const statForecast = displayableStatKeys.reduce<Record<string, number>>(
+		(acc, key, index) => {
+			const offset = index + 2;
+			acc[key] = index % 2 === 0 ? offset : -offset;
+			return acc;
+		},
+		{},
+	);
+	return {
+		activePlayer,
+		mockGame,
+		resourceForecast,
+		displayableStatKeys,
+		statForecast,
+	};
+}

--- a/packages/web/tests/helpers/sessionFixtures.ts
+++ b/packages/web/tests/helpers/sessionFixtures.ts
@@ -1,0 +1,231 @@
+import type {
+	EffectDef,
+	EngineSessionSnapshot,
+	PassiveRecordSnapshot,
+	PlayerId,
+	PlayerStateSnapshot,
+	RuleSnapshot,
+} from '@kingdom-builder/engine';
+import type { ResourceKey } from '@kingdom-builder/contents';
+import type { PlayerStartConfig } from '@kingdom-builder/protocol';
+
+interface SnapshotPlayerOptions {
+	id: PlayerId;
+	name?: string;
+	resources?: Record<string, number>;
+	stats?: Record<string, number>;
+	statsHistory?: Record<string, boolean>;
+	population?: Record<string, number>;
+	lands?: PlayerStateSnapshot['lands'];
+	buildings?: string[];
+	actions?: string[];
+	statSources?: PlayerStateSnapshot['statSources'];
+	skipPhases?: PlayerStateSnapshot['skipPhases'];
+	skipSteps?: PlayerStateSnapshot['skipSteps'];
+	passives?: PlayerStateSnapshot['passives'];
+}
+
+export function createSnapshotPlayer({
+	id,
+	name = `Player ${id}`,
+	resources = {},
+	stats = {},
+	statsHistory = {},
+	population = {},
+	lands = [],
+	buildings = [],
+	actions = [],
+	statSources = {},
+	skipPhases = {},
+	skipSteps = {},
+	passives = [],
+}: SnapshotPlayerOptions): PlayerStateSnapshot {
+	const clonedStatSources: PlayerStateSnapshot['statSources'] = {};
+	for (const [statId, contributions] of Object.entries(statSources)) {
+		const clonedContributions: Record<
+			string,
+			{ amount: number; meta: unknown }
+		> = {};
+		for (const [sourceId, entry] of Object.entries(contributions)) {
+			clonedContributions[sourceId] = {
+				amount: entry.amount,
+				meta: entry.meta,
+			};
+		}
+		clonedStatSources[statId] = clonedContributions;
+	}
+	const clonedSkipPhases: PlayerStateSnapshot['skipPhases'] = {};
+	for (const [phaseId, sources] of Object.entries(skipPhases)) {
+		clonedSkipPhases[phaseId] = { ...sources };
+	}
+	const clonedSkipSteps: PlayerStateSnapshot['skipSteps'] = {};
+	for (const [phaseId, stepMap] of Object.entries(skipSteps)) {
+		const clonedStepMap: Record<string, Record<string, true>> = {};
+		for (const [stepId, stepSources] of Object.entries(stepMap)) {
+			clonedStepMap[stepId] = { ...stepSources };
+		}
+		clonedSkipSteps[phaseId] = clonedStepMap;
+	}
+	return {
+		id,
+		name,
+		resources: { ...resources },
+		stats: { ...stats },
+		statsHistory: { ...statsHistory },
+		population: { ...population },
+		lands: lands.map((land) => ({
+			...land,
+			developments: [...land.developments],
+			slots: land.slots.map((slot) => ({ ...slot })),
+		})),
+		buildings: [...buildings],
+		actions: [...actions],
+		statSources: clonedStatSources,
+		skipPhases: clonedSkipPhases,
+		skipSteps: clonedSkipSteps,
+		passives: passives.map((passive) => ({
+			...passive,
+			meta: passive.meta ? { ...passive.meta } : undefined,
+		})),
+	};
+}
+
+interface PassiveRecordOptions {
+	id: string;
+	owner: PlayerId;
+	name?: string;
+	icon?: string;
+	detail?: string;
+	meta?: PassiveRecordSnapshot['meta'];
+	effects?: EffectDef[];
+	onGrowthPhase?: EffectDef[];
+	onUpkeepPhase?: EffectDef[];
+	onBeforeAttacked?: EffectDef[];
+	onAttackResolved?: EffectDef[];
+}
+
+export function createPassiveRecord({
+	id,
+	owner,
+	name,
+	icon,
+	detail,
+	meta,
+	effects,
+	onGrowthPhase,
+	onUpkeepPhase,
+	onBeforeAttacked,
+	onAttackResolved,
+}: PassiveRecordOptions): PassiveRecordSnapshot {
+	const record: PassiveRecordSnapshot = {
+		id,
+		owner,
+	} as PassiveRecordSnapshot;
+	if (name !== undefined) {
+		record.name = name;
+	}
+	if (icon !== undefined) {
+		record.icon = icon;
+	}
+	if (detail !== undefined) {
+		record.detail = detail;
+	}
+	if (meta !== undefined) {
+		record.meta = { ...meta };
+	}
+	if (effects) {
+		record.effects = effects.map((effect) => ({ ...effect }));
+	}
+	if (onGrowthPhase) {
+		record.onGrowthPhase = onGrowthPhase.map((effect) => ({ ...effect }));
+	}
+	if (onUpkeepPhase) {
+		record.onUpkeepPhase = onUpkeepPhase.map((effect) => ({ ...effect }));
+	}
+	if (onBeforeAttacked) {
+		record.onBeforeAttacked = onBeforeAttacked.map((effect) => ({ ...effect }));
+	}
+	if (onAttackResolved) {
+		record.onAttackResolved = onAttackResolved.map((effect) => ({ ...effect }));
+	}
+	return record;
+}
+
+interface SessionSnapshotOptions {
+	players: PlayerStateSnapshot[];
+	activePlayerId: PlayerId;
+	opponentId: PlayerId;
+	phases: EngineSessionSnapshot['phases'];
+	actionCostResource: ResourceKey;
+	ruleSnapshot: RuleSnapshot;
+	passiveRecords?: Record<PlayerId, PassiveRecordSnapshot[]>;
+	compensations?: Record<PlayerId, PlayerStartConfig>;
+	recentResourceGains?: EngineSessionSnapshot['recentResourceGains'];
+	turn?: number;
+	currentPhase?: string;
+	currentStep?: string;
+	phaseIndex?: number;
+	stepIndex?: number;
+	devMode?: boolean;
+}
+
+export function createSessionSnapshot({
+	players,
+	activePlayerId,
+	opponentId,
+	phases,
+	actionCostResource,
+	ruleSnapshot,
+	passiveRecords = {},
+	compensations = {},
+	recentResourceGains = [],
+	turn = 1,
+	currentPhase,
+	currentStep,
+	phaseIndex = 0,
+	stepIndex = 0,
+	devMode = false,
+}: SessionSnapshotOptions): EngineSessionSnapshot {
+	const phase = phases[phaseIndex] ?? phases[0];
+	const resolvedCurrentPhase =
+		currentPhase ?? phase?.id ?? phases[0]?.id ?? 'phase-0';
+	const resolvedCurrentStep =
+		currentStep ?? phase?.steps?.[stepIndex]?.id ?? resolvedCurrentPhase;
+	const activeIndex = players.findIndex(
+		(player) => player.id === activePlayerId,
+	);
+	const opponentIndex = players.findIndex((player) => player.id === opponentId);
+	const normalizedCompensations: Record<PlayerId, PlayerStartConfig> =
+		{} as Record<PlayerId, PlayerStartConfig>;
+	const normalizedPassiveRecords: Record<PlayerId, PassiveRecordSnapshot[]> =
+		{} as Record<PlayerId, PassiveRecordSnapshot[]>;
+	for (const player of players) {
+		normalizedCompensations[player.id] = {
+			...(compensations[player.id] ?? {}),
+		} as PlayerStartConfig;
+		normalizedPassiveRecords[player.id] = (passiveRecords[player.id] ?? []).map(
+			(record) => ({ ...record }),
+		);
+	}
+	return {
+		game: {
+			turn,
+			currentPlayerIndex: activeIndex >= 0 ? activeIndex : 0,
+			currentPhase: resolvedCurrentPhase,
+			currentStep: resolvedCurrentStep,
+			phaseIndex,
+			stepIndex,
+			devMode,
+			players,
+			activePlayerId,
+			opponentId:
+				opponentIndex >= 0 ? opponentId : (players[0]?.id ?? activePlayerId),
+		},
+		phases,
+		actionCostResource,
+		recentResourceGains: recentResourceGains.map((gain) => ({ ...gain })),
+		compensations: normalizedCompensations,
+		rules: ruleSnapshot,
+		passiveRecords: normalizedPassiveRecords,
+	};
+}


### PR DESCRIPTION
## Summary
- Build the `ResourceBar`, `PassiveDisplay`, and `PlayerPanel` component tests from `EngineSessionSnapshot` data wired through the translation context instead of legacy mocked contexts.
- Introduce reusable snapshot-aware helpers for players, sessions, and passive scenarios to keep the new tests declarative and aligned with engine data.
- Refresh the passive display game factory to supply translation-ready mocks so hover cards and summaries exercise the production formatting paths.

## Text formatting audit (required)
1. **Translator/formatter reuse:** [`createTranslationContext`](packages/web/src/translation/context.ts), [`describeEffects`](packages/web/src/translation/index.ts), [`splitSummary`](packages/web/src/translation/index.ts), [`buildTierEntries`](packages/web/src/components/player/buildTierEntries.tsx), [`resolvePassivePresentation`](packages/web/src/translation/log/passives.ts), [`formatPassiveRemoval`](packages/web/src/translation/log/passives.ts), [`formatStatValue`](packages/web/src/utils/stats.ts).
2. **Canonical keywords/icons/helpers touched:** `RULES.tieredResourceKey`, `RESOURCES`, `PHASES`, `ACTIONS`, `BUILDINGS`, `DEVELOPMENTS`, `STATS`, passive removal metadata tokens.
3. **Voice review:** Tests only; no player-facing copy changed.

## Standards compliance (required)
1. **File length limits respected:** Longest new helper (`packages/web/tests/helpers/sessionFixtures.ts`) is 231 lines (<250).
2. **Line length limits respected:** Updates are confined to test fixtures where existing suite conventions allow longer strings for accessibility labels and assertions.
3. **Domain separation upheld:** Tests source rule, resource, and passive metadata exclusively through engine snapshots and translation helpers, avoiding hard-coded game data.
4. **Code standards satisfied:** `npm run check` completed successfully (see console log below).
5. **Tests updated:** Component test suites were rewritten and executed via targeted `vitest` runs (see Testing section).
6. **Documentation updated:** Not required; test-only change.
7. **`npm run check` results:** Ran locally; refer to the `npm run check` invocation in the logs below (command exited without errors).
8. **`npm run test:coverage` results:** Ran locally; see the full coverage summary emitted by `vitest` in the logs below (all tests passed).

## Testing
- `npm test -- --run packages/web/tests/resource-bar.test.tsx packages/web/tests/passive-display.test.tsx packages/web/tests/PlayerPanel.test.tsx`
- `npm run check`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68e6772cee748325904ec414bb66d33f