### PR TITLE
Simplify session asset building by removing pre-computed base registries

### DIFF
--- a/packages/server/src/session/SessionManager.ts
+++ b/packages/server/src/session/SessionManager.ts
@@ -12,9 +12,7 @@ import { loadContentPackage, DEFAULT_CONTENT_ID } from '@boardsmith/contents';
 import type { SessionStaticMetadataPayload } from './buildSessionMetadata.js';
 import {
 	buildSessionAssets,
-	buildRegistriesFromBaseOptions,
 	type SessionBaseOptions,
-	type SessionResourceRegistry,
 } from './sessionConfigAssets.js';
 import type {
 	SessionPersistence,
@@ -64,7 +62,6 @@ export class SessionManager {
 	private readonly baseOptions: SessionBaseOptions;
 	private readonly registries: SessionRegistriesPayload;
 	private readonly metadata: SessionStaticMetadataPayload;
-	private readonly resourceOverrides: SessionResourceRegistry | undefined;
 	private readonly runtimeConfig: SessionRuntimeConfig;
 	private readonly persistence: SessionPersistence | undefined;
 	private readonly restorer: SessionRestorer | undefined;
@@ -92,7 +89,6 @@ export class SessionManager {
 		this.baseOptions = config.baseOptions;
 		this.registries = config.registries;
 		this.metadata = config.metadata;
-		this.resourceOverrides = config.resourceOverrides;
 		this.runtimeConfig = config.runtimeConfig;
 		if (persistence) {
 			const { actionCategories: _, ...restoreBaseOptions } = this.baseOptions;
@@ -166,16 +162,8 @@ export class SessionManager {
 		const session = createEngineSession(sessionOptions);
 		const timestamp = this.now();
 
-		const contentAssets = this.useStaticContent
-			? { registries: this.registries, metadata: this.metadata }
-			: buildRegistriesFromBaseOptions(contentBaseOptions);
 		const { registries, metadata } = buildSessionAssets(
-			{
-				baseOptions: contentBaseOptions,
-				resourceOverrides: this.resourceOverrides,
-				baseRegistries: contentAssets.registries,
-				baseMetadata: contentAssets.metadata,
-			},
+			{ baseOptions: contentBaseOptions },
 			config,
 		);
 		const creationOptions: SessionCreationOptions = { contentId };
@@ -393,16 +381,8 @@ export class SessionManager {
 		}
 
 		const timestamp = this.now();
-		const restoredAssets = this.useStaticContent
-			? { registries: this.registries, metadata: this.metadata }
-			: buildRegistriesFromBaseOptions(contentBaseOptions);
 		const { registries, metadata } = buildSessionAssets(
-			{
-				baseOptions: contentBaseOptions,
-				resourceOverrides: this.resourceOverrides,
-				baseRegistries: restoredAssets.registries,
-				baseMetadata: restoredAssets.metadata,
-			},
+			{ baseOptions: contentBaseOptions },
 			restored.creationOptions.config,
 		);
 		const record: SessionRecord = {

--- a/packages/server/src/session/SessionManagerConfig.ts
+++ b/packages/server/src/session/SessionManagerConfig.ts
@@ -34,10 +34,7 @@ import {
 	cloneRegistry,
 	freezeSerializedRegistry,
 } from './registryUtils.js';
-import type {
-	SessionBaseOptions,
-	SessionResourceRegistry,
-} from './sessionConfigAssets.js';
+import type { SessionBaseOptions } from './sessionConfigAssets.js';
 
 export type SessionRuntimeConfig = {
 	phases: PhaseConfig[];
@@ -51,7 +48,6 @@ export type SessionRuntimeConfig = {
 };
 
 export type EngineSessionOverrideOptions = Partial<SessionBaseOptions> & {
-	resourceRegistry?: SessionResourceRegistry;
 	actionCategoryRegistry?: SessionActionCategoryRegistry;
 	primaryIconId?: string | null;
 };
@@ -60,7 +56,6 @@ export interface SessionManagerConfigResult {
 	baseOptions: SessionBaseOptions;
 	registries: SessionRegistriesPayload;
 	metadata: SessionStaticMetadataPayload;
-	resourceOverrides: SessionResourceRegistry | undefined;
 	runtimeConfig: SessionRuntimeConfig;
 }
 
@@ -68,7 +63,6 @@ export function buildSessionManagerConfig(
 	engineOptions: EngineSessionOverrideOptions = {},
 ): SessionManagerConfigResult {
 	const {
-		resourceRegistry,
 		actionCategoryRegistry,
 		primaryIconId: primaryIconOverride,
 		...engineOverrides
@@ -93,9 +87,6 @@ export function buildSessionManagerConfig(
 	};
 
 	const primaryIconId = primaryIconOverride ?? PRIMARY_ICON_ID ?? null;
-	const resourceOverrides = resourceRegistry
-		? freezeSerializedRegistry(structuredClone(resourceRegistry))
-		: undefined;
 
 	const resourceCatalog = baseOptions.resourceCatalog;
 	const resources = freezeSerializedRegistry(
@@ -159,7 +150,6 @@ export function buildSessionManagerConfig(
 		baseOptions,
 		registries,
 		metadata,
-		resourceOverrides,
 		runtimeConfig,
 	};
 }

--- a/packages/server/src/session/sessionConfigAssets.ts
+++ b/packages/server/src/session/sessionConfigAssets.ts
@@ -45,9 +45,6 @@ export interface SessionBaseOptions {
 
 interface OverrideContext {
 	baseOptions: SessionBaseOptions;
-	resourceOverrides: SessionResourceRegistry | undefined;
-	baseRegistries: SessionRegistriesPayload;
-	baseMetadata: SessionStaticMetadataPayload;
 }
 
 export function buildSessionAssets(
@@ -57,18 +54,15 @@ export function buildSessionAssets(
 	registries: SessionRegistriesPayload;
 	metadata: SessionStaticMetadataPayload;
 } {
-	if (!config) {
-		return {
-			registries: context.baseRegistries,
-			metadata: context.baseMetadata,
-		};
-	}
-	const validated = validateGameConfig(config);
-	const { actions, buildings, developments } = applyConfigRegistries(
-		validated,
-		context.baseOptions,
-	);
-	const phases = validated.phases ?? context.baseOptions.phases;
+	const validated = config ? validateGameConfig(config) : undefined;
+	const { actions, buildings, developments } = validated
+		? applyConfigRegistries(validated, context.baseOptions)
+		: {
+				actions: context.baseOptions.actions,
+				buildings: context.baseOptions.buildings,
+				developments: context.baseOptions.developments,
+			};
+	const phases = validated?.phases ?? context.baseOptions.phases;
 	const resourceCatalog = context.baseOptions.resourceCatalog;
 	const resources = freezeSerializedRegistry(
 		structuredClone(resourceCatalog.resources.byId),
@@ -87,12 +81,21 @@ export function buildSessionAssets(
 		resourceGroups,
 		resourceCategories,
 	};
-	if (context.baseRegistries.actionCategories) {
-		registries.actionCategories = context.baseRegistries.actionCategories;
+	const actionCats = cloneActionCategoryRegistry(
+		context.baseOptions.actionCategories,
+	);
+	if (Object.keys(actionCats).length > 0) {
+		registries.actionCategories = freezeSerializedRegistry(
+			actionCats,
+		) as SessionActionCategoryRegistry;
 	}
-	if (context.baseRegistries.actionMetaCategories) {
-		registries.actionMetaCategories =
-			context.baseRegistries.actionMetaCategories;
+	const actionMetaCats = cloneRegistry(
+		context.baseOptions.actionMetaCategories,
+	);
+	if (Object.keys(actionMetaCats).length > 0) {
+		registries.actionMetaCategories = freezeSerializedRegistry(
+			actionMetaCats,
+		) as SessionActionMetaCategoryRegistry;
 	}
 	const metadata = buildSessionMetadata({
 		buildings,
@@ -101,25 +104,6 @@ export function buildSessionAssets(
 		phases,
 	});
 	return { registries, metadata };
-}
-
-/**
- * @deprecated Use resourceCatalog.resources.byId directly.
- * Kept temporarily for test compatibility.
- */
-export function buildResourceRegistry(
-	overrides: SessionResourceRegistry | undefined,
-): SessionResourceRegistry {
-	const registry = new Map<string, ResourceDefinition>();
-
-	// Apply any overrides first
-	if (overrides) {
-		for (const [key, definition] of Object.entries(overrides)) {
-			registry.set(key, structuredClone(definition));
-		}
-	}
-
-	return Object.fromEntries(registry.entries());
 }
 
 function applyConfigRegistries(
@@ -155,51 +139,4 @@ function applyConfigRegistries(
 		developments,
 	);
 	return { actions, buildings, developments };
-}
-
-/**
- * Builds registries and metadata from a SessionBaseOptions.
- * Used when creating sessions with dynamically loaded content
- * packages so the client receives registries matching the
- * engine's content rather than the constructor's defaults.
- */
-export function buildRegistriesFromBaseOptions(
-	baseOptions: SessionBaseOptions,
-): {
-	registries: SessionRegistriesPayload;
-	metadata: SessionStaticMetadataPayload;
-} {
-	const resourceCatalog = baseOptions.resourceCatalog;
-	const resources = freezeSerializedRegistry(
-		structuredClone(resourceCatalog.resources.byId),
-	);
-	const resourceGroups = freezeSerializedRegistry(
-		structuredClone(resourceCatalog.groups.byId),
-	);
-	const resourceCategories = freezeSerializedRegistry(
-		structuredClone(resourceCatalog.categories?.byId ?? {}),
-	);
-	const actionCategories = freezeSerializedRegistry(
-		cloneActionCategoryRegistry(baseOptions.actionCategories),
-	) as SessionActionCategoryRegistry;
-	const actionMetaCategories = freezeSerializedRegistry(
-		cloneRegistry(baseOptions.actionMetaCategories),
-	) as SessionActionMetaCategoryRegistry;
-	const registries: SessionRegistriesPayload = {
-		actions: cloneRegistry(baseOptions.actions),
-		actionCategories,
-		actionMetaCategories,
-		buildings: cloneRegistry(baseOptions.buildings),
-		developments: cloneRegistry(baseOptions.developments),
-		resources,
-		resourceGroups,
-		resourceCategories,
-	};
-	const metadata = buildSessionMetadata({
-		buildings: baseOptions.buildings,
-		developments: baseOptions.developments,
-		resources,
-		phases: baseOptions.phases,
-	});
-	return { registries, metadata };
 }

--- a/packages/server/tests/session/sessionConfigAssets.test.ts
+++ b/packages/server/tests/session/sessionConfigAssets.test.ts
@@ -1,70 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import type {
-	PhaseConfig,
-	RuleSet,
-	SessionResourceDefinition,
-	SerializedRegistry,
-	GameConfig,
-} from '@boardsmith/protocol';
+import type { PhaseConfig, RuleSet, GameConfig } from '@boardsmith/protocol';
 import {
 	createContentFactory,
 	createResourceRegistries,
 	resourceDefinition,
 } from '@boardsmith/testing';
 import {
-	buildResourceRegistry,
 	buildSessionAssets,
 	type SessionBaseOptions,
 } from '../../src/session/sessionConfigAssets.js';
-import {
-	freezeSerializedRegistry,
-	cloneRegistry,
-} from '../../src/session/registryUtils.js';
-
-describe('buildResourceRegistry', () => {
-	it('returns empty registry when no overrides provided', () => {
-		// The deprecated buildResourceRegistry only returns overrides
-		// Use resourceCatalog.resources.byId directly for the full registry
-		const registry = buildResourceRegistry(undefined);
-		expect(registry).toBeDefined();
-		expect(typeof registry).toBe('object');
-		// No overrides means empty registry
-		expect(Object.keys(registry).length).toBe(0);
-	});
-
-	it('applies resource overrides when provided', () => {
-		const overrides: SerializedRegistry<SessionResourceDefinition> = {
-			'resource:custom:test': {
-				key: 'resource:custom:test',
-				label: 'Custom Resource',
-				icon: '🌟',
-			},
-		};
-		const registry = buildResourceRegistry(overrides);
-		expect(registry['resource:custom:test']).toBeDefined();
-		expect(registry['resource:custom:test'].label).toBe('Custom Resource');
-	});
-
-	it('handles undefined overrides', () => {
-		const registry = buildResourceRegistry(undefined);
-		expect(registry).toBeDefined();
-		expect(typeof registry).toBe('object');
-	});
-
-	it('preserves override values over registry defaults', () => {
-		// Pick a known resource from registry and override it
-		const overrides: SerializedRegistry<SessionResourceDefinition> = {
-			'resource:core:gold': {
-				key: 'resource:core:gold',
-				label: 'Override Gold Label',
-				icon: '💰',
-			},
-		};
-		const registry = buildResourceRegistry(overrides);
-		// Override should take precedence
-		expect(registry['resource:core:gold'].label).toBe('Override Gold Label');
-	});
-});
 
 describe('buildSessionAssets', () => {
 	const createBaseOptions = (): SessionBaseOptions => {
@@ -94,6 +38,7 @@ describe('buildSessionAssets', () => {
 		return {
 			actions: factory.actions,
 			actionCategories: factory.categories,
+			actionMetaCategories: factory.actionMetaCategories,
 			buildings: factory.buildings,
 			developments: factory.developments,
 			phases,
@@ -102,81 +47,94 @@ describe('buildSessionAssets', () => {
 		};
 	};
 
-	it('returns base assets when config is undefined', () => {
+	it('builds registries from baseOptions when config is undefined', () => {
 		const baseOptions = createBaseOptions();
-		const baseRegistries = {
-			actions: freezeSerializedRegistry(cloneRegistry(baseOptions.actions)),
-			buildings: freezeSerializedRegistry(cloneRegistry(baseOptions.buildings)),
-			developments: freezeSerializedRegistry(
-				cloneRegistry(baseOptions.developments),
-			),
-			resources: {} as SerializedRegistry<SessionResourceDefinition>,
-			actionCategories: freezeSerializedRegistry(
-				cloneRegistry(baseOptions.actionCategories),
-			),
-		};
-		const baseMetadata = {};
-		const context = {
-			baseOptions,
-			resourceOverrides: undefined,
-			baseRegistries,
-			baseMetadata,
-		};
+		const context = { baseOptions };
 		const { registries, metadata } = buildSessionAssets(context, undefined);
-		expect(registries).toBe(baseRegistries);
-		expect(metadata).toBe(baseMetadata);
+		expect(registries).toBeDefined();
+		expect(registries.resources).toBeDefined();
+		expect(metadata).toBeDefined();
+		// Registries must contain the content from baseOptions
+		for (const [id] of baseOptions.developments.entries()) {
+			expect(registries.developments[id]).toBeDefined();
+		}
+		for (const [id] of baseOptions.actions.entries()) {
+			expect(registries.actions[id]).toBeDefined();
+		}
+		for (const [id] of baseOptions.buildings.entries()) {
+			expect(registries.buildings[id]).toBeDefined();
+		}
+	});
+
+	it('preserves content-specific IDs in registries', () => {
+		const factory = createContentFactory({ isolated: true });
+		factory.development({
+			id: 'dev:bse:farm',
+			name: 'Farm',
+			icon: '🌾',
+		});
+		factory.action({
+			id: 'action:bse:harvest',
+			name: 'Harvest',
+		});
+		const { resources, groups } = createResourceRegistries({
+			resources: [
+				resourceDefinition({
+					id: 'resource:bse:gold',
+					metadata: { label: 'Gold', icon: '🪙' },
+				}),
+			],
+		});
+		const baseOptions: SessionBaseOptions = {
+			actions: factory.actions,
+			actionCategories: factory.categories,
+			actionMetaCategories: factory.actionMetaCategories,
+			buildings: factory.buildings,
+			developments: factory.developments,
+			phases: [{ id: 'main', action: true, steps: [{ id: 'main' }] }],
+			rules: {
+				defaultActionAPCost: 1,
+				absorptionCapPct: 1,
+				absorptionRounding: 'down',
+				tieredResourceKey: 'resource:bse:gold',
+				tierDefinitions: [],
+				slotsPerNewLand: 1,
+				maxSlotsPerLand: 2,
+				basePopulationCap: 1,
+				winConditions: [],
+			},
+			resourceCatalog: { resources, groups },
+		};
+		const { registries } = buildSessionAssets({ baseOptions }, undefined);
+		expect(registries.developments['dev:bse:farm']).toBeDefined();
+		expect(registries.developments['dev:bse:farm'].name).toBe('Farm');
+		expect(registries.actions['action:bse:harvest']).toBeDefined();
+		expect(registries.actions['action:bse:harvest'].name).toBe('Harvest');
 	});
 
 	it('creates new registries when config is provided', () => {
 		const baseOptions = createBaseOptions();
-		const baseRegistries = {
-			actions: freezeSerializedRegistry(cloneRegistry(baseOptions.actions)),
-			buildings: freezeSerializedRegistry(cloneRegistry(baseOptions.buildings)),
-			developments: freezeSerializedRegistry(
-				cloneRegistry(baseOptions.developments),
-			),
-			resources: {} as SerializedRegistry<SessionResourceDefinition>,
-			actionCategories: freezeSerializedRegistry(
-				cloneRegistry(baseOptions.actionCategories),
-			),
-		};
-		const baseMetadata = {};
-		const context = {
-			baseOptions,
-			resourceOverrides: undefined,
-			baseRegistries,
-			baseMetadata,
-		};
-		// Any non-empty GameConfig triggers new registry creation
+		const context = { baseOptions };
+		// Any non-empty GameConfig triggers config validation path
 		const config: GameConfig = {};
 		const { registries, metadata } = buildSessionAssets(context, config);
-		expect(registries).not.toBe(baseRegistries);
-		// Resources should be populated from RESOURCE_REGISTRY
+		expect(registries).toBeDefined();
 		expect(registries.resources).toBeDefined();
 		expect(metadata).toBeDefined();
 	});
 
-	it('includes actionCategories from base when available', () => {
+	it('includes actionCategories from baseOptions', () => {
 		const baseOptions = createBaseOptions();
-		const baseRegistries = {
-			actions: freezeSerializedRegistry(cloneRegistry(baseOptions.actions)),
-			buildings: freezeSerializedRegistry(cloneRegistry(baseOptions.buildings)),
-			developments: freezeSerializedRegistry(
-				cloneRegistry(baseOptions.developments),
-			),
-			resources: {} as SerializedRegistry<SessionResourceDefinition>,
-			actionCategories: {
-				testCategory: { id: 'test', title: 'Test' },
-			} as never,
-		};
-		const context = {
-			baseOptions,
-			resourceOverrides: undefined,
-			baseRegistries,
-			baseMetadata: {},
-		};
+		const context = { baseOptions };
 		const config: GameConfig = {};
 		const { registries } = buildSessionAssets(context, config);
+		expect(registries.actionCategories).toBeDefined();
+	});
+
+	it('includes actionCategories when config is undefined', () => {
+		const baseOptions = createBaseOptions();
+		const context = { baseOptions };
+		const { registries } = buildSessionAssets(context, undefined);
 		expect(registries.actionCategories).toBeDefined();
 	});
 });


### PR DESCRIPTION
## Summary
This PR refactors the session asset building logic to compute registries on-demand rather than pre-computing and passing them through the context. This simplifies the API and reduces unnecessary state management.

## Key Changes
- **Removed pre-computed base registries from context**: The `OverrideContext` interface now only requires `baseOptions`, eliminating `baseRegistries`, `baseMetadata`, and `resourceOverrides` fields
- **Simplified `buildSessionAssets` logic**: Registries are now built directly from `baseOptions` whether or not a config is provided, rather than returning pre-computed values
- **Removed deprecated `buildResourceRegistry` function**: This function was marked as deprecated and only used in tests; removed along with its test suite
- **Updated `SessionManager` and `SessionManagerConfig`**: Removed resource override tracking and simplified the context passed to `buildSessionAssets`
- **Improved test coverage**: Updated tests to verify registry building behavior directly rather than testing pre-computed state, and added new tests for content-specific ID preservation

## Implementation Details
- The `buildSessionAssets` function now handles both undefined and defined config cases uniformly by building registries from `baseOptions` in both paths
- Action categories and meta-categories are cloned and frozen on-demand from `baseOptions` rather than being pre-computed
- Registry building is now more transparent and easier to trace through the codebase
- Tests were simplified to focus on the actual behavior of registry building rather than state management details

https://claude.ai/code/session_018gvnTNLLTTWYnBYRKSE3Rq