### PR TITLE
Extract phase panel styles and add playground content explorer

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -273,7 +273,6 @@ export default [
 			'packages/web/src/components/TimerCircle.tsx',
 			'packages/web/src/components/actions/ActionCard.tsx',
 			'packages/web/src/components/common/TimeControl.tsx',
-			'packages/web/src/components/phases/PhasePanel.tsx',
 			'packages/web/src/components/player/BuildingDisplay.tsx',
 			'packages/web/src/components/player/LandDisplay.tsx',
 			'packages/web/src/components/player/PassiveDisplay.tsx',

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { lazy, Suspense, type ReactNode } from 'react';
 import Game from './Game';
 import Menu from './Menu';
 import BackgroundMusic from './components/audio/BackgroundMusic';
@@ -6,6 +6,8 @@ import { useAppNavigation } from './state/useAppNavigation';
 import { usePlayerIdentity } from './state/playerIdentity';
 import { Screen } from './state/appHistory';
 import { SoundEffectsProvider } from './state/SoundEffectsContext';
+
+const Playground = lazy(() => import('./playground/Playground'));
 
 export default function App() {
 	const {
@@ -22,6 +24,7 @@ export default function App() {
 		startGameWithContent,
 		continueSavedGame,
 		returnToMenu,
+		navigateToPlayground,
 		toggleDarkMode,
 		toggleMusic,
 		toggleSound,
@@ -60,11 +63,25 @@ export default function App() {
 				/>
 			);
 			break;
+		case Screen.Playground:
+			screen = (
+				<Suspense
+					fallback={
+						<div className="flex min-h-screen items-center justify-center">
+							Loading...
+						</div>
+					}
+				>
+					<Playground onBack={returnToMenu} />
+				</Suspense>
+			);
+			break;
 		case Screen.Menu:
 		default:
 			screen = (
 				<Menu
 					onStartGame={startGameWithContent}
+					onOpenPlayground={navigateToPlayground}
 					resumePoint={resumePoint}
 					onContinue={continueSavedGame}
 					darkModeEnabled={isDarkMode}

--- a/packages/web/src/Menu.tsx
+++ b/packages/web/src/Menu.tsx
@@ -16,6 +16,7 @@ const RESUME_TURN_FORMATTER = new Intl.NumberFormat('en-US');
 
 interface MenuProps {
 	onStartGame: (contentId: string) => void;
+	onOpenPlayground: () => void;
 	resumePoint: ResumeSessionRecord | null;
 	onContinue: () => void;
 	darkModeEnabled: boolean;
@@ -35,6 +36,7 @@ interface MenuProps {
 
 export default function Menu({
 	onStartGame,
+	onOpenPlayground,
 	resumePoint,
 	onContinue,
 	darkModeEnabled,
@@ -135,6 +137,7 @@ export default function Menu({
 						resumePoint={resumePoint}
 						onContinue={onContinue}
 						onOpenSettings={() => setSettingsOpen(true)}
+						onOpenPlayground={onOpenPlayground}
 					/>
 					<HighlightsSection />
 				</ShowcaseLayout>

--- a/packages/web/src/components/phases/PhasePanel.tsx
+++ b/packages/web/src/components/phases/PhasePanel.tsx
@@ -3,6 +3,24 @@ import { useGameEngine } from '../../state/GameContext';
 import { useAdvanceAction } from '../../state/useAdvanceAction';
 import type { ActionResolution } from '../../state/useActionResolution';
 import Button from '../common/Button';
+import {
+	PANEL_CLASSES,
+	HEADER_CLASSES,
+	TURN_SUMMARY_CLASSES,
+	TURN_BADGE_CLASSES,
+	PLAYER_DETAILS_CLASSES,
+	PLAYER_LABEL_CLASSES,
+	PLAYER_NAME_CLASSES,
+	PHASE_SECTION_CLASSES,
+	PHASE_LIST_CLASSES,
+	PHASE_LIST_ITEM_CLASSES,
+	PHASE_LIST_ITEM_CONTENT_CLASSES,
+	PHASE_INDEX_WRAPPER_CLASSES,
+	PHASE_INDEX_HIGHLIGHT_CLASSES,
+	PHASE_INDEX_TEXT_CLASSES,
+	PHASE_ICON_CLASSES,
+	PHASE_LABEL_CLASSES,
+} from './phasePanelStyles';
 
 function normalizePhaseKey(id?: string, label?: string) {
 	const trimmedId = id?.trim();
@@ -23,101 +41,6 @@ interface PhaseSummary {
 	historyKey: string;
 	isActionPhase: boolean;
 }
-
-const panelClassName = [
-	'relative flex w-full flex-col gap-6 rounded-3xl border border-white/40',
-	'bg-gradient-to-br from-white/80 via-white/70 to-white/40 p-6 shadow-xl',
-	'backdrop-blur dark:border-white/10 dark:from-slate-900/80',
-	'dark:via-slate-900/70 dark:to-slate-900/60 dark:shadow-slate-900/40',
-].join(' ');
-
-const headerClassName = [
-	'flex flex-wrap items-center justify-between gap-4',
-].join(' ');
-
-const turnSummaryClassName = [
-	'flex flex-wrap items-center gap-4 rounded-2xl border border-white/60 px-4',
-	'py-3 text-sm text-slate-700 shadow-sm dark:border-white/10',
-	'dark:text-slate-100',
-].join(' ');
-
-const turnBadgeClassName = [
-	'flex items-center gap-2 rounded-xl bg-indigo-600/90 px-3 py-1',
-	'text-xs font-semibold uppercase tracking-[0.25em] text-white shadow',
-].join(' ');
-
-const playerDetailsClassName = ['flex flex-col gap-0.5 text-left'].join(' ');
-
-const playerLabelClassName = [
-	'uppercase tracking-[0.3em] text-[0.625rem] text-slate-500',
-	'dark:text-slate-300',
-].join(' ');
-
-const playerNameClassName = [
-	'text-base font-semibold text-slate-800 dark:text-white',
-].join(' ');
-
-const phaseSectionClassName = ['flex flex-col gap-3'].join(' ');
-
-const phaseListClassName = [
-	'grid gap-3',
-	'sm:grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] sm:gap-3',
-].join(' ');
-
-const phaseListItemClassName = [
-	'flex items-center rounded-2xl border border-white/40 px-3 py-2 text-left',
-	'text-sm font-medium tracking-[0.08em] text-slate-600 transition-all',
-	'duration-200 ease-out bg-white/70 shadow-sm dark:border-white/10',
-	'dark:bg-slate-900/60 dark:text-slate-100 hover:-translate-y-0.5',
-	'hover:bg-white/60 hover:shadow-lg hover:shadow-amber-500/10',
-	'dark:hover:bg-white/10 dark:hover:shadow-black/30',
-	'data-[active=true]:border-indigo-500 data-[active=true]:bg-indigo-50/80',
-	'data-[active=true]:text-indigo-800',
-	'data-[active=true]:hover:bg-indigo-50/80',
-	'data-[active=true]:hover:shadow-lg',
-	'dark:data-[active=true]:border-indigo-300/60',
-	'dark:data-[active=true]:bg-indigo-500/20',
-	'dark:data-[active=true]:text-white',
-	'dark:data-[active=true]:hover:bg-indigo-500/20',
-].join(' ');
-
-const phaseListItemContentClassName = ['flex w-full items-center gap-3'].join(
-	' ',
-);
-
-const phaseListItemIndexWrapperClassName = [
-	'relative grid h-10 w-10 place-items-center overflow-hidden rounded-2xl',
-	'bg-white/70 shadow-inner shadow-white/60 ring-1 ring-inset ring-white/70',
-	'backdrop-blur-[2px] transition-all duration-300 ease-out',
-	'dark:bg-white/10 dark:shadow-black/40 dark:ring-white/10',
-	'data-[active=true]:bg-gradient-to-br data-[active=true]:from-indigo-500/90',
-	'data-[active=true]:via-indigo-500/80 data-[active=true]:to-fuchsia-500/80',
-	'data-[active=true]:shadow-lg data-[active=true]:ring-indigo-200/80',
-	'dark:data-[active=true]:ring-indigo-300/60',
-].join(' ');
-
-const phaseListItemIndexHighlightClassName = [
-	'pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br',
-	'from-white/70 via-white/30 to-transparent opacity-0 transition-opacity',
-	'duration-300 ease-out data-[active=true]:opacity-60',
-	'dark:from-white/40 dark:via-white/5',
-].join(' ');
-
-const phaseListItemIndexTextClassName = [
-	'relative text-xs font-semibold uppercase tracking-[0.35em]',
-	'text-indigo-600 transition-colors duration-300 ease-out',
-	'data-[active=true]:text-white dark:text-indigo-200',
-	'dark:data-[active=true]:text-white font-mono tabular-nums',
-].join(' ');
-
-const phaseListItemIconClassName = [
-	'grid h-9 w-9 place-items-center rounded-xl bg-white/80 text-base',
-	'text-indigo-600 shadow-inner dark:bg-white/10 dark:text-indigo-200',
-].join(' ');
-
-const phaseListItemLabelClassName = [
-	'flex-1 text-xs uppercase tracking-[0.2em]',
-].join(' ');
 
 export default function PhasePanel() {
 	const {
@@ -246,10 +169,10 @@ export default function PhasePanel() {
 	const shouldShowManualStartButton =
 		advanceMode === 'start' && !shouldHideControls;
 	return (
-		<section className={panelClassName}>
-			<header className={headerClassName}>
-				<div className={turnSummaryClassName}>
-					<span className={turnBadgeClassName}>
+		<section className={PANEL_CLASSES}>
+			<header className={HEADER_CLASSES}>
+				<div className={TURN_SUMMARY_CLASSES}>
+					<span className={TURN_BADGE_CLASSES}>
 						<span className="text-[0.6rem] uppercase tracking-[0.45em]">
 							Turn
 						</span>
@@ -260,20 +183,20 @@ export default function PhasePanel() {
 						</span>
 					</span>
 					<span className="sr-only">Active player:</span>
-					<div className={playerDetailsClassName}>
-						<span className={playerLabelClassName}>Active Player</span>
-						<span className={playerNameClassName}>{activePlayerName}</span>
+					<div className={PLAYER_DETAILS_CLASSES}>
+						<span className={PLAYER_LABEL_CLASSES}>Active Player</span>
+						<span className={PLAYER_NAME_CLASSES}>{activePlayerName}</span>
 					</div>
 				</div>
 				<span className="sr-only" role="status" aria-live="polite">
 					Current phase: {currentPhaseLabel}
 				</span>
 			</header>
-			<div className={phaseSectionClassName}>
+			<div className={PHASE_SECTION_CLASSES}>
 				<p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-300">
 					Phases
 				</p>
-				<ul className={phaseListClassName}>
+				<ul className={PHASE_LIST_CLASSES}>
 					{phases.map((phaseDefinition, phaseIndex) => {
 						const historyKey = phaseDefinition.historyKey;
 						const playerKey = activePlayerId
@@ -289,7 +212,7 @@ export default function PhasePanel() {
 							!phaseDefinition.isActionPhase &&
 							!shouldSuppressHoverCards;
 						const resolvedPhaseListItemClassName = [
-							phaseListItemClassName,
+							PHASE_LIST_ITEM_CLASSES,
 							shouldShowHoverIndicator ? 'hoverable cursor-help' : '',
 						]
 							.filter(Boolean)
@@ -306,31 +229,28 @@ export default function PhasePanel() {
 								onMouseEnter={handlePhaseMouseEnter}
 								onMouseLeave={hidePhaseHistory}
 							>
-								<span className={phaseListItemContentClassName}>
+								<span className={PHASE_LIST_ITEM_CONTENT_CLASSES}>
 									<span
-										className={phaseListItemIndexWrapperClassName}
+										className={PHASE_INDEX_WRAPPER_CLASSES}
 										data-active={isActive ? 'true' : 'false'}
 										aria-hidden="true"
 									>
 										<span
-											className={phaseListItemIndexHighlightClassName}
+											className={PHASE_INDEX_HIGHLIGHT_CLASSES}
 											data-active={isActive ? 'true' : 'false'}
 											aria-hidden="true"
 										/>
 										<span
-											className={phaseListItemIndexTextClassName}
+											className={PHASE_INDEX_TEXT_CLASSES}
 											data-active={isActive ? 'true' : 'false'}
 										>
 											{String(phaseIndex + 1).padStart(2, '0')}
 										</span>
 									</span>
-									<span
-										className={phaseListItemIconClassName}
-										aria-hidden="true"
-									>
+									<span className={PHASE_ICON_CLASSES} aria-hidden="true">
 										{phaseDefinition.icon || '⚠️'}
 									</span>
-									<span className={phaseListItemLabelClassName}>
+									<span className={PHASE_LABEL_CLASSES}>
 										{phaseDefinition.label}
 									</span>
 								</span>

--- a/packages/web/src/components/phases/phasePanelStyles.ts
+++ b/packages/web/src/components/phases/phasePanelStyles.ts
@@ -1,0 +1,257 @@
+export const PANEL_CLASS_NAMES = [
+	'relative',
+	'flex',
+	'w-full',
+	'flex-col',
+	'gap-6',
+	'rounded-3xl',
+	'border',
+	'border-white/40',
+	'bg-gradient-to-br',
+	'from-white/80',
+	'via-white/70',
+	'to-white/40',
+	'p-6',
+	'shadow-xl',
+	'backdrop-blur',
+	'dark:border-white/10',
+	'dark:from-slate-900/80',
+	'dark:via-slate-900/70',
+	'dark:to-slate-900/60',
+	'dark:shadow-slate-900/40',
+] as const;
+
+export const HEADER_CLASS_NAMES = [
+	'flex',
+	'flex-wrap',
+	'items-center',
+	'justify-between',
+	'gap-4',
+] as const;
+
+export const TURN_SUMMARY_CLASS_NAMES = [
+	'flex',
+	'flex-wrap',
+	'items-center',
+	'gap-4',
+	'rounded-2xl',
+	'border',
+	'border-white/60',
+	'px-4',
+	'py-3',
+	'text-sm',
+	'text-slate-700',
+	'shadow-sm',
+	'dark:border-white/10',
+	'dark:text-slate-100',
+] as const;
+
+export const TURN_BADGE_CLASS_NAMES = [
+	'flex',
+	'items-center',
+	'gap-2',
+	'rounded-xl',
+	'bg-indigo-600/90',
+	'px-3',
+	'py-1',
+	'text-xs',
+	'font-semibold',
+	'uppercase',
+	'tracking-[0.25em]',
+	'text-white',
+	'shadow',
+] as const;
+
+export const PLAYER_DETAILS_CLASS_NAMES = [
+	'flex',
+	'flex-col',
+	'gap-0.5',
+	'text-left',
+] as const;
+
+export const PLAYER_LABEL_CLASS_NAMES = [
+	'uppercase',
+	'tracking-[0.3em]',
+	'text-[0.625rem]',
+	'text-slate-500',
+	'dark:text-slate-300',
+] as const;
+
+export const PLAYER_NAME_CLASS_NAMES = [
+	'text-base',
+	'font-semibold',
+	'text-slate-800',
+	'dark:text-white',
+] as const;
+
+export const PHASE_SECTION_CLASS_NAMES = ['flex', 'flex-col', 'gap-3'] as const;
+
+export const PHASE_LIST_CLASS_NAMES = [
+	'grid',
+	'gap-3',
+	'sm:grid-cols-[repeat(auto-fit,minmax(9rem,1fr))]',
+	'sm:gap-3',
+] as const;
+
+export const PHASE_LIST_ITEM_CLASS_NAMES = [
+	'flex',
+	'items-center',
+	'rounded-2xl',
+	'border',
+	'border-white/40',
+	'px-3',
+	'py-2',
+	'text-left',
+	'text-sm',
+	'font-medium',
+	'tracking-[0.08em]',
+	'text-slate-600',
+	'transition-all',
+	'duration-200',
+	'ease-out',
+	'bg-white/70',
+	'shadow-sm',
+	'dark:border-white/10',
+	'dark:bg-slate-900/60',
+	'dark:text-slate-100',
+	'hover:-translate-y-0.5',
+	'hover:bg-white/60',
+	'hover:shadow-lg',
+	'hover:shadow-amber-500/10',
+	'dark:hover:bg-white/10',
+	'dark:hover:shadow-black/30',
+	'data-[active=true]:border-indigo-500',
+	'data-[active=true]:bg-indigo-50/80',
+	'data-[active=true]:text-indigo-800',
+	'data-[active=true]:hover:bg-indigo-50/80',
+	'data-[active=true]:hover:shadow-lg',
+	'dark:data-[active=true]:border-indigo-300/60',
+	'dark:data-[active=true]:bg-indigo-500/20',
+	'dark:data-[active=true]:text-white',
+	'dark:data-[active=true]:hover:bg-indigo-500/20',
+] as const;
+
+export const PHASE_LIST_ITEM_CONTENT_CLASS_NAMES = [
+	'flex',
+	'w-full',
+	'items-center',
+	'gap-3',
+] as const;
+
+export const PHASE_INDEX_WRAPPER_CLASS_NAMES = [
+	'relative',
+	'grid',
+	'h-10',
+	'w-10',
+	'place-items-center',
+	'overflow-hidden',
+	'rounded-2xl',
+	'bg-white/70',
+	'shadow-inner',
+	'shadow-white/60',
+	'ring-1',
+	'ring-inset',
+	'ring-white/70',
+	'backdrop-blur-[2px]',
+	'transition-all',
+	'duration-300',
+	'ease-out',
+	'dark:bg-white/10',
+	'dark:shadow-black/40',
+	'dark:ring-white/10',
+	'data-[active=true]:bg-gradient-to-br',
+	'data-[active=true]:from-indigo-500/90',
+	'data-[active=true]:via-indigo-500/80',
+	'data-[active=true]:to-fuchsia-500/80',
+	'data-[active=true]:shadow-lg',
+	'data-[active=true]:ring-indigo-200/80',
+	'dark:data-[active=true]:ring-indigo-300/60',
+] as const;
+
+export const PHASE_INDEX_HIGHLIGHT_CLASS_NAMES = [
+	'pointer-events-none',
+	'absolute',
+	'inset-0',
+	'rounded-2xl',
+	'bg-gradient-to-br',
+	'from-white/70',
+	'via-white/30',
+	'to-transparent',
+	'opacity-0',
+	'transition-opacity',
+	'duration-300',
+	'ease-out',
+	'data-[active=true]:opacity-60',
+	'dark:from-white/40',
+	'dark:via-white/5',
+] as const;
+
+export const PHASE_INDEX_TEXT_CLASS_NAMES = [
+	'relative',
+	'text-xs',
+	'font-semibold',
+	'uppercase',
+	'tracking-[0.35em]',
+	'text-indigo-600',
+	'transition-colors',
+	'duration-300',
+	'ease-out',
+	'data-[active=true]:text-white',
+	'dark:text-indigo-200',
+	'dark:data-[active=true]:text-white',
+	'font-mono',
+	'tabular-nums',
+] as const;
+
+export const PHASE_ICON_CLASS_NAMES = [
+	'grid',
+	'h-9',
+	'w-9',
+	'place-items-center',
+	'rounded-xl',
+	'bg-white/80',
+	'text-base',
+	'text-indigo-600',
+	'shadow-inner',
+	'dark:bg-white/10',
+	'dark:text-indigo-200',
+] as const;
+
+export const PHASE_LABEL_CLASS_NAMES = [
+	'flex-1',
+	'text-xs',
+	'uppercase',
+	'tracking-[0.2em]',
+] as const;
+
+export const joinClassNames = (classNames: readonly string[]) =>
+	classNames.join(' ');
+
+export const PANEL_CLASSES = joinClassNames(PANEL_CLASS_NAMES);
+export const HEADER_CLASSES = joinClassNames(HEADER_CLASS_NAMES);
+export const TURN_SUMMARY_CLASSES = joinClassNames(TURN_SUMMARY_CLASS_NAMES);
+export const TURN_BADGE_CLASSES = joinClassNames(TURN_BADGE_CLASS_NAMES);
+export const PLAYER_DETAILS_CLASSES = joinClassNames(
+	PLAYER_DETAILS_CLASS_NAMES,
+);
+export const PLAYER_LABEL_CLASSES = joinClassNames(PLAYER_LABEL_CLASS_NAMES);
+export const PLAYER_NAME_CLASSES = joinClassNames(PLAYER_NAME_CLASS_NAMES);
+export const PHASE_SECTION_CLASSES = joinClassNames(PHASE_SECTION_CLASS_NAMES);
+export const PHASE_LIST_CLASSES = joinClassNames(PHASE_LIST_CLASS_NAMES);
+export const PHASE_LIST_ITEM_CLASSES = joinClassNames(
+	PHASE_LIST_ITEM_CLASS_NAMES,
+);
+export const PHASE_LIST_ITEM_CONTENT_CLASSES = joinClassNames(
+	PHASE_LIST_ITEM_CONTENT_CLASS_NAMES,
+);
+export const PHASE_INDEX_WRAPPER_CLASSES = joinClassNames(
+	PHASE_INDEX_WRAPPER_CLASS_NAMES,
+);
+export const PHASE_INDEX_HIGHLIGHT_CLASSES = joinClassNames(
+	PHASE_INDEX_HIGHLIGHT_CLASS_NAMES,
+);
+export const PHASE_INDEX_TEXT_CLASSES = joinClassNames(
+	PHASE_INDEX_TEXT_CLASS_NAMES,
+);
+export const PHASE_ICON_CLASSES = joinClassNames(PHASE_ICON_CLASS_NAMES);
+export const PHASE_LABEL_CLASSES = joinClassNames(PHASE_LABEL_CLASS_NAMES);

--- a/packages/web/src/components/player/HappinessBar.tsx
+++ b/packages/web/src/components/player/HappinessBar.tsx
@@ -50,7 +50,7 @@ const HappinessBar: React.FC<HappinessBarProps> = ({
 				/>
 				{/* Mask overlay that hides the unfilled portion */}
 				<div
-					className="absolute inset-y-0 right-0 rounded-r-lg bg-slate-800/90"
+					className="absolute inset-y-0 right-0 rounded-r-lg bg-slate-200/90 dark:bg-slate-800/90"
 					style={{
 						width: `${100 - percent}%`,
 					}}

--- a/packages/web/src/components/player/PlayerPanel.tsx
+++ b/packages/web/src/components/player/PlayerPanel.tsx
@@ -330,18 +330,9 @@ const PlayerPanel: FC<PlayerPanelProps> = ({
 					<span className="font-semibold text-[14px]">{player.name}</span>
 				</div>
 				{/* Grid for Economy | Military columns */}
-				<div
-					className="grid grid-cols-2"
-					style={{
-						gap: '1px',
-						background: 'rgba(255, 255, 255, 0.06)',
-					}}
-				>
+				<div className="panel-columns-grid">
 					{/* Economy Column */}
-					<div
-						className="flex flex-col gap-1.5 p-2.5"
-						style={{ background: 'rgba(15, 23, 42, 0.95)' }}
-					>
+					<div className="panel-column">
 						<div className="text-[9px] font-medium uppercase tracking-widest text-slate-500">
 							{translationContext.assets.sections.economy.label}
 						</div>
@@ -359,10 +350,7 @@ const PlayerPanel: FC<PlayerPanelProps> = ({
 					</div>
 
 					{/* Military Column */}
-					<div
-						className="flex flex-col gap-1.5 p-2.5"
-						style={{ background: 'rgba(15, 23, 42, 0.95)' }}
-					>
+					<div className="panel-column">
 						<div className="text-[9px] font-medium uppercase tracking-widest text-slate-500">
 							{translationContext.assets.sections.combat.label}
 						</div>

--- a/packages/web/src/components/player/ResourceGroupDisplay.tsx
+++ b/packages/web/src/components/player/ResourceGroupDisplay.tsx
@@ -267,7 +267,7 @@ const ResourceGroupDisplay: React.FC<ResourceGroupDisplayProps> = ({
 						{displayMetadata.icon}
 					</span>
 				)}
-				<span className="flex-1 text-left text-sm font-semibold text-slate-100">
+				<span className="flex-1 text-left text-sm font-semibold text-slate-800 dark:text-slate-100">
 					{displayValue}
 				</span>
 				{groupForecastDisplay && (

--- a/packages/web/src/menu/CallToActionSection.tsx
+++ b/packages/web/src/menu/CallToActionSection.tsx
@@ -82,6 +82,7 @@ export interface CallToActionProps {
 	resumePoint: ResumeSessionRecord | null;
 	onContinue: () => void;
 	onOpenSettings: () => void;
+	onOpenPlayground?: () => void;
 }
 
 export function CallToActionSection({
@@ -89,6 +90,7 @@ export function CallToActionSection({
 	resumePoint,
 	onContinue,
 	onOpenSettings,
+	onOpenPlayground,
 }: CallToActionProps) {
 	const { packages } = useContentPackages();
 	const [selectedSpace, setSelectedSpace] = useState<string | null>(null);
@@ -191,7 +193,19 @@ export function CallToActionSection({
 				</div>
 			) : null}
 
-			<div className="flex justify-center">{settingsButton}</div>
+			<div className="flex items-center justify-center gap-3">
+				{settingsButton}
+				{onOpenPlayground ? (
+					<Button
+						variant="dev"
+						className={SETTINGS_BUTTON_CLASS}
+						onClick={onOpenPlayground}
+						icon="🔬"
+					>
+						Playground
+					</Button>
+				) : null}
+			</div>
 		</ShowcaseCard>
 	);
 }

--- a/packages/web/src/playground/Playground.tsx
+++ b/packages/web/src/playground/Playground.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import Button from '../components/common/Button';
+import { usePlaygroundData } from './usePlaygroundData';
+import { ActionsTab } from './tabs/ActionsTab';
+import { BuildingsTab } from './tabs/BuildingsTab';
+import { ResourcesTab } from './tabs/ResourcesTab';
+
+type TabId = 'actions' | 'buildings' | 'resources';
+
+const TABS: Array<{ id: TabId; label: string; icon: string }> = [
+	{ id: 'actions', label: 'Actions', icon: '⚔️' },
+	{ id: 'buildings', label: 'Buildings', icon: '🏛️' },
+	{ id: 'resources', label: 'Resources', icon: '💰' },
+];
+
+const SURFACE_CLASS = [
+	'relative min-h-screen w-full overflow-hidden',
+	'bg-gradient-to-br from-purple-50 via-fuchsia-50 to-indigo-50',
+	'text-slate-900',
+	'dark:from-slate-950 dark:via-slate-900 dark:to-slate-950',
+	'dark:text-slate-100',
+].join(' ');
+
+const HEADER_CLASS = [
+	'flex flex-wrap items-center justify-between gap-4',
+	'rounded-3xl border border-white/50',
+	'bg-white/70 px-6 py-4 shadow-xl',
+	'dark:border-white/10 dark:bg-slate-900/70',
+	'dark:shadow-slate-900/40 frosted-surface',
+].join(' ');
+
+const TAB_BAR_CLASS = [
+	'flex rounded-full bg-slate-100/60 p-1',
+	'dark:bg-slate-800/50',
+].join(' ');
+
+const TAB_BUTTON_BASE = [
+	'flex items-center gap-2 rounded-full px-4 py-2',
+	'text-sm font-semibold transition cursor-pointer',
+	'focus:outline-none focus-visible:ring-2',
+	'focus-visible:ring-purple-300',
+	'dark:focus-visible:ring-purple-500/60',
+].join(' ');
+
+const TAB_ACTIVE_CLASS = [
+	'border border-purple-300 bg-purple-100 text-purple-900',
+	'shadow-sm shadow-purple-500/20',
+	'dark:border-purple-500/40 dark:bg-purple-500/20',
+	'dark:text-purple-100',
+].join(' ');
+
+const TAB_INACTIVE_CLASS = [
+	'border border-transparent text-slate-600',
+	'hover:bg-white/80 hover:text-purple-700',
+	'dark:text-slate-200',
+	'dark:hover:bg-white/10 dark:hover:text-purple-200',
+].join(' ');
+
+const CONTENT_CLASS = [
+	'rounded-3xl border border-white/50',
+	'bg-white/70 p-6 shadow-xl',
+	'dark:border-white/10 dark:bg-slate-900/70',
+	'dark:shadow-slate-900/40 frosted-surface',
+].join(' ');
+
+interface PlaygroundProps {
+	onBack: () => void;
+}
+
+export default function Playground({ onBack }: PlaygroundProps) {
+	const [activeTab, setActiveTab] = useState<TabId>('actions');
+	const { data, loading, error } = usePlaygroundData();
+
+	return (
+		<div className={SURFACE_CLASS}>
+			<div className="relative z-10 flex min-h-screen flex-col gap-6 px-4 py-8 sm:px-8 lg:px-12">
+				<div className={HEADER_CLASS}>
+					<div className="flex items-center gap-4">
+						<Button variant="ghost" icon="←" onClick={onBack}>
+							Menu
+						</Button>
+						<div>
+							<h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+								Playground
+							</h1>
+							<p className="text-xs text-slate-500 dark:text-slate-400">
+								Content explorer for product owners
+							</p>
+						</div>
+					</div>
+					<div className={TAB_BAR_CLASS}>
+						{TABS.map((tab) => (
+							<button
+								key={tab.id}
+								type="button"
+								className={`${TAB_BUTTON_BASE} ${
+									activeTab === tab.id ? TAB_ACTIVE_CLASS : TAB_INACTIVE_CLASS
+								}`}
+								onClick={() => setActiveTab(tab.id)}
+							>
+								<span aria-hidden>{tab.icon}</span>
+								<span>{tab.label}</span>
+							</button>
+						))}
+					</div>
+				</div>
+
+				<div className={CONTENT_CLASS}>
+					{loading && (
+						<p className="py-12 text-center text-slate-500">
+							Loading content data...
+						</p>
+					)}
+					{error && <p className="py-12 text-center text-rose-500">{error}</p>}
+					{data && activeTab === 'actions' && (
+						<ActionsTab registries={data.registries} />
+					)}
+					{data && activeTab === 'buildings' && (
+						<BuildingsTab registries={data.registries} />
+					)}
+					{data && activeTab === 'resources' && (
+						<ResourcesTab registries={data.registries} />
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/playground/tabs/ActionsTab.tsx
+++ b/packages/web/src/playground/tabs/ActionsTab.tsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from 'react';
+import type {
+	ActionConfig,
+	SessionRegistriesPayload,
+} from '@boardsmith/protocol';
+
+const TABLE_CLASS = ['w-full text-left text-sm'].join(' ');
+
+const TH_CLASS = [
+	'px-3 py-2 text-xs font-semibold uppercase tracking-wider',
+	'text-slate-500 dark:text-slate-400',
+	'border-b border-slate-200 dark:border-white/10',
+].join(' ');
+
+const TD_CLASS = [
+	'px-3 py-2 border-b border-slate-100 dark:border-white/5',
+].join(' ');
+
+const BADGE_CLASS = [
+	'inline-block rounded-full px-2 py-0.5 text-xs font-medium',
+].join(' ');
+
+const FILTER_BUTTON_CLASS = [
+	'rounded-full px-3 py-1 text-xs font-medium transition',
+	'cursor-pointer',
+].join(' ');
+
+function tierCount(action: ActionConfig): number {
+	return Object.keys(action.tiers).length;
+}
+
+function effectCount(action: ActionConfig): number {
+	let count = 0;
+	for (const tier of Object.values(action.tiers)) {
+		count += tier.effects.length;
+	}
+	return count;
+}
+
+interface ActionsTabProps {
+	registries: SessionRegistriesPayload;
+}
+
+export function ActionsTab({ registries }: ActionsTabProps) {
+	const [filter, setFilter] = useState<'all' | 'player' | 'system' | 'locked'>(
+		'all',
+	);
+	const [search, setSearch] = useState('');
+
+	const actions = useMemo(() => {
+		const list = Object.values(registries.actions);
+		return list.sort((first, second) => first.name.localeCompare(second.name));
+	}, [registries.actions]);
+
+	const metaCategories = useMemo(
+		() => registries.actionMetaCategories ?? {},
+		[registries.actionMetaCategories],
+	);
+
+	const filtered = useMemo(() => {
+		let result = actions;
+		if (filter === 'player') {
+			result = result.filter((a) => !a.system);
+		} else if (filter === 'system') {
+			result = result.filter((a) => a.system);
+		} else if (filter === 'locked') {
+			result = result.filter((a) => a.locked);
+		}
+		if (search.trim().length > 0) {
+			const query = search.toLowerCase();
+			result = result.filter(
+				(a) =>
+					a.name.toLowerCase().includes(query) ||
+					a.id.toLowerCase().includes(query),
+			);
+		}
+		return result;
+	}, [actions, filter, search]);
+
+	const filters: Array<{
+		id: typeof filter;
+		label: string;
+		count: number;
+	}> = [
+		{ id: 'all', label: 'All', count: actions.length },
+		{
+			id: 'player',
+			label: 'Player',
+			count: actions.filter((a) => !a.system).length,
+		},
+		{
+			id: 'system',
+			label: 'System',
+			count: actions.filter((a) => a.system).length,
+		},
+		{
+			id: 'locked',
+			label: 'Locked',
+			count: actions.filter((a) => a.locked).length,
+		},
+	];
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex flex-wrap items-center gap-3">
+				<h2 className="text-lg font-semibold">Actions Catalog</h2>
+				<span className="text-xs text-slate-500 dark:text-slate-400">
+					{filtered.length} of {actions.length}
+				</span>
+			</div>
+
+			<div className="flex flex-wrap items-center gap-2">
+				{filters.map((f) => (
+					<button
+						key={f.id}
+						type="button"
+						className={`${FILTER_BUTTON_CLASS} ${
+							filter === f.id
+								? 'bg-purple-100 text-purple-800 dark:bg-purple-500/20 dark:text-purple-200'
+								: 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10'
+						}`}
+						onClick={() => setFilter(f.id)}
+					>
+						{f.label} ({f.count})
+					</button>
+				))}
+				<input
+					type="text"
+					placeholder="Search actions..."
+					value={search}
+					onChange={(e) => setSearch(e.target.value)}
+					className="ml-auto rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-xs outline-none focus:border-purple-300 dark:border-white/10 dark:bg-slate-800/50 dark:focus:border-purple-500/40"
+				/>
+			</div>
+
+			<div className="overflow-x-auto">
+				<table className={TABLE_CLASS}>
+					<thead>
+						<tr>
+							<th className={TH_CLASS}>Icon</th>
+							<th className={TH_CLASS}>Name</th>
+							<th className={TH_CLASS}>ID</th>
+							<th className={TH_CLASS}>Meta-Category</th>
+							<th className={TH_CLASS}>Tiers</th>
+							<th className={TH_CLASS}>Effects</th>
+							<th className={TH_CLASS}>Flags</th>
+						</tr>
+					</thead>
+					<tbody>
+						{filtered.map((action) => {
+							const metaCat = metaCategories[action.metaCategory];
+							return (
+								<tr
+									key={action.id}
+									className="transition hover:bg-slate-50 dark:hover:bg-white/5"
+								>
+									<td className={TD_CLASS}>
+										<span className="text-lg">{action.icon ?? ''}</span>
+									</td>
+									<td className={`${TD_CLASS} font-medium`}>{action.name}</td>
+									<td
+										className={`${TD_CLASS} font-mono text-xs text-slate-500 dark:text-slate-400`}
+									>
+										{action.id}
+									</td>
+									<td className={TD_CLASS}>
+										{metaCat ? (
+											<span>
+												{metaCat.icon} {metaCat.label}
+											</span>
+										) : (
+											<span className="text-slate-400">
+												{action.metaCategory}
+											</span>
+										)}
+									</td>
+									<td className={`${TD_CLASS} tabular-nums`}>
+										{tierCount(action)}
+									</td>
+									<td className={`${TD_CLASS} tabular-nums`}>
+										{effectCount(action)}
+									</td>
+									<td className={TD_CLASS}>
+										<div className="flex flex-wrap gap-1">
+											{action.system && (
+												<span
+													className={`${BADGE_CLASS} bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-300`}
+												>
+													system
+												</span>
+											)}
+											{action.locked && (
+												<span
+													className={`${BADGE_CLASS} bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300`}
+												>
+													locked
+												</span>
+											)}
+											{action.oneTime && (
+												<span
+													className={`${BADGE_CLASS} bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300`}
+												>
+													one-time
+												</span>
+											)}
+											{action.free && (
+												<span
+													className={`${BADGE_CLASS} bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300`}
+												>
+													free
+												</span>
+											)}
+											{action.maxUsesPerTurn !== undefined && (
+												<span
+													className={`${BADGE_CLASS} bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300`}
+												>
+													max {action.maxUsesPerTurn}/turn
+												</span>
+											)}
+										</div>
+									</td>
+								</tr>
+							);
+						})}
+					</tbody>
+				</table>
+			</div>
+
+			{filtered.length === 0 && (
+				<p className="py-8 text-center text-sm text-slate-400">
+					No actions match the current filter.
+				</p>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/playground/tabs/BuildingsTab.tsx
+++ b/packages/web/src/playground/tabs/BuildingsTab.tsx
@@ -1,0 +1,183 @@
+import { useMemo, useState } from 'react';
+import type { SessionRegistriesPayload } from '@boardsmith/protocol';
+
+const TABLE_CLASS = 'w-full text-left text-sm';
+
+const TH_CLASS = [
+	'px-3 py-2 text-xs font-semibold uppercase tracking-wider',
+	'text-slate-500 dark:text-slate-400',
+	'border-b border-slate-200 dark:border-white/10',
+].join(' ');
+
+const TD_CLASS = [
+	'px-3 py-2 border-b border-slate-100 dark:border-white/5',
+].join(' ');
+
+function formatCosts(costs: Record<string, number> | undefined): string {
+	if (!costs) {
+		return '—';
+	}
+	const entries = Object.entries(costs);
+	if (entries.length === 0) {
+		return '—';
+	}
+	return entries
+		.map(([key, value]) => {
+			const shortKey = key.split(':').pop() ?? key;
+			return `${value} ${shortKey}`;
+		})
+		.join(', ');
+}
+
+function triggerCount(building: Record<string, unknown>): number {
+	const triggers = [
+		'onBuild',
+		'onBeforeAttacked',
+		'onAttackResolved',
+		'onPayUpkeepStep',
+		'onGainIncomeStep',
+		'onGainAPStep',
+	];
+	let count = 0;
+	for (const trigger of triggers) {
+		const value = building[trigger];
+		if (Array.isArray(value)) {
+			count += value.length;
+		}
+	}
+	return count;
+}
+
+interface BuildingsTabProps {
+	registries: SessionRegistriesPayload;
+}
+
+export function BuildingsTab({ registries }: BuildingsTabProps) {
+	const [search, setSearch] = useState('');
+	const [showType, setShowType] = useState<'buildings' | 'developments'>(
+		'buildings',
+	);
+
+	const buildings = useMemo(
+		() =>
+			Object.values(registries.buildings).sort((a, b) =>
+				a.name.localeCompare(b.name),
+			),
+		[registries.buildings],
+	);
+
+	const developments = useMemo(
+		() =>
+			Object.values(registries.developments).sort((a, b) =>
+				a.name.localeCompare(b.name),
+			),
+		[registries.developments],
+	);
+
+	const items = showType === 'buildings' ? buildings : developments;
+
+	const filtered = useMemo(() => {
+		if (search.trim().length === 0) {
+			return items;
+		}
+		const query = search.toLowerCase();
+		return items.filter(
+			(item) =>
+				item.name.toLowerCase().includes(query) ||
+				item.id.toLowerCase().includes(query),
+		);
+	}, [items, search]);
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex flex-wrap items-center gap-3">
+				<h2 className="text-lg font-semibold">
+					{showType === 'buildings' ? 'Buildings' : 'Developments'} Catalog
+				</h2>
+				<span className="text-xs text-slate-500 dark:text-slate-400">
+					{filtered.length} of {items.length}
+				</span>
+			</div>
+
+			<div className="flex flex-wrap items-center gap-2">
+				<button
+					type="button"
+					className={`rounded-full px-3 py-1 text-xs font-medium transition cursor-pointer ${
+						showType === 'buildings'
+							? 'bg-purple-100 text-purple-800 dark:bg-purple-500/20 dark:text-purple-200'
+							: 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10'
+					}`}
+					onClick={() => setShowType('buildings')}
+				>
+					Buildings ({buildings.length})
+				</button>
+				<button
+					type="button"
+					className={`rounded-full px-3 py-1 text-xs font-medium transition cursor-pointer ${
+						showType === 'developments'
+							? 'bg-purple-100 text-purple-800 dark:bg-purple-500/20 dark:text-purple-200'
+							: 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10'
+					}`}
+					onClick={() => setShowType('developments')}
+				>
+					Developments ({developments.length})
+				</button>
+				<input
+					type="text"
+					placeholder="Search..."
+					value={search}
+					onChange={(e) => setSearch(e.target.value)}
+					className="ml-auto rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-xs outline-none focus:border-purple-300 dark:border-white/10 dark:bg-slate-800/50 dark:focus:border-purple-500/40"
+				/>
+			</div>
+
+			<div className="overflow-x-auto">
+				<table className={TABLE_CLASS}>
+					<thead>
+						<tr>
+							<th className={TH_CLASS}>Icon</th>
+							<th className={TH_CLASS}>Name</th>
+							<th className={TH_CLASS}>ID</th>
+							<th className={TH_CLASS}>Costs</th>
+							<th className={TH_CLASS}>Upkeep</th>
+							<th className={TH_CLASS}>Triggers</th>
+						</tr>
+					</thead>
+					<tbody>
+						{filtered.map((item) => (
+							<tr
+								key={item.id}
+								className="transition hover:bg-slate-50 dark:hover:bg-white/5"
+							>
+								<td className={TD_CLASS}>
+									<span className="text-lg">{item.icon ?? ''}</span>
+								</td>
+								<td className={`${TD_CLASS} font-medium`}>{item.name}</td>
+								<td
+									className={`${TD_CLASS} font-mono text-xs text-slate-500 dark:text-slate-400`}
+								>
+									{item.id}
+								</td>
+								<td className={`${TD_CLASS} text-xs`}>
+									{'costs' in item ? formatCosts(item.costs) : '—'}
+								</td>
+								<td className={`${TD_CLASS} text-xs`}>
+									{formatCosts(item.upkeep)}
+								</td>
+								<td className={`${TD_CLASS} tabular-nums`}>
+									{triggerCount(item as unknown as Record<string, unknown>)}
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+
+			{filtered.length === 0 && (
+				<p className="py-8 text-center text-sm text-slate-400">
+					No items match the current search.
+				</p>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/playground/tabs/ResourcesTab.tsx
+++ b/packages/web/src/playground/tabs/ResourcesTab.tsx
@@ -1,0 +1,216 @@
+import { useMemo, useState } from 'react';
+import type { SessionRegistriesPayload } from '@boardsmith/protocol';
+
+const TABLE_CLASS = 'w-full text-left text-sm';
+
+const TH_CLASS = [
+	'px-3 py-2 text-xs font-semibold uppercase tracking-wider',
+	'text-slate-500 dark:text-slate-400',
+	'border-b border-slate-200 dark:border-white/10',
+].join(' ');
+
+const TD_CLASS = [
+	'px-3 py-2 border-b border-slate-100 dark:border-white/5',
+].join(' ');
+
+const BADGE_CLASS = [
+	'inline-block rounded-full px-2 py-0.5 text-xs font-medium',
+].join(' ');
+
+function formatBound(
+	bound: number | { resourceId: string } | undefined | null,
+): string {
+	if (bound === undefined || bound === null) {
+		return '—';
+	}
+	if (typeof bound === 'object') {
+		const shortId = bound.resourceId.split(':').pop() ?? bound.resourceId;
+		return `ref:${shortId}`;
+	}
+	return String(bound);
+}
+
+interface ResourcesTabProps {
+	registries: SessionRegistriesPayload;
+}
+
+export function ResourcesTab({ registries }: ResourcesTabProps) {
+	const [search, setSearch] = useState('');
+	const [groupFilter, setGroupFilter] = useState<string | null>(null);
+
+	const resources = useMemo(
+		() =>
+			Object.values(registries.resources).sort((a, b) =>
+				a.id.localeCompare(b.id),
+			),
+		[registries.resources],
+	);
+
+	const groups = useMemo(() => {
+		const groupMap = registries.resourceGroups ?? {};
+		return Object.values(groupMap).sort((a, b) => a.id.localeCompare(b.id));
+	}, [registries.resourceGroups]);
+
+	const filtered = useMemo(() => {
+		let result = resources;
+		if (groupFilter) {
+			result = result.filter((r) => r.groupId === groupFilter);
+		}
+		if (search.trim().length > 0) {
+			const query = search.toLowerCase();
+			result = result.filter(
+				(r) =>
+					r.id.toLowerCase().includes(query) ||
+					(r.label ?? '').toLowerCase().includes(query),
+			);
+		}
+		return result;
+	}, [resources, groupFilter, search]);
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex flex-wrap items-center gap-3">
+				<h2 className="text-lg font-semibold">Resources Catalog</h2>
+				<span className="text-xs text-slate-500 dark:text-slate-400">
+					{filtered.length} of {resources.length}
+				</span>
+			</div>
+
+			<div className="flex flex-wrap items-center gap-2">
+				<button
+					type="button"
+					className={`rounded-full px-3 py-1 text-xs font-medium transition cursor-pointer ${
+						groupFilter === null
+							? 'bg-purple-100 text-purple-800 dark:bg-purple-500/20 dark:text-purple-200'
+							: 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10'
+					}`}
+					onClick={() => setGroupFilter(null)}
+				>
+					All ({resources.length})
+				</button>
+				{groups.map((group) => {
+					const count = resources.filter((r) => r.groupId === group.id).length;
+					if (count === 0) {
+						return null;
+					}
+					return (
+						<button
+							key={group.id}
+							type="button"
+							className={`rounded-full px-3 py-1 text-xs font-medium transition cursor-pointer ${
+								groupFilter === group.id
+									? 'bg-purple-100 text-purple-800 dark:bg-purple-500/20 dark:text-purple-200'
+									: 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10'
+							}`}
+							onClick={() => setGroupFilter(group.id)}
+						>
+							{group.icon ?? ''} {group.label ?? group.id} ({count})
+						</button>
+					);
+				})}
+				<input
+					type="text"
+					placeholder="Search resources..."
+					value={search}
+					onChange={(e) => setSearch(e.target.value)}
+					className="ml-auto rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-xs outline-none focus:border-purple-300 dark:border-white/10 dark:bg-slate-800/50 dark:focus:border-purple-500/40"
+				/>
+			</div>
+
+			<div className="overflow-x-auto">
+				<table className={TABLE_CLASS}>
+					<thead>
+						<tr>
+							<th className={TH_CLASS}>Icon</th>
+							<th className={TH_CLASS}>Label</th>
+							<th className={TH_CLASS}>ID</th>
+							<th className={TH_CLASS}>Group</th>
+							<th className={TH_CLASS}>Lower</th>
+							<th className={TH_CLASS}>Upper</th>
+							<th className={TH_CLASS}>Flags</th>
+						</tr>
+					</thead>
+					<tbody>
+						{filtered.map((resource) => {
+							const group =
+								resource.groupId && registries.resourceGroups
+									? registries.resourceGroups[resource.groupId]
+									: undefined;
+							return (
+								<tr
+									key={resource.id}
+									className="transition hover:bg-slate-50 dark:hover:bg-white/5"
+								>
+									<td className={TD_CLASS}>
+										<span className="text-lg">{resource.icon ?? ''}</span>
+									</td>
+									<td className={`${TD_CLASS} font-medium`}>
+										{resource.label ?? resource.id}
+									</td>
+									<td
+										className={`${TD_CLASS} font-mono text-xs text-slate-500 dark:text-slate-400`}
+									>
+										{resource.id}
+									</td>
+									<td className={`${TD_CLASS} text-xs`}>
+										{group ? (
+											<span>
+												{group.icon ?? ''} {group.label ?? group.id}
+											</span>
+										) : (
+											'—'
+										)}
+									</td>
+									<td className={`${TD_CLASS} tabular-nums`}>
+										{formatBound(resource.lowerBound)}
+									</td>
+									<td className={`${TD_CLASS} tabular-nums`}>
+										{formatBound(resource.upperBound)}
+									</td>
+									<td className={TD_CLASS}>
+										<div className="flex flex-wrap gap-1">
+											{resource.displayAsPercent && (
+												<span
+													className={`${BADGE_CLASS} bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300`}
+												>
+													%
+												</span>
+											)}
+											{resource.tierTrack && (
+												<span
+													className={`${BADGE_CLASS} bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300`}
+												>
+													tiered
+												</span>
+											)}
+											{resource.globalCost && (
+												<span
+													className={`${BADGE_CLASS} bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300`}
+												>
+													global cost
+												</span>
+											)}
+											{resource.boundOf && (
+												<span
+													className={`${BADGE_CLASS} bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300`}
+												>
+													{resource.boundOf.boundType} bound
+												</span>
+											)}
+										</div>
+									</td>
+								</tr>
+							);
+						})}
+					</tbody>
+				</table>
+			</div>
+
+			{filtered.length === 0 && (
+				<p className="py-8 text-center text-sm text-slate-400">
+					No resources match the current filter.
+				</p>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/playground/usePlaygroundData.ts
+++ b/packages/web/src/playground/usePlaygroundData.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import type { SessionMetadataSnapshotResponse } from '@boardsmith/protocol';
+import { ensureGameApi } from '../state/gameApiInstance';
+
+interface PlaygroundData {
+	data: SessionMetadataSnapshotResponse | null;
+	loading: boolean;
+	error: string | null;
+}
+
+export function usePlaygroundData(): PlaygroundData {
+	const [data, setData] = useState<SessionMetadataSnapshotResponse | null>(
+		null,
+	);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		const api = ensureGameApi();
+		api
+			.fetchMetadataSnapshot()
+			.then((response) => {
+				if (!cancelled) {
+					setData(response);
+					setLoading(false);
+				}
+			})
+			.catch((err: unknown) => {
+				if (!cancelled) {
+					const message =
+						err instanceof Error ? err.message : 'Failed to load metadata';
+					setError(message);
+					setLoading(false);
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	return { data, loading, error };
+}

--- a/packages/web/src/state/appHistory.ts
+++ b/packages/web/src/state/appHistory.ts
@@ -1,6 +1,7 @@
 export enum Screen {
 	Menu = 'menu',
 	Game = 'game',
+	Playground = 'playground',
 }
 
 export interface HistoryState {

--- a/packages/web/src/state/appNavigationState.ts
+++ b/packages/web/src/state/appNavigationState.ts
@@ -15,6 +15,7 @@ export interface AppNavigationState {
 	startGameWithContent: (contentId: string) => void;
 	continueSavedGame: () => void;
 	returnToMenu: () => void;
+	navigateToPlayground: () => void;
 	toggleDarkMode: () => void;
 	toggleMusic: () => void;
 	toggleSound: () => void;

--- a/packages/web/src/state/useAppNavigation.ts
+++ b/packages/web/src/state/useAppNavigation.ts
@@ -250,6 +250,14 @@ export function useAppNavigation(): AppNavigationState {
 		],
 	);
 
+	const navigateToPlayground = useCallback(() => {
+		const nextState = buildHistoryState({
+			screen: Screen.Playground,
+		});
+		setCurrentScreen(Screen.Playground);
+		pushHistoryState(nextState);
+	}, [buildHistoryState, pushHistoryState]);
+
 	const continueSavedGame = useContinueSavedGame({
 		resumePoint,
 		currentGameKey,
@@ -306,6 +314,7 @@ export function useAppNavigation(): AppNavigationState {
 		startGameWithContent,
 		continueSavedGame,
 		returnToMenu,
+		navigateToPlayground,
 		toggleDarkMode,
 		toggleMusic,
 		toggleSound,

--- a/packages/web/src/styles/layout.css
+++ b/packages/web/src/styles/layout.css
@@ -131,9 +131,34 @@
 		color: #f1f5f9;
 	}
 
+	/* Panel column grid and column backgrounds */
+	.panel-columns-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1px;
+		background: rgba(0, 0, 0, 0.06);
+	}
+
+	html.dark .panel-columns-grid {
+		background: rgba(255, 255, 255, 0.06);
+	}
+
+	.panel-column {
+		@apply flex flex-col gap-1.5 p-2.5;
+		background: rgba(255, 255, 255, 0.92);
+	}
+
+	html.dark .panel-column {
+		background: rgba(15, 23, 42, 0.95);
+	}
+
 	/* Population group - expandable container */
 	.pop-group {
 		@apply rounded-lg overflow-hidden;
+		background: rgba(0, 0, 0, 0.03);
+	}
+
+	html.dark .pop-group {
 		background: rgba(255, 255, 255, 0.03);
 	}
 
@@ -142,6 +167,10 @@
 	}
 
 	.pop-header:hover {
+		background: rgba(0, 0, 0, 0.04);
+	}
+
+	html.dark .pop-header:hover {
 		background: rgba(255, 255, 255, 0.04);
 	}
 
@@ -178,16 +207,28 @@
 	/* Assets row at bottom */
 	.assets-row {
 		@apply flex gap-2 px-3 py-2.5 items-center justify-between;
+		border-top: 1px solid rgba(0, 0, 0, 0.06);
+	}
+
+	html.dark .assets-row {
 		border-top: 1px solid rgba(255, 255, 255, 0.06);
 	}
 
 	.asset-badge {
 		@apply inline-flex items-center gap-1.5 px-3 py-2 rounded-lg cursor-pointer transition-all;
 		font-size: 14px;
-		background: rgba(255, 255, 255, 0.04);
+		background: rgba(0, 0, 0, 0.04);
 	}
 
 	.asset-badge:hover {
+		background: rgba(0, 0, 0, 0.08);
+	}
+
+	html.dark .asset-badge {
+		background: rgba(255, 255, 255, 0.04);
+	}
+
+	html.dark .asset-badge:hover {
 		background: rgba(255, 255, 255, 0.1);
 	}
 


### PR DESCRIPTION
## Summary
This PR extracts phase panel styling into a dedicated constants file and introduces a new Playground feature for content exploration. The changes improve code maintainability by centralizing Tailwind class definitions and add a developer/product owner tool for browsing game content registries.

## Key Changes

### Style Extraction
- **New file**: `phasePanelStyles.ts` - Centralizes all Tailwind CSS class names for the phase panel component
  - Exports both individual class name arrays and pre-joined string constants
  - Includes styles for panel, header, turn summary, badges, player details, and phase list items
  - Provides a `joinClassNames` utility function for consistency
- **Updated**: `PhasePanel.tsx` - Refactored to import and use the extracted style constants instead of inline class strings

### Playground Feature
- **New component**: `Playground.tsx` - Main playground interface with tabbed navigation
  - Displays content catalogs for Actions, Buildings, and Resources
  - Responsive design with dark mode support
  - Tab-based navigation with visual indicators
- **New tabs**:
  - `ActionsTab.tsx` - Displays action configurations with filtering by type (player/system/locked) and search
  - `BuildingsTab.tsx` - Shows buildings and developments with cost/upkeep information
  - `ResourcesTab.tsx` - Lists resources with group filtering and bound information
- **New hook**: `usePlaygroundData.ts` - Fetches session metadata snapshot from the game API
- **Navigation integration**: Added `Playground` screen to app history and navigation state

### UI/Layout Updates
- **`layout.css`**: Added `.panel-columns-grid` and `.panel-column` utility classes for consistent panel layouts with light/dark mode support
- **`PlayerPanel.tsx`**: Refactored to use new panel column grid classes
- **`CallToActionSection.tsx`**: Added optional `onOpenPlayground` callback prop
- **`Menu.tsx`**: Added `onOpenPlayground` prop for navigation
- **`App.tsx`**: Lazy-loaded Playground component with Suspense boundary

### Configuration
- **`eslint.config.js`**: Removed PhasePanel from linting exceptions (now compliant after style extraction)

## Implementation Details
- The playground tabs use consistent table layouts with filtering and search capabilities
- All new components follow the existing design system with Tailwind CSS and dark mode support
- The style extraction uses TypeScript `as const` for type safety
- Playground data is fetched once on mount with proper error handling and loading states

https://claude.ai/code/session_014wVG8phVF5rhaiaek7FsYF