### PR TITLE
Fix AI controller infinite loop by marking test actions as non-free

### DIFF
--- a/packages/engine/tests/ai/ai-system.integration.test.ts
+++ b/packages/engine/tests/ai/ai-system.integration.test.ts
@@ -20,10 +20,14 @@ describe('AISystem with tax collector controller', () => {
 		options: { playerIndex?: number; action?: ActionOverrides } = {},
 	) {
 		const { playerIndex = 1, action = {} } = options;
-		// Use isolated mode so actionCostResource returns command-points
+		// Use isolated mode so actionCostResource returns command-points.
+		// free: false is required so the Commands meta-category applies its CP
+		// cost; otherwise the controller's while loop never terminates because
+		// performAction does not consume CP.
 		const content = createContentFactory({ isolated: true });
 		content.action({
 			id: TAX_ACTION_ID,
+			free: false,
 			baseCosts: {},
 			effects: [
 				{

--- a/packages/engine/tests/ai/tax-collector.test.ts
+++ b/packages/engine/tests/ai/tax-collector.test.ts
@@ -12,10 +12,14 @@ import { resourceAmountParams } from '../helpers/resourceParams.ts';
 describe('tax collector AI controller', () => {
 	function createControllerFixture(commandPoints: number = 2) {
 		// Use isolated mode so actionCostResource returns command-points
-		// (the meta-category binding resource) instead of gold from real actions
+		// (the meta-category binding resource) instead of gold from real actions.
+		// free: false is required so the Commands meta-category applies its CP
+		// cost; otherwise the controller's while loop never terminates because
+		// performAction does not consume CP.
 		const content = createContentFactory({ isolated: true });
 		content.action({
 			id: TAX_ACTION_ID,
+			free: false,
 			effects: [
 				{
 					type: 'resource',


### PR DESCRIPTION
## Summary
Fixed an infinite loop in AI controller tests by explicitly marking test actions as `free: false`, ensuring that the Commands meta-category applies its command point cost during action execution.

## Key Changes
- Added `free: false` property to the TAX_ACTION_ID action definition in both `ai-system.integration.test.ts` and `tax-collector.test.ts`
- Updated comments to clarify that `free: false` is required for the Commands meta-category to apply CP costs, preventing the controller's while loop from becoming infinite when `performAction` doesn't consume command points

## Implementation Details
In isolated mode, `actionCostResource` returns command-points (the meta-category binding resource) instead of real action resources. Without explicitly setting `free: false`, the test actions were not consuming command points during execution, causing the AI controller's while loop to never terminate. This change ensures that the Commands meta-category properly applies its CP cost to test actions, allowing the controller to function correctly and consume resources as expected.

https://claude.ai/code/session_01BKkErKHVqyRHTqtGjRHz6V