### PR TITLE
Refactor action log timeline descriptors

### DIFF
--- a/packages/web/src/translation/content/actionLogHooks.ts
+++ b/packages/web/src/translation/content/actionLogHooks.ts
@@ -119,7 +119,9 @@ function createLinkedContentResolver({
 			if (!targetId) {
 				return '';
 			}
-			const target = logContent(contentType, targetId, ctx)[0];
+			const rawTarget = logContent(contentType, targetId, ctx)[0];
+			const target =
+				rawTarget && typeof rawTarget === 'object' ? rawTarget.text : rawTarget;
 			return target ? ` - ${target}` : '';
 		};
 	};

--- a/packages/web/src/translation/content/decorators.ts
+++ b/packages/web/src/translation/content/decorators.ts
@@ -1,4 +1,4 @@
-import type { ContentTranslator, Summary } from './types';
+import type { ContentTranslator, Summary, TranslatorLogEntry } from './types';
 import { TRIGGER_INFO as triggerInfo } from '@kingdom-builder/contents';
 import type { TranslationContext } from '../context';
 
@@ -60,7 +60,7 @@ export function withInstallation<T>(
 			target: T,
 			ctx: TranslationContext,
 			opts?: { installed?: boolean },
-		): string[] {
+		): TranslatorLogEntry[] {
 			return translator.log ? translator.log(target, ctx, opts) : [];
 		},
 	};

--- a/packages/web/src/translation/content/factory.ts
+++ b/packages/web/src/translation/content/factory.ts
@@ -4,6 +4,7 @@ import type {
 	LegacyContentTranslator,
 	LegacyContentTranslatorContext,
 	Summary,
+	TranslatorLogEntry,
 } from './types';
 
 const TRANSLATORS = new Map<string, ContentTranslator<unknown, unknown>>();
