### PR TITLE
Add tier-progression-curve research panel with upgrade effects

### DIFF
--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -49,6 +49,8 @@ export interface ActionCardProps {
 	currentTier?: number | undefined;
 	/** Max tier for multi-tier actions */
 	maxTier?: number | undefined;
+	/** Pre-rendered summary for the next tier (for upgrade preview) */
+	nextTierSummary?: Summary | undefined;
 }
 
 export default function ActionCard({
@@ -81,6 +83,7 @@ export default function ActionCard({
 	resourceMetadata,
 	currentTier,
 	maxTier,
+	nextTierSummary,
 }: ActionCardProps): ReactElement {
 	const focusClass = getFocusGradient(focus);
 	const isBack = variant === 'back';
@@ -172,6 +175,24 @@ export default function ActionCard({
 			Tier {currentTier}/{maxTier}
 		</span>
 	) : null;
+	const showNextTierPreview =
+		variant === 'front' &&
+		implemented &&
+		nextTierSummary !== undefined &&
+		nextTierSummary.length > 0 &&
+		currentTier !== undefined &&
+		maxTier !== undefined &&
+		currentTier < maxTier;
+	const nextTierPreview = showNextTierPreview ? (
+		<div className="action-card__next-tier mt-2 border-t border-slate-200/60 dark:border-slate-700/60 pt-2">
+			<div className="text-[10px] font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400">
+				Next tier →
+			</div>
+			<ul className="action-card__summary action-card__summary--preview opacity-70 text-xs">
+				{renderSummary(nextTierSummary)}
+			</ul>
+		</div>
+	) : null;
 
 	return (
 		<div
@@ -211,6 +232,7 @@ export default function ActionCard({
 							</div>
 						</div>
 						<ul className="action-card__summary">{renderedSummary}</ul>
+						{nextTierPreview}
 					</div>
 				</button>
 				<div className="action-card__face action-card__face--back">

--- a/packages/web/src/components/actions/ActionsPanel.tsx
+++ b/packages/web/src/components/actions/ActionsPanel.tsx
@@ -6,6 +6,7 @@ import { hasAiController } from '../../state/sessionAi';
 import { isActionPhaseActive } from '../../utils/isActionPhaseActive';
 import { useResourceMetadata } from '../../contexts/RegistryMetadataContext';
 import MetaCategoryPanel from './MetaCategoryPanel';
+import ResearchProgressionPanel from './ResearchProgressionPanel';
 import {
 	INDICATOR_PILL_CLASSES,
 	OVERLAY_CLASSES,
@@ -189,6 +190,7 @@ export default function ActionsPanel() {
 				summarizeActionWithInstallation(
 					actionDefinition.id,
 					translationContext,
+					actionDefinition.currentTier,
 				),
 			);
 		});
@@ -304,20 +306,27 @@ export default function ActionsPanel() {
 			</div>
 
 			{/* Render each visible meta-category panel */}
-			{visibleMetaCategories.map((group) => (
-				<div key={group.metaCategory.id} className="relative">
-					{panelDisabled && <div aria-hidden className={OVERLAY_CLASSES} />}
-					<MetaCategoryPanel
-						metaCategory={group.metaCategory}
-						actions={group.actions}
-						summaries={actionSummaries}
-						player={selectedPlayer}
-						canInteract={canInteract}
-						selectResourceDescriptor={selectResourceDescriptor}
-						panelDisabled={panelDisabled}
-					/>
-				</div>
-			))}
+			{visibleMetaCategories.map((group) => {
+				const usesTierProgressionCurve =
+					group.metaCategory.pool?.fillMode.type === 'tier-progression-curve';
+				const Panel = usesTierProgressionCurve
+					? ResearchProgressionPanel
+					: MetaCategoryPanel;
+				return (
+					<div key={group.metaCategory.id} className="relative">
+						{panelDisabled && <div aria-hidden className={OVERLAY_CLASSES} />}
+						<Panel
+							metaCategory={group.metaCategory}
+							actions={group.actions}
+							summaries={actionSummaries}
+							player={selectedPlayer}
+							canInteract={canInteract}
+							selectResourceDescriptor={selectResourceDescriptor}
+							panelDisabled={panelDisabled}
+						/>
+					</div>
+				);
+			})}
 
 			{/* Hidden availability observers */}
 			{actions.map((actionDefinition) => (

--- a/packages/web/src/components/actions/GenericActionCard.tsx
+++ b/packages/web/src/components/actions/GenericActionCard.tsx
@@ -22,7 +22,10 @@ import { type Action, type DisplayPlayer, type HoverCardData } from './types';
 import { normalizeActionFocus } from './types';
 import type { UseActionMetadataResult } from '../../state/useActionMetadata';
 import { getActionAvailability } from './getActionAvailability';
-import { describeActionWithInstallation } from './actionSummaryHelpers';
+import {
+	describeActionWithInstallation,
+	summarizeActionWithInstallation,
+} from './actionSummaryHelpers';
 import { isBuildingAlreadyOwned } from './buildingOwnershipCheck';
 
 interface GenericActionCardProps {
@@ -174,7 +177,22 @@ function GenericActionCard({
 	const hoverContent = describeActionWithInstallation(
 		action.id,
 		translationContext,
+		action.currentTier,
 	);
+	const nextTierSummary = useMemo(() => {
+		if (
+			action.currentTier === undefined ||
+			action.maxTier === undefined ||
+			action.currentTier >= action.maxTier
+		) {
+			return undefined;
+		}
+		return summarizeActionWithInstallation(
+			action.id,
+			translationContext,
+			action.currentTier + 1,
+		);
+	}, [action.id, action.currentTier, action.maxTier, translationContext]);
 	const { effects, description } = splitSummary(hoverContent);
 	const createHoverDetails = (): HoverCardData => ({
 		title: hoverTitle,
@@ -220,6 +238,7 @@ function GenericActionCard({
 			onCancel={isPending ? cancelPending : undefined}
 			currentTier={action.currentTier}
 			maxTier={action.maxTier}
+			nextTierSummary={nextTierSummary}
 			onClick={() => {
 				if (!canInteract || !baseEnabled) {
 					return;

--- a/packages/web/src/components/actions/MetaCategoryPanel.tsx
+++ b/packages/web/src/components/actions/MetaCategoryPanel.tsx
@@ -3,6 +3,7 @@ import type { ActionMetaCategoryConfig } from '@kingdom-builder/protocol';
 import type { Summary } from '../../translation';
 import { useResourceMetadata } from '../../contexts/RegistryMetadataContext';
 import BasicOptions from './BasicOptions';
+import PoolSlots from './PoolSlots';
 import type { Action, DisplayPlayer } from './types';
 import type { ResourceDescriptorSelector } from './utils';
 import {
@@ -10,8 +11,6 @@ import {
 	HEADER_CLASSES,
 	SECTION_CLASSES,
 	TITLE_CLASSES,
-	POOL_SLOT_CLASSES,
-	POOL_SLOT_EMPTY_CLASSES,
 	POOL_STATUS_CLASSES,
 } from './actionsPanelStyles';
 
@@ -92,8 +91,6 @@ export default function MetaCategoryPanel({
 
 	// Pool display mode
 	if (hasPool) {
-		const emptySlots = Math.max(0, poolSize - metaCategoryActions.length);
-
 		return (
 			<section
 				className={SECTION_CLASSES}
@@ -110,29 +107,14 @@ export default function MetaCategoryPanel({
 						{metaCategoryActions.length} of {poolSize} available
 					</div>
 				</div>
-				<div className="grid grid-cols-3 gap-2 mt-4">
-					{metaCategoryActions.map((action) => (
-						<div key={action.id} className={POOL_SLOT_CLASSES}>
-							<BasicOptions
-								actions={[action]}
-								summaries={summaries}
-								player={player}
-								canInteract={canInteract}
-								selectResourceDescriptor={selectResourceDescriptor}
-							/>
-						</div>
-					))}
-					{/* Render empty slots */}
-					{Array.from({ length: emptySlots }).map((_, index) => (
-						<div
-							key={`empty-${index}`}
-							className={POOL_SLOT_EMPTY_CLASSES}
-							aria-label="Empty pool slot"
-						>
-							<span className="text-gray-400">Empty</span>
-						</div>
-					))}
-				</div>
+				<PoolSlots
+					actions={metaCategoryActions}
+					poolSize={poolSize}
+					summaries={summaries}
+					player={player}
+					canInteract={canInteract}
+					selectResourceDescriptor={selectResourceDescriptor}
+				/>
 			</section>
 		);
 	}

--- a/packages/web/src/components/actions/PoolSlots.tsx
+++ b/packages/web/src/components/actions/PoolSlots.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import type { Summary } from '../../translation';
+import BasicOptions from './BasicOptions';
+import type { Action, DisplayPlayer } from './types';
+import type { ResourceDescriptorSelector } from './utils';
+import {
+	POOL_SLOT_CLASSES,
+	POOL_SLOT_EMPTY_CLASSES,
+} from './actionsPanelStyles';
+
+interface PoolSlotsProps {
+	actions: Action[];
+	poolSize: number;
+	summaries: Map<string, Summary>;
+	player: DisplayPlayer;
+	canInteract: boolean;
+	selectResourceDescriptor: ResourceDescriptorSelector;
+}
+
+/**
+ * Renders the grid of pool slots for a meta-category pool, filling any unused
+ * capacity with placeholder "Empty" tiles. Shared by MetaCategoryPanel and
+ * ResearchProgressionPanel.
+ */
+export default function PoolSlots({
+	actions,
+	poolSize,
+	summaries,
+	player,
+	canInteract,
+	selectResourceDescriptor,
+}: PoolSlotsProps) {
+	const emptySlots = Math.max(0, poolSize - actions.length);
+	return (
+		<div className="grid grid-cols-3 gap-2 mt-4">
+			{actions.map((action) => (
+				<div key={action.id} className={POOL_SLOT_CLASSES}>
+					<BasicOptions
+						actions={[action]}
+						summaries={summaries}
+						player={player}
+						canInteract={canInteract}
+						selectResourceDescriptor={selectResourceDescriptor}
+					/>
+				</div>
+			))}
+			{Array.from({ length: emptySlots }).map((_, index) => (
+				<div
+					key={`empty-${index}`}
+					className={POOL_SLOT_EMPTY_CLASSES}
+					aria-label="Empty pool slot"
+				>
+					<span className="text-gray-400">Empty</span>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/packages/web/src/components/actions/ResearchProgressionPanel.tsx
+++ b/packages/web/src/components/actions/ResearchProgressionPanel.tsx
@@ -1,0 +1,394 @@
+import React, { useMemo } from 'react';
+import type {
+	ActionConfig,
+	ActionMetaCategoryConfig,
+	SessionActionState,
+} from '@kingdom-builder/protocol';
+import type { Summary } from '../../translation';
+import { useResourceMetadata } from '../../contexts/RegistryMetadataContext';
+import { useGameEngine } from '../../state/GameContext';
+import PoolSlots from './PoolSlots';
+import type { Action, DisplayPlayer } from './types';
+import type { ResourceDescriptorSelector } from './utils';
+import {
+	COST_LABEL_CLASSES,
+	HEADER_CLASSES,
+	SECTION_CLASSES,
+	TITLE_CLASSES,
+	POOL_STATUS_CLASSES,
+} from './actionsPanelStyles';
+
+interface ResearchProgressionPanelProps {
+	metaCategory: ActionMetaCategoryConfig;
+	actions: Action[];
+	summaries: Map<string, Summary>;
+	player: DisplayPlayer;
+	canInteract: boolean;
+	selectResourceDescriptor: ResourceDescriptorSelector;
+	panelDisabled: boolean;
+}
+
+interface CatalogEntry {
+	id: string;
+	definition: ActionConfig;
+	startingTier: number;
+	maxTier: number;
+	state: SessionActionState;
+}
+
+type CatalogStatus =
+	| { kind: 'available' }
+	| { kind: 'locked' }
+	| { kind: 'completed' }
+	| { kind: 'upgraded'; tier: number };
+
+function getTierRange(definition: ActionConfig): {
+	startingTier: number;
+	maxTier: number;
+} {
+	const tierKeys = Object.keys(definition.tiers ?? {});
+	const tierNumbers = tierKeys.map(Number).filter((n) => !isNaN(n));
+	if (tierNumbers.length === 0) {
+		return { startingTier: 1, maxTier: 1 };
+	}
+	return {
+		startingTier: Math.min(...tierNumbers),
+		maxTier: Math.max(...tierNumbers),
+	};
+}
+
+function resolveCatalogStatus(entry: CatalogEntry): CatalogStatus {
+	if (entry.state.exhausted) {
+		return { kind: 'completed' };
+	}
+	if (entry.state.locked) {
+		return { kind: 'locked' };
+	}
+	if (entry.state.poolLocked) {
+		return { kind: 'locked' };
+	}
+	if (entry.state.currentTier > entry.startingTier) {
+		return { kind: 'upgraded', tier: entry.state.currentTier };
+	}
+	return { kind: 'available' };
+}
+
+interface ProgressionCurveProps {
+	bindingSpent: number;
+	thresholds: ReadonlyArray<{
+		bindingSpent: number;
+		weights: Record<string, number>;
+	}>;
+	bindingIcon?: string | undefined;
+	bindingLabel: string;
+}
+
+function ProgressionCurve({
+	bindingSpent,
+	thresholds,
+	bindingIcon,
+	bindingLabel,
+}: ProgressionCurveProps) {
+	if (thresholds.length === 0) {
+		return null;
+	}
+	const sorted = [...thresholds].sort(
+		(a, b) => a.bindingSpent - b.bindingSpent,
+	);
+	const maxThreshold = sorted[sorted.length - 1]?.bindingSpent ?? 0;
+	const trackMax = Math.max(maxThreshold, bindingSpent, 1);
+	const currentPercent = Math.min(100, (bindingSpent / trackMax) * 100);
+	const barClasses = [
+		'relative',
+		'h-3',
+		'rounded-full',
+		'bg-slate-200/70',
+		'dark:bg-slate-700/70',
+		'overflow-visible',
+	].join(' ');
+	const fillClasses = [
+		'absolute',
+		'left-0',
+		'top-0',
+		'h-full',
+		'rounded-full',
+		'bg-gradient-to-r',
+		'from-emerald-400',
+		'to-sky-500',
+		'transition-[width]',
+	].join(' ');
+	return (
+		<div className="mb-4">
+			<div className="mb-2 flex items-center justify-between text-xs text-slate-600 dark:text-slate-300">
+				<span className="font-medium uppercase tracking-wider">
+					Progression curve
+				</span>
+				<span>
+					{bindingIcon ? `${bindingIcon} ` : ''}
+					{bindingSpent} {bindingLabel} spent
+				</span>
+			</div>
+			<div className={barClasses}>
+				<div
+					className={fillClasses}
+					style={{ width: `${currentPercent}%` }}
+					aria-hidden="true"
+				/>
+				{sorted.map((threshold, index) => {
+					const position = Math.min(
+						100,
+						(threshold.bindingSpent / trackMax) * 100,
+					);
+					const reached = bindingSpent >= threshold.bindingSpent;
+					const markerClasses = [
+						'absolute',
+						'top-1/2',
+						'-translate-x-1/2',
+						'-translate-y-1/2',
+						'h-4',
+						'w-4',
+						'rounded-full',
+						'border-2',
+						reached
+							? 'border-emerald-500 bg-emerald-300'
+							: 'border-slate-400 bg-white dark:bg-slate-800',
+					].join(' ');
+					const weightEntries = Object.entries(threshold.weights).sort(
+						([a], [b]) => Number(a) - Number(b),
+					);
+					const tooltip = weightEntries
+						.map(([tier, weight]) => `T${tier}: ${weight}`)
+						.join(' · ');
+					return (
+						<div
+							key={`threshold-${index}`}
+							className={markerClasses}
+							style={{ left: `${position}%` }}
+							title={`At ${threshold.bindingSpent} ${bindingLabel} — ${tooltip}`}
+							aria-label={`Threshold at ${threshold.bindingSpent} ${bindingLabel}`}
+						/>
+					);
+				})}
+			</div>
+			<div className="mt-1 flex justify-between text-[10px] text-slate-500 dark:text-slate-400">
+				{sorted.map((threshold, index) => (
+					<span key={`label-${index}`}>{threshold.bindingSpent}</span>
+				))}
+			</div>
+		</div>
+	);
+}
+
+interface CatalogRowProps {
+	entry: CatalogEntry;
+	status: CatalogStatus;
+}
+
+function CatalogRow({ entry, status }: CatalogRowProps) {
+	const { definition } = entry;
+	const icon = definition.icon ?? '';
+	const name = definition.name ?? entry.id;
+	const statusClasses = [
+		'ml-auto',
+		'rounded-full',
+		'px-2',
+		'py-0.5',
+		'text-[10px]',
+		'font-semibold',
+		'uppercase',
+		'tracking-wider',
+	];
+	let statusLabel: string;
+	let statusTone: string;
+	switch (status.kind) {
+		case 'available':
+			statusLabel = 'Available';
+			statusTone =
+				'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300';
+			break;
+		case 'locked':
+			statusLabel = 'Locked';
+			statusTone =
+				'bg-slate-200 text-slate-600 dark:bg-slate-800 dark:text-slate-300';
+			break;
+		case 'completed':
+			statusLabel = 'Completed';
+			statusTone =
+				'bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300';
+			break;
+		case 'upgraded':
+			statusLabel = `Tier ${status.tier}/${entry.maxTier}`;
+			statusTone =
+				'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300';
+			break;
+	}
+	const rowClasses = [
+		'flex',
+		'items-center',
+		'gap-2',
+		'rounded-md',
+		'px-2',
+		'py-1',
+		'text-sm',
+		'text-slate-700',
+		'dark:text-slate-200',
+		status.kind === 'locked' ? 'opacity-60' : '',
+	]
+		.filter(Boolean)
+		.join(' ');
+	return (
+		<li className={rowClasses}>
+			{icon && <span aria-hidden="true">{icon}</span>}
+			<span className="truncate">{name}</span>
+			<span className={[...statusClasses, statusTone].join(' ')}>
+				{statusLabel}
+			</span>
+		</li>
+	);
+}
+
+export default function ResearchProgressionPanel({
+	metaCategory,
+	actions,
+	summaries,
+	player,
+	canInteract,
+	selectResourceDescriptor,
+	panelDisabled,
+}: ResearchProgressionPanelProps) {
+	const { translationContext } = useGameEngine();
+	const resourceMetadata = useResourceMetadata();
+
+	const bindingDescriptor = useMemo(
+		() =>
+			resourceMetadata.byId[metaCategory.bindingResourceId] ??
+			resourceMetadata.select(metaCategory.bindingResourceId),
+		[resourceMetadata, metaCategory.bindingResourceId],
+	);
+	const bindingIcon = bindingDescriptor.icon;
+	const bindingLabel =
+		bindingDescriptor.label ?? metaCategory.bindingResourceId;
+
+	const isVisible = useMemo(() => {
+		if (metaCategory.visibilityTrigger === 'always') {
+			return true;
+		}
+		return player.resourceTouched[metaCategory.bindingResourceId] ?? false;
+	}, [metaCategory.visibilityTrigger, metaCategory.bindingResourceId, player]);
+
+	const poolSize = metaCategory.pool?.size ?? 0;
+	const poolActions = useMemo(
+		() => actions.filter((action) => action.metaCategory === metaCategory.id),
+		[actions, metaCategory.id],
+	);
+
+	const catalogEntries = useMemo<CatalogEntry[]>(() => {
+		const entries: CatalogEntry[] = [];
+		for (const [id, state] of Object.entries(player.actionStates)) {
+			let definition: ActionConfig;
+			try {
+				definition = translationContext.actions.get(id);
+			} catch {
+				continue;
+			}
+			if (definition.metaCategory !== metaCategory.id) {
+				continue;
+			}
+			if (definition.system) {
+				continue;
+			}
+			const { startingTier, maxTier } = getTierRange(definition);
+			entries.push({ id, definition, startingTier, maxTier, state });
+		}
+		return entries;
+	}, [player.actionStates, translationContext.actions, metaCategory.id]);
+
+	const groupedByTier = useMemo(() => {
+		const map = new Map<number, CatalogEntry[]>();
+		for (const entry of catalogEntries) {
+			const list = map.get(entry.startingTier) ?? [];
+			list.push(entry);
+			map.set(entry.startingTier, list);
+		}
+		for (const list of map.values()) {
+			list.sort((a, b) =>
+				(a.definition.name ?? a.id).localeCompare(b.definition.name ?? b.id),
+			);
+		}
+		return Array.from(map.entries()).sort(([a], [b]) => a - b);
+	}, [catalogEntries]);
+
+	const bindingValue = player.values?.[metaCategory.bindingResourceId] ?? 0;
+	const bindingSpent = player.metaCategoryBindingSpent?.[metaCategory.id] ?? 0;
+
+	if (!isVisible) {
+		return null;
+	}
+
+	return (
+		<section
+			className={SECTION_CLASSES}
+			aria-disabled={panelDisabled || undefined}
+		>
+			<div className={HEADER_CLASSES}>
+				<h2 className={TITLE_CLASSES}>
+					{metaCategory.icon} {metaCategory.label}
+					<span className={COST_LABEL_CLASSES + ' ml-2'}>
+						({bindingIcon ? `${bindingIcon} ` : ''}
+						{bindingValue} available · {bindingSpent} spent)
+					</span>
+				</h2>
+				<div className={POOL_STATUS_CLASSES}>
+					{poolActions.length} of {poolSize} available
+				</div>
+			</div>
+			<ProgressionCurve
+				bindingSpent={bindingSpent}
+				thresholds={metaCategory.pool?.fillMode.thresholds ?? []}
+				bindingIcon={bindingIcon}
+				bindingLabel={bindingLabel}
+			/>
+			<div className="mb-2 text-xs font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400">
+				Available now
+			</div>
+			<PoolSlots
+				actions={poolActions}
+				poolSize={poolSize}
+				summaries={summaries}
+				player={player}
+				canInteract={canInteract}
+				selectResourceDescriptor={selectResourceDescriptor}
+			/>
+			{groupedByTier.length > 0 && (
+				<div className="mt-6">
+					<div className="mb-2 text-xs font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400">
+						Catalog
+					</div>
+					<div className="flex flex-col gap-4">
+						{groupedByTier.map(([tier, entries]) => {
+							const completed = entries.filter(
+								(entry) => entry.state.exhausted,
+							).length;
+							return (
+								<div key={`tier-${tier}`} className="flex flex-col gap-1">
+									<div className="text-xs font-semibold text-slate-600 dark:text-slate-300">
+										Tier {tier} — {completed}/{entries.length} completed
+									</div>
+									<ul className="flex flex-col gap-0.5">
+										{entries.map((entry) => (
+											<CatalogRow
+												key={entry.id}
+												entry={entry}
+												status={resolveCatalogStatus(entry)}
+											/>
+										))}
+									</ul>
+								</div>
+							);
+						})}
+					</div>
+				</div>
+			)}
+		</section>
+	);
+}

--- a/packages/web/src/components/actions/actionSummaryHelpers.ts
+++ b/packages/web/src/components/actions/actionSummaryHelpers.ts
@@ -116,8 +116,16 @@ export function resolveInstallationTarget(
 export function summarizeActionWithInstallation(
 	actionId: string,
 	translationContext: TranslationContext,
+	currentTier?: number,
 ): Summary {
-	const baseSummary = summarizeContent('action', actionId, translationContext);
+	const actionOptions =
+		typeof currentTier === 'number' ? { currentTier } : undefined;
+	const baseSummary = summarizeContent(
+		'action',
+		actionId,
+		translationContext,
+		actionOptions,
+	);
 	const target = resolveInstallationTarget(actionId, translationContext);
 	if (!target) {
 		return baseSummary;
@@ -162,11 +170,15 @@ export function summarizeActionWithInstallation(
 export function describeActionWithInstallation(
 	actionId: string,
 	translationContext: TranslationContext,
+	currentTier?: number,
 ): Summary {
+	const actionOptions =
+		typeof currentTier === 'number' ? { currentTier } : undefined;
 	const baseDescription = describeContent(
 		'action',
 		actionId,
 		translationContext,
+		actionOptions,
 	);
 	const target = resolveInstallationTarget(actionId, translationContext);
 	if (!target) {

--- a/packages/web/src/state/buildActionResolution.ts
+++ b/packages/web/src/state/buildActionResolution.ts
@@ -45,6 +45,11 @@ export interface BuildActionResolutionOptions {
 	diffContext: TranslationDiffContext;
 	resourceKeys: readonly SessionResourceKey[];
 	resources: SessionRegistries['resources'];
+	/**
+	 * Current tier of the performed action at the time the player invoked it,
+	 * used to pick the correct tier-specific effects when rendering log lines.
+	 */
+	currentTier?: number;
 }
 
 export interface BuildActionResolutionResult {
@@ -252,8 +257,13 @@ export function buildActionResolution({
 	diffContext,
 	resourceKeys,
 	resources,
+	currentTier,
 }: BuildActionResolutionOptions): BuildActionResolutionResult {
-	const stepEffects = resolveActionEffects(actionDefinition, params);
+	const stepEffects = resolveActionEffects(
+		actionDefinition,
+		params,
+		currentTier,
+	);
 	const diffOptions = translationContext.rules.tieredResourceKey
 		? { tieredResourceKey: translationContext.rules.tieredResourceKey }
 		: undefined;
@@ -265,11 +275,15 @@ export function buildActionResolution({
 		Array.from(resourceKeys),
 		diffOptions,
 	);
+	const logOptions: Record<string, unknown> | undefined =
+		typeof currentTier === 'number'
+			? { ...(params ?? {}), currentTier }
+			: params;
 	const rawMessages = logContent(
 		'action',
 		actionId,
 		translationContext,
-		params,
+		logOptions,
 	);
 	const messages = ensureTimelineLines(rawMessages);
 	const costLines = buildActionCostLines({

--- a/packages/web/src/state/useActionPerformer.ts
+++ b/packages/web/src/state/useActionPerformer.ts
@@ -166,6 +166,8 @@ export function useActionPerformer({
 					});
 					return;
 				}
+				const actionTierBefore =
+					playerBefore.actionStates?.[action.id]?.currentTier;
 				const resolution = buildActionResolution({
 					actionId: action.id,
 					actionDefinition: stepDef,
@@ -178,6 +180,9 @@ export function useActionPerformer({
 					diffContext,
 					resourceKeys,
 					resources: registries.resources,
+					...(typeof actionTierBefore === 'number'
+						? { currentTier: actionTierBefore }
+						: {}),
 				});
 				const { timeline, logLines, summaries, headline } = resolution;
 				syncPhaseState(snapshotAfter);

--- a/packages/web/src/state/useAiRunner.ts
+++ b/packages/web/src/state/useAiRunner.ts
@@ -135,6 +135,8 @@ async function presentAiActions({
 			: afterSnapshot
 				? clonePlayerSnapshot(afterSnapshot)
 				: clonePlayerSnapshot(beforeState);
+		const actionTierBefore =
+			beforePlayer?.actionStates?.[actionResult.actionId]?.currentTier;
 		const resolution = buildActionResolution({
 			actionId: actionResult.actionId,
 			actionDefinition: stepDefinition,
@@ -147,6 +149,9 @@ async function presentAiActions({
 			diffContext,
 			resourceKeys,
 			resources: registries.resources,
+			...(typeof actionTierBefore === 'number'
+				? { currentTier: actionTierBefore }
+				: {}),
 		});
 		const actionMeta = buildResolutionActionMeta(
 			action,

--- a/packages/web/src/translation/content/action.ts
+++ b/packages/web/src/translation/content/action.ts
@@ -21,6 +21,29 @@ import type {
 } from '../log/timeline';
 import { formatActionTitle } from '../formatActionTitle';
 
+/**
+ * Reserved option key that callers use to tell the ActionTranslator which
+ * tier of a multi-tier action to render. Stripped before params are handed to
+ * resolveActionEffects so it never leaks into effect param substitution.
+ */
+const ACTION_TIER_OPTION_KEY = 'currentTier';
+
+function splitTierOption(options: Record<string, unknown> | undefined): {
+	tier: number | undefined;
+	params: ActionParametersPayload | undefined;
+} {
+	if (!options) {
+		return { tier: undefined, params: undefined };
+	}
+	const { [ACTION_TIER_OPTION_KEY]: rawTier, ...rest } = options;
+	const tier = typeof rawTier === 'number' ? rawTier : undefined;
+	const params =
+		Object.keys(rest).length > 0
+			? (rest as ActionParametersPayload)
+			: undefined;
+	return { tier, params };
+}
+
 class ActionTranslator implements ContentTranslator<
 	string,
 	Record<string, unknown>
@@ -31,10 +54,8 @@ class ActionTranslator implements ContentTranslator<
 		options?: Record<string, unknown>,
 	): Summary {
 		const definition = context.actions.get(id);
-		const resolved = resolveActionEffects(
-			definition,
-			options as ActionParametersPayload | undefined,
-		);
+		const { tier, params } = splitTierOption(options);
+		const resolved = resolveActionEffects(definition, params, tier);
 		const combined: Summary = [];
 		for (const step of resolved.steps) {
 			if (step.type === 'effects') {
@@ -51,10 +72,8 @@ class ActionTranslator implements ContentTranslator<
 		options?: Record<string, unknown>,
 	): Summary {
 		const definition = context.actions.get(id);
-		const resolved = resolveActionEffects(
-			definition,
-			options as ActionParametersPayload | undefined,
-		);
+		const { tier, params } = splitTierOption(options);
+		const resolved = resolveActionEffects(definition, params, tier);
 		const combined: Summary = [];
 		for (const step of resolved.steps) {
 			if (step.type === 'effects') {
@@ -68,18 +87,16 @@ class ActionTranslator implements ContentTranslator<
 	log(
 		id: string,
 		context: TranslationContext,
-		params?: Record<string, unknown>,
+		options?: Record<string, unknown>,
 	): ActionLogLineDescriptor[] {
 		const definition = context.actions.get(id);
 		let message = formatActionTitle(definition, context);
+		const { tier, params } = splitTierOption(options);
 		const extra = getActionLogHook(definition)?.(context, params);
 		if (extra) {
 			message += extra;
 		}
-		const resolved = resolveActionEffects(
-			definition,
-			params as ActionParametersPayload | undefined,
-		);
+		const resolved = resolveActionEffects(definition, params, tier);
 		const effectLogs: Summary = [];
 		for (const step of resolved.steps) {
 			if (step.type === 'effects') {

--- a/packages/web/src/translation/effects/formatters/action.ts
+++ b/packages/web/src/translation/effects/formatters/action.ts
@@ -56,6 +56,40 @@ function getActionPresentation(id: string, context: TranslationContext) {
 	return { icon, name, system, locked, label };
 }
 
+function getMetaCategoryPresentation(id: string, context: TranslationContext) {
+	try {
+		const definition = context.actionMetaCategories.get(id);
+		const label = formatActionLabel(definition.icon, definition.label) || id;
+		return { icon: definition.icon, label };
+	} catch {
+		return { icon: '', label: id };
+	}
+}
+
+type UpgradeTarget =
+	| { mode: 'action'; actionId: string }
+	| { mode: 'metaCategory'; metaCategoryId: string };
+
+function extractUpgradeTarget(
+	params: Record<string, unknown> | undefined,
+): UpgradeTarget | null {
+	if (!params) {
+		return null;
+	}
+	const targetAction = params['targetAction'];
+	if (typeof targetAction === 'string' && targetAction.length > 0) {
+		return { mode: 'action', actionId: targetAction };
+	}
+	const randomInMetaCategory = params['randomInMetaCategory'];
+	if (
+		typeof randomInMetaCategory === 'string' &&
+		randomInMetaCategory.length > 0
+	) {
+		return { mode: 'metaCategory', metaCategoryId: randomInMetaCategory };
+	}
+	return null;
+}
+
 registerEffectFormatter('action', 'add', {
 	summarize: (effect, context) => {
 		const id = effect.params?.['id'] as string;
@@ -116,6 +150,63 @@ registerEffectFormatter('action', 'remove', {
 		}
 		const { label } = getActionPresentation(id, context);
 		return formatActionChangeSentence('lose', label, 'log');
+	},
+});
+
+registerEffectFormatter('action', 'upgrade', {
+	summarize: (effect, context) => {
+		const target = extractUpgradeTarget(effect.params);
+		if (!target) {
+			return null;
+		}
+		if (target.mode === 'action') {
+			const { label } = getActionPresentation(target.actionId, context);
+			return `Upgrade ${label}`;
+		}
+		const { label } = getMetaCategoryPresentation(
+			target.metaCategoryId,
+			context,
+		);
+		return `Upgrade random ${label}`;
+	},
+	describe: (effect, context) => {
+		const target = extractUpgradeTarget(effect.params);
+		if (!target) {
+			return null;
+		}
+		if (target.mode === 'action') {
+			const { label } = getActionPresentation(target.actionId, context);
+			const card = describeContent('action', target.actionId, context);
+			return [
+				`Upgrade ${label} to the next tier`,
+				{
+					title: label,
+					items: card,
+					_hoist: true,
+					_desc: true,
+				},
+			];
+		}
+		const { label } = getMetaCategoryPresentation(
+			target.metaCategoryId,
+			context,
+		);
+		return `Upgrade a random ${label} action to the next tier`;
+	},
+	log: (effect, context) => {
+		const target = extractUpgradeTarget(effect.params);
+		if (!target) {
+			return null;
+		}
+		if (target.mode === 'action') {
+			const { label } = getActionPresentation(target.actionId, context);
+			return `Upgraded ${label}`;
+		}
+		const { label } = getMetaCategoryPresentation(
+			target.metaCategoryId,
+			context,
+		);
+		return `Upgraded a random ${label}`;
 	},
 });
 

--- a/packages/web/tests/action-upgrade-translation.test.ts
+++ b/packages/web/tests/action-upgrade-translation.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type {
+	ActionConfig,
+	ActionMetaCategoryConfig,
+	EffectDef,
+	SessionPlayerId,
+} from '@kingdom-builder/protocol';
+import {
+	summarizeEffects,
+	describeEffects,
+	logEffects,
+} from '../src/translation/effects';
+import { summarizeContent, describeContent } from '../src/translation/content';
+import { createTranslationContext } from '../src/translation/context';
+import { createTestSessionScaffold } from './helpers/testSessionScaffold';
+import {
+	createSessionSnapshot,
+	createSnapshotPlayer,
+} from './helpers/sessionFixtures';
+
+const TIER_ACTION_ID = 'test:tier_action';
+const META_CATEGORY_ID = 'meta:test-research';
+const BINDING_RESOURCE_ID = 'resource:core:happiness';
+
+function buildTieredActionConfig(): ActionConfig {
+	return {
+		id: TIER_ACTION_ID,
+		name: 'Tiered Action',
+		icon: '🧪',
+		category: 'basic',
+		metaCategory: META_CATEGORY_ID,
+		oneTime: true,
+		tiers: {
+			'1': {
+				costs: { [BINDING_RESOURCE_ID]: 2 },
+				effects: [
+					{
+						type: 'resource',
+						method: 'add',
+						params: {
+							resourceId: BINDING_RESOURCE_ID,
+							change: { type: 'amount', amount: 1 },
+						},
+					} satisfies EffectDef,
+				],
+			},
+			'2': {
+				costs: { [BINDING_RESOURCE_ID]: 4 },
+				effects: [
+					{
+						type: 'resource',
+						method: 'add',
+						params: {
+							resourceId: BINDING_RESOURCE_ID,
+							change: { type: 'amount', amount: 5 },
+						},
+					} satisfies EffectDef,
+				],
+			},
+			'3': {
+				costs: { [BINDING_RESOURCE_ID]: 8 },
+				effects: [
+					{
+						type: 'resource',
+						method: 'add',
+						params: {
+							resourceId: BINDING_RESOURCE_ID,
+							change: { type: 'amount', amount: 20 },
+						},
+					} satisfies EffectDef,
+				],
+			},
+		},
+	} as unknown as ActionConfig;
+}
+
+function buildMetaCategoryConfig(): ActionMetaCategoryConfig {
+	return {
+		id: META_CATEGORY_ID,
+		label: 'Test Research',
+		icon: '🧬',
+		bindingResourceId: BINDING_RESOURCE_ID,
+		costModel: 'per-item',
+		visibilityTrigger: 'always',
+		order: 99,
+	};
+}
+
+function createHarness() {
+	const scaffold = createTestSessionScaffold();
+	const tieredAction = buildTieredActionConfig();
+	scaffold.registries.actions.add(tieredAction.id, tieredAction);
+	scaffold.registries.actionMetaCategories.add(
+		META_CATEGORY_ID,
+		buildMetaCategoryConfig(),
+	);
+	const activePlayer = createSnapshotPlayer({
+		id: 'player:active' as SessionPlayerId,
+	});
+	const opponent = createSnapshotPlayer({
+		id: 'player:opponent' as SessionPlayerId,
+	});
+	const session = createSessionSnapshot({
+		players: [activePlayer, opponent],
+		activePlayerId: activePlayer.id,
+		opponentId: opponent.id,
+		phases: scaffold.phases,
+		actionCostResource: scaffold.ruleSnapshot.tieredResourceKey,
+		ruleSnapshot: scaffold.ruleSnapshot,
+		metadata: scaffold.metadata,
+	});
+	const context = createTranslationContext(
+		session,
+		scaffold.registries,
+		session.metadata,
+		{
+			ruleSnapshot: session.rules,
+			passiveRecords: session.passiveRecords,
+		},
+	);
+	return { context };
+}
+
+describe('action:upgrade effect formatter', () => {
+	let context: ReturnType<typeof createHarness>['context'];
+
+	beforeEach(() => {
+		context = createHarness().context;
+	});
+
+	it('summarizes targetAction upgrade with the action label', () => {
+		const summary = summarizeEffects(
+			[
+				{
+					type: 'action',
+					method: 'upgrade',
+					params: { targetAction: TIER_ACTION_ID },
+				} as EffectDef,
+			],
+			context,
+		);
+		expect(summary).toEqual(['Upgrade 🧪 Tiered Action']);
+	});
+
+	it('describes targetAction upgrade with a sentence and nested card', () => {
+		const described = describeEffects(
+			[
+				{
+					type: 'action',
+					method: 'upgrade',
+					params: { targetAction: TIER_ACTION_ID },
+				} as EffectDef,
+			],
+			context,
+		);
+		expect(described[0]).toBe('Upgrade 🧪 Tiered Action to the next tier');
+		expect(described[1]).toMatchObject({
+			title: '🧪 Tiered Action',
+			_hoist: true,
+			_desc: true,
+		});
+	});
+
+	it('logs targetAction upgrade in past tense', () => {
+		const logged = logEffects(
+			[
+				{
+					type: 'action',
+					method: 'upgrade',
+					params: { targetAction: TIER_ACTION_ID },
+				} as EffectDef,
+			],
+			context,
+		);
+		expect(logged).toEqual(['Upgraded 🧪 Tiered Action']);
+	});
+
+	it('summarizes randomInMetaCategory upgrade with the meta-category label', () => {
+		const summary = summarizeEffects(
+			[
+				{
+					type: 'action',
+					method: 'upgrade',
+					params: { randomInMetaCategory: META_CATEGORY_ID },
+				} as EffectDef,
+			],
+			context,
+		);
+		expect(summary).toEqual(['Upgrade random 🧬 Test Research']);
+	});
+
+	it('describes randomInMetaCategory upgrade', () => {
+		const described = describeEffects(
+			[
+				{
+					type: 'action',
+					method: 'upgrade',
+					params: { randomInMetaCategory: META_CATEGORY_ID },
+				} as EffectDef,
+			],
+			context,
+		);
+		expect(described).toEqual([
+			'Upgrade a random 🧬 Test Research action to the next tier',
+		]);
+	});
+
+	it('logs randomInMetaCategory upgrade in past tense', () => {
+		const logged = logEffects(
+			[
+				{
+					type: 'action',
+					method: 'upgrade',
+					params: { randomInMetaCategory: META_CATEGORY_ID },
+				} as EffectDef,
+			],
+			context,
+		);
+		expect(logged).toEqual(['Upgraded a random 🧬 Test Research']);
+	});
+
+	it('returns nothing when no target is specified', () => {
+		const summary = summarizeEffects(
+			[{ type: 'action', method: 'upgrade', params: {} } as EffectDef],
+			context,
+		);
+		expect(summary).toEqual([]);
+	});
+});
+
+describe('ActionTranslator tier-aware rendering', () => {
+	it('renders tier 1 effects by default', () => {
+		const { context } = createHarness();
+		const summary = summarizeContent('action', TIER_ACTION_ID, context);
+		const serialized = JSON.stringify(summary);
+		expect(serialized).toContain('+1');
+	});
+
+	it('renders the tier specified by options.currentTier', () => {
+		const { context } = createHarness();
+		const summary = summarizeContent('action', TIER_ACTION_ID, context, {
+			currentTier: 2,
+		});
+		const serialized = JSON.stringify(summary);
+		expect(serialized).toContain('+5');
+		expect(serialized).not.toContain('+1');
+	});
+
+	it('renders tier 3 effects when currentTier is 3', () => {
+		const { context } = createHarness();
+		const describe = describeContent('action', TIER_ACTION_ID, context, {
+			currentTier: 3,
+		});
+		const serialized = JSON.stringify(describe);
+		expect(serialized).toContain('+20');
+	});
+});


### PR DESCRIPTION
## Summary
This PR introduces a new research progression panel UI component and adds support for action upgrade effects. The changes enable displaying tiered actions with a progression curve visualization and catalog view, along with proper translation/formatting of upgrade effects.

## Key Changes

### New Components
- **ResearchProgressionPanel**: A specialized panel for meta-categories using `tier-progression-curve` pool fill mode. Displays:
  - A progression curve visualization showing binding resource spending thresholds
  - Pool slots for currently available actions
  - A catalog view grouping actions by tier with completion status
  - Tier-aware status indicators (Available, Locked, Completed, Tier X/Y)

- **PoolSlots**: Extracted shared component for rendering pool slot grids with empty slot placeholders. Used by both `MetaCategoryPanel` and `ResearchProgressionPanel`.

### Action Upgrade Effects
- Added `action:upgrade` effect formatter with three modes:
  - `summarize`: "Upgrade 🧪 Action Name" or "Upgrade random 🧬 Category"
  - `describe`: Includes nested card preview of the target action
  - `log`: Past tense "Upgraded..." format
- Supports two upgrade targets: specific action (`targetAction`) or random action in meta-category (`randomInMetaCategory`)

### Tier-Aware Action Rendering
- Modified `ActionTranslator` to accept `currentTier` option for rendering tier-specific effects
- Added `splitTierOption()` to extract and separate tier selection from other action parameters
- Updated `resolveActionEffects()` calls throughout to pass tier information
- Added next-tier preview in `ActionCard` showing effects of the next tier upgrade

### Integration Updates
- `ActionsPanel` now selects between `MetaCategoryPanel` and `ResearchProgressionPanel` based on pool fill mode
- `GenericActionCard` computes and displays next-tier summary for upgrade preview
- `buildActionResolution()` accepts `currentTier` to ensure correct tier effects are logged
- `useActionPerformer` and `useAiRunner` capture action tier before resolution for accurate logging

### Styling
- Reused existing action panel style constants
- Added progression curve visualization with gradient fill and threshold markers
- Catalog rows with status badges (color-coded by state)

## Notable Implementation Details
- Tier range detection handles missing or non-numeric tier keys gracefully
- Progression curve scales dynamically based on max threshold and current spending
- Catalog entries are sorted by tier then alphabetically by name
- Status resolution follows a priority order: exhausted → locked → upgraded → available
- The `currentTier` option is stripped before effect parameter substitution to prevent leakage

https://claude.ai/code/session_01SpqvRw3fKNbGDQoszoyEk6