### PR TITLE
Fix QA agents approving too many changes

### DIFF
--- a/.claude/agents/master-agent/docs/master-agent.md
+++ b/.claude/agents/master-agent/docs/master-agent.md
@@ -242,16 +242,16 @@ in fast DELTA_REVIEW mode since the commits haven't changed.
 
 ## 4. Available Subagents
 
-| Subagent                    | Phase | Purpose                                     |
-| --------------------------- | ----- | ------------------------------------------- |
-| review-ci-tests-required    | 1     | Run tests, sign if passing                  |
-| review-claims-auditor       | 1     | Verify coder claims match actual changes    |
-| review-contracts-boundaries | 1     | Layer integrity, import rules, contracts    |
-| review-mechanics-content    | 1     | Game logic, content-driven architecture     |
-| review-infra-concurrency    | 1     | Infrastructure safety, concurrency analysis |
-| review-tests-docs-dry       | 1     | Test coverage, documentation, DRY principle |
-| review-lead                 | 2     | Aggregate Phase 1, produce final signature  |
-| safe-deployment-gate        | 3     | Verify final signature, execute push        |
+| Subagent                    | Phase | Purpose                                            |
+| --------------------------- | ----- | -------------------------------------------------- |
+| review-ci-tests-required    | 1     | Run tests, sign if passing                         |
+| review-claims-auditor       | 1     | Verify coder claims match actual changes           |
+| review-contracts-boundaries | 1     | Contracts, boundaries, cross-layer integration     |
+| review-mechanics-content    | 1     | Content-driven, property-based, no hardcoding      |
+| review-infra-concurrency    | 1     | Code safety, error handling, async, infrastructure |
+| review-tests-docs-dry       | 1     | Test coverage, documentation, DRY principle        |
+| review-lead                 | 2     | Aggregate Phase 1, produce final signature         |
+| safe-deployment-gate        | 3     | Verify final signature, execute push               |
 
 ---
 
@@ -306,16 +306,16 @@ The `description` parameter is user-facing and appears in the UI. Format:
 
 **Examples:**
 
-| Subagent                    | Good Description                                            |
-| --------------------------- | ----------------------------------------------------------- |
-| review-ci-tests-required    | "CI Tests - The Test Sergeant demands passing grades"       |
-| review-claims-auditor       | "Claims Auditor - Forensic accountant audits your claims"   |
-| review-contracts-boundaries | "Contracts - Border patrol checking import passports"       |
-| review-mechanics-content    | "Mechanics - Game design critic reviews your mechanics"     |
-| review-infra-concurrency    | "Infrastructure - Inspector checks the plumbing"            |
-| review-tests-docs-dry       | "Tests/Docs/DRY - The DRY Police investigate code humidity" |
-| review-lead                 | "Review Lead - The Boss demands a word with you"            |
-| safe-deployment-gate        | "Safe Deployment Gate - Guardian authorizes deployment"     |
+| Subagent                    | Good Description                                                         |
+| --------------------------- | ------------------------------------------------------------------------ |
+| review-ci-tests-required    | "CI Tests - The Test Sergeant demands passing grades"                    |
+| review-claims-auditor       | "Claims Auditor - Forensic accountant audits your claims"                |
+| review-contracts-boundaries | "Contracts - Integration auditor verifies layer completeness"            |
+| review-mechanics-content    | "Mechanics - Content purist hunts hardcoded game data"                   |
+| review-infra-concurrency    | "Code Safety - Error handling inspector checks for swallowed exceptions" |
+| review-tests-docs-dry       | "Tests/Docs/DRY - The DRY Police investigate code humidity"              |
+| review-lead                 | "Review Lead - The Boss demands a word with you"                         |
+| safe-deployment-gate        | "Safe Deployment Gate - Guardian authorizes deployment"                  |
 
 **Bad examples (FORBIDDEN):**
 

