### PR TITLE
Build registries dynamically from base options for sessions

### DIFF
--- a/packages/server/src/session/SessionManager.ts
+++ b/packages/server/src/session/SessionManager.ts
@@ -12,6 +12,7 @@ import { loadContentPackage, DEFAULT_CONTENT_ID } from '@boardsmith/contents';
 import type { SessionStaticMetadataPayload } from './buildSessionMetadata.js';
 import {
 	buildSessionAssets,
+	buildRegistriesFromBaseOptions,
 	type SessionBaseOptions,
 	type SessionResourceRegistry,
 } from './sessionConfigAssets.js';
@@ -165,12 +166,15 @@ export class SessionManager {
 		const session = createEngineSession(sessionOptions);
 		const timestamp = this.now();
 
+		const contentAssets = this.useStaticContent
+			? { registries: this.registries, metadata: this.metadata }
+			: buildRegistriesFromBaseOptions(contentBaseOptions);
 		const { registries, metadata } = buildSessionAssets(
 			{
 				baseOptions: contentBaseOptions,
 				resourceOverrides: this.resourceOverrides,
-				baseRegistries: this.registries,
-				baseMetadata: this.metadata,
+				baseRegistries: contentAssets.registries,
+				baseMetadata: contentAssets.metadata,
 			},
 			config,
 		);
@@ -389,12 +393,15 @@ export class SessionManager {
 		}
 
 		const timestamp = this.now();
+		const restoredAssets = this.useStaticContent
+			? { registries: this.registries, metadata: this.metadata }
+			: buildRegistriesFromBaseOptions(contentBaseOptions);
 		const { registries, metadata } = buildSessionAssets(
 			{
 				baseOptions: contentBaseOptions,
 				resourceOverrides: this.resourceOverrides,
-				baseRegistries: this.registries,
-				baseMetadata: this.metadata,
+				baseRegistries: restoredAssets.registries,
+				baseMetadata: restoredAssets.metadata,
 			},
 			restored.creationOptions.config,
 		);

--- a/packages/server/src/session/sessionConfigAssets.ts
+++ b/packages/server/src/session/sessionConfigAssets.ts
@@ -14,6 +14,8 @@ import {
 	type SessionRegistriesPayload,
 	type ResourceDefinition,
 	type SerializedRegistry,
+	type SessionActionCategoryRegistry,
+	type SessionActionMetaCategoryRegistry,
 } from '@boardsmith/protocol';
 import { type ActionCategoryConfig } from '@boardsmith/contents';
 import type { ZodType } from 'zod';
@@ -21,7 +23,11 @@ import {
 	buildSessionMetadata,
 	type SessionStaticMetadataPayload,
 } from './buildSessionMetadata.js';
-import { cloneRegistry, freezeSerializedRegistry } from './registryUtils.js';
+import {
+	cloneActionCategoryRegistry,
+	cloneRegistry,
+	freezeSerializedRegistry,
+} from './registryUtils.js';
 import type { RuntimeResourceContent } from '@boardsmith/engine';
 
 export type SessionResourceRegistry = SerializedRegistry<ResourceDefinition>;
@@ -149,4 +155,51 @@ function applyConfigRegistries(
 		developments,
 	);
 	return { actions, buildings, developments };
+}
+
+/**
+ * Builds registries and metadata from a SessionBaseOptions.
+ * Used when creating sessions with dynamically loaded content
+ * packages so the client receives registries matching the
+ * engine's content rather than the constructor's defaults.
+ */
+export function buildRegistriesFromBaseOptions(
+	baseOptions: SessionBaseOptions,
+): {
+	registries: SessionRegistriesPayload;
+	metadata: SessionStaticMetadataPayload;
+} {
+	const resourceCatalog = baseOptions.resourceCatalog;
+	const resources = freezeSerializedRegistry(
+		structuredClone(resourceCatalog.resources.byId),
+	);
+	const resourceGroups = freezeSerializedRegistry(
+		structuredClone(resourceCatalog.groups.byId),
+	);
+	const resourceCategories = freezeSerializedRegistry(
+		structuredClone(resourceCatalog.categories?.byId ?? {}),
+	);
+	const actionCategories = freezeSerializedRegistry(
+		cloneActionCategoryRegistry(baseOptions.actionCategories),
+	) as SessionActionCategoryRegistry;
+	const actionMetaCategories = freezeSerializedRegistry(
+		cloneRegistry(baseOptions.actionMetaCategories),
+	) as SessionActionMetaCategoryRegistry;
+	const registries: SessionRegistriesPayload = {
+		actions: cloneRegistry(baseOptions.actions),
+		actionCategories,
+		actionMetaCategories,
+		buildings: cloneRegistry(baseOptions.buildings),
+		developments: cloneRegistry(baseOptions.developments),
+		resources,
+		resourceGroups,
+		resourceCategories,
+	};
+	const metadata = buildSessionMetadata({
+		buildings: baseOptions.buildings,
+		developments: baseOptions.developments,
+		resources,
+		phases: baseOptions.phases,
+	});
+	return { registries, metadata };
 }


### PR DESCRIPTION
## Summary
This PR adds support for building session registries and metadata dynamically from `SessionBaseOptions` when using dynamically loaded content packages, rather than always using the SessionManager's static defaults.

## Key Changes
- **New function `buildRegistriesFromBaseOptions`**: Extracts registry and metadata building logic to construct `SessionRegistriesPayload` and `SessionStaticMetadataPayload` directly from `SessionBaseOptions`. This enables sessions to use registries matching the engine's dynamically loaded content.
- **Updated imports**: Added `cloneActionCategoryRegistry` utility and new type imports (`SessionActionCategoryRegistry`, `SessionActionMetaCategoryRegistry`) to support the new function.
- **Conditional asset resolution in SessionManager**: Modified both `createSession` and `restoreSession` methods to conditionally use either:
  - Static registries/metadata from the SessionManager (when `useStaticContent` is true)
  - Dynamically built registries/metadata from base options (when using dynamic content packages)
- **Consistent registry handling**: Both session creation and restoration now follow the same pattern for determining which registries to use.

## Implementation Details
- The new `buildRegistriesFromBaseOptions` function mirrors the registry building logic from `buildSessionAssets` but operates directly on the base options, allowing it to work with dynamically loaded content.
- Resource catalogs are properly cloned and frozen to maintain immutability.
- Action categories use the specialized `cloneActionCategoryRegistry` utility while other registries use the standard `cloneRegistry` function.
- The change is backward compatible—sessions using static content continue to use the SessionManager's cached registries.

https://claude.ai/code/session_012SVqPKd4yh8LLX9pcV94qm