### PR TITLE
Track binding resource spent for pooled meta-categories

### DIFF
--- a/packages/engine/src/actions/action_execution.ts
+++ b/packages/engine/src/actions/action_execution.ts
@@ -78,6 +78,39 @@ function getCurrentTier(
 	return getStartingTier(actionDefinition);
 }
 
+/**
+ * Tracks binding resource spent for pooled meta-categories.
+ * This drives tier progression curves in the pool fill algorithm.
+ */
+function trackMetaCategoryBindingSpent(
+	actionDefinition: { metaCategory?: string },
+	finalCosts: Record<string, number | undefined>,
+	engineContext: EngineContext,
+): void {
+	const metaCategoryId = actionDefinition.metaCategory;
+	if (!metaCategoryId) {
+		return;
+	}
+	const metaCategories = engineContext.actionMetaCategories;
+	if (!metaCategories?.has(metaCategoryId)) {
+		return;
+	}
+	const metaCategory = metaCategories.get(metaCategoryId);
+	// Only track for pooled meta-categories
+	if (!metaCategory.pool) {
+		return;
+	}
+	const bindingResourceId = metaCategory.bindingResourceId;
+	const bindingAmount = finalCosts[bindingResourceId] ?? 0;
+	if (bindingAmount <= 0) {
+		return;
+	}
+	const player = engineContext.activePlayer;
+	const currentSpent = player.metaCategoryBindingSpent[metaCategoryId] ?? 0;
+	player.metaCategoryBindingSpent[metaCategoryId] =
+		currentSpent + bindingAmount;
+}
+
 function evaluateRequirements(
 	actionId: string,
 	engineContext: EngineContext,
@@ -172,6 +205,7 @@ function executeAction<T extends string>(
 		throw new Error(affordability);
 	}
 	deductCostsFromPlayer(finalCosts, engineContext.activePlayer, engineContext);
+	trackMetaCategoryBindingSpent(actionDefinition, finalCosts, engineContext);
 	const passiveManager = engineContext.passives;
 	withResourceSourceFrames(
 		engineContext,


### PR DESCRIPTION
## Summary
Added tracking of binding resource expenditure for pooled meta-categories to support tier progression calculations in the pool fill algorithm.

## Key Changes
- Added `trackMetaCategoryBindingSpent()` function that:
  - Validates that an action belongs to a pooled meta-category
  - Extracts the binding resource cost from the action's final costs
  - Accumulates the binding resource spent on the active player's meta-category tracking
- Integrated the tracking function into the action execution flow, called immediately after costs are deducted from the player

## Implementation Details
- The function safely handles missing meta-categories and non-pooled categories by returning early
- Only positive binding amounts are tracked to avoid negative accumulation
- Binding resource ID is retrieved from the meta-category configuration
- Accumulated spending is stored in `player.metaCategoryBindingSpent[metaCategoryId]` for use by tier progression logic

https://claude.ai/code/session_01QXpALr4Z2omYE4wzDBz7P5