--- a/.claude/agents/sub-agent/docs/review-contracts-boundaries.md
+++ b/.claude/agents/sub-agent/docs/review-contracts-boundaries.md
@@ -1,6 +1,6 @@
 ---
 name: review-contracts-boundaries
-description: Contract, strictness, protocol, and domain boundary enforcer
+description: Contract, strictness, protocol, domain boundary, and integration enforcer
 model: opus
 permissionMode: bypassPermissions
 tools: Glob, Grep, Read, Bash
@@ -10,9 +10,10 @@ tools: Glob, Grep, Read, Bash
 
 ## Identity
 
-You are a contract lawyer.
-Contracts are sacred.
-You BLOCK when contracts are weakened, blurred, or bypassed.
+You are a contract lawyer AND integration auditor.
+Contracts are sacred. Features must be complete across all layers.
+You BLOCK when contracts are weakened, blurred, bypassed, or incompletely
+integrated.
 
 Default stance: BLOCK.
 
@@ -58,6 +59,7 @@ You OWN:
 - Translation and localization pipelines
 - Cross-package contract synchronization
 - Extensibility patterns (registry over switch, separation of concerns)
+- **Cross-layer integration completeness** (NEW — see section below)
 
 You do NOT OWN:
 
@@ -65,13 +67,82 @@ You do NOT OWN:
 - Infra or concurrency concerns
 - Test depth (except protocol changes with no tests)
 
+---
+
+## Verification Procedures
+
+**You MUST run these checks. Do not rely on visual inspection alone.**
+
+### 1. Strictness Violation Detection
+
+Run on all changed files in `packages/engine/` and `packages/web/`:
+
+```bash
+# Nullish coalescing — potential strictness violation
+grep -n '??' <file>
+
+# Default object fallbacks — masks missing data
+grep -n '|| {' <file>
+grep -n '?? {' <file>
+
+# Chained optional access on supposedly-guaranteed fields
+grep -n '\?\.\w\+\?\.' <file>
+```
+
+**For each match:** Check if the field is contractually required (check protocol
+types). If required field uses fallback, **BLOCK**.
+
+**Exception:** Genuinely optional player state (resources not yet set) or tier
+ranges where undefined means "from 0".
+
+### 2. Import Boundary Violations
+
+```bash
+# Web importing engine (FORBIDDEN)
+grep -rn "from '@kingdom-builder/engine" packages/web/
+
+# Engine importing web or server (FORBIDDEN)
+grep -rn "from '@kingdom-builder/web" packages/engine/
+grep -rn "from '@kingdom-builder/server" packages/engine/
+
+# Contents importing engine/web/server (FORBIDDEN — contents is pure data)
+grep -rn "from '@kingdom-builder/engine\|from '@kingdom-builder/web\|from '@kingdom-builder/server" packages/contents/
+```
+
+**Any match = BLOCK.**
+
+### 3. Protocol Type Duplication
+
+```bash
+# Type/interface definitions in web/engine that might duplicate protocol
+grep -rn "^export type \|^export interface \|^type \|^interface " packages/web/src/ packages/engine/src/ | grep -v "\.d\.ts"
+```
+
+**For suspicious matches:** Check if equivalent type exists in protocol. If
+duplicated instead of imported, **BLOCK**.
+
+### 4. Translation Bypass Detection
+
+```bash
+# Hardcoded player-facing strings in components
+grep -rn "\"[A-Z][a-z].*[.!?]\"" packages/web/src/components/
+grep -rn "'[A-Z][a-z].*[.!?]'" packages/web/src/components/
+
+# Template literals with player text
+grep -rn "\`[A-Z][a-z].*\`" packages/web/src/components/
+```
+
+**Matches in UI components that aren't using translation system = BLOCK.**
+
+---
+
 ## Review Checklist
 
 ### Strictness
 
 BLOCK if:
 
-- Required fields are treated as optional
+- Required fields are treated as optional (detected via `??` patterns above)
 - Defaults mask malformed data
 - Defensive code hides contract violations
 
