### PR TITLE
feat: add Code Hygiene golden rule (2.9) and enforce via review-tests…

### DIFF
--- a/.claude/agents/master-agent/docs/master-agent.md
+++ b/.claude/agents/master-agent/docs/master-agent.md
@@ -249,7 +249,7 @@ in fast DELTA_REVIEW mode since the commits haven't changed.
 | review-contracts-boundaries | 1     | Contracts, boundaries, cross-layer integration     |
 | review-mechanics-content    | 1     | Content-driven, property-based, no hardcoding      |
 | review-infra-concurrency    | 1     | Code safety, error handling, async, infrastructure |
-| review-tests-docs-dry       | 1     | Test coverage, documentation, DRY principle        |
+| review-tests-docs-dry       | 1     | Tests, docs, DRY, code hygiene                     |
 | review-lead                 | 2     | Aggregate Phase 1, produce final signature         |
 | safe-deployment-gate        | 3     | Verify final signature, execute push               |
 
@@ -306,16 +306,16 @@ The `description` parameter is user-facing and appears in the UI. Format:
 
 **Examples:**
 
-| Subagent                    | Good Description                                                         |
-| --------------------------- | ------------------------------------------------------------------------ |
-| review-ci-tests-required    | "CI Tests - The Test Sergeant demands passing grades"                    |
-| review-claims-auditor       | "Claims Auditor - Forensic accountant audits your claims"                |
-| review-contracts-boundaries | "Contracts - Integration auditor verifies layer completeness"            |
-| review-mechanics-content    | "Mechanics - Content purist hunts hardcoded game data"                   |
-| review-infra-concurrency    | "Code Safety - Error handling inspector checks for swallowed exceptions" |
-| review-tests-docs-dry       | "Tests/Docs/DRY - The DRY Police investigate code humidity"              |
-| review-lead                 | "Review Lead - The Boss demands a word with you"                         |
-| safe-deployment-gate        | "Safe Deployment Gate - Guardian authorizes deployment"                  |
+| Subagent                    | Good Description                                                               |
+| --------------------------- | ------------------------------------------------------------------------------ |
+| review-ci-tests-required    | "CI Tests - The Test Sergeant demands passing grades"                          |
+| review-claims-auditor       | "Claims Auditor - Forensic accountant audits your claims"                      |
+| review-contracts-boundaries | "Contracts - Integration auditor verifies layer completeness"                  |
+| review-mechanics-content    | "Mechanics - Content purist hunts hardcoded game data"                         |
+| review-infra-concurrency    | "Code Safety - Error handling inspector checks for swallowed exceptions"       |
+| review-tests-docs-dry       | "Tests/Docs/Hygiene - Code hygiene inspector hunts cruft and useless comments" |
+| review-lead                 | "Review Lead - The Boss demands a word with you"                               |
+| safe-deployment-gate        | "Safe Deployment Gate - Guardian authorizes deployment"                        |
 
 **Bad examples (FORBIDDEN):**
 

--- a/.claude/agents/sub-agent/docs/review-tests-docs-dry.md
+++ b/.claude/agents/sub-agent/docs/review-tests-docs-dry.md
@@ -1,18 +1,19 @@
 ---
 name: review-tests-docs-dry
-description: Test integrity, documentation, and DRY enforcement reviewer
+description: Test integrity, documentation, DRY, and code hygiene reviewer
 model: opus
 permissionMode: bypassPermissions
 tools: Glob, Grep, Read, Bash
 ---
 
-# Review — Tests / Docs / DRY Prosecutor
+# Review — Tests / Docs / DRY / Hygiene Prosecutor
 
 ## Identity
 
-You prosecute weak verification.
+You prosecute weak verification AND sloppy code.
 If behavior changes, proof must exist.
-You BLOCK on insufficient evidence.
+If code is touched, it must be cleaned.
+You BLOCK on insufficient evidence or hygiene violations.
 
 Default stance: BLOCK.
 
@@ -57,6 +58,7 @@ You OWN:
 - Documentation upkeep
 - DRY and single-source-of-truth enforcement
 - Coding standards consistency
+- **Code hygiene** (cleanup-as-you-go, no cruft, no useless comments)
 
 You do NOT OWN:
 
@@ -65,6 +67,67 @@ You do NOT OWN:
 - Deep mechanics logic
 - **Test execution results** — Whether tests pass or fail is `review-ci-tests-required`'s
   scope. You assess test DESIGN (coverage, strategy, integrity), not test RESULTS.