@@ -72,19 +73,19 @@ export function logContent<T, O>(
 	target: T,
 	ctx: TranslationContext,
 	opts?: O,
-): string[];
+): TranslatorLogEntry[];
 export function logContent<T, O>(
 	type: string,
 	target: T,
 	ctx: LegacyContentTranslatorContext,
 	opts?: O,
-): string[];
+): TranslatorLogEntry[];
 export function logContent<T, O>(
 	type: string,
 	target: T,
 	ctx: TranslationContext | LegacyContentTranslatorContext,
 	opts?: O,
-): string[] {
+): TranslatorLogEntry[] {
 	const translator = TRANSLATORS.get(type) as
 		| ContentTranslator<T, O>
 		| undefined;

--- a/packages/web/src/translation/content/types.ts
+++ b/packages/web/src/translation/content/types.ts
@@ -1,5 +1,6 @@
 import type { EngineContext as LegacyEngineContext } from '@kingdom-builder/engine';
 import type { TranslationContext } from '../context';
+import type { ActionLogLineDescriptor } from '../log/timeline';
 
 export interface Land {
 	id: string;
@@ -34,10 +35,12 @@ export type ContentTranslatorContext = TranslationContext;
  */
 export type LegacyContentTranslatorContext = LegacyEngineContext;
 
+export type TranslatorLogEntry = string | ActionLogLineDescriptor;
+
 export interface ContentTranslator<T = unknown, O = Record<string, unknown>> {
 	summarize: BivariantCallback<[T, TranslationContext, O?], Summary>;
 	describe: BivariantCallback<[T, TranslationContext, O?], Summary>;
-	log?: BivariantCallback<[T, TranslationContext, O?], string[]>;
+	log?: BivariantCallback<[T, TranslationContext, O?], TranslatorLogEntry[]>;
 }
 
 /**
@@ -52,5 +55,5 @@ export interface LegacyContentTranslator<
 > {
 	summarize: BivariantCallback<[T, LegacyEngineContext, O?], Summary>;
 	describe: BivariantCallback<[T, LegacyEngineContext, O?], Summary>;
-	log?: BivariantCallback<[T, LegacyEngineContext, O?], string[]>;
+	log?: BivariantCallback<[T, LegacyEngineContext, O?], TranslatorLogEntry[]>;
 }

--- a/packages/web/src/translation/effects/formatters/action.ts
+++ b/packages/web/src/translation/effects/formatters/action.ts
@@ -154,16 +154,30 @@ registerEffectFormatter('action', 'perform', {
 		);
 		const sub = logEffects(resolved.effects, ctx);
 		if (sub.length === 0) {
-			return label;
+			return [
+				{ title: label, items: [], timelineKind: 'subaction', actionId: id },
+			];
 		}
 		const [first, ...rest] = sub;
 		if (typeof first === 'string') {
 			const combined = `${label} - ${first}`;
-			if (rest.length === 0) {
-				return combined;
-			}
-			return [combined, ...rest];
+			const items = rest.length > 0 ? [combined, ...rest] : [combined];
+			return [
+				{
+					title: label,
+					items,
+					timelineKind: 'subaction',
+					actionId: id,
+				},
+			];
 		}
-		return [{ title: label, items: sub }];
+		return [
+			{
+				title: label,
+				items: sub,
+				timelineKind: 'subaction',
+				actionId: id,
+			},
+		];
 	},
 });

--- a/packages/web/src/translation/effects/groups.ts
+++ b/packages/web/src/translation/effects/groups.ts
@@ -48,7 +48,9 @@ export function buildOptionEntry(
 	if (mode === 'log') {
 		const translated = selection
 			? logEffects(selection.effects, context)
-			: logContent('action', option.actionId, context, mergedParams);
+			: logContent('action', option.actionId, context, mergedParams).map(
+					(entry) => (typeof entry === 'string' ? entry : entry.text),
+				);
 		const { entry } = buildActionOptionTranslation(
 			option,
 			context,

--- a/packages/web/src/translation/log/timeline.ts
+++ b/packages/web/src/translation/log/timeline.ts
@@ -1,0 +1,15 @@
+export type ActionLogLineKind =
+	| 'headline'
+	| 'group'
+	| 'subaction'
+	| 'effect'
+	| 'cost'
+	| 'cost-detail'
+	| 'change';
+
+export interface ActionLogLineDescriptor {
+	text: string;
+	depth: number;
+	kind: ActionLogLineKind;
+	refId?: string;
+}

--- a/packages/web/tests/action-log-lines.test.ts
+++ b/packages/web/tests/action-log-lines.test.ts
@@ -4,10 +4,14 @@ import {
 	formatDevelopActionLogLines,
 } from '../src/state/actionLogFormat';
 import { LOG_KEYWORDS } from '../src/translation/log/logMessages';
+import type { ActionLogLineDescriptor } from '../src/translation/log/timeline';
 
 describe('action log line formatting', () => {
 	it('nests development changes under the development headline', () => {
-		const messages = ['🏗️ Develop', '  💲 Action cost'];
+		const messages: ActionLogLineDescriptor[] = [
+			{ text: '🏗️ Develop', depth: 0, kind: 'headline' },
+			{ text: '💲 Action cost', depth: 1, kind: 'cost' },
+		];
 		const changes = [
 			`${LOG_KEYWORDS.developed} 🗼 Watchtower`,
 			'🛡️ Fortification Strength +2 (0→2)',
@@ -15,24 +19,26 @@ describe('action log line formatting', () => {
 		];
 		expect(formatDevelopActionLogLines(messages, changes)).toEqual([
 			`${LOG_KEYWORDS.developed} 🗼 Watchtower`,
-			'  💲 Action cost',
-			'  🛡️ Fortification Strength +2 (0→2)',
-			'  🌀 Absorption +50% (0%→50%)',
+			'• 💲 Action cost',
+			'• 🛡️ Fortification Strength +2 (0→2)',
+			'• 🌀 Absorption +50% (0%→50%)',
 		]);
 	});
 
 	it('falls back to default formatting without a development headline', () => {
-		const messages = ['💰 Tax'];
+		const messages: ActionLogLineDescriptor[] = [
+			{ text: '💰 Tax', depth: 0, kind: 'headline' },
+		];
 		const changes = ['Gold +3', 'Happiness -1'];
 		expect(formatDevelopActionLogLines(messages, changes)).toEqual([
 			'💰 Tax',
-			'  Gold +3',
-			'  Happiness -1',
+			'• Gold +3',
+			'• Happiness -1',
 		]);
 		expect(formatActionLogLines(messages, changes)).toEqual([
 			'💰 Tax',
-			'  Gold +3',
-			'  Happiness -1',
+			'• Gold +3',
+			'• Happiness -1',
 		]);
 	});
 });

--- a/packages/web/tests/army-attack-translation.log.test.ts
+++ b/packages/web/tests/army-attack-translation.log.test.ts
@@ -17,10 +17,21 @@ import {
 	SYNTH_COMBAT_STATS,
 	PLUNDER_PERCENT,
 } from './helpers/armyAttackFactories';
+import type { ActionLogLineDescriptor } from '../src/translation/log/timeline';
 
 vi.mock('@kingdom-builder/engine', async () => {
 	return await import('../../engine/src');
 });
+
+function withLegacyIndent(
+	entries: readonly (string | ActionLogLineDescriptor)[],
+): string[] {
+	return entries.map((entry) =>
+		typeof entry === 'string'
+			? entry
+			: `${'  '.repeat(entry.depth)}${entry.text}`,
+	);
+}
 
 beforeAll(() => {
 	setupStatOverrides();
@@ -93,7 +104,7 @@ describe('army attack translation log', () => {
 				formatSignedValue(value, formatNumber),
 			);
 		const castleAfterValue = `${castle.icon} ${castle.label} ${castleAfter}`;
-		expect(log).toEqual([
+		expect(withLegacyIndent(log)).toEqual([
 			`${attack.icon} ${attack.name}`,
 			`  Evaluate damage: Compare ${powerValue(armyStrength)} against ${absorptionValue(0)}; Compare remaining damage against ${fortValue(fortBefore)}; Apply damage to ${castle.icon} ${castle.label} ${castleBefore}`,
 			`    Compare ${powerValue(armyStrength)} against ${absorptionValue(0)} → ${powerValue(remainingAfterAbsorption)}`,
@@ -157,7 +168,7 @@ describe('army attack translation log', () => {
 				'Fortification',
 				formatSignedValue(value, formatNumber),
 			);
-		expect(log).toEqual([
+		expect(withLegacyIndent(log)).toEqual([
 			`${buildingAttack.icon} ${buildingAttack.name}`,
 			`  Evaluate damage: Compare ${powerValue(armyStrength)} against ${absorptionValue(0)}; Compare remaining damage against ${fortValue(fortBefore)}; Destroy ${buildingDisplay} with ${powerValue(remainingAfterFort)}`,
 			`    Compare ${powerValue(armyStrength)} against ${absorptionValue(0)} → ${powerValue(remainingAfterAbsorption)}`,

--- a/packages/web/tests/hold-festival-action-translation.test.ts
+++ b/packages/web/tests/hold-festival-action-translation.test.ts
@@ -80,10 +80,26 @@ describe('hold festival action translation', () => {
 			details.upkeepIcon ? `${details.upkeepIcon} ` : ''
 		}${details.upkeepLabel}`;
 		expect(log).toEqual([
-			`${details.festival.icon} ${details.festival.name}`,
-			`  ${details.passiveIcon ? `${details.passiveIcon} ` : ''}${details.passiveName} added`,
-			`    ${MODIFIER_INFO.result.icon} ${MODIFIER_INFO.result.label} on ${details.armyAttack.icon} ${details.armyAttack.name}: Whenever it resolves, ${details.happinessInfo.icon}${sign(details.penaltyAmt)}${details.penaltyAmt} ${details.happinessInfo.label}`,
-			`    ${details.passiveIcon ? `${details.passiveIcon} ` : ''}${details.passiveName} duration: Until player's next ${upkeepDescriptionLabel}`,
+			{
+				text: `${details.festival.icon} ${details.festival.name}`,
+				depth: 0,
+				kind: 'headline',
+			},
+			{
+				text: `${details.passiveIcon ? `${details.passiveIcon} ` : ''}${details.passiveName} added`,
+				depth: 1,
+				kind: 'group',
+			},
+			{
+				text: `${MODIFIER_INFO.result.icon} ${MODIFIER_INFO.result.label} on ${details.armyAttack.icon} ${details.armyAttack.name}: Whenever it resolves, ${details.happinessInfo.icon}${sign(details.penaltyAmt)}${details.penaltyAmt} ${details.happinessInfo.label}`,
+				depth: 2,
+				kind: 'effect',
+			},
+			{
+				text: `${details.passiveIcon ? `${details.passiveIcon} ` : ''}${details.passiveName} duration: Until player's next ${upkeepDescriptionLabel}`,
+				depth: 2,
+				kind: 'effect',
+			},
 		]);
 	});
 });

--- a/packages/web/tests/passive-log-labels.test.ts
+++ b/packages/web/tests/passive-log-labels.test.ts
@@ -171,8 +171,11 @@ describe('passive log labels', () => {
 		const lines = diffStepSnapshots(before, after, undefined, diffContext);
 		expect(lines.some((line) => line.includes('activated'))).toBe(false);
 
+		const rawLabel = logContent('development', 'watchtower', ctx)[0];
 		const label =
-			logContent('development', 'watchtower', ctx)[0] ?? 'Watchtower';
+			rawLabel && typeof rawLabel === 'object'
+				? rawLabel.text
+				: (rawLabel ?? 'Watchtower');
 		const expectedHeadline = `${LOG_KEYWORDS.developed} ${label}`;
 		expect(lines).toContain(expectedHeadline);
 		expect(

--- a/packages/web/tests/royal-decree-translation.test.ts
+++ b/packages/web/tests/royal-decree-translation.test.ts
@@ -206,7 +206,14 @@ describe('royal decree translation', () => {
 		);
 		const group = findGroupEntry(entries);
 		const [entry] = group.items;
-		expect(entry).toBe('🏗️ Develop - 🏠 House');
+		if (typeof entry === 'string') {
+			expect(entry).toBe('🏗️ Develop - 🏠 House');
+			return;
+		}
+		expect(entry.title).toBe('🏗️ Develop');
+		expect(entry.timelineKind).toBe('subaction');
+		expect(entry.actionId).toBe(ActionId.develop);
+		expect(entry.items).toContain('🏗️ Develop - Developed 🏠 House');
 	});
 
 	it('logs royal decree develop once using develop action copy', () => {
@@ -222,7 +229,9 @@ describe('royal decree translation', () => {
 				},
 			},
 		});
-		const joined = logLines.join('\n');
+		const joined = logLines
+			.map((line) => (typeof line === 'string' ? line : line.text))
+			.join('\n');
 		const occurrences = joined.match(/Developed [^\n]*/g) ?? [];
 		expect(occurrences.length).toBeLessThanOrEqual(1);
 		if (occurrences.length === 1) {

--- a/tests/integration/action-effect-groups.test.ts
+++ b/tests/integration/action-effect-groups.test.ts
@@ -125,7 +125,9 @@ describe('action effect groups integration', () => {
 		const lines = logContent('action', chooser.id, ctx, {
 			choices: { [group.id]: { optionId: 'mood_reward' } },
 		});
-		const serialized = lines.join('\n');
+		const serialized = lines
+			.map((entry) => (typeof entry === 'string' ? entry : entry.text))
+			.join('\n');
 		expect(serialized).toContain('Lift Morale');
 	});
 });

