### PR TITLE
Preserve phase resolution when filtering entries returns empty

### DIFF
--- a/packages/web/src/state/useActionResolution.ts
+++ b/packages/web/src/state/useActionResolution.ts
@@ -124,7 +124,18 @@ function useActionResolution({
 			}
 			const entries = filteredEntries;
 			if (!entries.length) {
-				setResolution(null);
+				const resolvedEmptySource: ResolutionSource =
+					source ?? (action ? 'action' : 'phase');
+				const preserveExisting =
+					isPhaseSourceDetail(resolvedEmptySource) &&
+					shouldAppendPhaseResolution(
+						resolutionRef.current,
+						resolvedEmptySource,
+						requireAcknowledgement,
+					);
+				if (!preserveExisting) {
+					setResolution(null);
+				}
 				return Promise.resolve();
 			}
 			const resolvedTimelineEntries =

--- a/packages/web/src/state/usePhaseProgress.helpers.ts
+++ b/packages/web/src/state/usePhaseProgress.helpers.ts
@@ -197,6 +197,11 @@ export async function advanceToActionPhase({
 		if (!mountedRef.current) {
 			return;
 		}
+		await showResolution({
+			lines: [],
+			summaries: [],
+			requireAcknowledgement: false,
+		});
 		const refreshedRecord = getSessionRecord(sessionId);
 		const refreshed = refreshedRecord?.snapshot ?? snapshot;
 		if (!mountedRef.current) {

--- a/packages/web/tests/state/usePhaseProgress.helpers.test.ts
+++ b/packages/web/tests/state/usePhaseProgress.helpers.test.ts
@@ -226,7 +226,7 @@ describe('advanceToActionPhase', () => {
 			showResolution: showResolution as never,
 			registries: createSessionRegistries(),
 		});
-		expect(showResolution).toHaveBeenCalledTimes(2);
+		expect(showResolution).toHaveBeenCalledTimes(3);
 		const firstFormatCall = formatPhaseResolution.mock.calls[0]?.[0];
 		expect(firstFormatCall?.phaseDefinition).toEqual(
 			expect.objectContaining({ id: phases[0]?.id ?? 'phase-growth' }),
@@ -255,6 +255,14 @@ describe('advanceToActionPhase', () => {
 			expect.objectContaining({
 				lines: ['    ⚡ Action Points +1'],
 				actorLabel: '🌱 Growth Phase',
+			}),
+		);
+		expect(showResolution).toHaveBeenNthCalledWith(
+			3,
+			expect.objectContaining({
+				lines: [],
+				summaries: [],
+				requireAcknowledgement: false,
 			}),
 		);
 	});


### PR DESCRIPTION
## Summary
This PR improves the resolution handling logic to preserve existing phase resolutions when filter operations result in empty entry sets, while still clearing resolutions in other scenarios.

## Key Changes
- **useActionResolution.ts**: Added conditional logic to preserve existing resolutions when entries are filtered to empty. The resolution is only cleared if:
  - The source is not a phase source detail, OR
  - The phase resolution should not be appended based on `shouldAppendPhaseResolution` checks
  
- **usePhaseProgress.helpers.ts**: Added an explicit call to `showResolution` with empty lines and summaries before advancing to the action phase, ensuring proper resolution state management during phase transitions

## Implementation Details
- The new logic resolves the source to either the provided source, the action source, or the phase source as a fallback
- Uses `isPhaseSourceDetail` to determine if the current source is phase-related
- Respects the `shouldAppendPhaseResolution` helper to decide whether to preserve the existing resolution
- The empty resolution display in `advanceToActionPhase` ensures clean state transitions between phases

https://claude.ai/code/session_01VEmWvDRQ6ZfdMCAC4yy8rX