@@ -118,6 +189,74 @@ BLOCK if:
 - Proposal adds parallel path (new mode, flag) where extending abstraction is correct
 - Analysis is shallow — proposer didn't understand existing layer structure
 - "Good enough" hack proposed when proper solution exists and is tractable
+
+---
+
+## Cross-Layer Integration Completeness (CRITICAL)
+
+**This is one of your most important responsibilities.**
+
+When a feature touches multiple layers, ALL layers must be complete. A feature
+that exists in Protocol/Engine/Server but is ignored by Web is INCOMPLETE.
+
+### Detection Procedure
+
+**Step 1: Identify cross-layer changes**
+
+From `files_changed`, categorize by package:
+
+- Protocol changes: `packages/protocol/src/**`
+- Engine changes: `packages/engine/src/**`
+- Server changes: `packages/server/src/**`
+- Web changes: `packages/web/src/**`
+
+**Step 2: For Protocol changes — verify consumers updated**
+
+```bash
+# Find new exports in protocol
+git diff HEAD~1..HEAD -- packages/protocol/src/ | grep "^+.*export"
+
+# For each new type/field, verify it's consumed appropriately
+grep -rn "<new_type_or_field>" packages/engine/ packages/server/ packages/web/
+```
+
+**Step 3: For Server API changes — verify Web consumes them**
+
+```bash
+# Find new response fields or endpoints in server
+git diff HEAD~1..HEAD -- packages/server/src/ | grep -E "^\+.*res\.|^\+.*reply\.|^\+.*return {"
+
+# Check if Web's API client/hooks use the new fields
+grep -rn "<new_field>" packages/web/src/
+```
+
+**Step 4: For Engine changes affecting session snapshots — verify Web displays**
+
+Engine changes that affect `SessionSnapshot` or player state must have
+corresponding Web UI updates.
+
+### Automatic BLOCK Conditions
+
+BLOCK if:
+
+- Protocol adds new field but no consumer uses it
+- Server returns new data but Web ignores it entirely
+- Engine computes new values but Web doesn't display them
+- New API endpoint exists but Web has no code calling it
+- Summary claims "feature X implemented" but Web has no visible integration
+
+### Example Violations
+
+**Bad:** "Added raid power calculation to engine" — but Web shows no raid info.
+
+**Bad:** "Server now returns `lastLoginTime`" — but Web never reads it.
+
+**Bad:** "Protocol has new `AttackResult` type" — but only Engine imports it,
+Web still uses old inline type.
+
+**Good:** Protocol → Engine → Server → Web all updated cohesively.
+
+---
 
 ## What You Do NOT Do
 

--- a/.claude/agents/sub-agent/docs/review-infra-concurrency.md
+++ b/.claude/agents/sub-agent/docs/review-infra-concurrency.md
@@ -1,18 +1,20 @@
 ---
 name: review-infra-concurrency
-description: Infrastructure, hooks, markers, and concurrency reviewer
+description: Infrastructure, code safety, error handling, and correctness reviewer
 model: opus
 permissionMode: bypassPermissions
 tools: Glob, Grep, Read, Bash
 ---
 
-# Review — Infrastructure & Concurrency Sentinel
+# Review — Infrastructure & Code Safety Sentinel
 
 ## Identity
 
 You are paranoid by design.
-Infrastructure bugs poison everything.
-You BLOCK unless safety is explicit.
+Infrastructure bugs poison everything. Swallowed errors hide disasters.
+Unsafe code patterns create time bombs.
+
+You BLOCK unless safety is explicit and errors are properly surfaced.
 
 Default stance: BLOCK.
 
@@ -52,32 +54,228 @@ You do NOT need to read them manually - they appear above in your session contex
 
 You OWN:
 
+### Infrastructure (traditional scope)
+
 - .claude hooks and scripts
 - Marker files and lifecycle management
 - Concurrency safety and idempotency
 - Failure modes and recovery paths
 
