### PR TITLE
Implement Kingdom Builder tutorial content package

### DIFF
--- a/packages/contents/src/kingdom-builder/tutorial/index.ts
+++ b/packages/contents/src/kingdom-builder/tutorial/index.ts
@@ -1,16 +1,126 @@
 /**
  * Kingdom Builder - Tutorial Content Package
  *
- * A simplified starter mode that teaches players the basics.
- * Content to be implemented later.
+ * A simplified starter mode that teaches players the basics of
+ * kingdom management: expanding land, collecting taxes, developing
+ * farms and houses, and building a mill.
+ *
+ * Extends the base package by removing combat, research, hiring,
+ * and advanced content to reduce cognitive load for new players.
  */
 
 import type { ContentPackage } from '@kingdom-builder/contents-sdk';
+import { SystemRole, Types, ResourceMethods, LandMethods, DevelopmentMethods } from '@kingdom-builder/contents-sdk';
+import { createBasePackage } from '../base';
+import { ActionId, type ActionDef, SystemActions, BasicActions, DevelopActions, BuildActions, MetaCategory } from '../../actions';
+import { DevelopmentId } from '../../developments';
+import { BuildingId } from '../../buildings';
+import { Resource } from '../../internal';
+import { action, effect } from '../../infrastructure/builders';
+import { resourceChange } from '../../resource';
+
+/** Actions available in the tutorial (non-system). */
+const TUTORIAL_ACTION_IDS: ReadonlySet<string> = new Set([
+	BasicActions.expand,
+	BasicActions.tax,
+	DevelopActions.develop_farm,
+	DevelopActions.develop_house,
+	BuildActions.build_mill,
+	BuildActions.build_town_charter,
+]);
+
+/** System actions that must always be present. */
+const SYSTEM_ACTION_IDS: ReadonlySet<string> = new Set([SystemActions.initial_setup, SystemActions.initial_setup_devmode, SystemActions.compensation, BasicActions.till]);
+
+/** Developments available in the tutorial. */
+const TUTORIAL_DEVELOPMENT_IDS: ReadonlySet<string> = new Set([DevelopmentId.Farm, DevelopmentId.House, DevelopmentId.Garden]);
+
+/** Buildings available in the tutorial. */
+const TUTORIAL_BUILDING_IDS: ReadonlySet<string> = new Set([BuildingId.Mill, BuildingId.TownCharter]);
+
+/**
+ * Builds the tutorial initial_setup action.
+ *
+ * Compared to the base initial_setup:
+ * - 15 gold instead of 10 (more room to experiment)
+ * - 2 lands: one with a Farm, one tilled (ready for development)
+ * - Same castle HP, population cap, growth, and starting council
+ */
+function buildTutorialSetupAction(): ActionDef {
+	return action()
+		.id(ActionId.initial_setup)
+		.metaCategory(MetaCategory.Commands)
+		.name('Initial Setup')
+		.icon('🎮')
+		.system(SystemRole.INITIAL_SETUP)
+		.free()
+		.tier(1, (t) =>
+			t
+				// Resources — generous gold for experimentation
+				.effect(effect(Types.Resource, ResourceMethods.ADD).params(resourceChange(Resource.gold).amount(15).reject().build()).build())
+				.effect(effect(Types.Resource, ResourceMethods.ADD).params(resourceChange(Resource.castleHP).amount(100).reject().build()).build())
+				// Stats
+				.effect(effect(Types.Resource, ResourceMethods.ADD).params(resourceChange(Resource.populationMax).amount(1).reject().build()).build())
+				.effect(effect(Types.Resource, ResourceMethods.ADD).params(resourceChange(Resource.growth).amount(0.25).reject().build()).build())
+				// Population
+				.effect(effect(Types.Resource, ResourceMethods.ADD).params(resourceChange(Resource.council).amount(1).reject().build()).build())
+				// Land 1: with a pre-built Farm
+				.effect(effect(Types.Land, LandMethods.ADD).param('count', 1).build())
+				.effect(effect(Types.Development, DevelopmentMethods.ADD).param('id', DevelopmentId.Farm).build())
+				// Land 2: tilled and ready for development
+				.effect(effect(Types.Land, LandMethods.ADD).param('count', 1).build())
+				.effect(effect(Types.Land, LandMethods.TILL).build()),
+		)
+		.build();
+}
 
 /**
  * Creates the tutorial content package.
- * @throws Error - Tutorial content not yet implemented
+ *
+ * Imports the full base game and strips it down to a beginner-friendly
+ * subset: expand, tax, develop (farm/house), and build (mill/charter).
+ * No combat, research, or hiring — just core economy mechanics.
  */
 export function createTutorialPackage(): ContentPackage {
-	throw new Error('Tutorial content package is not yet implemented. ' + 'This is a placeholder for future development.');
+	const base = createBasePackage();
+
+	// --- Actions: keep only tutorial + system actions ---
+	for (const id of base.actions.keys()) {
+		if (!TUTORIAL_ACTION_IDS.has(id) && !SYSTEM_ACTION_IDS.has(id)) {
+			base.actions.remove(id);
+		}
+	}
+
+	// Override initial_setup with tutorial-friendly version
+	base.actions.remove(ActionId.initial_setup);
+	base.actions.add(ActionId.initial_setup, buildTutorialSetupAction());
+
+	// --- Meta-categories: remove Research entirely ---
+	base.actionMetaCategories.remove(MetaCategory.Research);
+
+	// --- Action categories: remove Hire (no hire actions) ---
+	if (base.actionCategories.has('hire')) {
+		base.actionCategories.remove('hire');
+	}
+
+	// --- Developments: keep only tutorial set ---
+	for (const id of base.developments.keys()) {
+		if (!TUTORIAL_DEVELOPMENT_IDS.has(id)) {
+			base.developments.remove(id);
+		}
+	}
+
+	// --- Buildings: keep only tutorial set ---
+	for (const id of base.buildings.keys()) {
+		if (!TUTORIAL_BUILDING_IDS.has(id)) {
+			base.buildings.remove(id);
+		}
+	}
+
+	return {
+		...base,
+		id: 'kingdom-builder:tutorial',
+		name: 'Kingdom Builder Tutorial',
+		description: 'Learn the basics with simplified gameplay' + ' — expand, tax, farm, and build.',
+	};
 }