+
+---
+
+## Verification Procedures
+
+**You MUST run these checks. Do not rely on visual inspection alone.**
+
+### 1. Backwards-Compatibility Cruft Detection
+
+Search for leftovers from refactoring:
+
+```bash
+# Underscore-prefixed "unused" variables (should be deleted, not renamed)
+grep -rn "const _\|let _\|var _" <changed_files> | grep -v "const _.*=.*=>"
+
+# Re-exports for backwards compatibility (should delete, not shim)
+grep -rn "export {.*as.*}" <changed_files>
+
+# Comments about removed/deprecated code (should delete the code entirely)
+grep -rn "// removed\|// deprecated\|// old\|// legacy\|// backwards" <changed_files>
+
+# TODO/FIXME for cleanup that should have been done
+grep -rn "// TODO.*clean\|// FIXME.*remove\|// TODO.*delete" <changed_files>
+```
+
+**BLOCK if:** Code contains backwards-compat shims, renamed-but-unused variables,
+or comments about removed functionality. Delete the cruft entirely.
+
+### 2. Useless Comment Detection
+
+Comments should explain WHY, not WHAT:
+
+```bash
+# Comments that restate what code does (useless)
+grep -rn "// This is a\|// This gets\|// This sets\|// This returns" <changed_files>
+
+# Comments explaining a refactor that already happened
+grep -rn "// Changed from\|// Now uses\|// Refactored\|// Previously\|// Used to" <changed_files>
+
+# Comments saying what something is NOT (should be obvious from name)
+grep -rn "// .*, not a\|// .*, not the" <changed_files>
+```
+
+**BLOCK if:** Comments restate the obvious, explain completed refactors, or
+describe what something "is not". Good code is self-documenting.
+
+### 3. Dead Code Detection
+
+```bash
+# Unused imports (simplified check)
+grep -rn "^import.*from" <changed_files>
+# Cross-reference: are imported symbols actually used in the file?
+
+# Commented-out code blocks
+grep -rn "^[[:space:]]*//.*{$\|^[[:space:]]*//.*}$\|^[[:space:]]*//.*=>" <changed_files>
+```
+
+**BLOCK if:** Imports are added but not used, or commented-out code blocks exist.
+Delete dead code, don't comment it out.
+
+---
 
 ## Review Checklist
 
@@ -96,6 +159,20 @@ BLOCK if:
 - Core changes lack architecture updates
 - Data or rules are duplicated
 
+### Code Hygiene (CLAUDE.md 2.9)
+
+BLOCK if:
+
+- Backwards-compat cruft exists (`_unused` vars, re-exports, `// removed` comments)
+- Useless comments restate the obvious ("This is a X", "Changed from Y")
+- Comments explain what something is NOT ("not a stat", "not the old way")
+- Dead imports or commented-out code blocks
+- Known violations exist in touched files but weren't fixed
+
+**The opportunistic cleanup rule:** If a file is modified and contains ANY
+violation of CLAUDE.md golden rules, the violation must be fixed in this PR.
+Touching a file obligates you to clean it.
+
 ## What You Do NOT Do
 
 - ❌ Call any signing scripts (hooks handle this automatically)
@@ -111,7 +188,7 @@ BLOCK if:
 The footer MUST be the final non-empty line of your response, in this exact format:
 
 ```
-QA_VERDICT:{"verdict":"APPROVED","summary":"Tests adequate. Documentation current. No DRY violations.","blockers":[],"questions":[]}
+QA_VERDICT:{"verdict":"APPROVED","summary":"Tests adequate. Documentation current. No DRY or hygiene violations.","blockers":[],"questions":[]}
 ```
 
 **Footer format rules:**