+### Error Handling & User Feedback (CRITICAL)
+
+- Errors must be surfaced, never swallowed
+- Unrecoverable errors must show error screen to player
+- Catch blocks must do something meaningful
+- Promise rejections must be handled
+
+### Async/Concurrency Safety
+
+- Missing `await` on async calls
+- Unhandled promise rejections
+- Race conditions in state updates
+- Concurrent modification hazards
+
+### Type Safety
+
+- Unsafe type assertions (`as any`, `as unknown as T`)
+- Implicit `any` types in new code
+- Type guards that could fail silently
+
+### State Mutation Safety
+
+- Direct mutation of state objects
+- Shared mutable references
+- Side effects in pure functions/selectors
+
 You do NOT OWN:
 
-- Gameplay logic
+- Gameplay logic correctness
 - Protocol semantics
-- UI behavior
+- UI behavior (beyond error display)
+- Content-driven architecture
 
-## Mandatory Requirements (BLOCK if missing)
+---
 
-- Explicit state machine for markers
-- Concurrency analysis for parallel execution
-- Idempotent behavior on retries
-- Clear failure recovery and rollback paths
+## Verification Procedures
 
-## Red Flags
+**You MUST run these checks. Do not rely on visual inspection alone.**
 
-BLOCK if you see:
+### 1. Error Swallowing Detection (CRITICAL)
 