### PR DESCRIPTION
## Summary
Implements the tutorial content package for Kingdom Builder, transforming it from a placeholder into a fully functional beginner-friendly game mode. The tutorial strips down the base game to core mechanics only, removing combat, research, and hiring systems to reduce cognitive load for new players.

## Key Changes
- **Implemented `createTutorialPackage()`**: Extends the base package and filters it to include only tutorial-appropriate content
- **Curated action set**: Keeps only essential actions (expand, tax, develop farm/house, build mill/charter) plus required system actions
- **Custom initial setup**: Provides 15 gold (vs 10 in base) and 2 starter lands (one with pre-built farm, one tilled) to give players more room to experiment
- **Removed advanced systems**: Strips out Research meta-category, Hire action category, and all non-tutorial developments/buildings
- **Updated documentation**: Enhanced JSDoc comments to clearly describe the tutorial's scope and design philosophy

## Implementation Details
- Uses allowlist approach: defines `TUTORIAL_ACTION_IDS`, `TUTORIAL_DEVELOPMENT_IDS`, and `TUTORIAL_BUILDING_IDS` sets, then removes everything else from the base package
- Custom `buildTutorialSetupAction()` function creates a tailored initial setup action with generous starting resources and pre-configured lands
- Maintains all system actions (initial_setup, compensation, till) to ensure core game functionality
- Returns a properly configured ContentPackage with tutorial-specific metadata (id, name, description)

https://claude.ai/code/session_01XEo5D39GJVuZwsUmMuLWNr