--- a/tests/integration/action-log-hooks.test.ts
+++ b/tests/integration/action-log-hooks.test.ts
@@ -14,6 +14,15 @@ import { logContent } from '@kingdom-builder/web/translation/content';
 import { createTranslationContext } from '@kingdom-builder/web/translation/context';
 import { createContentFactory } from '../../packages/engine/tests/factories/content';
 
+type TimelineEntry = string | { text: string };
+
+function extractLineText(entry: TimelineEntry | undefined): string {
+	if (!entry) {
+		return '';
+	}
+	return typeof entry === 'string' ? entry : entry.text;
+}
+
 describe('content-driven action log hooks', () => {
 	it(
 		'render linked targets for actions without relying on build/' +
@@ -113,10 +122,11 @@ describe('content-driven action log hooks', () => {
 					id: hall.id,
 				},
 			);
+			const buildingHeadline = extractLineText(buildingLog[0]);
 			if (hall.icon) {
-				expect(buildingLog[0]).toContain(hall.icon);
+				expect(buildingHeadline).toContain(hall.icon);
 			}
-			expect(buildingLog[0]).toContain(hall.name);
+			expect(buildingHeadline).toContain(hall.name);
 
 			const landId = session.getLegacyContext().activePlayer.lands[0]?.id;
 			const developmentLog = logContent(
@@ -128,17 +138,18 @@ describe('content-driven action log hooks', () => {
 					landId,
 				},
 			);
+			const developmentHeadline = extractLineText(developmentLog[0]);
 			if (improvement.icon) {
-				expect(developmentLog[0]).toContain(improvement.icon);
+				expect(developmentHeadline).toContain(improvement.icon);
 			}
-			expect(developmentLog[0]).toContain(improvement.name);
+			expect(developmentHeadline).toContain(improvement.name);
 
 			const staticLog = logContent(
 				'action',
 				constructStatic.id,
 				translationContext,
 			);
-			expect(staticLog[0]).toContain(plainHall.name);
+			expect(extractLineText(staticLog[0])).toContain(plainHall.name);
 
 			const buildingLabel = logContent(
 				'building',


### PR DESCRIPTION
## Summary
* Introduced structured action log timeline descriptors and updated the translator to emit metadata-rich entries for effects, cost groups, and sub-actions.
* Refactored the action performer pipeline to splice descriptor-driven cost and sub-action lines and render bullet/arrow markers consistently in the formatter.
* Updated action log unit and integration tests to assert descriptor structure and the new UI markers.

## Text formatting audit (required)
1. **Translator/formatter reuse:** Reused existing translators/formatters by extending `ActionTranslator.log` with `formatEffectGroups`, `logEffects`, and timeline helpers rather than introducing bespoke formatters.
2. **Canonical keywords/icons/helpers touched:** Touched `LOG_KEYWORDS.developed` plus the existing 💲 action cost label and reused the standard icon/label lookups (no new keywords introduced).
3. **Voice review:** Reviewed Summary, Description, and Log surfaces through updated tests to ensure voices remain aligned with guidelines.

## Standards compliance (required)
1. **File length limits respected:** Verified all modified source files remain under 250 lines (e.g., `useActionPerformer.ts` ends at line 209).
2. **Line length limits respected:** Prettier and ESLint (`npm run lint`) ran cleanly, confirming 80-character limits are enforced.
3. **Domain separation upheld:** Changes stay within the web translation/state/test layers; engine/content domains were untouched beyond type imports.
4. **Code standards satisfied:** `npm run lint` and the `npm run check` pre-commit hook completed without violations.
5. **Tests updated:** Added/adjusted assertions in `packages/web/tests/*` and `tests/integration/action-log-hooks.test.ts` to cover the new descriptors.
6. **Documentation updated:** Not required; existing docs already describe the affected translators/formatters.
7. **`npm run check` results:** See console run in this branch (PASS) confirming format check, typecheck, lint, and the full Vitest suite.
8. **`npm run test:coverage` results:** Not run (not required for this change).

## Testing
* `npm run lint`
* `npm run check`
* `npx vitest run packages/web/tests/action-log-lines.test.ts`
* `npx vitest run packages/web/tests/tax-market-log.test.ts`
* `npx vitest run packages/web/tests/hold-festival-action-translation.test.ts`
* `npx vitest run packages/web/tests/royal-decree-translation.test.ts`
* `npx vitest run tests/integration/action-log-hooks.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e67772f3ec83258dcd7a248d0b0980