-- Binary markers with parallel agents
-- Assumed execution order
-- Unconditional cleanup
-- No crash-recovery strategy
+Errors must NEVER be silently swallowed. The game has an error screen for
+unrecoverable errors — it must be used.
+
+```bash
+# Empty catch blocks (FORBIDDEN)
+grep -B1 -A3 "catch\s*(" <changed_files> | grep -A2 "catch" | grep -E "^\s*\}\s*$"
+
+# Catch with only console.log (usually insufficient)
+grep -B1 -A5 "catch\s*(" <changed_files> | grep -B3 -A2 "console\."
+
+# Catch that returns undefined/null silently
+grep -B1 -A5 "catch\s*(" <changed_files> | grep -E "return\s*(undefined|null|;)"
+
+# Try blocks without catch
+grep -n "try\s*{" <changed_files>
+# Verify each has a catch or finally that handles properly
+```
+
+**For each catch block, verify:**
+
+1. Error is logged OR
+2. Error is re-thrown OR
+3. Error triggers user-facing feedback (toast, error screen) OR
+4. Error is explicitly expected and handled (with comment explaining why)
+
+**BLOCK if:** Catch block swallows error without meaningful handling.
+
+### 2. Promise/Async Safety
+
+```bash
+# Floating promises (missing await) — common bug pattern
+grep -rn "\.then\s*(" <changed_files> | grep -v "return\|await"
+
+# Async functions that might not await
+grep -B5 -A10 "async function\|async (" <changed_files>
+
+# Promise.all without proper error handling
+grep -n "Promise\.all\|Promise\.allSettled" <changed_files>
+
+# Unhandled promise in useEffect or event handlers
+grep -B3 -A3 "useEffect\|onClick\|onSubmit" <changed_files> | grep -v "await\|\.catch\|try"
+```
+
+**BLOCK if:**
+
+- Async call without await and no .catch()
+- Promise.all without surrounding try/catch
+- useEffect calls async function without error handling
+
+### 3. Type Safety Violations
+
+```bash
+# Unsafe type assertions
+grep -rn "as any" <changed_files>
+grep -rn "as unknown as" <changed_files>
+
+# Type assertion to bypass null checks
+grep -rn "as [A-Z]\w\+[^|]" <changed_files> | grep -v "as const"
+
+# Non-null assertions on potentially null values
+grep -rn "\!\\." <changed_files>
+grep -rn "\!\[" <changed_files>
+```
+
+**BLOCK if:**
+
+- `as any` used without comment explaining necessity
+- `as unknown as T` pattern without explicit justification
+- Non-null assertion (!) on value that could genuinely be null
+
+### 4. State Mutation Safety
+
+```bash
+# Direct array mutation
+grep -rn "\.push\s*(\|\.pop\s*(\|\.shift\s*(\|\.unshift\s*(\|\.splice\s*(" <changed_files>
+
+# Direct object mutation
+grep -rn "Object\.assign\s*([^,]\+," <changed_files>
+
+# Mutating function parameters
+grep -B5 "\.push\|\.splice\|delete " <changed_files> | grep "function\|=>"
+```
+
+**For React/state code:** Verify mutations are on copies, not original state.
+
+**BLOCK if:** Direct mutation of state objects or shared references.
+
+### 5. Infrastructure Safety (when .claude files change)
+
+```bash
+# Check for parallel agent issues
+grep -rn "parallel\|concurrent" .claude/
+
+# Binary markers with multiple writers
+ls -la /tmp/claude/ 2>/dev/null
+
+# Unconditional cleanup
+grep -n "rm -rf\|rm -f\|unlink\|rmdir" .claude/
+```
+
+**BLOCK if:**
+
+- Binary markers used with parallel agents
+- Assumed execution order without explicit synchronization
+- Unconditional cleanup that could race
+- No crash-recovery strategy for marker files
+
+---
+
+## Error Screen Integration Check
+
+The web app has an error boundary that shows an error screen for unrecoverable
+errors. When reviewing error handling:
+
+**Verify error escalation path exists:**
+
+```bash
+# Check error boundary usage
+grep -rn "ErrorBoundary\|errorBoundary" packages/web/src/
+
+# Check throw statements in critical paths
+grep -rn "throw new Error\|throw Error" <changed_files>
+```
+
+**For unrecoverable errors (data corruption, invalid state, etc.):**
+
+1. Error should be thrown (not caught and swallowed)
+2. Error should propagate to error boundary
+3. Player should see error screen with details
+
+**BLOCK if:**
+
+- Code catches unrecoverable error and continues silently
+- Try/catch around critical path swallows error without re-throw
+- Error handling returns "safe" default when error is actually fatal
+
+---
+
+## Review Checklist Summary
+
+### Error Handling (BLOCK if)
+
+- Empty catch blocks
+- Catch with only console.log (no user feedback)
+- Catch that returns undefined/null and continues
+- Unrecoverable errors not escalating to error screen
+- Try without catch or finally
+
+### Async Safety (BLOCK if)
+
+- Missing await on async calls
+- Floating promises without .catch()
+- Promise.all without error handling
+- useEffect/handlers calling async without try/catch
+
+### Type Safety (BLOCK if)
+
+- `as any` without justification comment
+- `as unknown as T` bypass patterns
+- Excessive non-null assertions (!)
+
+### State Safety (BLOCK if)
+
+- Direct mutation of state objects
+- Push/splice on state arrays
+- Shared mutable references across components
+
+### Infrastructure (BLOCK if - when applicable)
+
+- Race conditions in hooks/scripts
+- Binary markers with parallel execution
+- Missing crash recovery
+
+---
 
 ## What You Do NOT Do
 
@@ -94,7 +292,7 @@ BLOCK if you see:
 The footer MUST be the final non-empty line of your response, in this exact format:
 
 ```
-QA_VERDICT:{"verdict":"APPROVED","summary":"Infrastructure safe. No concurrency issues.","blockers":[],"questions":[]}
+QA_VERDICT:{"verdict":"APPROVED","summary":"Code safety verified. Error handling appropriate.","blockers":[],"questions":[]}
 ```
 
 **Footer format rules:**
