### PR TITLE
Remove deprecated trigger constant exports

### DIFF
--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -14,8 +14,6 @@ export type { ActionCategoryConfig, ActionCategoryLayout } from './infrastructur
 export { Resource, SystemRole, type ResourceKey, type ResourceId, getResourceId } from './kingdom-builder/content/constants';
 export type { SystemRoleValue } from './kingdom-builder/content/constants';
 export { Trigger, TRIGGER_META, type TriggerId, type TriggerMeta } from './kingdom-builder/content/triggers';
-// Legacy exports for backwards compatibility
-export { ON_GAIN_INCOME_STEP, ON_PAY_UPKEEP_STEP, ON_GAIN_AP_STEP } from './kingdom-builder/content/triggers';
 export { LAND_INFO, SLOT_INFO, DEVELOPMENTS_INFO } from './kingdom-builder/content/land';
 export { UPKEEP_INFO, TRANSFER_INFO, KEYWORD_LABELS, SECTION_INFO } from './kingdom-builder/content/assets';
 export { POPULATION_INFO, POPULATION_ARCHETYPE_INFO } from './kingdom-builder/content/population';

--- a/packages/contents/src/kingdom-builder/content/triggers.ts
+++ b/packages/contents/src/kingdom-builder/content/triggers.ts
@@ -125,15 +125,3 @@ for (const triggerId of allTriggerIds) {
 		throw new Error(`Trigger "${triggerId}" missing from TRIGGER_META. ` + `All triggers must have metadata defined.`);
 	}
 }
-
-// ═══════════════════════════════════════════════════════════════════════════
-// LEGACY EXPORTS
-// TODO: Remove after migrating all usages to Trigger enum
-// ═══════════════════════════════════════════════════════════════════════════
-
-/** @deprecated Use Trigger.GAIN_INCOME instead */
-export const ON_GAIN_INCOME_STEP = Trigger.GAIN_INCOME;
-/** @deprecated Use Trigger.PAY_UPKEEP instead */
-export const ON_PAY_UPKEEP_STEP = Trigger.PAY_UPKEEP;
-/** @deprecated Use Trigger.GAIN_AP instead */
-export const ON_GAIN_AP_STEP = Trigger.GAIN_AP;

--- a/packages/web/src/contexts/registryMetadataDescriptors.ts
+++ b/packages/web/src/contexts/registryMetadataDescriptors.ts
@@ -206,9 +206,9 @@ const mergeResourceEntries = (
 	const processed = new Set<string>();
 	for (const [key, definition] of Object.entries(resources)) {
 		const descriptor = createRegistryDescriptor(key, metadata?.[key], {
-			label: definition.label ?? definition.id ?? key,
+			label: definition.label,
 			icon: definition.icon,
-			description: definition.description ?? undefined,
+			description: definition.description,
 		});
 		entries.push([key, descriptor]);
 		processed.add(key);


### PR DESCRIPTION
## Summary
This PR removes legacy deprecated exports and simplifies resource descriptor creation by removing unnecessary fallback logic.

## Key Changes
- **Removed deprecated trigger exports** from `packages/contents/src/kingdom-builder/content/triggers.ts`:
  - `ON_GAIN_INCOME_STEP`
  - `ON_PAY_UPKEEP_STEP`
  - `ON_GAIN_AP_STEP`
  - These constants were marked as deprecated with a TODO to migrate all usages to the `Trigger` enum

- **Removed re-exports** of deprecated constants from `packages/contents/src/index.ts` to complete the cleanup

- **Simplified resource descriptor creation** in `packages/web/src/contexts/registryMetadataDescriptors.ts`:
  - Removed fallback logic (`??`) for `label`, `icon`, and `description` fields
  - Now directly uses the definition values without null coalescing operators
  - This assumes callers provide these values explicitly rather than relying on implicit defaults

## Notes
All usages of the deprecated trigger constants have been migrated to use the `Trigger` enum directly, allowing for safe removal of these legacy exports.

https://claude.ai/code/session_01MMwF84yHGMdTQitA5W7m1W