### PR TITLE
Replace turns remaining resource with turn limit from rules

### DIFF
--- a/packages/contents/src/byte-sized-empire/actions.ts
+++ b/packages/contents/src/byte-sized-empire/actions.ts
@@ -120,7 +120,6 @@ export function createActionRegistry() {
 			.effect(resAdd(Res.defense, 0))
 			.effect(resAdd(Res.castleHP, 100))
 			.effect(resAdd(Res.ap, 2))
-			.effect(resAdd(Res.turnsRemaining, 30))
 			.effect(resAdd(Res.t1Done, 0))
 			.effect(resAdd(Res.t2Done, 0))
 			.effect(effect(Types.Land, LandMethods.ADD).param('count', 4).build())

--- a/packages/contents/src/byte-sized-empire/ids.ts
+++ b/packages/contents/src/byte-sized-empire/ids.ts
@@ -17,7 +17,6 @@ export const Res = {
 	happiness: 'resource:bse:happiness',
 	vp: 'resource:bse:vp',
 	ap: 'resource:bse:action-points',
-	turnsRemaining: 'resource:bse:turns-remaining',
 	t1Done: 'resource:bse:t1-research-done',
 	t2Done: 'resource:bse:t2-research-done',
 } as const;
@@ -117,7 +116,6 @@ export const Step = {
 	foodResolution: 'step:bse:food-resolution',
 	warRecovery: 'step:bse:war-recovery',
 	gainAP: 'step:bse:gain-ap',
-	decrementTurns: 'step:bse:decrement-turns',
 	main: 'step:bse:main',
 } as const;
 

--- a/packages/contents/src/byte-sized-empire/phases.ts
+++ b/packages/contents/src/byte-sized-empire/phases.ts
@@ -62,11 +62,6 @@ export const PHASES: readonly PhaseConfig[] = [
 				.title('Gain Action Points')
 				.effect(effect(Types.Resource, ResourceMethods.ADD).params(resourceAmountChange(Res.ap, 2)).build()),
 		)
-		.step(
-			step(Step.decrementTurns)
-				.title('Decrement Turns')
-				.effect(effect(Types.Resource, ResourceMethods.REMOVE).params(resourceAmountChange(Res.turnsRemaining, 1)).build()),
-		)
 		.build(),
 
 	// ═══════════════════════════════════════════════════════

--- a/packages/contents/src/byte-sized-empire/resources.ts
+++ b/packages/contents/src/byte-sized-empire/resources.ts
@@ -104,14 +104,6 @@ const apResource = resource(Res.ap)
 	.section('economy')
 	.build();
 
-const turnsRemainingResource = resource(Res.turnsRemaining)
-	.icon('\u23F3')
-	.label('Turns Remaining')
-	.description('The number of turns left before the game ends and ' + 'scores are compared.')
-	.lowerBound(0)
-	.section('economy')
-	.build();
-
 const t1DoneResource = resource(Res.t1Done)
 	.icon('\u{1F4D6}')
 	.label('T1 Research Done')
@@ -191,7 +183,6 @@ const secondaryCategory = resourceCategory('resource-category:bse:secondary')
 	.resource(Res.defense)
 	.resource(Res.happiness)
 	.resource(Res.castleHP)
-	.resource(Res.turnsRemaining)
 	.build();
 
 // ═══════════════════════════════════════════════════════════════════
@@ -212,7 +203,6 @@ export function getResourceDefinitions(): readonly ResourceDefinition[] {
 		happinessResource,
 		vpResource,
 		apResource,
-		turnsRemainingResource,
 		t1DoneResource,
 		t2DoneResource,
 	];

--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -123,6 +123,7 @@ export default function PhasePanel() {
 	const {
 		sessionSnapshot,
 		selectors,
+		ruleSnapshot,
 		phase,
 		resolution,
 		log,
@@ -152,6 +153,14 @@ export default function PhasePanel() {
 			}),
 		[sessionSnapshot.phases],
 	);
+	const turnLimit = useMemo(() => {
+		for (const condition of ruleSnapshot.winConditions) {
+			if (condition.trigger.type === 'turn-limit') {
+				return condition.trigger.maxTurns;
+			}
+		}
+		return null;
+	}, [ruleSnapshot.winConditions]);
 	const phaseHistory = useMemo(() => {
 		const byPhase = new Map<string, ActionResolution>();
 		const byPlayer = new Map<string, ActionResolution>();
@@ -245,7 +254,9 @@ export default function PhasePanel() {
 							Turn
 						</span>
 						<span className="text-base tracking-[0.15em]">
-							{phase.turnNumber}
+							{turnLimit !== null
+								? `${phase.turnNumber} / ${turnLimit}`
+								: phase.turnNumber}
 						</span>
 					</span>
 					<span className="sr-only">Active player:</span>


### PR DESCRIPTION
## Summary
Refactored turn tracking to use the turn limit defined in game rules instead of maintaining a separate "turns remaining" resource that decrements each turn. This simplifies game state management by deriving turn information from the authoritative rules configuration.

## Key Changes
- **PhasePanel.tsx**: Added `ruleSnapshot` to component dependencies and implemented `turnLimit` memo that extracts the max turn count from win conditions. Updated turn display to show "current / max" format when a turn limit exists.
- **resources.ts**: Removed `turnsRemainingResource` definition and its registration in the secondary resource category.
- **phases.ts**: Removed the "Decrement Turns" step that was subtracting from the turns remaining resource each phase.
- **ids.ts**: Removed `turnsRemaining` resource ID and `decrementTurns` step ID constants.
- **actions.ts**: Removed initialization of `turnsRemaining` resource (30 turns) from player setup.

## Implementation Details
The turn limit is now dynamically extracted from `ruleSnapshot.winConditions` by checking for conditions with `trigger.type === 'turn-limit'`. This makes the UI always reflect the actual game rules without requiring a separate resource to track countdown, reducing state synchronization issues.

https://claude.ai/code/session_01TUv1wDWgjDpV4txCmLt9jz