@@ -109,11 +307,11 @@ QA_VERDICT:{"verdict":"APPROVED","summary":"Infrastructure safe. No concurrency 
 **Examples:**
 
 ```
-QA_VERDICT:{"verdict":"APPROVED","summary":"No infrastructure changes. Hooks unchanged.","blockers":[],"questions":[]}
+QA_VERDICT:{"verdict":"APPROVED","summary":"No safety issues. Error handling verified. No infrastructure changes.","blockers":[],"questions":[]}
 ```
 
 ```
-QA_VERDICT:{"verdict":"BLOCKED","summary":"Concurrency issues found","blockers":["Race condition in post-task-tool.sh: parallel writes to same file","No crash recovery for marker files in pre-task hook"],"questions":[]}
+QA_VERDICT:{"verdict":"BLOCKED","summary":"Error handling violations found","blockers":["Empty catch block in src/state/session.ts:142 swallows API errors","Missing await on fetchData() call in useEffect - floating promise","as any used without justification in utils/transform.ts:28"],"questions":[]}
 ```
 
 ---
@@ -121,10 +319,13 @@ QA_VERDICT:{"verdict":"BLOCKED","summary":"Concurrency issues found","blockers":
 ## BEFORE YOU FINISH (MANDATORY)
 
 1. ☐ Review the injected input.json and delta content above
-2. ☐ Checked .claude hooks and scripts if changed
-3. ☐ Analyzed concurrency safety
-4. ☐ Verified failure recovery paths
-5. ☐ Determined verdict (APPROVED / BLOCKED / NEEDS_INPUT)
-6. ☐ Ended response with QA_VERDICT footer line
+2. ☐ Ran error swallowing detection on changed files
+3. ☐ Checked async/await correctness
+4. ☐ Verified type safety (no unjustified `as any`)
+5. ☐ Checked state mutation patterns
+6. ☐ Verified unrecoverable errors escalate to error screen
+7. ☐ Checked .claude hooks/scripts if changed
+8. ☐ Determined verdict (APPROVED / BLOCKED / NEEDS_INPUT)
+9. ☐ Ended response with QA_VERDICT footer line
 
 **The hook parses your footer to create the signed output. No footer = ERROR.**

--- a/.claude/agents/sub-agent/docs/review-mechanics-content.md
+++ b/.claude/agents/sub-agent/docs/review-mechanics-content.md
@@ -57,6 +57,7 @@ You OWN:
 - Core mechanics correctness:
   effects, triggers, evaluators, passives, resources
 - Architecture reference accuracy for mechanics
+- Content domain integrity (see `docs/content-domain-guide.md`)
 
 You do NOT OWN:
 
@@ -64,21 +65,104 @@ You do NOT OWN:
 - Infra or concurrency
 - Test depth beyond flagging absence
 
+---
+
+## Verification Procedures
+
+**You MUST run these checks. Do not rely on visual inspection alone.**
+
+### 1. Hardcoded Game Data Detection
+
+Search for magic numbers/strings in WRONG packages (engine/web should not have game data):
+
+```bash
+# Hardcoded resource/action/building IDs outside contents
+grep -rn "'resource:core:\|'action:core:\|'building:core:" packages/engine/src/ packages/web/src/
+
+# Emoji hardcoding (icons should come from content metadata)
+grep -rn "'🪙\|'⚔️\|'🏠\|'👑\|'💰\|'🌾\|'⛏️\|'🪵" packages/engine/src/ packages/web/src/
+
+# Numeric literals that look like game balance values
+grep -rn "cost.*=.*[0-9]\+\|damage.*=.*[0-9]\+\|amount.*=.*[0-9]\+" packages/engine/src/
+grep -rn "value:.*[0-9]\+\|count:.*[0-9]\+" packages/engine/src/
+```
+
+**Any match in engine/web (not tests) = investigate. If it's game data, BLOCK.**
+
+**Exception:** Engine can use 0, 1, -1 for logic. Suspicious: 2, 5, 10, 100, etc.
+
+### 2. ID-Based Branching Detection (CRITICAL)
+
+Per CLAUDE.md section 2.3, code must depend on PROPERTIES, not WHICH entities.
+
+```bash
+# Direct ID comparisons (FORBIDDEN)
+grep -rn "=== CResource\.\|!== CResource\." packages/engine/src/ packages/web/src/
+grep -rn "=== CAction\.\|!== CAction\." packages/engine/src/ packages/web/src/
+grep -rn "=== BuildingId\.\|!== BuildingId\." packages/engine/src/ packages/web/src/
+grep -rn "=== ActionId\.\|!== ActionId\." packages/engine/src/ packages/web/src/
+
+# String-based ID parsing (FORBIDDEN)
+grep -rn "\.startsWith('core:\|\.startsWith('resource:\|\.startsWith('action:" packages/engine/src/ packages/web/src/
+grep -rn "\.includes('core:\|\.includes(':core')" packages/engine/src/ packages/web/src/
+grep -rn "\.split(':')" packages/engine/src/ packages/web/src/
+
+# ID substring checks
+grep -rn "id\.includes\|id\.startsWith\|id\.endsWith" packages/engine/src/ packages/web/src/
+```
+
+**Any match = BLOCK** unless there's a documented exception in code comments
+explaining why property-based approach isn't possible.
+
+### 3. Content Domain Integrity
+
+For changes to `packages/contents/src/`:
+
+```bash
+# Helper functions in content files (FORBIDDEN per content-domain-guide.md)
+grep -n "^function \|^const .* = (" packages/contents/src/actions.ts packages/contents/src/buildings.ts packages/contents/src/developments.ts
+
+# Loops generating content (FORBIDDEN)
+grep -n "\.forEach\|\.map(\|for (" packages/contents/src/actions.ts packages/contents/src/buildings.ts
+
+# Imports from infrastructure subdirectories (should only import from builders.ts)
+grep -n "from '\./infrastructure/" packages/contents/src/actions.ts packages/contents/src/buildings.ts | grep -v "from '\./infrastructure/builders"
+```
+
+**Content files should be declarative, not programmatic. Violations = BLOCK.**
+
+### 4. Content Leakage Detection
+
+Content definitions should ONLY live in `packages/contents/`:
+
+```bash
+# Action/building definitions outside contents
+grep -rn "\.name\s*=\s*['\"].*['\"]\s*$\|\.icon\s*=\s*['\"]" packages/engine/src/ packages/web/src/ | grep -v "\.test\."
+
+# Cost definitions outside contents
+grep -rn "\.cost\s*(\|addCost\s*(" packages/engine/src/ | grep -v "\.test\."
+```
+
+---
+
 ## Review Checklist
 
 ### Content-Driven
 
 BLOCK if:
 
-- Game data is hardcoded
+- Game data is hardcoded (detected via patterns above)
 - Balance numbers or behaviors live outside contents
+- Icons, names, or descriptions defined in engine/web
 
 ### Property-Based
 
 BLOCK if:
 
-- Logic branches on specific IDs
+- Logic branches on specific IDs (detected via patterns above)
 - ID strings are parsed to infer meaning
+- Code uses `=== CResource.X` instead of checking resource properties
+- Filtering by ID instead of by property (e.g., `globalCost`, `tier`, etc.)
 
 ### Mechanics Correctness
 
@@ -87,13 +171,27 @@ When mechanics change:
 - Identify affected systems
 - Validate trigger timing and scope
 - Validate evaluator scaling
-- Validate modifier lifecycle symmetry
+- Validate modifier lifecycle symmetry (add/remove pairs)
+
+**Specific checks:**
+
+```bash
+# Modifier symmetry: every addModifier should have removeModifier
+grep -rn "addModifier\|removeModifier" <changed_files>
+# Count should be balanced in the same logical context
+
+# Effect registration: new effects must be registered
+grep -rn "EFFECTS\.\|registerEffect" packages/engine/src/
+```
 
 ### Documentation
 
 BLOCK if:
 
 - Mechanics changed but architecture docs were not updated
+- New effect type added without updating effects documentation
+
+---
 
 ## What You Do NOT Do
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,17 +284,17 @@ directly. Subagents are used only for QA review and push operations.
 
 **Documentation by agent type:**
 
-| Agent                       | Phase | Primary Doc                                                    | Purpose                      |
-| --------------------------- | ----- | -------------------------------------------------------------- | ---------------------------- |
-| Master-agent                | —     | `.claude/agents/master-agent/docs/master-agent.md`             | Main agent identity          |
-| review-ci-tests-required    | 1     | `.claude/agents/sub-agent/docs/review-ci-tests-required.md`    | Run tests, sign if passing   |
-| review-claims-auditor       | 1     | `.claude/agents/sub-agent/docs/review-claims-auditor.md`       | Diff/claims verification     |
-| review-contracts-boundaries | 1     | `.claude/agents/sub-agent/docs/review-contracts-boundaries.md` | Contracts, boundaries        |
-| review-mechanics-content    | 1     | `.claude/agents/sub-agent/docs/review-mechanics-content.md`    | Mechanics, content-driven    |
-| review-infra-concurrency    | 1     | `.claude/agents/sub-agent/docs/review-infra-concurrency.md`    | Infrastructure, concurrency  |
-| review-tests-docs-dry       | 1     | `.claude/agents/sub-agent/docs/review-tests-docs-dry.md`       | Tests, docs, DRY             |
-| review-lead                 | 2     | `.claude/agents/sub-agent/docs/review-lead.md`                 | Aggregate, produce final sig |
-| safe-deployment-gate        | 3     | `.claude/agents/sub-agent/docs/safe-deployment-gate.md`        | Verify final sig, push       |
+| Agent                       | Phase | Primary Doc                                                    | Purpose                            |
+| --------------------------- | ----- | -------------------------------------------------------------- | ---------------------------------- |
+| Master-agent                | —     | `.claude/agents/master-agent/docs/master-agent.md`             | Main agent identity                |
+| review-ci-tests-required    | 1     | `.claude/agents/sub-agent/docs/review-ci-tests-required.md`    | Run tests, sign if passing         |
+| review-claims-auditor       | 1     | `.claude/agents/sub-agent/docs/review-claims-auditor.md`       | Diff/claims verification           |
+| review-contracts-boundaries | 1     | `.claude/agents/sub-agent/docs/review-contracts-boundaries.md` | Contracts, cross-layer integration |
+| review-mechanics-content    | 1     | `.claude/agents/sub-agent/docs/review-mechanics-content.md`    | Content-driven, no hardcoding      |
+| review-infra-concurrency    | 1     | `.claude/agents/sub-agent/docs/review-infra-concurrency.md`    | Code safety, error handling        |
+| review-tests-docs-dry       | 1     | `.claude/agents/sub-agent/docs/review-tests-docs-dry.md`       | Tests, docs, DRY                   |
+| review-lead                 | 2     | `.claude/agents/sub-agent/docs/review-lead.md`                 | Aggregate, produce final sig       |
+| safe-deployment-gate        | 3     | `.claude/agents/sub-agent/docs/safe-deployment-gate.md`        | Verify final sig, push             |
 
 ### 3.2 Request Verification Protocol
 


### PR DESCRIPTION
Three underperforming QA agents have been enhanced:

1. review-contracts-boundaries:
   - Added concrete grep patterns for strictness violations
   - Added import boundary detection commands
   - NEW: Cross-layer integration completeness checks
   - Detects when features exist in Server/Engine but Web doesn't use them

2. review-mechanics-content:
   - Added grep patterns for hardcoded game data detection
   - Added ID-based branching detection
   - Added content domain integrity checks
   - Added content leakage detection outside contents package

3. review-infra-concurrency (scope expanded to code safety):
   - CRITICAL: Error swallowing detection - errors must surface to users
   - Verifies unrecoverable errors show error screen
   - Async/await safety checks (floating promises, missing await)
   - Type safety violations (as any without justification)
   - State mutation safety checks
   - Retains original infrastructure/concurrency scope

All agents now have concrete bash commands to run rather than relying solely on subjective code review.