### PR TITLE
Move next tier preview from ActionCard to HoverCard

### DIFF
--- a/packages/web/src/components/HoverCard.tsx
+++ b/packages/web/src/components/HoverCard.tsx
@@ -207,6 +207,16 @@ export default function HoverCard() {
 					<ul className={CARD_LIST_CLASS}>{effectSummary}</ul>
 				</div>
 			)}
+			{renderedData.nextTierEffects &&
+				renderedData.nextTierEffects.length > 0 &&
+				!renderedData.thermometer && (
+					<div className="mt-2">
+						<div className={CARD_LABEL_CLASS}>Next tier →</div>
+						<ul className={CARD_LIST_CLASS}>
+							{renderSummary(renderedData.nextTierEffects)}
+						</ul>
+					</div>
+				)}
 			{(() => {
 				const desc = renderedData.description;
 				const hasDescription =

--- a/packages/web/src/components/actions/ActionCard.tsx
+++ b/packages/web/src/components/actions/ActionCard.tsx
@@ -49,8 +49,6 @@ export interface ActionCardProps {
 	currentTier?: number | undefined;
 	/** Max tier for multi-tier actions */
 	maxTier?: number | undefined;
-	/** Pre-rendered summary for the next tier (for upgrade preview) */
-	nextTierSummary?: Summary | undefined;
 }
 
 export default function ActionCard({
@@ -83,7 +81,6 @@ export default function ActionCard({
 	resourceMetadata,
 	currentTier,
 	maxTier,
-	nextTierSummary,
 }: ActionCardProps): ReactElement {
 	const focusClass = getFocusGradient(focus);
 	const isBack = variant === 'back';
@@ -175,24 +172,6 @@ export default function ActionCard({
 			Tier {currentTier}/{maxTier}
 		</span>
 	) : null;
-	const showNextTierPreview =
-		variant === 'front' &&
-		implemented &&
-		nextTierSummary !== undefined &&
-		nextTierSummary.length > 0 &&
-		currentTier !== undefined &&
-		maxTier !== undefined &&
-		currentTier < maxTier;
-	const nextTierPreview = showNextTierPreview ? (
-		<div className="action-card__next-tier mt-2 border-t border-slate-200/60 dark:border-slate-700/60 pt-2">
-			<div className="text-[10px] font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400">
-				Next tier →
-			</div>
-			<ul className="action-card__summary action-card__summary--preview opacity-70 text-xs">
-				{renderSummary(nextTierSummary)}
-			</ul>
-		</div>
-	) : null;
 
 	return (
 		<div
@@ -232,7 +211,6 @@ export default function ActionCard({
 							</div>
 						</div>
 						<ul className="action-card__summary">{renderedSummary}</ul>
-						{nextTierPreview}
 					</div>
 				</button>
 				<div className="action-card__face action-card__face--back">

--- a/packages/web/src/components/actions/GenericActionCard.tsx
+++ b/packages/web/src/components/actions/GenericActionCard.tsx
@@ -22,10 +22,7 @@ import { type Action, type DisplayPlayer, type HoverCardData } from './types';
 import { normalizeActionFocus } from './types';
 import type { UseActionMetadataResult } from '../../state/useActionMetadata';
 import { getActionAvailability } from './getActionAvailability';
-import {
-	describeActionWithInstallation,
-	summarizeActionWithInstallation,
-} from './actionSummaryHelpers';
+import { describeActionWithInstallation } from './actionSummaryHelpers';
 import { isBuildingAlreadyOwned } from './buildingOwnershipCheck';
 
 interface GenericActionCardProps {
@@ -179,7 +176,7 @@ function GenericActionCard({
 		translationContext,
 		action.currentTier,
 	);
-	const nextTierSummary = useMemo(() => {
+	const nextTierEffects = useMemo(() => {
 		if (
 			action.currentTier === undefined ||
 			action.maxTier === undefined ||
@@ -187,11 +184,12 @@ function GenericActionCard({
 		) {
 			return undefined;
 		}
-		return summarizeActionWithInstallation(
+		const nextTierContent = describeActionWithInstallation(
 			action.id,
 			translationContext,
 			action.currentTier + 1,
 		);
+		return splitSummary(nextTierContent).effects;
 	}, [action.id, action.currentTier, action.maxTier, translationContext]);
 	const { effects, description } = splitSummary(hoverContent);
 	const createHoverDetails = (): HoverCardData => ({
@@ -204,6 +202,9 @@ function GenericActionCard({
 		...(notImplementedDetails ?? {}),
 		bgClass: hoverBackground,
 		...(hasGroups ? { multiStep: true } : {}),
+		...(nextTierEffects && nextTierEffects.length > 0
+			? { nextTierEffects }
+			: {}),
 	});
 	const handleMouseEnter = isPending
 		? undefined
@@ -238,7 +239,6 @@ function GenericActionCard({
 			onCancel={isPending ? cancelPending : undefined}
 			currentTier={action.currentTier}
 			maxTier={action.maxTier}
-			nextTierSummary={nextTierSummary}
 			onClick={() => {
 				if (!canInteract || !baseEnabled) {
 					return;

--- a/packages/web/src/state/useHoverCard.ts
+++ b/packages/web/src/state/useHoverCard.ts
@@ -27,6 +27,8 @@ export interface HoverCard {
 	breakdown?: Summary;
 	/** Optional thermometer visualization for tiered resources */
 	thermometer?: TierThermometerData;
+	/** Optional preview of the next tier for multi-tier actions */
+	nextTierEffects?: Summary;
 }
 
 interface HoverCardOptions {


### PR DESCRIPTION
## Summary
Refactored the next tier preview UI from being displayed directly on the ActionCard component to being shown in the HoverCard instead. This improves the UI/UX by reducing clutter on the card itself while still providing upgrade preview information when users hover over multi-tier actions.

## Key Changes
- **Removed from ActionCard**: Deleted the `nextTierSummary` prop and the associated preview rendering logic that displayed "Next tier →" information below the action summary
- **Moved to HoverCard**: Added `nextTierEffects` to the HoverCard data structure to display next tier information in the hover tooltip instead
- **Updated GenericActionCard**: Changed from passing `nextTierSummary` to ActionCard to instead computing `nextTierEffects` and including it in the hover card details
- **Enhanced HoverCard**: Added rendering logic to display next tier effects in the hover card with the same styling as the current tier effects, but only when not showing a thermometer visualization

## Implementation Details
- The next tier effects are now extracted from the action description using the existing `splitSummary` utility
- The preview is only shown when hovering over the action, reducing visual noise on the card itself
- The thermometer visualization takes precedence over the next tier effects display to avoid conflicting information
- All tier comparison logic remains the same; only the presentation location has changed

https://claude.ai/code/session_01HYLCZLVbMwaFFPfoTitWz2