### PR TITLE
Analyze and optimize test suite performance

### DIFF
--- a/scripts/run-verification.mjs
+++ b/scripts/run-verification.mjs
@@ -3,9 +3,8 @@ import { createWriteStream } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 const baseTasks = [
-	{ label: 'check', script: 'check' },
-	{ label: 'test-infrastructure', script: 'test:infrastructure' },
-	{ label: 'test-coverage', script: 'test:coverage' },
+	{ label: 'check', script: 'check:ci' },
+	{ label: 'test-parallel', script: 'test:parallel' },
 ];
 
 const isWindows = process.platform === 'win32';


### PR DESCRIPTION
- Use check:ci instead of check (removes duplicate test run)
- Use test:parallel instead of sequential test:coverage
- Tests were running twice: once in check script, again in test:coverage
- Now runs lint/typecheck first, then all 6 test suites in parallel