### PR TITLE
Move AP gain step from Growth phase to Upkeep phase

### DIFF
--- a/packages/contents/src/phases.ts
+++ b/packages/contents/src/phases.ts
@@ -20,7 +20,6 @@ export const PHASES: PhaseDef[] = [
 		.label('Growth')
 		.icon('🌳')
 		.step(step(PhaseStepId.GainIncome).title('Gain Income').icon('💰').triggers(Trigger.GAIN_INCOME))
-		.step(step(PhaseStepId.GainActionPoints).title('Gain Action Points').triggers(Trigger.GAIN_AP))
 		.step(
 			step(PhaseStepId.RaiseStrength)
 				.title('Raise Strength')
@@ -60,6 +59,7 @@ export const PHASES: PhaseDef[] = [
 						.build(),
 				),
 		)
+		.step(step(PhaseStepId.GainActionPoints).title('Gain Action Points').triggers(Trigger.GAIN_AP))
 		.build(),
 	phase(PhaseId.Main).label('Main').icon('🎯').action().step(step(PhaseStepId.Main).title('Main Phase')).build(),
 ];

--- a/packages/contents/src/resources.ts
+++ b/packages/contents/src/resources.ts
@@ -194,7 +194,7 @@ function buildPopulationResources(): readonly ResourceDefinition[] {
 		resource('resource:core:council')
 			.icon('⚖️')
 			.label('Council')
-			.description('The Council advises the crown and generates Action Points ' + 'during the Growth phase. Keeping them employed fuels your economy.')
+			.description('The Council advises the crown and generates Action Points ' + 'during the Upkeep phase. Keeping them employed fuels your economy.')
 			.group(POPULATION_GROUP_ID, { order: POPULATION_GROUP_ORDER })
 			.order(1)
 			.lowerBound(0)

--- a/packages/engine/tests/advance-skip.test.ts
+++ b/packages/engine/tests/advance-skip.test.ts
@@ -18,12 +18,6 @@ const upkeepPhase =
 const upkeepPhaseId = upkeepPhase?.id ?? '';
 const warRecoveryStepId =
 	upkeepPhase?.steps.find((step) => step.id.includes('war-recovery'))?.id ?? '';
-const mainPhase =
-	PHASES[
-		(PHASES.findIndex((phase) => phase.id === upkeepPhaseId) + 1) %
-			PHASES.length
-	];
-
 const phaseSummary = 'test.summary.phase';
 const stepSummary = 'test.summary.step';
 
@@ -125,9 +119,14 @@ describe('advance skip handling', () => {
 		expect(result.skipped?.stepId).toBe(warRecoveryStepId);
 		expect(result.skipped?.sources[0]?.detail).toBe(stepSummary);
 
-		expect(engineContext.game.currentPhase).toBe(mainPhase?.id ?? '');
-		const expectedStep = mainPhase?.steps[0]?.id ?? '';
-		expect(engineContext.game.currentStep).toBe(expectedStep);
+		// After skipping WarRecovery, engine advances to the next Upkeep
+		// step (GainActionPoints), not to Main.
+		expect(engineContext.game.currentPhase).toBe(upkeepPhaseId);
+		const warRecoveryIndex =
+			upkeepPhase?.steps.findIndex((step) => step.id === warRecoveryStepId) ??
+			0;
+		const nextStepId = upkeepPhase?.steps[warRecoveryIndex + 1]?.id ?? '';
+		expect(engineContext.game.currentStep).toBe(nextStepId);
 	});
 
 	it('collects metadata for every skip source to support logging', () => {

--- a/packages/engine/tests/council-ap-scaling.test.ts
+++ b/packages/engine/tests/council-ap-scaling.test.ts
@@ -75,21 +75,18 @@ function createRealContentEngine() {
 }
 
 function positionAtGainApStep(engine: ReturnType<typeof createEngine>) {
-	// Find the growth phase and gain AP step indices
-	const growthPhaseIndex = PHASES.findIndex(
-		(phase) => phase.id === PhaseId.Growth,
+	const upkeepPhaseIndex = PHASES.findIndex(
+		(phase) => phase.id === PhaseId.Upkeep,
 	);
-	const growthPhase = PHASES[growthPhaseIndex]!;
-	const gainApStepIndex = growthPhase.steps.findIndex((step) =>
+	const upkeepPhase = PHASES[upkeepPhaseIndex]!;
+	const gainApStepIndex = upkeepPhase.steps.findIndex((step) =>
 		step.triggers?.includes('onGainAPStep'),
 	);
 
-	// Position directly at the gain AP step
-	// (without advancing through other phases)
-	engine.game.phaseIndex = growthPhaseIndex;
+	engine.game.phaseIndex = upkeepPhaseIndex;
 	engine.game.stepIndex = gainApStepIndex;
-	engine.game.currentPhase = PhaseId.Growth;
-	engine.game.currentStep = growthPhase.steps[gainApStepIndex]?.id ?? '';
+	engine.game.currentPhase = PhaseId.Upkeep;
+	engine.game.currentStep = upkeepPhase.steps[gainApStepIndex]?.id ?? '';
 }
 
 describe('council AP scaling', () => {

--- a/packages/engine/tests/effect-clone-mutation.test.ts
+++ b/packages/engine/tests/effect-clone-mutation.test.ts
@@ -197,19 +197,19 @@ describe('Cross-Execution Isolation', () => {
 		player.resourceValues[Resource.council] = 5;
 		player.resourceValues[Resource.cp] = 0;
 
-		// Position at gain AP step
-		const growthPhaseIndex = PHASES.findIndex(
-			(phase) => phase.id === PhaseId.Growth,
+		// Position at gain AP step (now in Upkeep phase)
+		const upkeepPhaseIndex = PHASES.findIndex(
+			(phase) => phase.id === PhaseId.Upkeep,
 		);
-		const growthPhase = PHASES[growthPhaseIndex]!;
-		const gainApStepIndex = growthPhase.steps.findIndex((step) =>
+		const upkeepPhase = PHASES[upkeepPhaseIndex]!;
+		const gainApStepIndex = upkeepPhase.steps.findIndex((step) =>
 			step.triggers?.includes('onGainAPStep'),
 		);
 
-		engine.game.phaseIndex = growthPhaseIndex;
+		engine.game.phaseIndex = upkeepPhaseIndex;
 		engine.game.stepIndex = gainApStepIndex;
-		engine.game.currentPhase = PhaseId.Growth;
-		engine.game.currentStep = growthPhase.steps[gainApStepIndex]?.id ?? '';
+		engine.game.currentPhase = PhaseId.Upkeep;
+		engine.game.currentStep = upkeepPhase.steps[gainApStepIndex]?.id ?? '';
 
 		advance(engine);
 
@@ -234,19 +234,19 @@ describe('Cross-Execution Isolation', () => {
 			player.resourceValues[Resource.council] = 3;
 			player.resourceValues[Resource.cp] = 0;
 
-			// Position at gain AP step
-			const growthPhaseIndex = PHASES.findIndex(
-				(phase) => phase.id === PhaseId.Growth,
+			// Position at gain AP step (now in Upkeep phase)
+			const upkeepPhaseIndex = PHASES.findIndex(
+				(phase) => phase.id === PhaseId.Upkeep,
 			);
-			const growthPhase = PHASES[growthPhaseIndex]!;
-			const gainApStepIndex = growthPhase.steps.findIndex((s) =>
+			const upkeepPhase = PHASES[upkeepPhaseIndex]!;
+			const gainApStepIndex = upkeepPhase.steps.findIndex((s) =>
 				s.triggers?.includes('onGainAPStep'),
 			);
 
-			engine.game.phaseIndex = growthPhaseIndex;
+			engine.game.phaseIndex = upkeepPhaseIndex;
 			engine.game.stepIndex = gainApStepIndex;
-			engine.game.currentPhase = PhaseId.Growth;
-			engine.game.currentStep = growthPhase.steps[gainApStepIndex]?.id ?? '';
+			engine.game.currentPhase = PhaseId.Upkeep;
+			engine.game.currentStep = upkeepPhase.steps[gainApStepIndex]?.id ?? '';
 
 			advance(engine);
 

--- a/packages/engine/tests/evaluator-scaling-audit.test.ts
+++ b/packages/engine/tests/evaluator-scaling-audit.test.ts
@@ -149,7 +149,7 @@ describe('Trigger Effect Scaling', () => {
 					player.resourceValues[Resource.council] = councilCount;
 					player.resourceValues[Resource.cp] = 0;
 
-					positionAtStep(engine, PhaseId.Growth, 'onGainAPStep');
+					positionAtStep(engine, PhaseId.Upkeep, 'onGainAPStep');
 					advance(engine);
 
 					const apGained = player.resourceValues[Resource.cp];
@@ -172,14 +172,14 @@ describe('Trigger Effect Scaling', () => {
 			const engine5 = createMinimalEngine();
 			engine5.activePlayer.resourceValues[Resource.council] = 5;
 			engine5.activePlayer.resourceValues[Resource.cp] = 0;
-			positionAtStep(engine5, PhaseId.Growth, 'onGainAPStep');
+			positionAtStep(engine5, PhaseId.Upkeep, 'onGainAPStep');
 			advance(engine5);
 			const ap5 = engine5.activePlayer.resourceValues[Resource.cp];
 
 			const engine10 = createMinimalEngine();
 			engine10.activePlayer.resourceValues[Resource.council] = 10;
 			engine10.activePlayer.resourceValues[Resource.cp] = 0;
-			positionAtStep(engine10, PhaseId.Growth, 'onGainAPStep');
+			positionAtStep(engine10, PhaseId.Upkeep, 'onGainAPStep');
 			advance(engine10);
 			const ap10 = engine10.activePlayer.resourceValues[Resource.cp];
 
@@ -452,7 +452,7 @@ describe('Combinatorial Scaling', () => {
 					player.resourceValues[Resource.gold] = 100;
 
 					// Test AP gain (should only count councils)
-					positionAtStep(engine, PhaseId.Growth, 'onGainAPStep');
+					positionAtStep(engine, PhaseId.Upkeep, 'onGainAPStep');
 					advance(engine);
 
 					const apGained = player.resourceValues[Resource.cp];

--- a/packages/engine/tests/phases/fixtures.ts
+++ b/packages/engine/tests/phases/fixtures.ts
@@ -20,7 +20,7 @@ const phaseIds = {
 const stepIds = {
 	raiseStrength: 'synthetic:step:growth:raise-strength',
 	gainIncome: 'synthetic:step:growth:gain-income',
-	gainAp: 'synthetic:step:growth:gain-ap',
+	gainAp: 'synthetic:step:upkeep:gain-ap',
 	payUpkeep: 'synthetic:step:upkeep:pay',
 	warRecovery: 'synthetic:step:upkeep:war-recovery',
 	main: 'synthetic:step:main',
@@ -58,28 +58,6 @@ export function createPhaseTestEnvironment() {
 			id: phaseIds.growth,
 			steps: [
 				{ id: stepIds.gainIncome, triggers: ['onGainIncomeStep'] },
-				{
-					id: stepIds.gainAp,
-					// Council members grant AP - use resource evaluator
-					effects: [
-						{
-							evaluator: {
-								type: 'resource',
-								params: { resourceId: populationKeys.council },
-							},
-							effects: [
-								{
-									type: 'resource',
-									method: 'add',
-									params: {
-										resourceId: resourceKeys.ap,
-										change: { type: 'amount', amount: AP_GAIN_PER_COUNCIL },
-									},
-								},
-							],
-						},
-					],
-				},
 				{
 					id: stepIds.raiseStrength,
 					// Legion raises army strength, Fortifier raises fortification
@@ -209,6 +187,30 @@ export function createPhaseTestEnvironment() {
 									params: {
 										resourceId: statKeys.war,
 										change: { type: 'amount', amount: 1 },
+									},
+								},
+							],
+						},
+					],
+				},
+				{
+					id: stepIds.gainAp,
+					effects: [
+						{
+							evaluator: {
+								type: 'resource',
+								params: { resourceId: populationKeys.council },
+							},
+							effects: [
+								{
+									type: 'resource',
+									method: 'add',
+									params: {
+										resourceId: resourceKeys.ap,
+										change: {
+											type: 'amount',
+											amount: AP_GAIN_PER_COUNCIL,
+										},
 									},
 								},
 							],

--- a/packages/engine/tests/phases/growth.test.ts
+++ b/packages/engine/tests/phases/growth.test.ts
@@ -3,27 +3,22 @@ import { advance } from '../../src/index.ts';
 import { createPhaseTestEnvironment } from './fixtures.ts';
 
 describe('Growth phase', () => {
-	it('triggers population and development effects', () => {
-		const { engineContext, ids, roles, resources, values } =
+	it('triggers income and strength effects (AP is granted in Upkeep)', () => {
+		const { engineContext, ids, resources, values } =
 			createPhaseTestEnvironment();
 		const player = engineContext.activePlayer;
-		// resources.ap IS the Resource ID directly
 		const apBefore = player.resourceValues[resources.ap] ?? 0;
 		const goldBefore = player.resourceValues[resources.gold] ?? 0;
 		while (engineContext.game.currentPhase === ids.phases.growth) {
 			advance(engineContext);
 		}
-		// roles.council IS the Resource ID directly
-		const councils = player.resourceValues[roles.council] ?? 0;
-		expect(player.resourceValues[resources.ap]).toBe(
-			apBefore + values.councilApGain * councils,
-		);
 		expect(player.resourceValues[resources.gold]).toBe(
 			goldBefore + values.farmIncome,
 		);
+		expect(player.resourceValues[resources.ap]).toBe(apBefore);
 	});
 
-	it('applies player B compensation at start and not during growth', () => {
+	it('applies player B compensation at start and not during AP gain', () => {
 		const { engineContext, phases, ids, roles, resources, values } =
 			createPhaseTestEnvironment();
 		const baseAp = values.baseAp;
@@ -33,17 +28,17 @@ describe('Growth phase', () => {
 		expect(playerA.resourceValues[resources.ap]).toBe(baseAp);
 		expect(playerB.resourceValues[resources.ap]).toBe(baseAp + comp);
 
-		const growthPhaseIndex = phases.findIndex(
-			(phase) => phase.id === ids.phases.growth,
+		const upkeepPhaseIndex = phases.findIndex(
+			(phase) => phase.id === ids.phases.upkeep,
 		);
-		const gainApIdx = phases[growthPhaseIndex]!.steps.findIndex(
+		const gainApIdx = phases[upkeepPhaseIndex]!.steps.findIndex(
 			(step) => step.id === ids.steps.gainAp,
 		);
 
 		engineContext.game.currentPlayerIndex = 0;
-		engineContext.game.phaseIndex = growthPhaseIndex;
+		engineContext.game.phaseIndex = upkeepPhaseIndex;
 		engineContext.game.stepIndex = gainApIdx;
-		engineContext.game.currentPhase = ids.phases.growth;
+		engineContext.game.currentPhase = ids.phases.upkeep;
 		engineContext.game.currentStep = ids.steps.gainAp;
 		playerA.resourceValues[resources.ap] = 0;
 		advance(engineContext);
@@ -53,9 +48,9 @@ describe('Growth phase', () => {
 		);
 
 		engineContext.game.currentPlayerIndex = 1;
-		engineContext.game.phaseIndex = growthPhaseIndex;
+		engineContext.game.phaseIndex = upkeepPhaseIndex;
 		engineContext.game.stepIndex = gainApIdx;
-		engineContext.game.currentPhase = ids.phases.growth;
+		engineContext.game.currentPhase = ids.phases.upkeep;
 		engineContext.game.currentStep = ids.steps.gainAp;
 		playerB.resourceValues[resources.ap] = 0;
 		advance(engineContext);
@@ -66,9 +61,9 @@ describe('Growth phase', () => {
 
 		for (let iterationIndex = 0; iterationIndex < 3; iterationIndex++) {
 			engineContext.game.currentPlayerIndex = 1;
-			engineContext.game.phaseIndex = growthPhaseIndex;
+			engineContext.game.phaseIndex = upkeepPhaseIndex;
 			engineContext.game.stepIndex = gainApIdx;
-			engineContext.game.currentPhase = ids.phases.growth;
+			engineContext.game.currentPhase = ids.phases.upkeep;
 			engineContext.game.currentStep = ids.steps.gainAp;
 			playerB.resourceValues[resources.ap] = 0;
 			advance(engineContext);

--- a/packages/engine/tests/phases/upkeep.test.ts
+++ b/packages/engine/tests/phases/upkeep.test.ts
@@ -77,6 +77,29 @@ describe('Upkeep phase', () => {
 		expect(engineContext.activePlayer.resourceValues[stats.war]).toBe(1);
 	});
 
+	it('grants AP based on council count', () => {
+		const { engineContext, phases, ids, roles, resources, values } =
+			createPhaseTestEnvironment();
+		const upkeepIndex = phases.findIndex(
+			(phase) => phase.id === ids.phases.upkeep,
+		);
+		const gainApIndex = phases[upkeepIndex]!.steps.findIndex(
+			(step) => step.id === ids.steps.gainAp,
+		);
+		engineContext.game.phaseIndex = upkeepIndex;
+		engineContext.game.currentPhase = ids.phases.upkeep;
+		engineContext.game.stepIndex = gainApIndex;
+		engineContext.game.currentStep = ids.steps.gainAp;
+		const councils =
+			engineContext.activePlayer.resourceValues[roles.council] ?? 0;
+		engineContext.activePlayer.resourceValues[resources.ap] = 0;
+		advance(engineContext);
+		engineContext.game.currentPlayerIndex = 0;
+		expect(engineContext.activePlayer.resourceValues[resources.ap]).toBe(
+			values.councilApGain * councils,
+		);
+	});
+
 	it('does not drop war weariness below zero', () => {
 		const { engineContext, phases, ids, stats } = createPhaseTestEnvironment();
 		const upkeepIndex = phases.findIndex(

--- a/tests/integration/dev-mode-start-config.test.ts
+++ b/tests/integration/dev-mode-start-config.test.ts
@@ -116,7 +116,7 @@ describe('dev mode start configuration', () => {
 			DEV_MODE_RESOURCES.get(fortifierId),
 		);
 		expect(opponent.values[castleId]).toBe(DEV_MODE_RESOURCES.get(castleId));
-		// CP starts at 0; it is granted during the Growth phase by Council members
+		// CP starts at 0; it is granted during the Upkeep phase by Council members
 		expect(player.values[cpId]).toBe(0);
 		expect(player.resourceBounds[goldId]?.lowerBound).toBe(0);
 		expect(snapshot.game.resourceCatalog.resources.byId[goldId]).toBeDefined();

--- a/tests/integration/resource-calculation-integrity.test.ts
+++ b/tests/integration/resource-calculation-integrity.test.ts
@@ -226,23 +226,23 @@ describe('Linear Scaling Through Stack', () => {
 				ctx.activePlayer.resourceValues[Resource.council] = councilCount;
 				ctx.activePlayer.resourceValues[Resource.cp] = 0;
 
-				// Position at AP gain step
-				const growthIndex = PHASES.findIndex(
-					(phase) => phase.id === PhaseId.Growth,
+				// Position at AP gain step (in Upkeep phase)
+				const upkeepIndex = PHASES.findIndex(
+					(phase) => phase.id === PhaseId.Upkeep,
 				);
-				const growthPhase = PHASES[growthIndex];
-				if (!growthPhase) {
-					throw new Error('Growth phase not found');
+				const upkeepPhase = PHASES[upkeepIndex];
+				if (!upkeepPhase) {
+					throw new Error('Upkeep phase not found');
 				}
 
-				const apStepIndex = growthPhase.steps.findIndex((step) =>
+				const apStepIndex = upkeepPhase.steps.findIndex((step) =>
 					step.triggers?.includes('onGainAPStep'),
 				);
 
-				ctx.game.phaseIndex = growthIndex;
+				ctx.game.phaseIndex = upkeepIndex;
 				ctx.game.stepIndex = apStepIndex;
-				ctx.game.currentPhase = PhaseId.Growth;
-				ctx.game.currentStep = growthPhase.steps[apStepIndex]?.id ?? '';
+				ctx.game.currentPhase = PhaseId.Upkeep;
+				ctx.game.currentStep = upkeepPhase.steps[apStepIndex]?.id ?? '';
 
 				// Advance through the step
 				advance(ctx);


### PR DESCRIPTION
## Summary
Reorganized the game phase structure by moving the "Gain Action Points" step from the Growth phase to the Upkeep phase. This change affects both the phase definitions and all related test fixtures and test cases.

## Key Changes

- **Phase Structure**: Moved the `GainActionPoints` step from Growth phase to Upkeep phase in the phase definitions
- **Step ID Update**: Updated the step ID from `synthetic:step:growth:gain-ap` to `synthetic:step:upkeep:gain-ap` to reflect the new phase location
- **Test Fixtures**: Updated `createPhaseTestEnvironment()` to define the AP gain step in the Upkeep phase instead of Growth phase
- **Test Updates**: 
  - Updated all test cases that reference the AP gain step to look in the Upkeep phase instead of Growth phase
  - Modified Growth phase tests to verify that AP is NOT gained during Growth (moved to Upkeep)
  - Added new test in Upkeep phase to verify AP is granted based on council count
  - Updated integration tests and audit tests to reference the correct phase
- **Documentation**: Updated resource descriptions and test comments to reflect that AP is now generated during the Upkeep phase

## Implementation Details

The AP gain mechanism remains functionally identical—it still grants AP based on the number of council members. Only the timing within the turn cycle has changed, moving it from the Growth phase (which focuses on income and strength) to the Upkeep phase (which handles maintenance and resource generation).

All phase indices, step indices, and phase/step ID references have been updated consistently across test files to maintain test integrity.

https://claude.ai/code/session_016h5zLJXrLTsSNdT1WeW1j4