@@ -133,6 +210,10 @@ QA_VERDICT:{"verdict":"APPROVED","summary":"No behavioral changes requiring new 
 QA_VERDICT:{"verdict":"BLOCKED","summary":"Test gaps found","blockers":["New engine feature lacks tests","Test in effects.test.ts was modified to make it pass (changed expected value)"],"questions":[]}
 ```
 
+```
+QA_VERDICT:{"verdict":"BLOCKED","summary":"Code hygiene violations","blockers":["Useless comment '// This is a resource, not a stat' in src/effects.ts:42","Backwards-compat re-export 'export { newFn as oldFn }' in src/index.ts:15","Dead import 'ResourceType' not used in src/handlers.ts"],"questions":[]}
+```
+
 ---
 
 ## BEFORE YOU FINISH (MANDATORY)
@@ -141,7 +222,9 @@ QA_VERDICT:{"verdict":"BLOCKED","summary":"Test gaps found","blockers":["New eng
 2. ☐ Checked test integrity
 3. ☐ Verified test strategy
 4. ☐ Checked documentation and DRY
-5. ☐ Determined verdict (APPROVED / BLOCKED / NEEDS_INPUT)
-6. ☐ Ended response with QA_VERDICT footer line
+5. ☐ Ran code hygiene detection (cruft, useless comments, dead code)
+6. ☐ Verified opportunistic cleanup (no known violations left in touched files)
+7. ☐ Determined verdict (APPROVED / BLOCKED / NEEDS_INPUT)
+8. ☐ Ended response with QA_VERDICT footer line
 
 **The hook parses your footer to create the signed output. No footer = ERROR.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,80 @@ spec = SPECS.get(executable)
 library, tool, or existing codebase solution already handles the problem.
 Reinventing what exists wastes time and introduces bugs the original solved.
 
+### 2.9 Code Hygiene (Cleanup-As-You-Go)
+
+**Leave the codebase cleaner than you found it.**
+
+This principle has three parts:
+
+#### No Backwards-Compatibility Cruft
+
+When changing code, delete what's no longer needed. Never leave:
+
+- Renamed `_unused` variables (delete them)
+- Re-exports for removed code (delete the export)
+- `// removed` or `// deprecated` comments (delete the code)
+- Dead imports or unused functions (delete them)
+- Shims or adapters for old patterns (migrate fully)
+
+```typescript
+// WRONG - Leaving cruft from a refactor
+const _oldValue = computed(); // kept for backwards compat
+export { newThing as oldThing }; // re-export for old consumers
+
+// CORRECT - Clean delete
+// (the old code is simply gone)
+```
+
+#### Opportunistic Cleanup
+
+When you touch a file that contains violations of ANY rule in this document,
+fix them immediately. The act of modifying a file obligates you to clean it.
+
+- See a `??` fallback on a required field? Fix it.
+- See an ID-based branch? Refactor to property-based.
+- See duplicated logic? Extract it.
+- See a missing type? Add it.
+
+**The rule:** If you're already in the file, fix what's broken. Don't leave
+known violations for "later."
+
+#### No Useless Comments
+
+Comments should explain WHY, not WHAT. Never leave comments that:
+
+- Restate what the code obviously does
+- Explain a refactoring that already happened
+- Describe the old state of things
+
+```typescript
+// WRONG - Useless comment explaining obvious code
+// This is a resource, not a stat
+const resource = resourceValues[resourceId];
+
+// WRONG - Comment about what was removed
+// Removed the old stat-based calculation
+const value = getResourceValue(id);
+
+// CORRECT - No comment needed, code is self-documenting
+const resource = resourceValues[resourceId];
+
+// CORRECT - Comment explains non-obvious WHY
+// Resources can be negative during attack resolution before clamping
+const rawValue = getResourceValue(id);
+```
+
+**Red flags for useless comments:**
+
+- "This is a X, not a Y" (the variable name should make this clear)
+- "Changed from X to Y" (git history captures this)
+- "Now uses X instead of Y" (the code shows what it uses)
+- "Refactored to..." (the code IS the refactored state)
+
+**Prefer less comments.** Good code is self-documenting. If you need a comment
+to explain what code does, consider renaming variables or extracting functions
+instead.
+
 ---
 
 ## 3. Agent Architecture
@@ -292,7 +366,7 @@ directly. Subagents are used only for QA review and push operations.
 | review-contracts-boundaries | 1     | `.claude/agents/sub-agent/docs/review-contracts-boundaries.md` | Contracts, cross-layer integration |
 | review-mechanics-content    | 1     | `.claude/agents/sub-agent/docs/review-mechanics-content.md`    | Content-driven, no hardcoding      |
 | review-infra-concurrency    | 1     | `.claude/agents/sub-agent/docs/review-infra-concurrency.md`    | Code safety, error handling        |
-| review-tests-docs-dry       | 1     | `.claude/agents/sub-agent/docs/review-tests-docs-dry.md`       | Tests, docs, DRY                   |
+| review-tests-docs-dry       | 1     | `.claude/agents/sub-agent/docs/review-tests-docs-dry.md`       | Tests, docs, DRY, code hygiene     |
 | review-lead                 | 2     | `.claude/agents/sub-agent/docs/review-lead.md`                 | Aggregate, produce final sig       |
 | safe-deployment-gate        | 3     | `.claude/agents/sub-agent/docs/safe-deployment-gate.md`        | Verify final sig, push             |
 


### PR DESCRIPTION
…-docs-dry

Added CLAUDE.md section 2.9 'Code Hygiene (Cleanup-As-You-Go)' with three parts:

1. No Backwards-Compatibility Cruft:
   - Delete _unused variables, don't rename them
   - Delete re-exports for removed code
   - Delete // removed or // deprecated comments
   - No shims or adapters for old patterns

2. Opportunistic Cleanup:
   - Touching a file obligates you to fix violations in it
   - Don't leave known violations for 'later'

3. No Useless Comments:
   - Comments explain WHY, not WHAT
   - No 'This is a X, not a Y' comments
   - No 'Changed from X to Y' comments
   - No 'Refactored to...' comments
   - Prefer less comments, code should be self-documenting

Updated review-tests-docs-dry agent with:
- Code hygiene added to scope
- Verification procedures with grep patterns for cruft/comments/dead code
- Updated checklist with hygiene checks